### PR TITLE
nexus: avoid submitting IO we know that will fail

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -54,7 +54,11 @@ build-mayastor:
   artifacts:
     expire_in: 1 day
     paths:
-      - target/debug/
+        - target/debug/mayastor
+        - target/debug/mayastor-agent
+        - target/debug/mayastor-client
+        - target/debug/mctl
+        - target/debug/spdk
 
 # Test mayastor grpc & cli interfaces using JS mocha test framework.
 test-mayastor:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -937,6 +937,7 @@ dependencies = [
  "log",
  "nix 0.16.0",
  "rpc",
+ "run_script",
  "serde",
  "serde_json",
  "snafu",
@@ -1033,19 +1034,6 @@ name = "nix"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c722bee1037d430d0f8e687bbdbf222f27cc6e4e68d5caf630857bb2b6dbdce"
-dependencies = [
- "bitflags",
- "cc",
- "cfg-if",
- "libc",
- "void",
-]
-
-[[package]]
-name = "nix"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2e0b4f3320ed72aaedb9a5ac838690a8047c7b275da22711fddff4f8a14229"
 dependencies = [
  "bitflags",
  "cc",

--- a/mayastor/Cargo.toml
+++ b/mayastor/Cargo.toml
@@ -26,6 +26,7 @@ libc = "0.2"
 log = "0.4.6"
 nix = "0.16.0"
 rpc = { path = "../rpc"}
+run_script = "0.3.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.39"
 snafu = "0.6.0"

--- a/mayastor/src/bdev/mod.rs
+++ b/mayastor/src/bdev/mod.rs
@@ -23,6 +23,8 @@ use spdk_sys::{
 };
 
 use crate::executor::cb_arg;
+use serde::export::{fmt::Error, Formatter};
+use std::fmt::Debug;
 
 /// Allocate C string and return pointer to it.
 /// NOTE: you must explicitly free it, otherwise the memory is leaked!
@@ -62,9 +64,6 @@ where
     }
 }
 
-/// Wrapper interface over raw bdev pointers, currently bdevs are
-/// not held while processing.
-#[derive(Debug)]
 pub struct Bdev {
     pub inner: *mut spdk_bdev,
 }
@@ -347,5 +346,17 @@ pub fn bdev_lookup_by_name(name: &str) -> Option<Bdev> {
         } else {
             Some(Bdev::from(b))
         }
+    }
+}
+
+impl Debug for Bdev {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
+        writeln!(
+            f,
+            "{} {} {}",
+            self.name(),
+            self.driver(),
+            self.product_name()
+        )
     }
 }

