### PR TITLE
Add IP of remote replica to URI used by nexus.

### DIFF
--- a/deploy/mayastor-daemonset.yaml
+++ b/deploy/mayastor-daemonset.yaml
@@ -30,6 +30,11 @@ spec:
       - name: mayastor
         image: mayadata/mayastor:latest
         imagePullPolicy: Always
+        env:
+        - name: MY_POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         args: ["--rpc-socket", "/mayastor/spdk.sock"]
         securityContext:
           privileged: true

--- a/mayastor-test/test_cli.js
+++ b/mayastor-test/test_cli.js
@@ -106,7 +106,7 @@ describe('cli', function() {
             share: 1,
           },
           output: {
-            uri: 'nvmf://' + UUID,
+            uri: 'nvmf://192.168.0.1:4444/' + UUID,
           },
         },
         {
@@ -123,7 +123,7 @@ describe('cli', function() {
             share: 2,
           },
           output: {
-            uri: 'iscsi://' + UUID,
+            uri: 'iscsi://192.168.0.1:4444/' + UUID,
           },
         },
         {
@@ -136,7 +136,7 @@ describe('cli', function() {
                 pool: POOL,
                 thin: true,
                 share: 0,
-                uri: 'bdev://' + UUID,
+                uri: 'bdev:///' + UUID,
                 size: 10000 * (1024 * 1024),
               },
               {
@@ -144,7 +144,7 @@ describe('cli', function() {
                 pool: POOL,
                 thin: false,
                 share: 1,
-                uri: 'nvmf://' + UUID,
+                uri: 'nvmf://192.168.0.1:4444/' + UUID,
                 size: 10 * (1024 * 1024),
               },
               {
@@ -152,7 +152,7 @@ describe('cli', function() {
                 pool: POOL,
                 thin: false,
                 share: 2,
-                uri: 'iscsi://' + UUID,
+                uri: 'iscsi://192.168.0.1:4444/' + UUID,
                 size: 10 * (1024 * 1024),
               },
             ],
@@ -351,7 +351,7 @@ describe('cli', function() {
         assert.equal(repls[0].share, 'none');
         assert.equal(repls[0].size, '9.8'); // 10000MiB -> 9.8 GiB
         assert.equal(repls[0].size_unit, 'GiB');
-        assert.match(repls[0].uri, /^bdev:\/\//);
+        assert.match(repls[0].uri, /^bdev:\/\/\/\d+/);
 
         assert.equal(repls[1].name, UUID2);
         assert.equal(repls[1].pool, POOL);
@@ -359,7 +359,7 @@ describe('cli', function() {
         assert.equal(repls[1].share, 'nvmf');
         assert.equal(repls[1].size, '10.0');
         assert.equal(repls[1].size_unit, 'MiB');
-        assert.match(repls[1].uri, /^nvmf:\/\//);
+        assert.match(repls[1].uri, /^nvmf:\/\/\d+/);
 
         assert.equal(repls[2].name, UUID3);
         assert.equal(repls[2].pool, POOL);
@@ -367,7 +367,7 @@ describe('cli', function() {
         assert.equal(repls[2].share, 'iscsi');
         assert.equal(repls[2].size, '10.0');
         assert.equal(repls[2].size_unit, 'MiB');
-        assert.match(repls[2].uri, /^iscsi:\/\//);
+        assert.match(repls[2].uri, /^iscsi:\/\/\d+/);
 
         done();
       });

--- a/mayastor/Cargo.toml
+++ b/mayastor/Cargo.toml
@@ -13,6 +13,7 @@ bytes = "0.4.12"
 bincode = "1.2.0"
 crc = "1.8.1"
 futures-preview = "=0.3.0-alpha.19"
+futures-timer = "0.4.0"
 git-version = "0.3.1"
 ioctl-gen = "0.1.1"
 lazy_static = "1.3.0"
@@ -31,4 +32,3 @@ url_serde = "0.2.0"
 uuid = { version = "0.7", features = ["v4"] }
 rpc = { path = "../rpc"}
 sysfs = { path = "../sysfs"}
-futures-timer = "0.4.0"

--- a/mayastor/src/bdev/nexus/nexus_bdev.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev.rs
@@ -359,7 +359,7 @@ impl Nexus {
 
             let r = child.destroy().await;
             if r.is_err() {
-                warn!("Failed to destroy child {}", child.name);
+                error!("Failed to destroy child {}", child.name);
             }
         }
 

--- a/mayastor/src/bdev/nexus/nexus_rpc.rs
+++ b/mayastor/src/bdev/nexus/nexus_rpc.rs
@@ -29,7 +29,7 @@ fn uuid_to_name(uuid: &str) -> Result<String, JsonRpcError> {
         Ok(uuid) => Ok(format!("nexus-{}", uuid.to_hyphenated().to_string())),
         Err(_) => Err(JsonRpcError::new(
             Code::InvalidParams,
-            "Invalid UUID".to_owned(),
+            format!("Invalid nexus uuid '{}'", uuid),
         )),
     }
 }

--- a/mayastor/src/lib.rs
+++ b/mayastor/src/lib.rs
@@ -41,6 +41,7 @@ use std::{
     env,
     ffi::{c_void, CString},
     iter::Iterator,
+    net::Ipv4Addr,
     ptr::null_mut,
     time::Duration,
     vec::Vec,
@@ -71,7 +72,7 @@ extern "C" fn usage() {
 /// when spdk initialization is done.
 ///
 /// TODO: When needed add possibility to specify additional program
-/// arguments.
+/// arguments (current workaround is to use env variables).
 pub fn mayastor_start<T, F>(name: &str, mut args: Vec<T>, start_cb: F) -> i32
 where
     T: Into<Vec<u8>>,
@@ -153,22 +154,35 @@ extern "C" fn app_start_cb<F>(arg1: *mut c_void)
 where
     F: FnOnce(),
 {
-    if cfg!(debug_assertions) {
-        if let Some(_key) = std::env::var_os("DELAY") {
-            warn!("*** Delaying reactor every 1000us ***");
-            unsafe {
-                spdk_sys::spdk_poller_register(
-                    Some(developer_delay),
-                    std::ptr::null_mut(),
-                    1000,
-                )
-            };
-        }
+    // use in cases when you want to burn less cpu and speed does not matter
+    if let Some(_key) = std::env::var_os("DELAY") {
+        warn!("*** Delaying reactor every 1000us ***");
+        unsafe {
+            spdk_sys::spdk_poller_register(
+                Some(developer_delay),
+                std::ptr::null_mut(),
+                1000,
+            )
+        };
     }
+    let address = match std::env::var("MY_POD_IP") {
+        Ok(val) => {
+            let _ipv4: Ipv4Addr = match val.parse() {
+                Ok(val) => val,
+                Err(_) => {
+                    error!("Invalid IP address: MY_POD_IP={}", val);
+                    mayastor_stop(-1);
+                    return;
+                }
+            };
+            val
+        }
+        Err(_) => "127.0.0.1".to_owned(),
+    };
     executor::start();
     pool::register_pool_methods();
     replica::register_replica_methods();
-    if let Err(msg) = iscsi_target::init_iscsi() {
+    if let Err(msg) = iscsi_target::init_iscsi(&address) {
         error!("Failed to initialize Mayastor iscsi: {}", msg);
         mayastor_stop(-1);
         return;
@@ -176,9 +190,9 @@ where
 
     // asynchronous initialization routines
     let fut = async move {
-        if let Err(msg) = nvmf_target::init_nvmf().await {
+        if let Err(msg) = nvmf_target::init_nvmf(&address).await {
             error!("Failed to initialize Mayastor nvmf target: {}", msg);
-            //spdk_stop(-1);
+            mayastor_stop(-1);
             return;
         }
         let cb: Box<Box<F>> = unsafe { Box::from_raw(arg1 as *mut Box<F>) };

--- a/mayastor/src/nvme_dev.rs
+++ b/mayastor/src/nvme_dev.rs
@@ -197,16 +197,10 @@ impl TryFrom<&Url> for NvmfBdev {
         // the storage service fabric (s) if that too fails, we error
         // out.
 
-        if let Some(port) = u.port() {
-            n.trsvcid = port.to_string();
-        } else {
-            n.trsvcid = match u.scheme() {
-                "nvmf" => "4420".into(),
-                "nvmfn" => "4420".into(),
-                "nvmfs" => "4421".into(),
-                _ => return Err(UriError::InvalidScheme),
-            }
-        }
+        n.trsvcid = match u.port() {
+            Some(port) => port.to_string(),
+            None => "4420".to_owned(),
+        };
 
         n.traddr = u.host_str().unwrap().to_string();
         n.name = u.to_string();


### PR DESCRIPTION
The pod's IP in k8s environment is passed to mayastor process through
environment variable. If undefined it is set to 127.0.0.1. Other
minor fixes include:

* unifying domain name used in nqn and iqn strings.
* changing port of nvmf target to 8420 which does not appear to be used
  by anything else.
* allow DEBUG env var even in release version of mayastor so that we
  don't need to rebuild image if we want to use it for testing.