### PR TITLE
nexus: add initial rebuild support

### DIFF
--- a/mayastor/src/aio_dev.rs
+++ b/mayastor/src/aio_dev.rs
@@ -8,7 +8,7 @@ use spdk_sys::{bdev_aio_delete, create_aio_bdev};
 use std::{convert::TryFrom, ffi::CString};
 use url::Url;
 
-#[derive(Default, Debug)]
+#[derive(Default, Clone, Debug)]
 pub struct AioBdev {
     pub name: String,
     pub file: String,

--- a/mayastor/src/bdev/nexus/mod.rs
+++ b/mayastor/src/bdev/nexus/mod.rs
@@ -83,6 +83,7 @@ pub mod nexus_io;
 pub mod nexus_label;
 pub mod nexus_module;
 pub mod nexus_nbd;
+pub mod nexus_rebuild;
 pub mod nexus_rpc;
 pub mod nexus_share;
 /// public function which simply calls register module

--- a/mayastor/src/bdev/nexus/nexus_module.rs
+++ b/mayastor/src/bdev/nexus/nexus_module.rs
@@ -4,6 +4,7 @@ use spdk_sys::{
     spdk_bdev_module,
     spdk_bdev_module_examine_done,
     spdk_bdev_module_list_add,
+    spdk_get_thread,
 };
 
 use crate::bdev::{
@@ -86,8 +87,14 @@ impl NexusModule {
         }
     }
 
-    /// return instances
+    /// return instances, we ensure that this can only ever be called on a
+    /// properly allocated thread
     pub fn get_instances() -> &'static mut Vec<Box<Nexus>> {
+        let thread = unsafe { spdk_get_thread() };
+
+        if thread.is_null() {
+            panic!("not on spdk thread");
+        }
         unsafe { &mut (*NEXUS_INSTANCES.inner.get()) }
     }
 

--- a/mayastor/src/bdev/nexus/nexus_rebuild.rs
+++ b/mayastor/src/bdev/nexus/nexus_rebuild.rs
@@ -1,0 +1,132 @@
+//!
+//! This file contains the main routines that implement the rebuild process of
+//! an nexus instance.
+
+use crate::{
+    bdev::nexus::{
+        nexus_bdev::{Nexus, NexusState},
+        nexus_child::ChildState,
+        Error,
+    },
+    descriptor::Descriptor,
+    event::spawm_on_core,
+    rebuild::RebuildTask,
+};
+use std::rc::Rc;
+
+impl Nexus {
+    /// find any child that requires a rebuild. Children in the faulted state
+    /// are eligible for a rebuild closed children are not and must be
+    /// opened first.
+    fn find_rebuild_target(&mut self) -> Option<Rc<Descriptor>> {
+        if self.state != NexusState::Degraded {
+            trace!(
+                "{}: does not require any rebuild operation as its state: {}",
+                self.name,
+                self.state.to_string()
+            );
+        }
+
+        for child in &self.children {
+            if child.state == ChildState::Faulted {
+                trace!(
+                    "{}: child {} selected as rebuild target",
+                    self.name,
+                    child.name
+                );
+                return Some(child.descriptor.as_ref()?.clone());
+            }
+        }
+        None
+    }
+
+    /// find a child which can be used as a rebuild source
+    fn find_rebuild_source(&mut self) -> Option<Rc<Descriptor>> {
+        if self.children.len() == 1 {
+            trace!("{}: not enough children to initiate rebuild", self.name);
+            return None;
+        }
+
+        for child in &self.children {
+            if child.state == ChildState::Open {
+                trace!(
+                    "{}: child {} selected as rebuild source",
+                    self.name,
+                    child.name
+                );
+                return Some(child.descriptor.as_ref()?.clone());
+            }
+        }
+        None
+    }
+
+    pub fn start_rebuild(&mut self, core: u32) -> Result<NexusState, Error> {
+        let target = self.find_rebuild_target();
+        let source = self.find_rebuild_source();
+
+        if target.is_none() || source.is_none() {
+            return Err(Error::Internal(
+                "{}: cannot construct rebuild solution".into(),
+            ));
+        }
+
+        let copy_task =
+            RebuildTask::new(source.unwrap(), target.unwrap()).unwrap();
+
+        let ctx = spawm_on_core(core, copy_task, |task| task.run());
+
+        if let Ok(ctx) = ctx {
+            self.rebuild_handle = Some(ctx);
+            Ok(self.set_state(NexusState::Remuling))
+        } else {
+            Err(Error::Internal("unable to start rebuild".into()))
+        }
+    }
+
+    pub async fn rebuild_completion(&mut self) -> Result<bool, Error> {
+        if let Some(task) = self.rebuild_handle.as_mut() {
+            if let Ok(r) = task.completed().await {
+                let _ = self.rebuild_handle.take();
+                Ok(r)
+            } else {
+                Ok(false)
+            }
+        } else {
+            Err(Error::Invalid("No rebuild task registered".into()))
+        }
+    }
+
+    pub fn rebuild_suspend(&mut self) -> Result<(), Error> {
+        if let Some(mut task) = self.rebuild_handle.take() {
+            let _state = task.suspend().unwrap();
+            self.rebuild_handle = Some(task);
+            Ok(())
+        } else {
+            Err(Error::Invalid("no rebuild task configured".into()))
+        }
+    }
+
+    pub fn rebuild_resume(&mut self) -> Result<(), Error> {
+        if let Some(mut task) = self.rebuild_handle.take() {
+            let _state = task.resume().unwrap();
+            self.rebuild_handle = Some(task);
+            Ok(())
+        } else {
+            Err(Error::Invalid("no rebuild task configured".into()))
+        }
+    }
+
+    pub fn rebuild_get_current(&mut self) -> Result<u64, Error> {
+        if let Some(task) = self.rebuild_handle.as_ref() {
+            Ok(task.current())
+        } else {
+            Err(Error::Invalid("no rebuild task configured".into()))
+        }
+    }
+
+    pub fn log_progress(&mut self) {
+        if let Some(hdl) = self.rebuild_handle.as_ref() {
+            info!(":{} {:?} {}", self.name, self.state, hdl.current());
+        }
+    }
+}

