### PR TITLE
Clean up IO handling and introduce proper io context

### DIFF
--- a/cli/src/mctl.rs
+++ b/cli/src/mctl.rs
@@ -173,7 +173,7 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
             uuid,
             key,
         } => serde_json::to_string_pretty(
-            &call(
+            &call::<_, PublishNexusReply>(
                 &opt.socket,
                 "publish_nexus",
                 Some(json!({ "uuid": uuid , "key" : key})),

--- a/mayastor/src/bdev/nexus/nexus_fn_table.rs
+++ b/mayastor/src/bdev/nexus/nexus_fn_table.rs
@@ -79,7 +79,7 @@ impl NexusFnTable {
     }
 
     // Main entry point to submit IO to the underlying children this uses
-    // callbacks rather then futures and closures.
+    // callbacks rather than futures and closures.
 
     extern "C" fn io_submit(
         channel: *mut spdk_io_channel,
@@ -87,7 +87,6 @@ impl NexusFnTable {
     ) {
         if let Some(io_type) = Bio::io_type(io) {
             let nio = Bio::from(io);
-
             let mut ch = NexusChannel::inner_from_channel(channel);
             let nexus = nio.nexus_as_ref();
 
@@ -112,7 +111,7 @@ impl NexusFnTable {
                 _ => panic!("{} Received unsupported IO!", nexus.name()),
             };
         } else {
-            // something is every very wrong ...
+            // something is very wrong ...
             error!("Received unknown IO type {}", unsafe { (*io).type_ });
         }
     }
@@ -124,7 +123,7 @@ impl NexusFnTable {
         unsafe { spdk_get_io_channel(ctx) }
     }
 
-    /// called when the a nexus instance is unregister
+    /// called when the nexus instance is unregister
     extern "C" fn destruct(ctx: *mut c_void) -> i32 {
         let nexus = unsafe { Nexus::from_raw(ctx) };
         nexus.close().unwrap();

--- a/mayastor/src/bdev/nexus/nexus_io.rs
+++ b/mayastor/src/bdev/nexus/nexus_io.rs
@@ -31,12 +31,12 @@ use num;
 /// the mirror and mount the individual children without a nexus driver, and use
 /// filesystem checks.
 #[derive(Debug)]
-pub(crate) struct Nio {
+pub(crate) struct Bio {
     pub io: *mut spdk_bdev_io,
 }
 
 #[derive(FromPrimitive, Debug)]
-pub enum NioType {
+pub enum BioType {
     /// an invalid IO type
     Invalid = 0,
     /// READ IO
@@ -63,13 +63,13 @@ pub enum NioType {
     NumTypes = 11,
 }
 
-impl From<i32> for NioType {
+impl From<i32> for BioType {
     fn from(io: i32) -> Self {
         num::FromPrimitive::from_i32(io).unwrap()
     }
 }
 
-impl From<u32> for NioType {
+impl From<u32> for BioType {
     fn from(io: u32) -> Self {
         num::FromPrimitive::from_u32(io).unwrap()
     }
@@ -85,23 +85,23 @@ pub(crate) enum IoStatus {
     NoMemory = SPDK_BDEV_IO_STATUS_NOMEM as isize,
 }
 
-impl From<*mut spdk_bdev_io> for Nio {
+impl From<*mut spdk_bdev_io> for Bio {
     fn from(io: *mut spdk_bdev_io) -> Self {
-        Nio {
+        Bio {
             io,
         }
     }
 }
 
-impl From<*mut c_void> for Nio {
+impl From<*mut c_void> for Bio {
     fn from(io: *mut c_void) -> Self {
-        Nio {
+        Bio {
             io: io as *const _ as *mut _,
         }
     }
 }
 
-impl Nio {
+impl Bio {
     /// obtain tbe Bdev this IO is associated with
     pub(crate) fn bdev_as_ref(&self) -> Bdev {
         unsafe { Bdev::from((*self.io).bdev) }
@@ -209,7 +209,7 @@ impl Nio {
 
     /// determine the type of this IO
     #[inline]
-    pub(crate) fn io_type(io: *mut spdk_bdev_io) -> Option<NioType> {
+    pub(crate) fn io_type(io: *mut spdk_bdev_io) -> Option<BioType> {
         unsafe { num::FromPrimitive::from_u8((*io).type_) }
     }
 

--- a/mayastor/src/bdev/nexus/nexus_module.rs
+++ b/mayastor/src/bdev/nexus/nexus_module.rs
@@ -7,7 +7,10 @@ use spdk_sys::{
 };
 
 use crate::bdev::{
-    nexus::nexus_bdev::{Nexus, NexusState},
+    nexus::{
+        nexus_bdev::{Nexus, NexusState},
+        nexus_io::NioCtx,
+    },
     Bdev,
 };
 use std::{cell::UnsafeCell, ffi::CString};
@@ -148,7 +151,7 @@ impl NexusModule {
     }
 
     extern "C" fn nexus_ctx_size() -> i32 {
-        0
+        std::mem::size_of::<NioCtx>() as i32
     }
 }
 

--- a/mayastor/src/bdev/nexus/nexus_share.rs
+++ b/mayastor/src/bdev/nexus/nexus_share.rs
@@ -68,7 +68,10 @@ impl Nexus {
                 self.nbd_disk = Some(disk);
                 Ok(device_path)
             }
-            Err(err) => Err(err),
+            Err(err) => {
+                self.share_handle.take();
+                Err(err)
+            }
         }
     }
 


### PR DESCRIPTION
Initially we used the the driver_ctx pointer itself to keep track of the IO status and (abused) the io outstanding fields in the bdev_io.

These changes remove that and add a proper io context which is work needed prior to rebuild