### PR TITLE
nvmf: use CString when setting target name

### DIFF
--- a/mayastor/src/nvmf_target.rs
+++ b/mayastor/src/nvmf_target.rs
@@ -44,12 +44,12 @@ use spdk_sys::{
     spdk_poller,
     spdk_poller_register,
     spdk_poller_unregister,
+    NVMF_TGT_NAME_MAX_LENGTH,
     SPDK_NVME_TRANSPORT_TCP,
     SPDK_NVMF_ADRFAM_IPV4,
     SPDK_NVMF_SUBTYPE_NVME,
     SPDK_NVMF_TRADDR_MAX_LEN,
     SPDK_NVMF_TRSVCID_MAX_LEN,
-    NVMF_TGT_NAME_MAX_LENGTH,
 };
 use std::{
     cell::RefCell,
@@ -261,10 +261,10 @@ pub(crate) struct TargetOpts {
 impl TargetOpts {
     fn new(name: &str, max_subsystems: u32) -> Self {
         let mut opts = spdk_nvmf_target_opts::default();
-
+        let cstr = CString::new(name).unwrap();
         unsafe {
             std::ptr::copy_nonoverlapping(
-                name.as_ptr() as *const _ as *mut libc::c_void,
+                cstr.as_ptr() as *const _ as *mut libc::c_void,
                 &mut opts.name[0] as *const _ as *mut libc::c_void,
                 NVMF_TGT_NAME_MAX_LENGTH as usize,
             );


### PR DESCRIPTION
Notice the unwrap(). This is during init so we actually want to fail if we can not allocate the memory to contain the CString. 