### PR TITLE
nix: use package libspdk

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v1.2.3
+    rev: v2.3.0
     hooks:
     -   id: trailing-whitespace
 -   repo: local

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+git:
+  depth: false
+  submodules: false
+
 dist: bionic
 cache:
   cargo: true
@@ -8,7 +12,10 @@ cache:
     - mayastor-test/node_modules
 
 before_script:
-  - sudo mkdir /etc/nix && echo 'sandbox = true' | sudo tee /etc/nix/nix.conf
+  - nix-env -iA cachix -f https://cachix.org/api/v1/install
+  - cachix use mayastor
+  - export NIX_PATH="$NIX_PATH:nixpkgs-overlays=/home/travis/build/openebs/MayaStor/nix"
+  - git submodule update --init
   - sudo modprobe nbd
   - sudo modprobe iscsi_tcp
   - sudo modprobe xfs
@@ -16,7 +23,6 @@ before_script:
   - source $HOME/.nvm/nvm.sh
   - nvm install 10
   - curl -sSf https://build.travis-ci.org/files/rustup-init.sh | sh -s -- --default-toolchain=nightly-2019-08-15 -y
-  - git submodule update --init --recursive
 language: nix
 
 script:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1918,8 +1918,6 @@ version = "0.1.0"
 dependencies = [
  "bindgen 0.47.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
- "glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/mayastor-test/test_common.js
+++ b/mayastor-test/test_common.js
@@ -204,20 +204,6 @@ function restartMayastor(ping, done) {
   );
 }
 
