### PR TITLE
Fix issues found by clippy in rust code

### DIFF
--- a/csi/src/mount.rs
+++ b/csi/src/mount.rs
@@ -138,7 +138,7 @@ pub fn probe_filesystems() -> Result<Vec<Fs>, String> {
     for fsname in supported_fs.iter() {
         match probe_defaults(fsname) {
             Ok(opts) => filesystems.push(Fs {
-                name: fsname.to_string(),
+                name: (*fsname).to_string(),
                 defaults: opts,
             }),
             Err(err) => {

--- a/jsonrpc/src/test.rs
+++ b/jsonrpc/src/test.rs
@@ -5,10 +5,11 @@ use super::*;
 use nix::errno::Errno;
 use serde_json::json;
 use std::{fs, panic, path::Path};
-use tokio::{net::UnixListener, runtime::current_thread::Runtime};
-
-use futures::StreamExt;
-use tokio::io::{AsyncReadExt, ErrorKind};
+use tokio::{
+    net::UnixListener,
+    runtime::current_thread::Runtime,
+    io::{AsyncReadExt, ErrorKind},
+};
 
 /// Socket path to the test json-rpc server
 const SOCK_PATH: &str = "/tmp/jsonrpc-ut.sock";

--- a/mayastor/examples/nvmf_uri.rs
+++ b/mayastor/examples/nvmf_uri.rs
@@ -1,4 +1,3 @@
-#![feature(async_await)]
 use log::error;
 use mayastor::{
     bdev::nexus::nexus_bdev::nexus_create,

--- a/mayastor/src/bdev/nexus/nexus_bdev_children.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev_children.rs
@@ -20,7 +20,7 @@ use futures::future::join_all;
 
 impl Nexus {
     fn hold_io_channel(&self) -> IoChannel {
-        IoChannel::new(self.as_ptr())
+        unsafe { IoChannel::new(self.as_ptr()) }
     }
 
     /// Add the child bdevs to the nexus instance in the "init state"

--- a/mayastor/src/descriptor/mod.rs
+++ b/mayastor/src/descriptor/mod.rs
@@ -346,11 +346,14 @@ pub struct IoChannel {
 impl IoChannel {
     /// Acquire an io channel for the given nexus.
     /// This channel has guard semantics, and will be released when dropped.
-    pub fn new(nexus: *mut c_void) -> Self {
-        unsafe {
-            IoChannel {
-                handle: spdk_get_io_channel(nexus),
-            }
+    ///
+    /// # Safety
+    ///
+    /// The pointer specified must be io_device pointer which has been
+    /// previously registered using spdk_io_device_register()
+    pub unsafe fn new(nexus: *mut c_void) -> Self {
+        IoChannel {
+            handle: spdk_get_io_channel(nexus),
         }
     }
 }

--- a/mayastor/src/lib.rs
+++ b/mayastor/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(async_await)]
 #![feature(try_trait)]
 #![feature(drain_filter)]
 #[macro_use]

--- a/mayastor/tests/io.rs
+++ b/mayastor/tests/io.rs
@@ -1,4 +1,3 @@
-#![feature(async_await)]
 use mayastor::{mayastor_start, spdk_stop};
 
 use mayastor::{

--- a/mayastor/tests/nexus_label.rs
+++ b/mayastor/tests/nexus_label.rs
@@ -1,4 +1,3 @@
-#![feature(async_await)]
 use mayastor::bdev::nexus::nexus_label::{GPTHeader, GptEntry};
 use std::io::{Cursor, Read};
 

--- a/mayastor/tests/reconfigure.rs
+++ b/mayastor/tests/reconfigure.rs
@@ -1,4 +1,3 @@
-#![feature(async_await)]
 #![allow(clippy::cognitive_complexity)]
 use mayastor::{
     bdev::{


### PR DESCRIPTION
The errors were found by clippy from rust nightly toolchain 2019-10-20.
It is recommended that people upgrade to at least this version of
nightly or later.