--- a/mayastor/src/bdev/nexus/nexus_rpc.rs
+++ b/mayastor/src/bdev/nexus/nexus_rpc.rs
@@ -213,7 +213,7 @@ pub(crate) fn register_rpc_methods() {
     jsonrpc_register("add_child_nexus", |args: AddChildNexusRequest| {
         let fut = async move {
             let nexus = nexus_lookup(&args.uuid)?;
-            match nexus.create_and_add_child(&args.uri).await {
+            match nexus.register_child(&args.uri).await {
                 Ok(_) => Ok(()),
                 Err(err) => Err(JsonRpcError::new(
                     Code::InternalError,

--- a/mayastor/src/event.rs
+++ b/mayastor/src/event.rs
@@ -1,47 +1,134 @@
 use crate::bdev::nexus::Error;
-use spdk_sys::{spdk_event, spdk_event_allocate, spdk_event_call};
-use std::os::raw::c_void;
+use spdk_sys::{
+    spdk_event_allocate,
+    spdk_event_call,
+    spdk_get_thread,
+    spdk_set_thread,
+    spdk_thread,
+    spdk_thread_create,
+    spdk_thread_destroy,
+    spdk_thread_exit,
+    spdk_thread_poll,
+};
 
-pub struct Event {
-    /// pointer to the allocated event
-    inner: *mut spdk_event,
+/// trait that ensures we can get the context passed to FFI threads
+pub trait MayaCtx {
+    type Item;
+    fn into_ctx<'a>(arg: *mut c_void) -> &'a mut Self::Item;
 }
+
+use std::os::raw::c_void;
 
 pub type EventFn = extern "C" fn(*mut c_void, *mut c_void);
 
-impl Event {
-    /// create a new event that can be called later by the reactor. T will be
-    /// forgotten and passed over to FFI. If this function returns an error,
-    /// T is implicitly dropped as it consumes T when called.
-    pub(crate) fn new<T>(
-        core: u32,
-        start_fn: EventFn,
-        argx: Box<T>,
-    ) -> Result<Self, Error> {
-        let ptr = Box::into_raw(argx);
-        let inner = unsafe {
-            spdk_event_allocate(
-                core,
-                Some(start_fn),
-                ptr as *mut _,
-                std::ptr::null_mut(),
-            )
-        };
+struct Mthread(*mut spdk_thread);
 
-        if inner.is_null() {
-            // take a hold of the data again to ensure it is dropped
-            let _ = unsafe { Box::from_raw(ptr) };
-            Err(Error::Internal("failed to allocate event".into()))
-        } else {
-            Ok(Self {
-                inner,
-            })
+impl Drop for Mthread {
+    fn drop(&mut self) {
+        unsafe {
+            if !self.0.is_null() {
+                spdk_thread_exit(self.0);
+                spdk_thread_destroy(self.0);
+            }
+        }
+    }
+}
+
+///
+/// spawn closure `F` on the reactor running on core `core`. This function must
+/// be called within the context of the reactor. This is verified at runtime, to
+/// accidental mistakes.
+///
+/// Async closures are not supported (yet) as there is only a single executor on
+/// core 0
+pub fn spawm_on_core<T, F>(
+    core: u32,
+    arg: Box<T>,
+    f: F,
+) -> Result<Box<T>, Error>
+where
+    T: MayaCtx,
+    F: FnOnce(&mut T::Item),
+{
+    extern "C" fn unwrap<F, T>(f: *mut c_void, t: *mut c_void)
+    where
+        F: FnOnce(&mut T::Item),
+        T: MayaCtx,
+    {
+        unsafe {
+            let f: Box<F> = Box::from_raw(f as *mut F);
+            let arg = T::into_ctx(t);
+            f(arg)
         }
     }
 
-    /// call the event (or more accurately add it to the reactor) when called
-    /// the event is put back into the pool
-    pub fn call(self) {
-        unsafe { spdk_event_call(self.inner) }
+    let thread = { unsafe { spdk_get_thread() } };
+
+    if thread.is_null() {
+        return Err(Error::InvalidThread);
     }
+
+    let ptr = Box::into_raw(Box::new(f)) as *mut c_void;
+    let arg_ptr = &*arg as *const _ as *mut c_void;
+    let event = unsafe {
+        spdk_event_allocate(core, Some(unwrap::<F, T>), ptr, arg_ptr)
+    };
+
+    if event.is_null() {
+        panic!("failed to allocate event");
+    }
+    unsafe { spdk_event_call(event) };
+    Ok(arg)
+}
+
+/// create a new thread, on which core is unpredictable right now. Once the
+/// thread is created run the closure within that context of that thread until
+/// the reactor is empty. Once all events are processed the thread is
+/// destroyed.
+pub fn spawn_thread<F>(f: F) -> Result<(), Error>
+where
+    F: FnOnce(),
+{
+    let thread = Mthread(unsafe {
+        spdk_thread_create(std::ptr::null_mut(), std::ptr::null_mut())
+    });
+
+    if thread.0.is_null() {
+        return Err(Error::InvalidThread);
+    }
+
+    unsafe { spdk_set_thread(thread.0) };
+
+    f();
+    let mut done = false;
+
+    while !done {
+        let rc = unsafe { spdk_thread_poll(thread.0, 0, 0) };
+        if rc < 1 {
+            done = true
+        }
+    }
+
+    Ok(())
+}
+
+pub fn on_core<F: FnOnce()>(core: u32, f: F) {
+    extern "C" fn unwrap<F>(args: *mut c_void, _arg2: *mut c_void)
+    where
+        F: FnOnce(),
+    {
+        unsafe {
+            let f: Box<F> = Box::from_raw(args as *mut F);
+            f()
+        }
+    }
+    let ptr = Box::into_raw(Box::new(f)) as *mut c_void;
+    let event = unsafe {
+        spdk_event_allocate(core, Some(unwrap::<F>), ptr, std::ptr::null_mut())
+    };
+
+    if event.is_null() {
+        panic!("failed to allocate event");
+    }
+    unsafe { spdk_event_call(event) }
 }

--- a/mayastor/src/executor.rs
+++ b/mayastor/src/executor.rs
@@ -186,7 +186,7 @@ extern "C" fn tick(_ptr: *mut c_void) -> i32 {
                 let ctx = ctx_maybe.as_ref().unwrap();
                 // Tasks which are generated while the executor runs are
                 // left in the queue until the tick() is called again.
-                let _work = ctx.pool.borrow_mut().try_run_one();
+                ctx.pool.borrow_mut().run_until_stalled();
             }
         }
     });

--- a/mayastor/tests/common/mod.rs
+++ b/mayastor/tests/common/mod.rs
@@ -7,7 +7,8 @@ pub fn mayastor_test_init() {
     mayastor::CPS_INIT!();
 }
 
-pub fn dd_random_file(path: &str, bs: &str, count: &str) {
+pub fn dd_random_file(path: &str, bs: u32, size: u64) {
+    let count = size * 1024 / bs as u64;
     let output = Command::new("dd")
         .args(&[
             "if=/dev/urandom",
@@ -21,9 +22,9 @@ pub fn dd_random_file(path: &str, bs: &str, count: &str) {
     assert_eq!(output.status.success(), true);
 }
 
-pub fn truncate_file(path: &str, size: &str) {
+pub fn truncate_file(path: &str, size: u64) {
     let output = Command::new("truncate")
-        .args(&["-s", size, path])
+        .args(&["-s", &format!("{}m", size / 1024), path])
         .output()
         .expect("failed exec truncate");
 

--- a/mayastor/tests/rebuild.rs
+++ b/mayastor/tests/rebuild.rs
@@ -1,25 +1,23 @@
 use mayastor::{
-    aio_dev::AioBdev,
-    descriptor::Descriptor,
+    bdev::nexus::nexus_bdev::{nexus_create, nexus_lookup},
     mayastor_start,
     mayastor_stop,
-    rebuild::RebuildTask,
 };
 
-static DISKNAME1: &str = "/tmp/source.img";
-static BDEVNAME1: &str = "aio:///tmp/source.img?blk_size=512";
+static DISKNAME1: &str = "/tmp/disk1.img";
+static BDEVNAME1: &str = "aio:///tmp/disk1.img?blk_size=512";
 
-static DISKNAME2: &str = "/tmp/target.img";
-static BDEVNAME2: &str = "aio:///tmp/target.img?blk_size=512";
+static DISKNAME2: &str = "/tmp/disk2.img";
+static BDEVNAME2: &str = "aio:///tmp/disk2.img?blk_size=512";
 
 mod common;
 #[test]
 fn copy_task() {
     common::mayastor_test_init();
-    let args = vec!["rebuild_task", "-m", "0x2"];
+    let args = vec!["rebuild_task", "-m", "0x3"];
 
-    common::dd_random_file(DISKNAME1, "4096", "16384");
-    common::truncate_file(DISKNAME2, "64M");
+    common::dd_random_file(DISKNAME1, 4096, 64 * 1024);
+    common::truncate_file(DISKNAME2, 64 * 1024);
 
     let rc: i32 = mayastor_start("test", args, || {
         mayastor::executor::spawn(works());
@@ -31,39 +29,24 @@ fn copy_task() {
     common::delete_file(&[DISKNAME1.into(), DISKNAME2.into()]);
 }
 
-async fn create_bdevs() {
-    let source = AioBdev {
-        name: BDEVNAME1.to_string(),
-        file: DISKNAME1.to_string(),
-        blk_size: 4096,
-    };
+async fn create_nexus() {
+    let ch = vec![BDEVNAME1.to_string(), BDEVNAME2.to_string()];
+    nexus_create("rebuild_nexus", 64 * 1024 * 1024, None, &ch)
+        .await
+        .unwrap();
+}
 
-    let target = AioBdev {
-        name: BDEVNAME2.to_string(),
-        file: DISKNAME2.to_string(),
-        blk_size: 4096,
-    };
-
-    if source.create().await.is_err() {
-        panic!("failed to create source device for rebuild test");
-    }
-
-    if target.create().await.is_err() {
-        panic!("failed to create target device for rebuild test");
-    }
+async fn rebuild_nexus_online() {
+    let nexus = nexus_lookup("rebuild_nexus").unwrap();
+    // fault a child which will allow us to rebuild it
+    nexus.fault_child(BDEVNAME1).await.unwrap();
+    nexus.start_rebuild(0).unwrap();
+    nexus.rebuild_completion().await.unwrap();
+    nexus.close().unwrap();
 }
 
 async fn works() {
-    create_bdevs().await;
-
-    let source = Descriptor::open(BDEVNAME1, false).unwrap();
-    let target = Descriptor::open(BDEVNAME2, true).unwrap();
-
-    let copy_task = RebuildTask::new(source, target).unwrap();
-
-    if let Ok(r) = RebuildTask::start_rebuild(copy_task) {
-        let done = r.await.expect("rebuild task already gone!");
-        assert_eq!(done, true);
-        mayastor_stop(0);
-    }
+    create_nexus().await;
+    rebuild_nexus_online().await;
+    mayastor_stop(0);
 }


### PR DESCRIPTION
Most importantly, this adds support for spawning tasks onto a reactor directly (or more precise the default thread on the reactor) as well as adding support for dynamically creating new threads that will run on a reactor but need to be polled explicitly. 