### PR TITLE
MayaStor buildenv needs to contain stable rust ...

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,6 @@ COPY shell.nix $NIX_EXPR_DIR/
 COPY nix $NIX_EXPR_DIR/nix
 COPY csi/moac/*.nix $NIX_EXPR_DIR/csi/moac/
 
-RUN cd $NIX_EXPR_DIR && nix-shell --command "echo Dependencies were pre-built"
+RUN cd $NIX_EXPR_DIR && \
+  nix-shell --argstr channel nightly --command "echo Debug dependencies done" && \
+  nix-shell --argstr channel stable --command "echo Release dependencies done"


### PR DESCRIPTION
... in order to avoid downloading the rust and rebuilding libspdk
whenever CI/CD job is run. As a result the image size has grown
to 5G (uncompressed). So it becomes more important to cache the
image locally at CI/CD side to avoid downloading it from the internet.
But that is to be done later.