-// Execute spdk's rpc.py with given arguments
-function rpcCommand(args, done) {
-  exec(
-    '../spdk-sys/spdk/scripts/rpc.py -s ' + SOCK + ' ' + args,
-    (err, stdout, stderr) => {
-      if (err) {
-        done(new Error(stderr));
-      } else {
-        done();
-      }
-    }
-  );
-}
-
 // Execute rpc method using dumb jsonrpc client
 function dumbCommand(method, args, done) {
   exec(
@@ -247,6 +233,5 @@ module.exports = {
   waitForMayastor,
   restartMayastor,
   endpoint,
-  rpcCommand,
   dumbCommand,
 };

--- a/mayastor-test/test_csi.js
+++ b/mayastor-test/test_csi.js
@@ -168,7 +168,7 @@ describe('csi', function() {
           }, next);
         },
         next => {
-          common.rpcCommand('construct_lvol_store Malloc0 tpool', next);
+          common.dumbCommand('construct_lvol_store', {'bdev_name': 'Malloc0', 'lvs_name': 'tpool'}, next);
         },
         next => {
           async.times(

--- a/nix/pkgs/libiscsi/default.nix
+++ b/nix/pkgs/libiscsi/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit, autoreconfHook}:
+{ stdenv, fetchgit, autoreconfHook }:
 
 stdenv.mkDerivation rec {
   version = "1.19.0";
@@ -10,6 +10,7 @@ stdenv.mkDerivation rec {
     sha256 = "0ajrkkg5awmi8m4b3mha7h07ylg18k252qprvk1sgq0qbyd66zy7";
   };
 
+  outputs = [ "out" "bin" "lib" "dev" ];
   nativeBuildInputs = [ autoreconfHook ];
   meta = {
     description = "User space iscsi library";
@@ -21,8 +22,7 @@ stdenv.mkDerivation rec {
       but a synchronous layer is also provided for ease of use for simpler
       applications.
     '';
-    homepage =
-      "https://github.com/sahlberg/libiscsi";
+    homepage = "https://github.com/sahlberg/libiscsi";
     licenses = stdenv.lib.licenses.gpl2;
     maintainers = "gila@openebs.io";
     platforms = stdenv.lib.platforms.x86_64;

--- a/nix/pkgs/libspdk/default.nix
+++ b/nix/pkgs/libspdk/default.nix
@@ -12,8 +12,17 @@ stdenv.mkDerivation rec {
     fetchSubmodules = true;
   };
 
-  buildInputs =
-    [ binutils libaio libiscsi libuuid nasm numactl openssl python rdma-core ];
+  buildInputs = [
+    binutils
+    libaio
+    libiscsi.dev
+    libuuid
+    nasm
+    numactl
+    openssl
+    python
+    rdma-core
+  ];
 
   CONFIGURE_OPTS = ''
     --enable-debug --without-isal --with-iscsi-initiator --with-rdma
@@ -55,7 +64,9 @@ stdenv.mkDerivation rec {
   # todo -- split out in dev and normal pkg
   installPhase = ''
     find include/ -type f -name "*.h" -exec install -D "{}" $out/{} \;
-    find lib/ -type f -name "*.h" -exec install -D "{}" $out/include/{} \;
+    pushd lib
+    find . -type f -name "*.h" -exec install -D "{}" $out/include/{} \;
+    popd
     mkdir -p $out/lib
     cp libspdk_fat.so $out/lib
   '';

--- a/nix/pkgs/libspdk/default.nix
+++ b/nix/pkgs/libspdk/default.nix
@@ -5,10 +5,10 @@ stdenv.mkDerivation rec {
   version = "19.07.x-mayastor";
   name = "libspdk";
   src = fetchFromGitHub {
-    rev = "1274d250a6f49731aecbbcc925fff208a25f4b95";
-    repo = "spdk";
     owner = "openebs";
-    sha256 = "148dp6nm8a2dglc8wk5yakjjd8r6s6drn1afff5afafa50fkcjgd";
+    repo = "spdk";
+    rev = "0deb6044b7e4dd5073f7070378bb69942c53b78a";
+    sha256 = "0qm5df0jrmqbhp5bzkmgpapzy3b6x69k2wnpf8f0bcbxh75pfx9s";
     fetchSubmodules = true;
   };
 
@@ -16,8 +16,9 @@ stdenv.mkDerivation rec {
     [ binutils libaio libiscsi libuuid nasm numactl openssl python rdma-core ];
 
   CONFIGURE_OPTS = ''
-    --enable-debug --without-isal --with-iscsi-initiator --with-rdma   
-        --with-internal-vhost-lib --disable-tests --with-dpdk-machine=native'';
+    --enable-debug --without-isal --with-iscsi-initiator --with-rdma
+    --with-internal-vhost-lib --disable-tests --with-dpdk-machine=native
+  '';
 
   enableParallelBuilding = true;
 
@@ -53,8 +54,9 @@ stdenv.mkDerivation rec {
 
   # todo -- split out in dev and normal pkg
   installPhase = ''
+    find include/ -type f -name "*.h" -exec install -D "{}" $out/{} \;
+    find lib/ -type f -name "*.h" -exec install -D "{}" $out/include/{} \;
     mkdir -p $out/lib
-    cp -ar include $out
     cp libspdk_fat.so $out/lib
   '';
 

--- a/shell.nix
+++ b/shell.nix
@@ -13,7 +13,8 @@ stdenv.mkDerivation rec {
     git
     gptfdisk
     libaio
-    libiscsi
+    libiscsi.lib
+    libiscsi.bin
     libspdk
     libuuid
     llvmPackages.libclang
@@ -30,6 +31,7 @@ stdenv.mkDerivation rec {
     gdb
     utillinux
     xfsprogs
+    pre-commit
   ];
 
   propagatedBuildInputs = [ clang ];

--- a/shell.nix
+++ b/shell.nix
@@ -8,13 +8,13 @@ stdenv.mkDerivation rec {
   name = "MayaStor";
 
   buildInputs = [
-    bash
     binutils
     gcc
     git
     gptfdisk
     libaio
     libiscsi
+    libspdk
     libuuid
     llvmPackages.libclang
     nasm

--- a/test.sh
+++ b/test.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 set -euxo pipefail
-spdk-sys/build.sh --enable-debug
 export PATH=$PATH:${HOME}/.cargo/bin
 cargo build --all
 


### PR DESCRIPTION
This change moves SPDK within the nixpkg sets which allows us to
start using the chachix and avoid rebuilding SPDK all the time.

Unfortunately, due to a lack of control of the Travis image, packages pushed from my dev box
do not result in the same hash as Travis defaults to tracking unstable. The solution to that is to have
Travis push the pkg after successful run but I've not figured out how to have it do that yet. 