### PR TITLE
Start using snafu error crate in replica RPC methods.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -415,6 +415,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "doc-comment"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "923dea538cea0aa3025e8685b20d6ee21ef99c4f77e954a30febbaac5ec73a97"
+
+[[package]]
 name = "either"
 version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -929,10 +935,11 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
- "nix 0.15.0",
+ "nix 0.16.0",
  "rpc",
  "serde",
  "serde_json",
+ "snafu",
  "spdk-sys",
  "stderrlog",
  "sysfs",
@@ -1633,6 +1640,27 @@ name = "smallvec"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ecf3b85f68e8abaa7555aa5abdb1153079387e60b718283d732f03897fcfc86"
+
+[[package]]
+name = "snafu"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41207ca11f96a62cd34e6b7fdf73d322b25ae3848eb9d38302169724bb32cf27"
+dependencies = [
+ "doc-comment",
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c5e338c8b0577457c9dda8e794b6ad7231c96e25b1b0dd5842d52249020c1c0"
+dependencies = [
+ "proc-macro2 1.0.6",
+ "quote 1.0.2",
+ "syn 1.0.11",
+]
 
 [[package]]
 name = "spdk-sys"

--- a/csi/src/mayastor_svc.rs
+++ b/csi/src/mayastor_svc.rs
@@ -134,10 +134,7 @@ impl service::server::Mayastor for MayastorService {
         {
             Ok(val) => Ok(Response::new(val)),
             Err(err) => {
-                error!(
-                    "Failed to create replica {} on {}: {}",
-                    uuid, pool, err
-                );
+                error!("{}", err);
                 Err(err.into())
             }
         }
@@ -162,7 +159,7 @@ impl service::server::Mayastor for MayastorService {
                 Ok(Response::new(Null {}))
             }
             Err(err) => {
-                error!("Failed to destroy replica {}: {}", uuid, err);
+                error!("{}", err);
                 Err(err.into())
             }
         }
@@ -191,7 +188,7 @@ impl service::server::Mayastor for MayastorService {
                 Ok(Response::new(reply))
             }
             Err(err) => {
-                error!("Failed to share replica {}: {}", uuid, err);
+                error!("{}", err);
                 Err(err.into())
             }
         }
@@ -236,7 +233,7 @@ impl service::server::Mayastor for MayastorService {
                 Ok(resp)
             }
             Err(err) => {
-                error!("Getting replicas failed: {}", err);
+                error!("{}", err);
                 Err(err.into_status())
             }
         }

