### PR TITLE
nexus_label: adjust the cursor to the right offset

### DIFF
--- a/mayastor/src/bdev/nexus/nexus_bdev.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev.rs
@@ -453,6 +453,9 @@ impl Nexus {
                 serialize_into(&mut writer, &p)?;
             }
 
+            // depending on the number of entries we need to adjust cursor
+            writer.seek(SeekFrom::Start((1 << 14) as u64)).unwrap();
+
             serialize_into(&mut writer, &backup)?;
 
             for child in &mut self.children {


### PR DESCRIPTION
When we only write two partitions, we in fact only have 2 partitions
in memory. This may sound logical but other tools simply always write
out 128 partitions.

Initially we did the same but prior to integration this was
changed and we forgot to adjust the offset before writing out the
backup label to disk

With the change:

$ mctl create gpt  -r aio:///code/disk1.img?blk_size=512 -s 1GiB -b 512
"gpt"

$ sgdisk -p /code/disk1.img

Found valid GPT with corrupt MBR; using GPT and will write new
protective MBR on save.
Disk /code/disk1.img: 2097152 sectors, 1024.0 MiB
Sector size (logical): 512 bytes
Disk identifier (GUID): 3D1034D1-C0B0-40B4-BB80-4B8D9E903CB3
Partition table holds up to 2 entries
Main partition table begins at sector 2 and ends at sector 2
First usable sector is 2048, last usable sector is 2097118
Partitions will be aligned on 2048-sector boundaries
Total free space is 0 sectors (0 bytes)

Number  Start (sector)    End (sector)  Size       Code  Name
   1            2048           10239   4.0 MiB     FFFF  MayaMeta
   2           10240         2097118   1019.0 MiB  FFFF  MayaData

Note how it mentions the MBR to be corrupt, which is not entirely true.
It is, in fact, simply missing which is captured under issue #8