--- a/mayastor/src/bdev/nexus/nexus_bdev.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev.rs
@@ -494,6 +494,13 @@ impl Nexus {
 
         // if any child IO has failed record this within the io context
         if !success {
+            trace!(
+                "child IO {:p} ({}) of parent {:p} failed",
+                child_io,
+                (*child_io).type_,
+                parent_io
+            );
+
             pio.io_ctx_as_mut_ref().status = io_status::FAILED;
         }
 

--- a/mayastor/src/bdev/nexus/nexus_fn_table.rs
+++ b/mayastor/src/bdev/nexus/nexus_fn_table.rs
@@ -88,7 +88,7 @@ impl NexusFnTable {
         io: *mut spdk_bdev_io,
     ) {
         if let Some(io_type) = Bio::io_type(io) {
-            let mut nio = Bio::from(io);
+            let mut nio = Bio(io);
             let mut ch = NexusChannel::inner_from_channel(channel);
             let nexus = nio.nexus_as_ref();
 

--- a/mayastor/src/bdev/nexus/nexus_fn_table.rs
+++ b/mayastor/src/bdev/nexus/nexus_fn_table.rs
@@ -131,7 +131,7 @@ impl NexusFnTable {
     /// called when the nexus instance is unregister
     extern "C" fn destruct(ctx: *mut c_void) -> i32 {
         let nexus = unsafe { Nexus::from_raw(ctx) };
-        nexus.close().unwrap();
+        nexus.destruct().unwrap();
         let instances = instances();
         // removing the nexus from the list should cause a drop
         instances.retain(|x| x.name() != nexus.name());

--- a/mayastor/src/bdev/nexus/nexus_io.rs
+++ b/mayastor/src/bdev/nexus/nexus_io.rs
@@ -127,6 +127,9 @@ impl Bio {
 
         if self.io_ctx_as_mut_ref().in_flight == 0 {
             if self.io_ctx_as_mut_ref().status < io_status::PENDING {
+                trace!("failing parent IO {:p} ({})", self.io, unsafe {
+                    (*self.io).type_
+                });
                 self.fail();
             } else {
                 self.ok();

--- a/mayastor/src/bdev/nexus/nexus_io.rs
+++ b/mayastor/src/bdev/nexus/nexus_io.rs
@@ -30,14 +30,16 @@ pub struct NioCtx {
 /// the mirror and mount the individual children without a nexus driver, and use
 /// filesystem checks.
 ///
-///  # Safety
+/// # Safety
 ///
 /// Some notes on the io pointer:
 ///
-///  1. The pointers are never freed rather, they are put back in to the mem
-/// pool in effect     accessing the pointers from rust is to be considered a
-/// mutable borrow. 2.  The IO pointers are never accessed from any other thread
-/// and care must be taken that you     never pass an IO ptr to another core
+/// 1. The pointers are never freed rather, they are put back in to the mem
+/// pool in effect accessing the pointers from rust is to be considered a
+/// mutable borrow.
+///
+/// 2.  The IO pointers are never accessed from any other thread
+/// and care must be taken that you never pass an IO ptr to another core
 pub(crate) struct Bio(pub *mut spdk_bdev_io);
 
 /// redefinition of IO types to make them (a) shorter and (b) get rid of the

--- a/mayastor/src/rebuild.rs
+++ b/mayastor/src/rebuild.rs
@@ -175,6 +175,7 @@ impl RebuildTask {
         ctx: *mut c_void,
     ) {
         let task = RebuildTask::into_ctx(ctx);
+        trace!("rebuild read complete {:?}", Bio(io));
         if success {
             let _r = task.target_write_blocks(io);
         } else {
@@ -191,6 +192,8 @@ impl RebuildTask {
         ctx: *mut c_void,
     ) {
         let task = RebuildTask::into_ctx(ctx);
+
+        trace!("rebuild write complete {:?}", Bio(io));
         Bio::io_free(io);
 
         if !success {
@@ -340,7 +343,7 @@ impl RebuildTask {
         &mut self,
         io: *mut spdk_bdev_io,
     ) -> Result<(), Error> {
-        let bio = Bio::from(io);
+        let bio = Bio(io);
         let rc = unsafe {
             spdk_bdev_write_blocks(
                 self.target.desc,

--- a/mayastor/tests/common/mod.rs
+++ b/mayastor/tests/common/mod.rs
@@ -1,4 +1,5 @@
 use mayastor::mayastor_logger_init;
+use run_script::{self, ScriptOptions};
 use std::{env, io, io::Write, process::Command};
 
 pub fn mayastor_test_init() {
@@ -28,6 +29,17 @@ pub fn truncate_file(path: &str, size: u64) {
         .output()
         .expect("failed exec truncate");
 
+    assert_eq!(output.status.success(), true);
+}
+
+pub fn fscheck(device: &str) {
+    let output = Command::new("fsck")
+        .args(&[device, "-n"])
+        .output()
+        .expect("fsck exec failed");
+
+    io::stdout().write_all(&output.stderr).unwrap();
+    io::stdout().write_all(&output.stdout).unwrap();
     assert_eq!(output.status.success(), true);
 }
 
@@ -66,5 +78,80 @@ pub fn compare_files(a: &str, b: &str) {
         .output()
         .expect("failed to execute \"cmp\"");
 
+    io::stdout().write_all(&output.stderr).unwrap();
+    io::stdout().write_all(&output.stdout).unwrap();
     assert_eq!(output.status.success(), true);
+}
+
+pub fn mount_umount(device: &str) -> String {
+    let (exit, stdout, _stderr) = run_script::run(
+        r#"
+        mkdir /tmp/__test
+        mount $1 /tmp/__test
+        umount /tmp/__test
+        exit 0
+    "#,
+        &vec![device.into()],
+        &run_script::ScriptOptions::new(),
+    )
+    .unwrap();
+    assert_eq!(exit, 0);
+    stdout
+}
+
+pub fn mount_and_write_file(device: &str) -> String {
+    let mut options = ScriptOptions::new();
+    options.capture_output = true;
+    options.exit_on_error = true;
+    options.print_commands = false;
+
+    let (exit, stdout, _stderr) = run_script::run(
+        r#"
+        mkdir /tmp/__test
+        mount $1 /tmp/__test
+        echo test > /tmp/__test/test
+        md5sum /tmp/__test/test
+        umount /tmp/__test
+        rm -rf /tmp/__test
+        exit 0
+    "#,
+        &vec![device.into()],
+        &options,
+    )
+    .unwrap();
+    assert_eq!(exit, 0);
+    stdout.trim_end().to_string()
+}
+
+pub fn mount_and_get_md5(device: &str) -> String {
+    let (exit, stdout, _stderr) = run_script::run(
+        r#"
+        mkdir /tmp/__test
+        mount $1 /tmp/__test
+        md5sum /tmp/__test/test
+        umount /tmp/__test
+        rm -rf /tmp/__test
+        exit 0
+    "#,
+        &vec![device.into()],
+        &run_script::ScriptOptions::new(),
+    )
+    .unwrap();
+    assert_eq!(exit, 0);
+    stdout
+}
+
+pub fn fio_run_verify(device: &str) -> String {
+    let (exit, stdout, _stderr) = run_script::run(
+        r#"
+        fio --name=randrw --rw=randrw --ioengine=libaio --direct=1 --time_based=1 \
+        --runtime=60 --bs=4k --verify=crc32 --group_reporting=1 --output-format=terse \
+        --verify_fatal=1 --verify_async=2 --filename=$1
+    "#,
+        &vec![device.into()],
+        &run_script::ScriptOptions::new(),
+    )
+    .unwrap();
+    assert_eq!(exit, 0);
+    stdout
 }

--- a/mayastor/tests/common/mod.rs
+++ b/mayastor/tests/common/mod.rs
@@ -1,5 +1,5 @@
 use mayastor::mayastor_logger_init;
-use std::{env, process::Command};
+use std::{env, io, io::Write, process::Command};
 
 pub fn mayastor_test_init() {
     mayastor_logger_init("DEBUG");
@@ -28,6 +28,25 @@ pub fn truncate_file(path: &str, size: u64) {
         .output()
         .expect("failed exec truncate");
 
+    assert_eq!(output.status.success(), true);
+}
+
+pub fn mkfs(path: &str, fstype: &str) {
+    let (fs, args) = match fstype {
+        "xfs" => ("mkfs.xfs", ["-f", path]),
+        "ext4" => ("mkfs.ext4", ["-F", path]),
+        _ => {
+            panic!("unsupported fstype");
+        }
+    };
+
+    let output = Command::new(fs)
+        .args(&args)
+        .output()
+        .expect("mkfs exec truncate");
+
+    io::stdout().write_all(&output.stderr).unwrap();
+    io::stdout().write_all(&output.stdout).unwrap();
     assert_eq!(output.status.success(), true);
 }
 

--- a/mayastor/tests/common/mod.rs
+++ b/mayastor/tests/common/mod.rs
@@ -2,7 +2,7 @@ use mayastor::mayastor_logger_init;
 use std::{env, io, io::Write, process::Command};
 
 pub fn mayastor_test_init() {
-    mayastor_logger_init("DEBUG");
+    mayastor_logger_init("TRACE");
     env::set_var("MAYASTOR_LOGLEVEL", "4");
     mayastor::CPS_INIT!();
 }

--- a/mayastor/tests/create_destroy.rs
+++ b/mayastor/tests/create_destroy.rs
@@ -1,0 +1,45 @@
+use mayastor::{
+    bdev::nexus::nexus_bdev::{nexus_create, nexus_lookup},
+    mayastor_start,
+    mayastor_stop,
+};
+
+static DISKNAME1: &str = "/tmp/disk1.img";
+static BDEVNAME1: &str = "aio:///tmp/disk1.img?blk_size=512";
+
+static DISKNAME2: &str = "/tmp/disk2.img";
+static BDEVNAME2: &str = "aio:///tmp/disk2.img?blk_size=512";
+
+pub mod common;
+#[test]
+fn create_destroy() {
+    common::mayastor_test_init();
+    let args = vec!["rebuild_task", "-m", "0x3", "-L", "bdev", "-L", "aio"];
+
+    common::truncate_file(DISKNAME1, 64 * 1024);
+    common::truncate_file(DISKNAME2, 64 * 1024);
+
+    let rc: i32 = mayastor_start("test", args, || {
+        mayastor::executor::spawn(works());
+    });
+
+    assert_eq!(rc, 0);
+}
+
+async fn works() {
+    for _i in 0 .. 100 {
+        nexus_create(
+            "create",
+            64 * 1024 * 1024,
+            None,
+            &[BDEVNAME1.into(), BDEVNAME2.into()],
+        )
+        .await
+        .unwrap();
+
+        let n = nexus_lookup("create").unwrap();
+        n.share(None).await.unwrap();
+        n.destroy().await;
+    }
+    mayastor_stop(0);
+}

--- a/mayastor/tests/mount_fs.rs
+++ b/mayastor/tests/mount_fs.rs
@@ -1,4 +1,5 @@
 use futures::channel::oneshot;
+use log::*;
 use mayastor::{
     bdev::nexus::{
         nexus_bdev::{nexus_create, nexus_lookup},
@@ -18,9 +19,9 @@ pub mod common;
 #[test]
 fn mount_fs() {
     common::mayastor_test_init();
-    let args = vec!["io_type", "-m", "0x3"];
+    let args = vec!["io_type", "-m", "0x3", "-L", "bdev"];
 
-    common::dd_random_file(DISKNAME1, 4096, 64 * 1024);
+    common::truncate_file(DISKNAME1, 64 * 1024);
     common::truncate_file(DISKNAME2, 64 * 1024);
 
     let rc: i32 = mayastor_start("test", args, || {
@@ -38,7 +39,20 @@ async fn create_nexus() {
         .unwrap();
 }
 
-async fn works() {
+async fn create_nexus_splitted() {
+    let ch = vec![BDEVNAME1.to_string()];
+    nexus_create("left", 64 * 1024 * 1024, None, &ch)
+        .await
+        .unwrap();
+
+    let ch = vec![BDEVNAME2.to_string()];
+    nexus_create("right", 64 * 1024 * 1024, None, &ch)
+        .await
+        .unwrap();
+}
+
+async fn mirror_fs_test<'a>(fstype: String) {
+    info!("running mirror test: {}", fstype);
     create_nexus().await;
     let nexus = nexus_lookup("nexus").unwrap();
 
@@ -51,15 +65,78 @@ async fn works() {
     assert_eq!(false, nexus.io_is_supported(nexus_io::io_type::UNMAP));
 
     let device = nexus.share(None).await.unwrap();
-    let (s, r) = oneshot::channel::<bool>();
+    let (s, r) = oneshot::channel::<String>();
 
-    // we cannot block the reactor
+    // create an XFS filesystem on the nexus device, mount it, create a file and
+    // return the md5 of that file
+
     std::thread::spawn(move || {
-        common::mkfs(&device, "xfs");
-        common::mkfs(&device, "ext4");
-        s.send(true)
+        common::mkfs(&device, &fstype);
+        let md5 = common::mount_and_write_file(&device);
+        s.send(md5)
     });
 
     r.await.unwrap();
+    // destroy the share and the nexus
+    nexus.unshare().await.unwrap();
+    nexus.destroy().await;
+
+    // create a split nexus, i.e two nexus devices which each one leg of the
+    // mirror
+    create_nexus_splitted().await;
+
+    let left = nexus_lookup("left").unwrap();
+    let right = nexus_lookup("right").unwrap();
+
+    // share both nexuses
+    let left_device = left.share(None).await.unwrap();
+    let right_device = right.share(None).await.unwrap();
+
+    let (s, r) = oneshot::channel::<String>();
+
+    // read back the md5 from the left leg
+    //
+    // XXX note -- as the filesystems are mirrors of one and other, you cannot
+    // mount them both at the same time. This will be rejected by XFS
+    // because they have the same exact UUID
+    //
+
+    std::thread::spawn(move || s.send(common::mount_and_get_md5(&left_device)));
+
+    let md5_left = r.await.unwrap();
+    left.unshare().await.unwrap();
+    left.destroy().await;
+
+    // read the md5 of the right side of the mirror
+    let (s, r) = oneshot::channel::<String>();
+    std::thread::spawn(move || {
+        s.send(common::mount_and_get_md5(&right_device))
+    });
+
+    let md5_right = r.await.unwrap();
+
+    right.unshare().await.unwrap();
+    right.destroy().await;
+    assert_eq!(md5_left, md5_right);
+}
+
+async fn run_fio_on_nexus() {
+    create_nexus().await;
+    let nexus = nexus_lookup("nexus").unwrap();
+
+    let device = nexus.share(None).await.unwrap();
+    let (s, r) = oneshot::channel::<String>();
+
+    std::thread::spawn(move || s.send(common::fio_run_verify(&device)));
+
+    r.await.unwrap();
+    nexus.destroy().await;
+}
+
+async fn works() {
+    mirror_fs_test("xfs".into()).await;
+    mirror_fs_test("ext4".into()).await;
+    run_fio_on_nexus().await;
+
     mayastor_stop(0);
 }

--- a/mayastor/tests/mount_fs.rs
+++ b/mayastor/tests/mount_fs.rs
@@ -1,0 +1,65 @@
+use futures::channel::oneshot;
+use mayastor::{
+    bdev::nexus::{
+        nexus_bdev::{nexus_create, nexus_lookup},
+        nexus_io,
+    },
+    mayastor_start,
+    mayastor_stop,
+};
+
+static DISKNAME1: &str = "/tmp/disk1.img";
+static BDEVNAME1: &str = "aio:///tmp/disk1.img?blk_size=512";
+
+static DISKNAME2: &str = "/tmp/disk2.img";
+static BDEVNAME2: &str = "aio:///tmp/disk2.img?blk_size=512";
+
+pub mod common;
+#[test]
+fn mount_fs() {
+    common::mayastor_test_init();
+    let args = vec!["io_type", "-m", "0x3"];
+
+    common::dd_random_file(DISKNAME1, 4096, 64 * 1024);
+    common::truncate_file(DISKNAME2, 64 * 1024);
+
+    let rc: i32 = mayastor_start("test", args, || {
+        mayastor::executor::spawn(works());
+    });
+
+    assert_eq!(rc, 0);
+    common::delete_file(&[DISKNAME1.into(), DISKNAME2.into()]);
+}
+
+async fn create_nexus() {
+    let ch = vec![BDEVNAME1.to_string(), BDEVNAME2.to_string()];
+    nexus_create("nexus", 64 * 1024 * 1024, None, &ch)
+        .await
+        .unwrap();
+}
+
+async fn works() {
+    create_nexus().await;
+    let nexus = nexus_lookup("nexus").unwrap();
+
+    assert_eq!(true, nexus.io_is_supported(nexus_io::io_type::READ));
+    assert_eq!(true, nexus.io_is_supported(nexus_io::io_type::WRITE));
+    assert_eq!(true, nexus.io_is_supported(nexus_io::io_type::FLUSH));
+    assert_eq!(true, nexus.io_is_supported(nexus_io::io_type::RESET));
+
+    // for aio bdevs this is set to false;
+    assert_eq!(false, nexus.io_is_supported(nexus_io::io_type::UNMAP));
+
+    let device = nexus.share(None).await.unwrap();
+    let (s, r) = oneshot::channel::<bool>();
+
+    // we cannot block the reactor
+    std::thread::spawn(move || {
+        common::mkfs(&device, "xfs");
+        common::mkfs(&device, "ext4");
+        s.send(true)
+    });
+
+    r.await.unwrap();
+    mayastor_stop(0);
+}

--- a/shell.nix
+++ b/shell.nix
@@ -18,6 +18,7 @@ mkShell {
 
   buildInputs = [
     figlet
+    fio
     gdb
     gptfdisk
     libiscsi.bin

--- a/shell.nix
+++ b/shell.nix
@@ -21,6 +21,7 @@ mkShell {
     gdb
     gptfdisk
     libiscsi.bin
+    libspdk
     nodePackages.jshint
     nodePackages.prettier
     nodejs-10_x


### PR DESCRIPTION
Add test cases for creating filesystems on a nexus device. Today, I had very strange failures, that looked like, to be related to UNMAP but that turned out to be incorrect. 

There appear to be some issues with NVMe and mkfs, but I can't reproduce the error anymore. In any case, it is likely a good idea to test the creation of filesystems.

If we submit IO to a child that does not support UNMAP, we should get back two failures (in case of two replicas) before we fail the parent IO. I've added trace!() statements to observe that in the future. However,  if we know we don't support it, we might as well safe the two IO's to begin with. As such, we verify that that all child devices support UNMAP before passing it down. If this turns out to be white hot in production we can make it a variable within the nexus itself.
