### PR TITLE
travis: fix test

### DIFF
--- a/mayastor-test/test_common.js
+++ b/mayastor-test/test_common.js
@@ -82,7 +82,7 @@ function waitForMayastor(ping, done) {
 
 // Start mayastor process and wait for them to come up.
 function startMayastor(config, done) {
-  let args = ['-r', SOCK, '-Lnbd'];
+  let args = ['-r', SOCK];
 
   if (config) {
     fs.writeFileSync(CONFIG_PATH, config);


### PR DESCRIPTION
When we started use non-debug builds for spdk-sys; the debug flags
became invalid which resulted in the tests failing.

As the output of the tests is so verbose, it was kinda hard to spot as we don't stop (anymore) on first failure rather, we continue with MOAC tests. This fixes the tests again by removing the -L flag to NBD.

Even though we are moving to gitlab 🎉 having travis pass can never hurt.