### PR TITLE
nexus: add more test cases for adding children

### DIFF
--- a/mayastor/src/bdev/nexus/mod.rs
+++ b/mayastor/src/bdev/nexus/mod.rs
@@ -9,7 +9,7 @@ use crate::{
     nexus_uri::{self, UriError},
 };
 
-#[derive(Debug)]
+#[derive(Debug, PartialOrd, PartialEq)]
 pub enum Error {
     /// Nobody knows
     Internal(String),

--- a/mayastor/src/bdev/nexus/nexus_bdev.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev.rs
@@ -263,6 +263,10 @@ impl Nexus {
         &self.name
     }
 
+    pub fn child_count(&self) -> u32 {
+        self.child_count
+    }
+
     /// returns the size in bytes of the nexus instance
     pub fn size(&self) -> u64 {
         u64::from(self.bdev.block_len()) * self.bdev.num_blocks()

--- a/mayastor/src/bdev/nexus/nexus_bdev_children.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev_children.rs
@@ -133,6 +133,12 @@ impl Nexus {
     /// Destroy child with given uri.
     /// If the child does not exist the method returns success.
     pub async fn remove_child(&mut self, uri: &str) -> Result<(), Error> {
+        if self.child_count == 1 {
+            return Err(Error::Invalid(
+                "cannot delete the last replica".into(),
+            ));
+        }
+
         let idx = match self.children.iter().position(|c| c.name == uri) {
             None => return Ok(()),
             Some(val) => val,

--- a/mayastor/src/bdev/nexus/nexus_child.rs
+++ b/mayastor/src/bdev/nexus/nexus_child.rs
@@ -70,6 +70,7 @@ pub struct NexusChild {
     pub(crate) ch: *mut spdk_io_channel,
     /// current state of the child
     pub(crate) state: ChildState,
+    pub(crate) repairing: bool,
     #[serde(skip_serializing)]
     pub(crate) descriptor: Option<Rc<Descriptor>>,
 }
@@ -222,6 +223,7 @@ impl NexusChild {
             ch: std::ptr::null_mut(),
             state: ChildState::Init,
             descriptor: None,
+            repairing: false,
         }
     }
 

--- a/mayastor/src/bdev/nexus/nexus_rpc.rs
+++ b/mayastor/src/bdev/nexus/nexus_rpc.rs
@@ -213,7 +213,7 @@ pub(crate) fn register_rpc_methods() {
     jsonrpc_register("add_child_nexus", |args: AddChildNexusRequest| {
         let fut = async move {
             let nexus = nexus_lookup(&args.uuid)?;
-            match nexus.register_child(&args.uri).await {
+            match nexus.add_child(&args.uri).await {
                 Ok(_) => Ok(()),
                 Err(err) => Err(JsonRpcError::new(
                     Code::InternalError,
@@ -227,7 +227,7 @@ pub(crate) fn register_rpc_methods() {
     jsonrpc_register("remove_child_nexus", |args: RemoveChildNexusRequest| {
         let fut = async move {
             let nexus = nexus_lookup(&args.uuid)?;
-            match nexus.destroy_child(&args.uri).await {
+            match nexus.remove_child(&args.uri).await {
                 Ok(_) => Ok(()),
                 Err(err) => Err(JsonRpcError::new(
                     Code::InternalError,

--- a/mayastor/src/event.rs
+++ b/mayastor/src/event.rs
@@ -41,7 +41,7 @@ impl Drop for Mthread {
 ///
 /// Async closures are not supported (yet) as there is only a single executor on
 /// core 0
-pub fn spawm_on_core<T, F>(
+pub fn spawn_on_core<T, F>(
     core: u32,
     arg: Box<T>,
     f: F,

--- a/mayastor/tests/nexus_add_remove.rs
+++ b/mayastor/tests/nexus_add_remove.rs
@@ -1,0 +1,134 @@
+use mayastor::{
+    bdev::nexus::{
+        instances,
+        nexus_bdev::{nexus_create, nexus_lookup, NexusState},
+        Error,
+        Error::{ChildExists, CreateFailed, Invalid},
+    },
+    mayastor_start,
+    mayastor_stop,
+    rebuild::RebuildState,
+};
+
+static DISKNAME1: &str = "/tmp/disk1.img";
+static BDEVNAME1: &str = "aio:///tmp/disk1.img?blk_size=512";
+
+static DISKNAME2: &str = "/tmp/disk2.img";
+static BDEVNAME2: &str = "aio:///tmp/disk2.img?blk_size=512";
+
+static DISKNAME3: &str = "/tmp/disk3.img";
+//static BDEVNAME3: &str = "aio:///tmp/disk3.img?blk_size=512";
+pub mod common;
+#[test]
+
+/// main test
+fn nexus_add_remove() {
+    common::mayastor_test_init();
+    let args = vec!["rebuild_task", "-m", "0x3"];
+
+    //    common::dd_random_file(DISKNAME1, 4096, 64 * 1024);
+    common::truncate_file(DISKNAME1, 64 * 1024);
+    common::truncate_file(DISKNAME2, 64 * 1024);
+    common::truncate_file(DISKNAME3, 64 * 1024);
+
+    let rc: i32 = mayastor_start("test", args, || {
+        mayastor::executor::spawn(works());
+    });
+
+    assert_eq!(rc, 0);
+
+    //common::compare_files(DISKNAME1, DISKNAME2);
+    //common::delete_file(&[DISKNAME1.into(), DISKNAME2.into()]);
+}
+
+/// test creation of a nexus with no children
+async fn create_nexus() {
+    let ch = vec![];
+    let r = nexus_create("add_remove", 64 * 1024 * 1024, None, &ch).await;
+    assert_eq!(r, Err(Error::NexusIncomplete));
+    assert!(instances().is_empty());
+
+    let nexus = nexus_lookup("add_remove");
+    assert_eq!(true, nexus.is_none());
+}
+
+/// test creation of a nexus using an invalid scheme
+async fn nexus_add_invalid_schema() {
+    let ch = vec!["/does/not/exist.img".to_string()];
+    let r = nexus_create("add_remove", 64 * 1024 * 1024, None, &ch).await;
+
+    assert_eq!(true, r.is_err());
+    assert_eq!(r, Err(Invalid("InvalidScheme".into())));
+
+    let nexus = nexus_lookup("add_remove");
+    assert_eq!(true, nexus.is_none());
+}
+
+/// test creation with an invalid disks
+async fn nexus_add_invalid_disk() {
+    let ch = vec!["aio:///does/not/exist.img".to_string()];
+    let r = nexus_create("add_remove", 64 * 1024 * 1024, None, &ch).await;
+
+    assert_eq!(r, Err(CreateFailed));
+
+    let nexus = nexus_lookup("add_remove");
+    assert_eq!(true, nexus.is_none());
+}
+
+/// create a nexus with one disk
+async fn nexus_add_step1() {
+    let ch = vec![BDEVNAME1.to_string()];
+    let r = nexus_create("add_remove", 64 * 1024 * 1024, None, &ch).await;
+
+    assert_eq!(r, Ok(()));
+
+    let nexus = nexus_lookup("add_remove").unwrap();
+    assert_eq!(NexusState::Online, nexus.status());
+}
+
+/// add a second disk to the already created nexus
+async fn nexus_add_step2() {
+    let nexus = nexus_lookup("add_remove").unwrap();
+    assert_eq!(NexusState::Online, nexus.status());
+
+    let result = nexus.add_child(BDEVNAME2).await;
+    assert_eq!(NexusState::Degraded, result.unwrap());
+}
+
+/// adding the same disk to the nexus
+async fn nexus_add_step3() {
+    let nexus = nexus_lookup("add_remove").unwrap();
+    assert_eq!(NexusState::Degraded, nexus.status());
+
+    let result = nexus.add_child(BDEVNAME2).await;
+    assert_eq!(result, Err(ChildExists));
+    assert_eq!(NexusState::Degraded, nexus.status());
+}
+
+async fn nexus_rebuild_1() {
+    let nexus = nexus_lookup("add_remove").unwrap();
+    assert_eq!(NexusState::Degraded, nexus.status());
+
+    let result = nexus.start_rebuild(0).unwrap();
+
+    assert_eq!(NexusState::Remuling, nexus.status());
+    assert_eq!(NexusState::Remuling, result);
+
+    let result = nexus.rebuild_completion().await.unwrap();
+
+    assert_eq!(result, RebuildState::Completed);
+}
+
+async fn works() {
+    create_nexus().await;
+    nexus_add_invalid_schema().await;
+    nexus_add_invalid_disk().await;
+
+    nexus_add_step1().await;
+    nexus_add_step2().await;
+    nexus_add_step3().await;
+
+    nexus_rebuild_1().await;
+
+    mayastor_stop(0)
+}

--- a/mayastor/tests/rebuild.rs
+++ b/mayastor/tests/rebuild.rs
@@ -10,7 +10,7 @@ static BDEVNAME1: &str = "aio:///tmp/disk1.img?blk_size=512";
 static DISKNAME2: &str = "/tmp/disk2.img";
 static BDEVNAME2: &str = "aio:///tmp/disk2.img?blk_size=512";
 
-mod common;
+pub mod common;
 #[test]
 fn copy_task() {
     common::mayastor_test_init();

--- a/mayastor/tests/reconfigure.rs
+++ b/mayastor/tests/reconfigure.rs
@@ -9,6 +9,7 @@ use mayastor::{
     mayastor_stop,
 };
 
+use mayastor::bdev::nexus::nexus_bdev::NexusState;
 use std::process::Command;
 
 static DISKNAME1: &str = "/tmp/disk1.img";
@@ -81,6 +82,7 @@ async fn works() {
 
     // open the nexus in read write
     let nd = Descriptor::open("hello", true).expect("failed open bdev");
+    assert_eq!(nexus.status(), NexusState::Online);
     // open the children in RO
 
     let cd1 = Descriptor::open(&child1, false).expect("failed open bdev");
@@ -122,6 +124,7 @@ async fn works() {
 
     // turn one child offline
     nexus.offline_child(&child2).await.unwrap();
+    assert_eq!(nexus.status(), NexusState::Degraded);
 
     // write 0xF0 to the nexus
     for i in 0 .. 10 {
@@ -152,6 +155,7 @@ async fn works() {
 
     // bring back the offlined child
     nexus.online_child(&child2).await.unwrap();
+    assert_eq!(nexus.status(), NexusState::Degraded);
 
     buf.fill(0xAA);
     // write 0xAA to the nexus


### PR DESCRIPTION
There was some confusion around adding devices to an existing nexus.
This was mostly caused by the method names themselves where not that
clear about what they do.

online/offline puts an existing child into the online state taking part
in the nexus IO path. (For online this not the true yet because of WIP
around rebuild). The child is not implicitly removed.

registering children -- is done during creating of the nexus, these
methods where initially named add_children but now are called
register_xx.

add/remove will add or remove a child to/from the nexus. And will
attempt to destroy the bdev itself.