### PR TITLE
Set the default block size in case it is explicitly set to zero

### DIFF
--- a/mayastor-test/test_grpc.js
+++ b/mayastor-test/test_grpc.js
@@ -38,7 +38,12 @@ function createTestDisk(done) {
 
     stderr = '';
     stdout = '';
-    let child = common.runAsRoot('losetup', ['--show', '-f', DISK_FILE]);
+    let child = common.runAsRoot(
+      'losetup',
+      // Explicitly set blksiz to 512 to be different from the
+      // default in mayastor (4096) to test it.
+      ['--show', '-b', '512', '-f', DISK_FILE]
+    );
 
     child.stderr.on('data', data => {
       stderr += data;

--- a/mayastor/src/bdev/nexus/nexus_rpc.rs
+++ b/mayastor/src/bdev/nexus/nexus_rpc.rs
@@ -92,6 +92,8 @@ pub(crate) fn register_rpc_methods() {
                 Ok(name) => name,
                 Err(err) => return Err(err),
             };
+            // TODO: get rid of hardcoded nexus block size (possibly by
+            // deriving it from child bdevs's block sizes).
             match nexus_create(
                 &name,
                 4096,

--- a/mayastor/src/pool.rs
+++ b/mayastor/src/pool.rs
@@ -397,9 +397,17 @@ pub fn register_pool_methods() {
                         format!("Base bdev {} already exists", disk),
                     ));
                 }
-                if let Err(err) =
-                    create_base_bdev(disk, args.block_size.unwrap_or(4096))
-                {
+                // The block size may be missing or explicitly set to zero. In
+                // both cases we want to provide our own default value instead
+                // of SPDK's default which is 512.
+                //
+                // NOTE: Keep this in sync with nexus block size which is
+                // hardcoded to 4096.
+                let mut block_size = args.block_size.unwrap_or(0);
+                if block_size == 0 {
+                    block_size = 4096;
+                }
+                if let Err(err) = create_base_bdev(disk, block_size) {
                     return Err(err);
                 };
 


### PR DESCRIPTION
Just a side note: the change in test suite does not really verify the fix. To test the fix fully we would need to create the pool, replica and nexus all in one test. That would be an interesting task for the future. The fix was tested manually on the k8s cluster for perf testing.