### PR TITLE
Add enableDebug param to libspdk nix package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ COPY shell.nix $NIX_EXPR_DIR/
 COPY nix $NIX_EXPR_DIR/nix
 COPY csi/moac/*.nix $NIX_EXPR_DIR/csi/moac/
 
-RUN cd $NIX_EXPR_DIR && nix-shell --command "echo Good job"
+RUN cd $NIX_EXPR_DIR && nix-shell --command "echo Dependencies were pre-built"

--- a/nix/mayastor-overlay.nix
+++ b/nix/mayastor-overlay.nix
@@ -1,10 +1,10 @@
 self: super: {
   libiscsi = super.callPackage ./pkgs/libiscsi {};
   nvme-cli = super.callPackage ./pkgs/nvme-cli {};
-  libspdk = super.callPackage ./pkgs/libspdk {};
-  mayastor = (super.callPackage ./pkgs/mayastor{}).mayastor;
-  mayastorImage = (super.callPackage ./pkgs/mayastor{}).mayastorImage;
-  mayastorCSIImage = (super.callPackage ./pkgs/mayastor{}).mayastorCSIImage;
+  libspdk = super.callPackage ./pkgs/libspdk { enableDebug = false; };
+  mayastor = (super.callPackage ./pkgs/mayastor {}).mayastor;
+  mayastorImage = (super.callPackage ./pkgs/mayastor {}).mayastorImage;
+  mayastorCSIImage = (super.callPackage ./pkgs/mayastor {}).mayastorCSIImage;
   k9s = super.callPackage ./pkgs/k9s {};
   stern = super.callPackage ./pkgs/stern {};
   node-moac = (import ./../csi/moac { pkgs = super; }).package;

--- a/nix/pkgs/libspdk/default.nix
+++ b/nix/pkgs/libspdk/default.nix
@@ -11,7 +11,10 @@
 , nasm
 , callPackage
 , libiscsi
+, enableDebug ? false
 }:
+
+with stdenv.lib;
 
 stdenv.mkDerivation rec {
   version = "19.07.x-mayastor";
@@ -37,6 +40,7 @@ stdenv.mkDerivation rec {
   ];
 
   CONFIGURE_OPTS = ''
+    ${optionalString enableDebug "--enable-debug"}
     --without-isal --with-iscsi-initiator --with-rdma
     --with-internal-vhost-lib --disable-tests --with-dpdk-machine=native
     --with-crypto
@@ -86,6 +90,6 @@ stdenv.mkDerivation rec {
     cp libspdk_fat.so $out/lib
   '';
 
-  separateDebugInfo = true;
-
+  dontStrip = enableDebug;
+  separateDebugInfo = !enableDebug;
 }

--- a/nix/pkgs/stern/default.nix
+++ b/nix/pkgs/stern/default.nix
@@ -1,5 +1,5 @@
 { stdenv, pkgs ? import <nixpkgs> {} }:
-pkgs.stdenv.mkDerivation {
+pkgs.stdenv.mkDerivation rec {
   name = "stern";
   version = "1.11.9";
   src = pkgs.fetchurl {


### PR DESCRIPTION
If set to true it adds --enable-debug configure option to libspdk.
Currently it is not used by anything. In future we might use it to
build debug flavour of mayastor.