--- a/doc/errors.md
+++ b/doc/errors.md
@@ -1,0 +1,259 @@
+# Errors in MayaStor
+
+This document describes error handling within MayaStor.
+Unhandled errors result in a crash/panic message with
+a stack trace. The expected ones are represented by an object which bubbles
+up through the layers of the code up to the RPC method handler, where the
+error is serialized and sent back to the client.
+
+## Background
+
+Originally we started representing errors by `JsonRpcError` object with
+`code` and `message` fields. That worked quite well, but had a major
+limitation.
+
+Constructing error stacks is cumbersome. An error which originates deep
+in the code far from RPC method entry point needs to be augmented by
+contextual information, which is not available when the error occurs.
+Thus adding more context to an error from within lower layer should be easy,
+but it was not.
+
+## Snafu crate
+
+Snafu is one of many libraries in rust for representing failures. We picked
+snafu because:
+
+1. It seems relatively popular in rust
+2. It provides an elegant way of chaining errors and the definition of errors and error
+   messages makes use of a preprocessor and is easy.
+
+An example of an error definition follows. We introduce a new enum type with three
+variants. These are high-level errors for the replica RPC methods. The`source` field
+is a link to lower level error describing the problem in more detail.
+
+```rust
+#[derive(Debug, Snafu)]
+pub enum RpcError {
+    #[snafu(display("Failed to create replica {}", uuid))]
+    CreateReplica { source: Error, uuid: String },
+    #[snafu(display("Failed to destroy replica {}", uuid))]
+    DestroyReplica { source: Error, uuid: String },
+    #[snafu(display("Failed to (un)share replica {}", uuid))]
+    ShareReplica { source: Error, uuid: String },
+}
+```
+
+## SPDK errors
+
+MayaStor, essentially wraps around the errors originating {S,D} PDK.
+Many errors originate in SPDK functions/callbacks which return some kind of boolean status
+(success/failure) or an `errno` value. We want to make handling such errors straightforward.
+As soon as the `errno` returns to rust a `nix::errno::Errno` object should be
+created for it. This object will take care of mapping the `errno` (i32) value to
+a human readable format. Such errors are never returned directly from RPC methods.
+Instead, they must be wrapped by a snafu error, which provides more context than
+just textual representation of the `errno`. There are utility functions for returning errno
+results from async callbacks to avoid code duplication.
+
+## Design of the new errors
+
+1. We want the errors to be decentralized. Instead of a giant list of all
+   potential mayastor errors we want them to be defined where they are used.
+   The error definition can be per file or per group of closely related files.
+
+2. Error names should be short, clear and consistent across the whole
+   code base. If the error is a high level error specifying context of the
+   error, its name should be `Operation` + `Object` (i.e. `CreateReplica`). If
+   the error describes the root cause of a problem, then the name should be
+   `Object` + `Problem` (i.e. `PoolNotFound`).
+
+3. Take care to assign the right context data to the right layer or errors.
+   For example if we have a high level `CreateReplica` error, that's where
+   `uuid` of the replica should be mentioned. There may be 10 different reasons why
+   the create operation failed, and those reasons (errors) may contain more
+   detailed information. However, all those 10 errors don't need to contain uuid, because
+   that information is already added by the `CreateReplica` context.
+
+4. Errors returned by RPC methods must implement `RpcErrorCode` trait. This
+   is a specific requirement to mayastor because the RPC handler must know
+   which RPC error code to associate with the error. Low level errors which
+   aren't directly passed to RPC handlers don't need to implement the trait.
+
+## Error context
+
+Creating a leaf error is straightforward. Consider the following error definition:
+
+```rust
+#[derive(Debug, Snafu)]
+pub enum Error {
+    // ...
+    #[snafu(display("Invalid nvmf target address \"{}\"", addr))]
+    TargetAddress { addr: String },
+    // ...
+}
+```
+
+```rust
+return Err(Error::TargetAddress { addr });
+```
+
+But how to create a context error? Well, snafu macro generates a helper struct
+for that. You don't specify the source member, only the other properties. The
+source is taken from the `self` which is a `Result`. In a different module:
+
+```rust
+#[derive(Debug, Snafu)]
+pub enum Error {
+    // ...
+    #[snafu(display("Failed to create target {}", nqn))]
+    CreateTarget { nqn: String },
+    // ...
+}
+```
+```rust
+create_target(addr).context(CreateTarget { nqn })?;
+```
+
+Note that we did not use `Error::CreateTarget` but just `CreateTarget`, which is
+the helper for context errors. The result now is that we have a chain of two
+errors.
+
+## Example implementation
+
+Consider the situation of adding new RPC methods for implementing
+replica RPC methods: create, destroy and share. We start with these high level
+errors:
+
+```rust
+/// These are high-level context errors one for each rpc method.
+#[derive(Debug, Snafu)]
+pub enum RpcError {
+    #[snafu(display("Failed to create replica {}", uuid))]
+    CreateReplica { source: Error, uuid: String },
+    #[snafu(display("Failed to destroy replica {}", uuid))]
+    DestroyReplica { source: Error, uuid: String },
+    #[snafu(display("Failed to (un)share replica {}", uuid))]
+    ShareReplica { source: Error, uuid: String },
+}
+```
+
+It has to implement `RpcErrorCode` trait because the errors are used in the RPC
+handlers. The impl trait is simple because we go deeper down the error
+chain to find out the appropriate RPC code.
+
+```rust
+impl RpcErrorCode for RpcError {
+    fn rpc_error_code(&self) -> Code {
+        match self {
+            RpcError::CreateReplica { source, .. } => source.rpc_error_code(),
+            RpcError::DestroyReplica { source, .. } => source.rpc_error_code(),
+            RpcError::ShareReplica { source, .. } => source.rpc_error_code(),
+        }
+    }
+}
+```
+
+The second layer of errors are the errors used in in the Replica object methods.
+Some of them are terminal errors, and some go even to deeper layers of code.
+
+```rust
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display("The pool \"{}\" does not exist", pool))]
+    PoolNotFound { pool: String },
+    #[snafu(display("Replica already exists"))]
+    ReplicaExists { },
+    #[snafu(display("Invalid parameters"))]
+    InvalidParams { },
+    #[snafu(display("Failed to create lvol"))]
+    CreateLvol { source: Errno },
+    #[snafu(display("Failed to destroy lvol"))]
+    DestroyLvol { source: Errno },
+    #[snafu(display("Replica has been already shared"))]
+    ReplicaShared { },
+    #[snafu(display("share nvmf"))]
+    ShareNvmf { source: nvmf_target::Error },
+    #[snafu(display("share iscsi"))]
+    ShareIscsi { source: iscsi_target::Error },
+    #[snafu(display("unshare nvmf"))]
+    UnshareNvmf { source: nvmf_target::Error },
+    #[snafu(display("unshare iscsi"))]
+    UnshareIscsi { source: iscsi_target::Error },
+    #[snafu(display("Invalid share protocol {} in request", protocol))]
+    InvalidProtocol { protocol: i32 },
+    #[snafu(display("Replica does not exist"))]
+    ReplicaNotFound { },
+}
+
+impl RpcErrorCode for Error {
+    fn rpc_error_code(&self) -> Code {
+        match self {
+            Error::PoolNotFound { .. } => Code::NotFound,
+            Error::ReplicaNotFound { .. } => Code::NotFound,
+            Error::ReplicaExists { .. } => Code::AlreadyExists,
+            Error::InvalidParams { .. } => Code::InvalidParams,
+            Error::CreateLvol { .. } => Code::InvalidParams,
+            Error::InvalidProtocol { .. } => Code::InvalidParams,
+            Error::ShareNvmf { source, .. } => source.rpc_error_code(),
+            Error::ShareIscsi { source, .. } => source.rpc_error_code(),
+            Error::UnshareNvmf { source, .. } => source.rpc_error_code(),
+            Error::UnshareIscsi { source, .. } => source.rpc_error_code(),
+            _ => Code::InternalError,
+        }
+    }
+}
+```
+
+Sharing of replica is implemented either by the nvmf or iscsi target module.
+Each module comes with its own error type. For brevity, we mention only nvmf
+target errors and not all of them:
+
+```rust
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display("Failed to create nvmf target {}:{}", addr, port))]
+    CreateTarget { addr: String, port: u16 },
+    #[snafu(display(
+        "Failed to destroy nvmf target {}: {}",
+        endpoint,
+        source
+    ))]
+    DestroyTarget { source: Errno, endpoint: String },
+    #[snafu(display("Invalid nvmf target address \"{}\"", addr))]
+    TargetAddress { addr: String },
+    #[snafu(display("Failed to init opts for nvmf tcp transport"))]
+    InitOpts {},
+    #[snafu(display("Failed to create nvmf tcp transport"))]
+    TcpTransport {},
+    #[snafu(display("Failed to add nvmf tcp transport: {}", source))]
+    AddTransport { source: Errno },
+    #[snafu(display("nvmf target listen failed: {}", source))]
+    ListenTarget { source: Errno },
+    #[snafu(display("Failed to create a poll group"))]
+    CreatePollGroup {},
+    // ...
+}
+
+impl RpcErrorCode for Error {
+    fn rpc_error_code(&self) -> Code {
+        match self {
+            Error::TargetAddress {
+                ..
+            } => Code::InvalidParams,
+            _ => Code::InternalError,
+        }
+    }
+}
+```
+
+We have seen how the tree of errors from the least specific context errors to
+most specific root cause errors implemented. Now let's see it in action.
+What is behind the following log file:
+
+```
+jsonrpc.rs: 218:: *ERROR*: Failed to create replica dbe4d7eb-118a-4d15-b789-a18d9af6ff21: Replica already exists
+```
+
+A stack of composable errors:
+1. `Failed to create replica dbe4d7eb-118a-4d15-b789-a18d9af6ff21`
+2. `Replica already exists`

