### PR TITLE
nix: support for multiple rust versions and debug builds

### DIFF
--- a/nix/lib/rust.nix
+++ b/nix/lib/rust.nix
@@ -1,5 +1,3 @@
-# As soon as async becomes stable; we dont need to import the mozilla overlay
-# anymore. This will greatly simplify the expression.
 { fetchFromGitHub, pkgs ? import <nixpkgs> }:
 let
   mozilla = fetchFromGitHub {
@@ -11,6 +9,13 @@ let
 
   overlay = import (builtins.toPath "${mozilla}/package-set.nix") { inherit pkgs; };
 in
-overlay.rustChannelOf {
-  channel = "stable";
+rec {
+  nightly = overlay.rustChannelOf {
+    date = "2019-11-25";
+    channel = "nightly";
+  };
+
+  stable = overlay.rustChannelOf {
+    channel = "stable";
+  };
 }

--- a/nix/mayastor-overlay.nix
+++ b/nix/mayastor-overlay.nix
@@ -1,7 +1,7 @@
 self: super: {
   libiscsi = super.callPackage ./pkgs/libiscsi {};
   nvme-cli = super.callPackage ./pkgs/nvme-cli {};
-  libspdk = super.callPackage ./pkgs/libspdk { enableDebug = false; };
+  libspdk = super.callPackage ./pkgs/libspdk {};
   mayastor = (super.callPackage ./pkgs/mayastor {}).mayastor;
   mayastorImage = (super.callPackage ./pkgs/mayastor {}).mayastorImage;
   mayastorCSIImage = (super.callPackage ./pkgs/mayastor {}).mayastorCSIImage;

--- a/nix/pkgs/mayastor/default.nix
+++ b/nix/pkgs/mayastor/default.nix
@@ -19,7 +19,6 @@
 , dockerTools
 , writeScriptBin
 , pkgs ? import <nixpkgs>
-, buildType ? "release"
 }:
 
 let
@@ -28,25 +27,11 @@ let
     inherit pkgs;
   };
   rustPlatform = makeRustPlatform {
-    rustc = channel.rust;
-    cargo = channel.cargo;
+    rustc = channel.stable.rust;
+    cargo = channel.stable.cargo;
   };
 in
 rec {
-  # An alternative approach is to build separate outputs for the workspaces:
-  #
-  # sidecar = rustPlatform.buildRustPackage rec {
-  #   name = "mayastor-sidecar";
-  #   ....
-  #
-  #   buildPhase = ''
-  #    cargo build ${stdenv.lib.optionalString (buildType == "release") "--release"} \
-  #    --target ${stdenv.hostPlatform.config} -p csi
-  #    '';
-  #   };
-  #
-  #   The downside of this is that we compile twice but maybe that is not the case
-  #   if the src are fetched from github instead of the working as it is right now.
 
   mayastor = rustPlatform.buildRustPackage rec {
     name = "mayastor";

--- a/shell.nix
+++ b/shell.nix
@@ -1,10 +1,8 @@
 { channel ? "nightly"
 , pkgs ? import <nixpkgs> {
-
     # import the mayastor-overlay
     overlays = [ (import ./nix/mayastor-overlay.nix) ];
   }
-,
 }:
 with pkgs;
 
@@ -14,9 +12,10 @@ let
     inherit pkgs;
   };
 
-  libspdk = enableDebugging pkgs.libspdk;
+  libspdk = pkgs.libspdk.override { enableDebug = true; };
 in
 mkShell {
+
   buildInputs = [
     figlet
     gdb
@@ -28,12 +27,7 @@ mkShell {
     nvme-cli
     pre-commit
     python3
-    rustChannel.${channel}.clippy-preview
-    rustChannel.${channel}.rls-preview
     rustChannel.${channel}.rust
-    rustChannel.${channel}.rust-src
-    rustChannel.${channel}.rustc
-    rustChannel.${channel}.rustfmt-preview
     xfsprogs
   ] ++ mayastor.buildInputs;
 

--- a/shell.nix
+++ b/shell.nix
@@ -1,7 +1,10 @@
-{ pkgs ? import <nixpkgs> {
-    # ensure that we import the mayastor-overlay
+{ channel ? "nightly"
+, pkgs ? import <nixpkgs> {
+
+    # import the mayastor-overlay
     overlays = [ (import ./nix/mayastor-overlay.nix) ];
   }
+,
 }:
 with pkgs;
 
@@ -10,10 +13,12 @@ let
     inherit fetchFromGitHub;
     inherit pkgs;
   };
+
+  libspdk = enableDebugging pkgs.libspdk;
 in
 mkShell {
-  inputsFrom = [ mayastor ];
   buildInputs = [
+    figlet
     gdb
     gptfdisk
     libiscsi.bin
@@ -23,15 +28,20 @@ mkShell {
     nvme-cli
     pre-commit
     python3
-    rustChannel.cargo
-    rustChannel.clippy-preview
-    rustChannel.rls-preview
-    rustChannel.rustfmt-preview
+    rustChannel.${channel}.clippy-preview
+    rustChannel.${channel}.rls-preview
+    rustChannel.${channel}.rust
+    rustChannel.${channel}.rust-src
+    rustChannel.${channel}.rustc
+    rustChannel.${channel}.rustfmt-preview
     xfsprogs
-    # TODO: Install cargo make
-  ];
+  ] ++ mayastor.buildInputs;
 
   LIBCLANG_PATH = mayastor.LIBCLANG_PATH;
   PROTOC = mayastor.PROTOC;
   PROTOC_INCLUDE = mayastor.PROTOC_INCLUDE;
+
+  shellHook = ''
+    figlet ${channel}
+  '';
 }


### PR DESCRIPTION
This change adds support for selecting what channel we want to use via `--argstr channel stable` for example when invoking nix-shell.

By default, it is set to nightly. The followup commit enabled debug build by default. Testing with -L flag works as expected (which only works with debug enabled)