### PR TITLE
Update spdk-sys subrepo to v19.10 branch and other minor bugfixes

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -114,10 +114,18 @@ image-mayastor:
   before_script:
     - git submodule update --init
   script:
+    # This is a bit dirty but artifacts can be stored only in the source
+    # directory and we cannot store them there while building the images
+    # because it would clobber mayastor dir and change the hash of mayastor
+    # src in nix hence build the mayastor twice.
     - NIX_PATH="$NIX_PATH:nixpkgs-overlays=`pwd`/nix" nix-build '<nixpkgs>' -A mayastorImage
-    - cp result image-mayastor
+    - readlink -f result >/tmp/artifact1
+    - rm result
     - NIX_PATH="$NIX_PATH:nixpkgs-overlays=`pwd`/nix" nix-build '<nixpkgs>' -A mayastorCSIImage
-    - cp result image-mayastor-csi
+    - readlink -f result >/tmp/artifact2
+    - rm result
+    - cp `cat /tmp/artifact1` image-mayastor
+    - cp `cat /tmp/artifact2` image-mayastor-csi
   artifacts:
     expire_in: 1 day
     paths:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
     -   id: rust-lint
         name: Rust lint
         description: Run cargo clippy on files included in the commit. clippy should be installed before-hand.
-        entry: cargo clippy --all --all-features --all-targets -- -D warnings
+        entry: cargo clippy --all --all-targets -- -D warnings
         pass_filenames: false
         types: [file, rust]
         language: system

--- a/csi/moac/default.nix
+++ b/csi/moac/default.nix
@@ -35,7 +35,7 @@ result // rec {
   #    one big layer (~800MB) with everything else. That defeats the purpose
   #    of layering.
   buildImage = pkgs.dockerTools.buildLayeredImage {
-    name = "moac";
+    name = "mayadata/moac";
     tag = "latest";
     created = "now";
     contents = [ pkgs.bash pkgs.coreutils pkgs.nano pkgs.less package ];

--- a/mayastor/src/nvmf_target.rs
+++ b/mayastor/src/nvmf_target.rs
@@ -49,6 +49,7 @@ use spdk_sys::{
     SPDK_NVMF_SUBTYPE_NVME,
     SPDK_NVMF_TRADDR_MAX_LEN,
     SPDK_NVMF_TRSVCID_MAX_LEN,
+    NVMF_TGT_NAME_MAX_LENGTH,
 };
 use std::{
     cell::RefCell,
@@ -265,7 +266,7 @@ impl TargetOpts {
             std::ptr::copy_nonoverlapping(
                 name.as_ptr() as *const _ as *mut libc::c_void,
                 &mut opts.name[0] as *const _ as *mut libc::c_void,
-                255,
+                NVMF_TGT_NAME_MAX_LENGTH as usize,
             );
         }
 

--- a/nix/pkgs/mayastor/default.nix
+++ b/nix/pkgs/mayastor/default.nix
@@ -49,7 +49,7 @@ rec {
 
   mayastor = rustPlatform.buildRustPackage rec {
     name = "mayastor";
-    cargoSha256 = "150w3paf53104vqr45z3nw2kyb08zi90ccxwf39k3rp6gsid06gr";
+    cargoSha256 = "1b5d7ji3dvk127ghycda4gy3c8pnkavw6wv32gwq7ixb45ah119v";
     version = "unstable";
     src = ../../../.;
 
@@ -80,16 +80,23 @@ rec {
   };
 
   mayastorImage = pkgs.dockerTools.buildLayeredImage {
-    name = "mayastor";
+    name = "mayadata/mayastor";
     tag = "latest";
     created = "now";
-    contents = [ mayastor ];
+    contents = [ pkgs.bash pkgs.coreutils mayastor ];
+    config = {
+      Entrypoint = [ "/bin/mayastor" ];
+    };
   };
 
   mayastorCSIImage = pkgs.dockerTools.buildLayeredImage {
-    name = "mayastor-csi";
+    name = "mayadata/mayastor-grpc";
     tag = "latest";
     created = "now";
-    contents = [ mayastor ];
+    contents = [ pkgs.bash pkgs.coreutils mayastor ];
+    config = {
+      Entrypoint = [ "/bin/mayastor-agent" ];
+      ExposedPorts = { "10124/tcp" = {}; };
+    };
   };
 }


### PR DESCRIPTION
Minor bugfixes:
* checksum for cargo deps of mayastor in nix was wrong
* avoid building mayastor twice when building the images in gitlab
* use NVMF_TGT_NAME_MAX_LENGTH instead of hardcoded constant
* name docker images properly and add some more metadata