--- a/mayastor/Cargo.toml
+++ b/mayastor/Cargo.toml
@@ -24,10 +24,11 @@ ioctl-gen = "0.1.1"
 lazy_static = "1.3.0"
 libc = "0.2"
 log = "0.4.6"
-nix = "0.15.0"
+nix = "0.16.0"
 rpc = { path = "../rpc"}
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.39"
+snafu = "0.6.0"
 spdk-sys = { path = "../spdk-sys" }
 stderrlog = "0.4.1"
 sysfs = { path = "../sysfs"}

--- a/mayastor/src/bdev/nexus/nexus_rpc.rs
+++ b/mayastor/src/bdev/nexus/nexus_rpc.rs
@@ -64,7 +64,7 @@ fn name_to_uuid(name: &str) -> &str {
 
 pub(crate) fn register_rpc_methods() {
     // JSON rpc method to list the nexus and their states
-    jsonrpc_register::<(), _, _>("list_nexus", |_| {
+    jsonrpc_register::<(), _, _, JsonRpcError>("list_nexus", |_| {
         future::ok(ListNexusReply {
             nexus_list: instances()
                 .iter()
@@ -122,14 +122,17 @@ pub(crate) fn register_rpc_methods() {
         fut.boxed_local()
     });
 
-    jsonrpc_register("destroy_nexus", |args: DestroyNexusRequest| {
-        let fut = async move {
-            let nexus = nexus_lookup(&args.uuid)?;
-            nexus.destroy().await;
-            Ok(())
-        };
-        fut.boxed_local()
-    });
+    jsonrpc_register::<_, _, _, JsonRpcError>(
+        "destroy_nexus",
+        |args: DestroyNexusRequest| {
+            let fut = async move {
+                let nexus = nexus_lookup(&args.uuid)?;
+                nexus.destroy().await;
+                Ok(())
+            };
+            fut.boxed_local()
+        },
+    );
 
     jsonrpc_register("publish_nexus", |args: PublishNexusRequest| {
         let fut = async move {

--- a/mayastor/src/executor.rs
+++ b/mayastor/src/executor.rs
@@ -14,6 +14,7 @@ use futures::{
     task::LocalSpawnExt,
 };
 use libc::c_void;
+use nix::errno::Errno;
 use spdk_sys::{spdk_poller, spdk_poller_register, spdk_poller_unregister};
 use std::{
     cell::{Cell, RefCell},
@@ -193,6 +194,9 @@ extern "C" fn tick(_ptr: *mut c_void) -> i32 {
     0
 }
 
+/// Result having Errno error.
+pub type ErrnoResult<T, E = Errno> = Result<T, E>;
+
 /// Construct callback argument for spdk async function.
 /// The argument is a oneshot sender channel for result of the operation.
 pub fn cb_arg<T>(sender: oneshot::Sender<T>) -> *mut c_void {
@@ -217,4 +221,32 @@ where
     sender
         .send(val)
         .expect("done callback receiver side disappeared");
+}
+
+/// Callback for spdk async functions called with errno value.
+/// Special case of the more general done_cb() above. The advantage being
+/// that it converts the errno value to Result before it is sent so the
+/// receiver can use receiver.await.expect(...)? notation for processing
+/// the result.
+pub extern "C" fn done_errno_cb(sender_ptr: *mut c_void, errno: i32) {
+    let sender = unsafe {
+        Box::from_raw(sender_ptr as *mut oneshot::Sender<ErrnoResult<()>>)
+    };
+
+    sender
+        .send(errno_result_from_i32((), errno))
+        .expect("done callback receiver side disappeared");
+}
+
+/// Utility function for converting i32 errno value returned by SPDK to
+/// a Result with Errno error holding the appropriate message for given
+/// errno value. The idea is that callbacks should send this over the
+/// channel and caller can then use just `.await.expect(...)?` expression
+/// to process the result.
+pub fn errno_result_from_i32<T>(val: T, errno: i32) -> ErrnoResult<T> {
+    if errno == 0 {
+        Ok(val)
+    } else {
+        Err(Errno::from_i32(errno.abs()))
+    }
 }

--- a/mayastor/src/lib.rs
+++ b/mayastor/src/lib.rs
@@ -2,11 +2,13 @@
 extern crate ioctl_gen;
 #[macro_use]
 extern crate lazy_static;
+extern crate nix;
 #[macro_use]
 extern crate log;
 #[macro_use]
 extern crate serde;
 extern crate serde_json;
+extern crate snafu;
 extern crate spdk_sys;
 use log::{logger, Level, Record};
 
@@ -295,9 +297,7 @@ where
 /// Cleanly exit from the program.
 /// NOTE: cannot be called from a future -> double borrow of executor.
 pub fn mayastor_stop(rc: i32) {
-    if let Err(msg) = iscsi_target::fini_iscsi() {
-        error!("Failed to finalize iscsi: {}", msg);
-    }
+    iscsi_target::fini_iscsi();
     let fut = async move {
         if let Err(msg) = nvmf_target::fini_nvmf().await {
             error!("Failed to finalize nvmf target: {}", msg);

--- a/mayastor/src/pool.rs
+++ b/mayastor/src/pool.rs
@@ -258,7 +258,10 @@ impl Pool {
         // unshare all replicas on the pool at first
         for replica in ReplicaIter::new() {
             if replica.get_pool_name() == name {
-                replica.unshare().await?;
+                // XXX temporary
+                replica.unshare().await.map_err(|err| {
+                    JsonRpcError::new(Code::InternalError, err.to_string())
+                })?;
             }
         }
 
@@ -440,7 +443,7 @@ pub fn register_pool_methods() {
         fut.boxed_local()
     });
 
-    jsonrpc_register::<(), _, _>("list_pools", |_| {
+    jsonrpc_register::<(), _, _, JsonRpcError>("list_pools", |_| {
         future::ok(list_pools()).boxed_local()
     });
 }


### PR DESCRIPTION
This is a proof of concept done on replica methods. Nexus methods will follow shortly.