### PR TITLE
Add protective MBR and automatically calculate nexus geometry 

### DIFF
--- a/mayastor/examples/nvmf_uri.rs
+++ b/mayastor/examples/nvmf_uri.rs
@@ -19,7 +19,7 @@ async fn works() {
         "aio:////disk1.img?blk_size=512".to_string(),
         "aio:////disk2.img?blk_size=512".into(),
     ];
-    let name = nexus_create("hello", 512, 131_072, None, &children).await;
+    let name = nexus_create("hello", 512 * 131_072, None, &children).await;
 
     if let Err(name) = name {
         error!("{:?}", name);

--- a/mayastor/src/bdev/mod.rs
+++ b/mayastor/src/bdev/mod.rs
@@ -115,7 +115,7 @@ impl Bdev {
     }
 
     /// returns the block_size of the underlying device
-    pub fn block_size(&self) -> u32 {
+    pub fn block_len(&self) -> u32 {
         unsafe { spdk_bdev_get_block_size(self.inner) }
     }
 
@@ -124,10 +124,22 @@ impl Bdev {
         unsafe { spdk_bdev_get_num_blocks(self.inner) }
     }
 
-    pub fn set_num_blocks(&self, count: u64) {
+    /// set the block count of this device
+    pub fn set_block_count(&self, count: u64) {
         unsafe {
             (*self.inner).blockcnt = count;
         }
+    }
+
+    /// set the blocklen of the device in bytes
+    pub fn set_block_len(&self, len: u32) {
+        unsafe {
+            (*self.inner).blocklen = len;
+        }
+    }
+
+    pub fn size_in_bytes(&self) -> u64 {
+        self.num_blocks() * self.block_len() as u64
     }
 
     /// whenever the underlying device needs alignment to the page size

--- a/mayastor/src/bdev/nexus/mod.rs
+++ b/mayastor/src/bdev/nexus/mod.rs
@@ -13,20 +13,20 @@ use std::option::NoneError;
 pub enum Error {
     /// Nobody knows
     Internal(String),
-    /// spdk functions are called on a non SPDK thread
+    /// function is not called in the context of an SPDK thread
     InvalidThread,
     /// OOM but its not possible to know if this is spdk_dma_malloc() or
     /// malloc()
     OutOfMemory,
-    /// the bdev is already claimed by some other parent
+    /// the bdev is already claimed by device
     AlreadyClaimed,
-    /// the bdev can can only be opened RO as its been claimed with write
+    /// the bdev can can only be opened RO as it's been claimed with write
     /// options already
     ReadOnly,
-    /// resource does not exist or can not be found (i.e bdev, share etc)
+    /// resource does not exist or cannot be found (i.e bdev, share etc)
     NotFound,
-    /// Invalid arguments
-    Invalid,
+    /// Invalid arguments or incompatible arguments for creating the nexus
+    Invalid(String),
     /// the bdev creation failed
     CreateFailed,
     /// a bdev with either the same name or alias already exists
@@ -50,8 +50,8 @@ impl From<std::ffi::NulError> for Error {
 }
 
 impl From<nexus_uri::UriError> for Error {
-    fn from(_: UriError) -> Self {
-        Error::Invalid
+    fn from(e: UriError) -> Self {
+        Error::Invalid(format!("{:?}", e))
     }
 }
 
@@ -75,7 +75,7 @@ impl From<i32> for Error {
 
 impl From<NoneError> for Error {
     fn from(_e: NoneError) -> Self {
-        Error::Invalid
+        Error::Internal("Expected Some(T) found None".into())
     }
 }
 

--- a/mayastor/src/bdev/nexus/mod.rs
+++ b/mayastor/src/bdev/nexus/mod.rs
@@ -113,14 +113,9 @@ pub fn instances() -> &'static mut Vec<Box<Nexus>> {
 }
 
 /// function used to create a new nexus when parsing a config file
-pub fn nexus_instance_new(
-    name: String,
-    size: u64,
-    blksize: u32,
-    children: Vec<String>,
-) {
+pub fn nexus_instance_new(name: String, size: u64, children: Vec<String>) {
     let list = instances();
-    if let Ok(nexus) = Nexus::new(&name, blksize, size, None, Some(&children)) {
+    if let Ok(nexus) = Nexus::new(&name, size, None, Some(&children)) {
         list.push(nexus);
     }
 }

--- a/mayastor/src/bdev/nexus/nexus_bdev.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev.rs
@@ -411,7 +411,10 @@ impl Nexus {
             self.children.iter_mut().map(|c| c.close()).for_each(drop);
             self.set_state(NexusState::Faulted);
             return Err(match rc.neg() {
-                libc::EINVAL => Error::Invalid,
+                libc::EINVAL => Error::Invalid(
+                    "trying to register device that with invalid parameters"
+                        .into(),
+                ),
                 libc::EEXIST => Error::Exists,
                 libc::ENOMEM => Error::OutOfMemory,
                 _ => Error::Internal("Failed to register bdev".to_owned()),

--- a/mayastor/src/bdev/nexus/nexus_child.rs
+++ b/mayastor/src/bdev/nexus/nexus_child.rs
@@ -106,7 +106,10 @@ impl NexusChild {
             );
 
             self.state = ChildState::ConfigInvalid;
-            return Err(nexus::Error::Invalid);
+            return Err(nexus::Error::Invalid(
+                "requested nexus size is larger than some of its children"
+                    .into(),
+            ));
         }
 
         let mut rc = unsafe {
@@ -223,7 +226,10 @@ impl NexusChild {
             }
         } else {
             // a bdev type we dont support is being used by the nexus
-            Err(nexus::Error::Invalid)
+            Err(nexus::Error::Invalid(format!(
+                "requested bdev: {} type is not supported by the nexus",
+                self.name
+            )))
         }
     }
 
@@ -238,7 +244,10 @@ impl NexusChild {
                 self.parent, self.name
             );
             // TODO add better errors
-            return Err(nexus::Error::Invalid);
+            return Err(nexus::Error::Invalid(format!(
+                "{}: child {} is read only",
+                self.parent, self.name
+            )));
         }
 
         let block_size = self.bdev.as_ref()?.block_len();
@@ -263,7 +272,10 @@ impl NexusChild {
                 "{}: {}: Primary and backup label are invalid!",
                 self.parent, self.name
             );
-            return Err(Error::Invalid);
+            return Err(Error::Invalid(format!(
+                "{}: {}: Primary and backup label are invalid!",
+                self.parent, self.name
+            )));
         }
 
         let label = label.unwrap();
@@ -285,7 +297,10 @@ impl NexusChild {
 
         if GptEntry::checksum(&partitions) != label.table_crc {
             info!("{}: {}: Partition crc invalid!", self.parent, self.name);
-            return Err(Error::Invalid);
+            return Err(Error::Invalid(format!(
+                "{}: {}: Partition crc invalid!",
+                self.parent, self.name
+            )));
         }
 
         // some tools write 128 partition entries, even though only two are

--- a/mayastor/src/bdev/nexus/nexus_config.rs
+++ b/mayastor/src/bdev/nexus/nexus_config.rs
@@ -68,7 +68,7 @@ pub(crate) fn parse_ini_config_file() -> i32 {
             name, lu_size, block_size, &child_bdevs
         );
 
-        nexus_instance_new(name, lu_size, block_size, child_bdevs);
+        nexus_instance_new(name, lu_size, child_bdevs);
         devnum += 1;
     }
     0

--- a/mayastor/src/bdev/nexus/nexus_label.rs
+++ b/mayastor/src/bdev/nexus/nexus_label.rs
@@ -306,7 +306,7 @@ impl GPTHeader {
             || gpt.signature != [0x45, 0x46, 0x49, 0x20, 0x50, 0x41, 0x52, 0x54]
             || gpt.revision != [0x00, 0x00, 0x01, 0x00]
         {
-            return Err(Error::Invalid);
+            return Err(Error::Invalid("GPT header size is invalid".into()));
         }
 
         let crc = gpt.self_checksum;
@@ -315,7 +315,7 @@ impl GPTHeader {
 
         if gpt.self_checksum != crc {
             info!("GPT label crc mismatch");
-            return Err(Error::Invalid);
+            return Err(Error::Invalid("GPT label crc mismatch".into()));
         }
 
         if gpt.lba_self > gpt.lba_alt {

--- a/mayastor/src/bdev/nexus/nexus_rpc.rs
+++ b/mayastor/src/bdev/nexus/nexus_rpc.rs
@@ -96,8 +96,7 @@ pub(crate) fn register_rpc_methods() {
             // deriving it from child bdevs's block sizes).
             match nexus_create(
                 &name,
-                4096,
-                args.size / 4096,
+                args.size,
                 Some(&args.uuid),
                 &args.children,
             )

--- a/mayastor/src/bdev/nexus/nexus_rpc.rs
+++ b/mayastor/src/bdev/nexus/nexus_rpc.rs
@@ -50,7 +50,7 @@ fn nexus_lookup(uuid: &str) -> Result<&mut Nexus, JsonRpcError> {
 /// Convert nexus name to uuid.
 ///
 /// This function never fails which means that if there is a nexus with
-/// unconventional name which likely means it was not created using nexus
+/// unconventional name that likely means it was not created using nexus
 /// jsonrpc api, we return the whole name without modifications as it is.
 fn name_to_uuid(name: &str) -> &str {
     if name.starts_with("nexus-") {
@@ -108,6 +108,9 @@ pub(crate) fn register_rpc_methods() {
                     Code::InternalError,
                     "child bdev already exists",
                 )),
+                Err(Error::Invalid(msg)) => {
+                    Err(JsonRpcError::new(Code::InternalError, msg))
+                }
                 Err(_) => Err(JsonRpcError::new(
                     Code::InternalError,
                     "failed to create nexus",

--- a/mayastor/src/descriptor/mod.rs
+++ b/mayastor/src/descriptor/mod.rs
@@ -302,7 +302,7 @@ impl Descriptor {
             desc,
             ch,
             alignment: bdev.alignment(),
-            blk_size: bdev.block_size(),
+            blk_size: bdev.block_len(),
         })
     }
 

--- a/mayastor/src/nvme_dev.rs
+++ b/mayastor/src/nvme_dev.rs
@@ -166,7 +166,9 @@ impl NvmfBdev {
             libc::ENODEV => Err(nexus::Error::NotFound),
             libc::ENOMEM => Err(nexus::Error::OutOfMemory),
             0 => Ok(()),
-            _ => Err(nexus::Error::Invalid),
+            _ => Err(nexus::Error::Internal(
+                "Failed to delete nvme device".into(),
+            )),
         }
     }
 }

--- a/mayastor/src/nvme_dev.rs
+++ b/mayastor/src/nvme_dev.rs
@@ -158,7 +158,7 @@ impl NvmfBdev {
     /// destroy a nvme_bdev directly
     pub fn destroy(self) -> Result<(), nexus::Error> {
         let mut name = self.name;
-        name.split_off(name.len() - 2);
+        let name = name.split_off(name.len() - 2);
         let cname = CString::new(name).unwrap();
         let res = unsafe { spdk_sys::spdk_bdev_nvme_delete(cname.as_ptr()) };
 

--- a/mayastor/src/replica.rs
+++ b/mayastor/src/replica.rs
@@ -248,7 +248,7 @@ impl Replica {
     /// Get size of the replica in bytes.
     pub fn get_size(&self) -> u64 {
         let bdev: Bdev = unsafe { (*self.lvol_ptr).bdev.into() };
-        u64::from(bdev.block_size()) * bdev.num_blocks()
+        u64::from(bdev.block_len()) * bdev.num_blocks()
     }
 
     /// Get name of the pool which replica belongs to.

--- a/mayastor/tests/nexus_label.rs
+++ b/mayastor/tests/nexus_label.rs
@@ -115,7 +115,7 @@ fn test_known_label() {
 /// device
 async fn make_nexus() {
     let ch = vec![BDEVNAME1.to_string(), BDEVNAME2.to_string()];
-    nexus_create("gpt_nexus", 512, 131_072, None, &ch)
+    nexus_create("gpt_nexus", 512 * 131_072, None, &ch)
         .await
         .unwrap();
 }

--- a/mayastor/tests/reconfigure.rs
+++ b/mayastor/tests/reconfigure.rs
@@ -73,7 +73,7 @@ async fn works() {
 
     let children = vec![child1.clone(), child2.clone()];
 
-    nexus_create("hello", 512, 131_072, None, &children)
+    nexus_create("hello", 512 * 131_072, None, &children)
         .await
         .unwrap();
 


### PR DESCRIPTION
The commits messages on their own provide mode details in short

 - make the nexus configure itself automatically removing the need for blksize completely
 - add a protective MBR to the labels as on some machines the partitions did not show up automatically

Next PR will add more test cases where we purposefully try to create nexus devices with bad value and validate proper behaviour. 

As an example; i've created a zvol and exported that over nvmf. After creating the nexus, the node with has that volume shows:

```
zd0                    230:0    0     1G  0 disk 
├─zd0p1                230:1    0     4M  0 part 
└─zd0p2                230:2    0  1019M  0 part 
```

Printing the partition table

```
$ sgdisk -p /dev/zd0
Disk /dev/zd0: 2097152 sectors, 1024.0 MiB
Sector size (logical/physical): 512/8192 bytes
Disk identifier (GUID): 6B0976BF-7B28-4DD4-A6C3-E0B4350ECC67
Partition table holds up to 2 entries
Main partition table begins at sector 2 and ends at sector 2
First usable sector is 2048, last usable sector is 2097118
Partitions will be aligned on 2048-sector boundaries
Total free space is 0 sectors (0 bytes)

Number  Start (sector)    End (sector)  Size       Code  Name
   1            2048           10239   4.0 MiB     FFFF  MayaMeta
   2           10240         2097118   1019.0 MiB  FFFF  MayaData
```

Removing the nexus and using the host initiator instead of the nexus shows:

```
 $ sudo nvme connect -t tcp -a 192.168.1.2 -s 4420 -n nqn.2019-05.io.openebs:cnode2
 $ lsblk

nvme1n1     259:5    0    1G  0 disk
├─nvme1n1p1 254:0    0    4M  0 part
└─nvme1n1p2 254:1    0 1019M  0 part

$ sudo sgdisk -p /dev/nvme1n1
Disk /dev/nvme1n1: 2097152 sectors, 1024.0 MiB
Model: NEXUSController2
Sector size (logical/physical): 512/512 bytes
Disk identifier (GUID): 6B0976BF-7B28-4DD4-A6C3-E0B4350ECC67
Partition table holds up to 2 entries
Main partition table begins at sector 2 and ends at sector 2
First usable sector is 2048, last usable sector is 2097118
Partitions will be aligned on 2048-sector boundaries
Total free space is 0 sectors (0 bytes)

Number  Start (sector)    End (sector)  Size       Code  Name
   1            2048           10239   4.0 MiB     FFFF  MayaMeta
   2           10240         2097118   1019.0 MiB  FFFF  MayaData
```

Note that the GUIDs are the same. 

When using the nexus we see in the logs:

```
nexus_bdev.rs: 288:: *NOTICE*: nexus-6c16f4bc-e93c-4528-92ae-cbd1326fe291: GUID: 6b0976bf-7b28-4dd4-a6c3-e0b4350ecc67
        Header crc32 176377081
        Partition table crc32 1305302667
        Partition number 0
        GUID: a3e0dd98-61b5-4a4f-bd23-7cad6af8e2c7
        Type GUID: 27663382-e5e6-11e9-81b4-ca5ca5ca5ca5
        Logical block start: 2048, end: 10239
        Partition number 1
        GUID: a0daf91c-fe4f-4f9f-8a49-7819b916a020
        Type GUID: 27663382-e5e6-11e9-81b4-ca5ca5ca5ca5
        Logical block start: 10240, end: 2097118
```
