### PR TITLE
Fix illegal instruction crash in mayastor io unit test

### DIFF
--- a/mayastor/examples/nvmf_uri.rs
+++ b/mayastor/examples/nvmf_uri.rs
@@ -1,5 +1,4 @@
 #![feature(async_await)]
-use futures::task::LocalSpawnExt;
 use log::error;
 use mayastor::{
     bdev::nexus::nexus_bdev::nexus_create,
@@ -13,8 +12,7 @@ fn main() {
     mayastor::CPS_INIT!();
     let args = vec!["-c", "../etc/test.conf"];
     mayastor_start("test", args, || {
-        let mut spawn = mayastor::executor::get_spawner();
-        spawn.spawn_local(works()).unwrap();
+        mayastor::executor::spawn(works());
     });
 }
 async fn works() {

--- a/mayastor/src/executor.rs
+++ b/mayastor/src/executor.rs
@@ -1,6 +1,9 @@
 //! Future executor and a couple of related utility functions.
 //! The executor is started on current thread and saved to TLS.
-//! It is a local single-threaded executor.
+//! It is a local single-threaded executor. It is fine to use it for
+//! mgmt tasks but it should not be used for IO which should scale with
+//! number of cpu cores.
+//!
 //! Any code wishing to spawn a future and runnig on the same thread
 //! can obtain the spawner for executor in TLS and spawn it.
 
@@ -12,81 +15,79 @@ use futures::{
 };
 use libc::c_void;
 use spdk_sys::{spdk_poller, spdk_poller_register, spdk_poller_unregister};
-use std::{cell::RefCell, fmt, ptr, thread};
+use std::{
+    cell::{Cell, RefCell},
+    fmt,
+    ptr,
+    thread,
+};
 
 /// Everything we need to store to thread local storage (kinda global state) to
 /// manage and dispatch tasks to executor.
+///
+/// More on how concurrent access to the context is guaranteed to be safe:
+/// The context is stored in TLS and it is not sent between threads so the
+/// concurrent access is not possible. Still we must prevent situations like:
+///
+/// fn A has mut ref of member 1, it calls fn B which obtains mut ref of
+/// member 1 from TLS. Thus fn A has no way of knowing that the data it has
+/// referenced might have been changed after fn B finished executing. Simply
+/// put: mut-mut, mut-const combinations should be forbidden as always in Rust.
+///
+/// This can happen easily. If tick() which references executor, executes a
+/// future and the future calls start, stop or spawn function. To prevent
+/// getting into these unsafe situations, we have following basic rules:
+///
+///   1) no restrictions on start() as it is creating the context and
+///      there can't be prior reference to the context.
+///   2) after the executor is created the only place where mutable ref to the
+///      executor may be obtained is the tick().
+///   3) spawn() may only use pre-allocated spawner from the context structure.
+///   4) stop() may only set shutdown_cb, but the actual release of
+///      executor must be done inside the tick().
 struct ExecutorCtx {
-    pool: LocalPool,
+    /// The local pool executor.
+    pool: RefCell<LocalPool>,
+    /// The handle for spawning new futures on the executor.
+    spawner: RefCell<LocalSpawner>,
+    /// Spdk poller routine - the work horse of futures.
     poller: *mut spdk_poller,
+    /// Shutdown callback. If set, the spdk poller for executor is unregistered
+    /// and the executor destroyed in tick. The shutdown callback is called
+    /// afterwards.
+    shutdown_cb: Cell<Option<Box<dyn FnOnce()>>>,
 }
 
 thread_local! {
-    /// Executor context.
+    /// Thread local executor context.
     static EXECUTOR_CTX: RefCell<Option<ExecutorCtx>> = RefCell::new(None);
-    /// Shutdown callback. If set, the executor poller is unregistered and
-    /// the executor destroyed. The callback is called afterwards.
-    ///
-    /// NOTE: The reason why shutdown cb cannot be part of executor context
-    /// above is that we need to be able to set it from a future executing on
-    /// the executor. If it was placed in executor ctx it would result in
-    /// double mutable reference.
-    static SHUTDOWN_CB: RefCell<Option<Box<dyn FnOnce()>>> = RefCell::new(None);
-}
-
-/// Run whatever work might be queued for the executor without blocking.
-/// Or shutdown executor if "global" shutdown callback is set.
-extern "C" fn tick(_ctx: *mut c_void) -> i32 {
-    let shutdown_cb_maybe = SHUTDOWN_CB.with(|cb| cb.borrow_mut().take());
-
-    EXECUTOR_CTX.with(move |ctx| {
-        if let Some(shutdown_cb) = shutdown_cb_maybe {
-            debug!(
-                "Stopping future executor on thread {:?}",
-                thread::current().id()
-            );
-            match ctx.borrow_mut().take() {
-                Some(mut ctx) => unsafe {
-                    // unregister will write NULL pointer to poller but that
-                    // should be ok as we won't be using
-                    // poller pointer anymore
-                    spdk_poller_unregister(&mut ctx.poller)
-                },
-                None => panic!("Executor was not started on this thread"),
-            }
-            shutdown_cb();
-        } else {
-            match &mut *ctx.borrow_mut() {
-                Some(ctx) => {
-                    // Tasks which are generated while the executor runs are
-                    // left in the queue until the tick() is
-                    // called again.
-                    let _work = ctx.pool.try_run_one();
-                }
-                None => panic!(
-                    "tick was called while the executor has been shut down"
-                ),
-            }
-        }
-    });
-    0
 }
 
 /// Start future executor and register its poll method with spdk so that the
 /// tasks can make steady progress.
-pub fn start_executor() {
-    EXECUTOR_CTX.with(|ctx| {
-        if (*ctx.borrow()).is_some() {
-            panic!("Executor was already started on this thread");
+pub fn start() {
+    EXECUTOR_CTX.with(|ctx_cell| {
+        let mut ctx_maybe = ctx_cell.try_borrow_mut().expect(
+            "start executor must be called before any other executor method",
+        );
+
+        if ctx_maybe.is_some() {
+            panic!(
+                "Executor was already started on thread {:?}",
+                thread::current().id()
+            );
         }
 
         let pool = LocalPool::new();
+        let spawner = pool.spawner();
         let poller =
             unsafe { spdk_poller_register(Some(tick), ptr::null_mut(), 1000) };
 
-        *ctx.borrow_mut() = Some(ExecutorCtx {
-            pool,
+        *ctx_maybe = Some(ExecutorCtx {
+            pool: RefCell::new(pool),
             poller,
+            spawner: RefCell::new(spawner),
+            shutdown_cb: Cell::new(None),
         });
     });
 
@@ -96,28 +97,100 @@ pub fn start_executor() {
     );
 }
 
-/// Return task spawner for executor started on current thread.
-pub fn get_spawner() -> LocalSpawner {
-    EXECUTOR_CTX.with(|ctx| match &*ctx.borrow() {
-        Some(ctx) => ctx.pool.spawner(),
-        None => panic!("Executor was not started on this thread"),
+/// Spawn a future on the executor running on the same thread.
+pub fn spawn<F>(f: F)
+where
+    F: Future<Output = ()> + 'static,
+{
+    EXECUTOR_CTX.with(|ctx_cell| {
+        let ctx_maybe = ctx_cell.borrow();
+
+        match ctx_maybe.as_ref() {
+            // The only place we grab ref to spawner is here and since only
+            // a single thread can access it, it is safe.
+            Some(ctx) => ctx.spawner.borrow_mut().spawn_local(f).unwrap(),
+            None => panic!(
+                "Executor was not started on thread {:?}",
+                thread::current().id()
+            ),
+        }
     })
 }
 
 /// Stop and deallocate executor but only after the provided future has
 /// completed. When done, call the provided callback function.
-pub fn stop_executor<T, F>(fut: T, cb: Box<F>)
+pub fn stop<F, T>(f: F, cb: Box<T>)
 where
-    T: Future<Output = ()> + 'static,
-    F: FnOnce() + 'static,
+    F: Future<Output = ()> + 'static,
+    T: FnOnce() + 'static,
 {
-    // Chain provided future with a code indicating that the future has
-    // completed.
-    let fut = async {
-        fut.await;
-        SHUTDOWN_CB.with(|shutdown_cb| *shutdown_cb.borrow_mut() = Some(cb));
+    // Chain a code which sets shutdown flag at the end of the future
+    let wrapped_f = async {
+        f.await;
+        EXECUTOR_CTX.with(|ctx_cell| {
+            let ctx_maybe = ctx_cell.borrow();
+            match ctx_maybe.as_ref() {
+                Some(ctx) => {
+                    if ctx.shutdown_cb.replace(Some(cb)).is_some() {
+                        panic!("stop executor called twice");
+                    }
+                }
+                None => panic!(
+                    "Executor was not started on thread {:?}",
+                    thread::current().id()
+                ),
+            }
+        })
     };
-    get_spawner().spawn_local(fut).unwrap();
+    debug!(
+        "Initiating shutdown of future executor on thread {:?}",
+        thread::current().id()
+    );
+    spawn(wrapped_f);
+}
+
+/// Run whatever work might be queued for the executor without blocking
+/// or shutdown executor if shutdown flag is set.
+extern "C" fn tick(_ptr: *mut c_void) -> i32 {
+    EXECUTOR_CTX.with(|ctx_cell| {
+        let ctx_maybe = ctx_cell.borrow();
+
+        let shutdown_cb = match ctx_maybe.as_ref() {
+            Some(ctx) => ctx.shutdown_cb.take(),
+            None => panic!(
+                "tick was called on thread {:?} while executor has been shut down",
+                thread::current().id()
+            )
+        };
+        // drop the ref so that we can grab a mutable ref later
+        drop(ctx_maybe);
+
+        match shutdown_cb {
+            Some(cb) => {
+                debug!(
+                    "Stopping future executor on thread {:?}",
+                    thread::current().id()
+                );
+                // we won't be running any futures so it is safe to grab mut ref
+                let mut ctx = ctx_cell.borrow_mut().take().unwrap();
+                unsafe {
+                    // unregister will write NULL pointer to poller but that
+                    // should be ok as we won't be using poller pointer anymore
+                    spdk_poller_unregister(&mut ctx.poller);
+                }
+                cb();
+            }
+            None => {
+                let ctx_maybe = ctx_cell.borrow();
+                // we know that ctx is "some" from previous step
+                let ctx = ctx_maybe.as_ref().unwrap();
+                // Tasks which are generated while the executor runs are
+                // left in the queue until the tick() is called again.
+                let _work = ctx.pool.borrow_mut().try_run_one();
+            }
+        }
+    });
+    0
 }
 
 /// Construct callback argument for spdk async function.

--- a/mayastor/src/jsonrpc.rs
+++ b/mayastor/src/jsonrpc.rs
@@ -4,7 +4,7 @@
 //! for executing async code in jsonrpc handlers.
 
 use crate::executor;
-use futures::{future::Future, task::LocalSpawnExt};
+use futures::future::Future;
 use nix::errno::Errno;
 use serde::{Deserialize, Serialize};
 use spdk_sys::{
@@ -193,7 +193,7 @@ unsafe extern "C" fn jsonrpc_handler<H, P, R>(
                     }
                 }
             };
-            executor::get_spawner().spawn_local(fut).unwrap();
+            executor::spawn(fut);
         }
         Err(err) => {
             // parameters are not what is expected

--- a/mayastor/tests/io.rs
+++ b/mayastor/tests/io.rs
@@ -1,5 +1,4 @@
 #![feature(async_await)]
-use futures::task::LocalSpawnExt;
 use mayastor::{mayastor_start, spdk_stop};
 
 use mayastor::{
@@ -24,8 +23,7 @@ fn io_test() {
     assert_eq!(output.status.success(), true);
 
     mayastor_start("io-testing", vec![""], || {
-        let mut spawn = mayastor::executor::get_spawner();
-        spawn.spawn_local(start()).unwrap();
+        mayastor::executor::spawn(start());
     });
 
     let output = Command::new("rm")

--- a/mayastor/tests/reconfigure.rs
+++ b/mayastor/tests/reconfigure.rs
@@ -1,6 +1,5 @@
 #![feature(async_await)]
 #![allow(clippy::cognitive_complexity)]
-use futures::task::LocalSpawnExt;
 use mayastor::{
     bdev::{
         nexus::nexus_bdev::{nexus_create, nexus_lookup},
@@ -43,8 +42,7 @@ fn reconfigure() {
     assert_eq!(output.status.success(), true);
 
     let rc = mayastor_start("test", args, || {
-        let mut spawn = mayastor::executor::get_spawner();
-        spawn.spawn_local(works()).unwrap();
+        mayastor::executor::spawn(works());
     });
 
     assert_eq!(rc, 0);


### PR DESCRIPTION
Dynamic mutable reference on executor was obtained twice in the tick
function. Clear rules for using the executor context have been defined,
which should prevent similar problems in future. Also the executor's API
was simplified.