### PR TITLE
Convert all error types in nexus code to snafu errors.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,6 +19,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_matches"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7deb0a829ca7bcfaf5da70b073a8d128619259a7be8216a355e23f00763059e5"
+
+[[package]]
 name = "async-stream"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -924,6 +930,7 @@ checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 name = "mayastor"
 version = "0.1.0"
 dependencies = [
+ "assert_matches",
  "bincode",
  "bytes",
  "crc",

--- a/mayastor-test/test_nexus.js
+++ b/mayastor-test/test_nexus.js
@@ -293,7 +293,7 @@ describe('nexus', function() {
 
     client.CreateNexus(args, (err, res) => {
       if (!err) return done(new Error('Expected error'));
-      assert.equal(err.code, 13);
+      assert.equal(err.code, grpc.status.INVALID_ARGUMENT);
       done();
     });
   });
@@ -309,7 +309,7 @@ describe('nexus', function() {
     };
 
     client.CreateNexus(args, (err, res) => {
-      assert.equal(err.code, 13);
+      assert.equal(err.code, grpc.status.INVALID_ARGUMENT);
       done();
     });
   });
@@ -393,7 +393,7 @@ describe('nexus', function() {
     };
     client.CreateNexus(args, (err, data) => {
       if (!err) return done(new Error('Expected error'));
-      assert.equal(err.code, 13);
+      assert.equal(err.code, grpc.status.INVALID_ARGUMENT);
       done();
     });
   });
@@ -410,7 +410,7 @@ describe('nexus', function() {
 
     client.CreateNexus(args, (err, data) => {
       if (!err) return done(new Error('Expected error'));
-      assert.equal(err.code, 13);
+      assert.equal(err.code, grpc.status.INVALID_ARGUMENT);
       done();
     });
   });

--- a/mayastor/Cargo.toml
+++ b/mayastor/Cargo.toml
@@ -13,6 +13,7 @@ name = "spdk"
 path = "src/bin/spdk.rs"
 
 [dependencies]
+assert_matches = "1.3.0"
 bincode = "1.2.0"
 bytes = "0.4.12"
 crc = "1.8.1"

--- a/mayastor/src/aio_dev.rs
+++ b/mayastor/src/aio_dev.rs
@@ -1,12 +1,23 @@
 use crate::{
-    bdev::{bdev_lookup_by_name, nexus},
-    executor::{cb_arg, done_cb},
-    nexus_uri::UriError,
+    bdev::bdev_lookup_by_name,
+    executor::{cb_arg, done_errno_cb, errno_result_from_i32, ErrnoResult},
+    nexus_uri::{self, BdevError},
 };
-use futures::{channel::oneshot, future};
+use futures::channel::oneshot;
+use snafu::{ResultExt, Snafu};
 use spdk_sys::{bdev_aio_delete, create_aio_bdev};
 use std::{convert::TryFrom, ffi::CString};
 use url::Url;
+
+#[derive(Debug, Snafu)]
+pub enum ParseError {
+    #[snafu(display("Missing path to aio device"))]
+    PathMissing {},
+    #[snafu(display("Block size is not a number"))]
+    BlockSizeInvalid {
+        source: <u32 as std::str::FromStr>::Err,
+    },
+}
 
 #[derive(Default, Clone, Debug)]
 pub struct AioBdev {
@@ -15,60 +26,67 @@ pub struct AioBdev {
     pub blk_size: u32,
 }
 
-// XXX we cant use a trait as it does not support async yet
+// TODO: we cant use a trait as it does not support async yet
 impl AioBdev {
     /// create an AIO bdev. The reason this is async is to avoid type errors
     /// when creating things concurrently.
-    pub async fn create(self) -> Result<String, nexus::Error> {
+    pub async fn create(self) -> Result<String, BdevError> {
         if bdev_lookup_by_name(&self.name).is_some() {
-            info!("A bdev with name already exists {} exists", self.name);
-            return Err(nexus::Error::ChildExists);
+            return Err(BdevError::BdevExists {
+                name: self.name.clone(),
+            });
         }
 
         let cname = CString::new(self.name.clone()).unwrap();
         let filename = CString::new(self.file).unwrap();
 
-        let rc = unsafe {
+        let errno = unsafe {
             create_aio_bdev(cname.as_ptr(), filename.as_ptr(), self.blk_size)
         };
+        let name = self.name.clone();
 
-        let fut = if rc == 0 {
-            future::ok(self.name)
-        } else {
-            // upstream reports a better error, integrate that.
-            future::err(nexus::Error::CreateFailed)
-        };
-
-        fut.await
+        async {
+            errno_result_from_i32(name.clone(), errno).context(
+                nexus_uri::InvalidParams {
+                    name,
+                },
+            )
+        }
+        .await
     }
 
     /// destroy the given aio bdev
-    pub async fn destroy(self) -> Result<(), nexus::Error> {
-        type AioT = i32;
-        if let Some(bdev) = bdev_lookup_by_name(&self.name) {
-            let (s, r) = oneshot::channel::<AioT>();
-            unsafe { bdev_aio_delete(bdev.as_ptr(), Some(done_cb), cb_arg(s)) };
-            if r.await.unwrap() != 0 {
-                Err(nexus::Error::Internal("Delete AIO bdev failed".to_owned()))
-            } else {
-                Ok(())
+    pub async fn destroy(self, bdev_name: &str) -> Result<(), BdevError> {
+        if let Some(bdev) = bdev_lookup_by_name(bdev_name) {
+            let (s, r) = oneshot::channel::<ErrnoResult<()>>();
+            unsafe {
+                bdev_aio_delete(bdev.as_ptr(), Some(done_errno_cb), cb_arg(s));
             }
+            r.await.expect("Cancellation is not supported").context(
+                nexus_uri::DestroyBdev {
+                    name: self.name.clone(),
+                },
+            )
         } else {
-            Err(nexus::Error::NotFound)
+            Err(BdevError::BdevNotFound {
+                name: self.name.clone(),
+            })
         }
     }
 }
+
 /// Converts an aio url to AioArgs
 impl TryFrom<&Url> for AioBdev {
-    type Error = UriError;
-    fn try_from(u: &Url) -> Result<Self, Self::Error> {
+    type Error = ParseError;
+
+    fn try_from(u: &Url) -> std::result::Result<Self, Self::Error> {
         let mut n = AioBdev::default();
         n.name = u.to_string();
         n.file = match u
             .path_segments()
             .map(std::iter::Iterator::collect::<Vec<_>>)
         {
-            None => return Err(UriError::InvalidPathSegment),
+            None => return Err(ParseError::PathMissing {}),
             Some(s) => format!("/{}", s.join("/")),
         };
         n.blk_size = 0;
@@ -76,7 +94,10 @@ impl TryFrom<&Url> for AioBdev {
         let qp = u.query_pairs();
         for i in qp {
             if let "blk_size" = i.0.as_ref() {
-                n.blk_size = i.1.parse().unwrap()
+                n.blk_size = i.1.parse().context(BlockSizeInvalid {})?;
+                break;
+            } else {
+                warn!("query parameter {} ignored", i.0);
             }
         }
         Ok(n)

--- a/mayastor/src/bdev/nexus/mod.rs
+++ b/mayastor/src/bdev/nexus/mod.rs
@@ -1,77 +1,10 @@
 #![allow(clippy::vec_box)]
-use crate::{
-    bdev::nexus::{
-        nexus_bdev::Nexus,
-        nexus_fn_table::NexusFnTable,
-        nexus_module::NexusModule,
-        nexus_rpc::register_rpc_methods,
-    },
-    nexus_uri::{self, UriError},
+use crate::bdev::nexus::{
+    nexus_bdev::Nexus,
+    nexus_fn_table::NexusFnTable,
+    nexus_module::NexusModule,
+    nexus_rpc::register_rpc_methods,
 };
-
-#[derive(Debug, PartialOrd, PartialEq)]
-pub enum Error {
-    /// Nobody knows
-    Internal(String),
-    /// function is not called in the context of an SPDK thread
-    InvalidThread,
-    /// OOM but its not possible to know if this is spdk_dma_malloc() or
-    /// malloc()
-    OutOfMemory,
-    /// the bdev is already claimed by device
-    AlreadyClaimed,
-    /// the bdev can can only be opened RO as it's been claimed with write
-    /// options already
-    ReadOnly,
-    /// resource does not exist or cannot be found (i.e bdev, share etc)
-    NotFound,
-    /// Invalid arguments or incompatible arguments for creating the nexus
-    Invalid(String),
-    /// the bdev creation failed
-    CreateFailed,
-    /// a bdev with either the same name or alias already exists
-    Exists,
-    /// the child bdev for the nexus already exits
-    ChildExists,
-    /// the nexus is does not have enough children to come online
-    NexusIncomplete,
-    /// error during serial or deserialize
-    SerDerError,
-    /// error indicating sharing failed for this nexus
-    ShareError(String),
-    /// resource unavailable
-    Unavailable(String),
-}
-
-impl From<std::ffi::NulError> for Error {
-    fn from(_: std::ffi::NulError) -> Self {
-        Error::OutOfMemory
-    }
-}
-
-impl From<nexus_uri::UriError> for Error {
-    fn from(e: UriError) -> Self {
-        Error::Invalid(format!("{:?}", e))
-    }
-}
-
-impl From<bincode::Error> for Error {
-    fn from(_e: bincode::Error) -> Self {
-        Error::SerDerError
-    }
-}
-
-/// Generic conversions of errors
-/// SPDK uses different ENOXXX at various levels the conversions here
-/// are known to be consistent
-impl From<i32> for Error {
-    fn from(e: i32) -> Self {
-        match e {
-            libc::ENOMEM => Error::OutOfMemory,
-            _ => Error::Internal(format!("errno {}", e)),
-        }
-    }
-}
 
 pub mod nexus_bdev;
 pub mod nexus_bdev_children;
@@ -86,6 +19,7 @@ pub mod nexus_nbd;
 pub mod nexus_rebuild;
 pub mod nexus_rpc;
 pub mod nexus_share;
+
 /// public function which simply calls register module
 pub fn register_module() {
     register_rpc_methods();
@@ -110,7 +44,5 @@ pub fn instances() -> &'static mut Vec<Box<Nexus>> {
 /// function used to create a new nexus when parsing a config file
 pub fn nexus_instance_new(name: String, size: u64, children: Vec<String>) {
     let list = instances();
-    if let Ok(nexus) = Nexus::new(&name, size, None, Some(&children)) {
-        list.push(nexus);
-    }
+    list.push(Nexus::new(&name, size, None, Some(&children)));
 }

--- a/mayastor/src/bdev/nexus/nexus_fn_table.rs
+++ b/mayastor/src/bdev/nexus/nexus_fn_table.rs
@@ -131,7 +131,7 @@ impl NexusFnTable {
     /// called when the nexus instance is unregister
     extern "C" fn destruct(ctx: *mut c_void) -> i32 {
         let nexus = unsafe { Nexus::from_raw(ctx) };
-        nexus.destruct().unwrap();
+        nexus.destruct();
         let instances = instances();
         // removing the nexus from the list should cause a drop
         instances.retain(|x| x.name() != nexus.name());

--- a/mayastor/src/bdev/nexus/nexus_rebuild.rs
+++ b/mayastor/src/bdev/nexus/nexus_rebuild.rs
@@ -7,13 +7,36 @@ use crate::{
         nexus_bdev::{Nexus, NexusState},
         nexus_channel::DREvent,
         nexus_child::ChildState,
-        Error,
     },
     descriptor::Descriptor,
-    event::spawn_on_core,
+    event,
     rebuild::{RebuildState, RebuildTask},
 };
+use snafu::{ResultExt, Snafu};
 use std::rc::Rc;
+
+#[derive(Debug, Snafu)]
+pub enum RebuildError {
+    #[snafu(display(
+        "Can only do one rebuild per nexus {} at the same time",
+        name
+    ))]
+    OnlyOneRebuild { name: String },
+    #[snafu(display(
+        "There is no rebuild task in progress for the nexus {}",
+        name
+    ))]
+    NoRebuildTask { name: String },
+    #[snafu(display("Cannot find a rebuild solution for nexus {}", name))]
+    NoSolution { name: String },
+    #[snafu(display("Unable to spawn rebuild task for nexus {}", name))]
+    SpawnRebuild { source: event::Error, name: String },
+    #[snafu(display("Rebuild task for nexus {} disappeared halfway", name))]
+    Disappeared { name: String },
+    #[snafu(display("Rebuild for nexus {} failed; sender is gone", name))]
+    SenderIsGone { name: String },
+}
+
 impl Nexus {
     /// find any child that requires a rebuild. Children in the faulted state
     /// are eligible for a rebuild closed children are not and must be
@@ -61,39 +84,42 @@ impl Nexus {
         None
     }
 
-    pub fn start_rebuild(&mut self, core: u32) -> Result<NexusState, Error> {
+    pub fn start_rebuild(
+        &mut self,
+        core: u32,
+    ) -> Result<NexusState, RebuildError> {
         if self.state == NexusState::Remuling {
             assert_eq!(true, self.children.iter().any(|c| c.repairing));
-            return Err(Error::Invalid(
-                "can only do one rebuild per nexus at the same time for now"
-                    .into(),
-            ));
+            return Err(RebuildError::OnlyOneRebuild {
+                name: self.name.clone(),
+            });
         }
 
         let target = self.find_rebuild_target();
         let source = self.find_rebuild_source();
 
         if target.is_none() || source.is_none() {
-            return Err(Error::Internal(
-                "{}: cannot construct rebuild solution".into(),
-            ));
+            return Err(RebuildError::NoSolution {
+                name: self.name.clone(),
+            });
         }
 
         let rebuild_task =
             RebuildTask::new(source.unwrap(), target.unwrap()).unwrap();
 
-        let ctx = spawn_on_core(core, rebuild_task, |task| task.run());
+        let ctx = event::spawn_on_core(core, rebuild_task, |task| task.run())
+            .context(SpawnRebuild {
+            name: self.name.clone(),
+        })?;
 
-        if let Ok(ctx) = ctx {
-            self.rebuild_handle = Some(ctx);
-            Ok(self.set_state(NexusState::Remuling))
-        } else {
-            Err(Error::Internal("unable to start rebuild".into()))
-        }
+        self.rebuild_handle = Some(ctx);
+        Ok(self.set_state(NexusState::Remuling))
     }
 
     /// await the completion of the rebuild.
-    pub async fn rebuild_completion(&mut self) -> Result<RebuildState, Error> {
+    pub async fn rebuild_completion(
+        &mut self,
+    ) -> Result<RebuildState, RebuildError> {
         if let Some(task) = self.rebuild_handle.as_mut() {
             // get a hold of the child that is in the repairing state
             let mut child = match self.children.iter_mut().find(|c| c.repairing)
@@ -104,9 +130,9 @@ impl Nexus {
                     // in case we did not handle properly.
                     // The task is gone, but the state has not been updated
                     // properly.
-                    return Err(Error::Internal(
-                        "rebuild process disappeared halfway".into(),
-                    ));
+                    return Err(RebuildError::Disappeared {
+                        name: self.name.clone(),
+                    });
                 }
             };
 
@@ -131,43 +157,48 @@ impl Nexus {
 
                 Err(_) => {
                     self.set_state(NexusState::Degraded);
-                    Err(Error::Internal(
-                        "rebuild failed; sender is gone".into(),
-                    ))
+                    Err(RebuildError::SenderIsGone {
+                        name: self.name.clone(),
+                    })
                 }
             };
             let rebuild = self.rebuild_handle.take();
             drop(rebuild);
             result
         } else {
-            Err(Error::Invalid(
-                "No rebuild task registered or rebuild already completed"
-                    .into(),
-            ))
+            Err(RebuildError::NoRebuildTask {
+                name: self.name.clone(),
+            })
         }
     }
 
-    pub fn rebuild_suspend(&mut self) -> Result<RebuildState, Error> {
+    pub fn rebuild_suspend(&mut self) -> Result<RebuildState, RebuildError> {
         if let Some(task) = self.rebuild_handle.as_mut() {
             Ok(task.suspend().unwrap())
         } else {
-            Err(Error::Invalid("no rebuild task configured".into()))
+            Err(RebuildError::NoRebuildTask {
+                name: self.name.clone(),
+            })
         }
     }
 
-    pub fn rebuild_resume(&mut self) -> Result<RebuildState, Error> {
+    pub fn rebuild_resume(&mut self) -> Result<RebuildState, RebuildError> {
         if let Some(task) = self.rebuild_handle.as_mut() {
             Ok(task.resume().unwrap())
         } else {
-            Err(Error::Invalid("no rebuild task configured".into()))
+            Err(RebuildError::NoRebuildTask {
+                name: self.name.clone(),
+            })
         }
     }
 
-    pub fn rebuild_get_current(&mut self) -> Result<u64, Error> {
+    pub fn rebuild_get_current(&mut self) -> Result<u64, RebuildError> {
         if let Some(task) = self.rebuild_handle.as_ref() {
             Ok(task.current())
         } else {
-            Err(Error::Invalid("no rebuild task configured".into()))
+            Err(RebuildError::NoRebuildTask {
+                name: self.name.clone(),
+            })
         }
     }
 

--- a/mayastor/src/lib.rs
+++ b/mayastor/src/lib.rs
@@ -47,7 +47,7 @@ pub mod iscsi_dev;
 pub mod iscsi_target;
 pub mod jsonrpc;
 pub mod nexus_uri;
-pub mod nvme_dev;
+pub mod nvmf_dev;
 pub mod nvmf_target;
 pub mod poller;
 pub mod pool;

--- a/mayastor/src/nexus_uri.rs
+++ b/mayastor/src/nexus_uri.rs
@@ -1,32 +1,101 @@
-use crate::{aio_dev::AioBdev, iscsi_dev::IscsiBdev, nvme_dev::NvmfBdev};
+use crate::{
+    aio_dev,
+    iscsi_dev,
+    jsonrpc::{Code, RpcErrorCode},
+    nvmf_dev,
+};
+use nix::errno::Errno;
+use snafu::{ResultExt, Snafu};
 use std::convert::TryFrom;
-use url::Url;
+use url::{ParseError, Url};
 
-#[derive(Debug)]
-pub enum UriError {
-    /// the provided scheme is invalid
-    InvalidScheme,
-    /// the schema is valid but we do not support it
-    Unsupported,
-    /// the path segment of the uri is invalid for the schema
-    InvalidPathSegment,
+// parse URI and bdev create/destroy errors common for all types of bdevs
+#[derive(Debug, Snafu)]
+#[snafu(visibility = "pub(crate)")]
+pub enum BdevError {
+    // URI parse errors
+    #[snafu(display("Invalid URI \"{}\"", uri))]
+    UriInvalid { source: ParseError, uri: String },
+    #[snafu(display("Unsupported URI scheme \"{}\"", scheme))]
+    UriSchemeUnsupported { scheme: String },
+    #[snafu(display("Failed to parse aio URI \"{}\"", uri))]
+    ParseAioUri {
+        source: aio_dev::ParseError,
+        uri: String,
+    },
+    #[snafu(display("Failed to parse iscsi URI \"{}\"", uri))]
+    ParseIscsiUri {
+        source: iscsi_dev::ParseError,
+        uri: String,
+    },
+    #[snafu(display("Failed to parse nvmf URI \"{}\"", uri))]
+    ParseNvmfUri {
+        source: nvmf_dev::ParseError,
+        uri: String,
+    },
+    // bdev create/destroy errors
+    #[snafu(display("bdev {} already exists", name))]
+    BdevExists { name: String },
+    #[snafu(display("bdev {} not found", name))]
+    BdevNotFound { name: String },
+    #[snafu(display("Invalid parameters for bdev create {}", name))]
+    InvalidParams { source: Errno, name: String },
+    #[snafu(display("Failed to create bdev {}", name))]
+    CreateBdev { source: Errno, name: String },
+    #[snafu(display("Failed to destroy bdev {}", name))]
+    DestroyBdev { source: Errno, name: String },
 }
+
+impl RpcErrorCode for BdevError {
+    fn rpc_error_code(&self) -> Code {
+        match self {
+            BdevError::UriInvalid {
+                ..
+            } => Code::InvalidParams,
+            BdevError::UriSchemeUnsupported {
+                ..
+            } => Code::InvalidParams,
+            BdevError::ParseAioUri {
+                ..
+            } => Code::InvalidParams,
+            BdevError::ParseIscsiUri {
+                ..
+            } => Code::InvalidParams,
+            BdevError::ParseNvmfUri {
+                ..
+            } => Code::InvalidParams,
+            BdevError::BdevExists {
+                ..
+            } => Code::AlreadyExists,
+            BdevError::BdevNotFound {
+                ..
+            } => Code::NotFound,
+            BdevError::InvalidParams {
+                ..
+            } => Code::InvalidParams,
+            _ => Code::InternalError,
+        }
+    }
+}
+
 /// enum type of URL to args we currently support
 #[derive(Debug)]
 pub enum BdevType {
     /// you should not be using this other then testing
-    Aio(AioBdev),
+    Aio(aio_dev::AioBdev),
     /// backend iSCSI target most stable
-    Iscsi(IscsiBdev),
+    Iscsi(iscsi_dev::IscsiBdev),
     /// backend NVMF target pretty unstable as of Linux 5.2
-    Nvmf(NvmfBdev),
+    Nvmf(nvmf_dev::NvmfBdev),
     /// bdev type is arbitrary bdev found in spdk (used for local replicas)
     Bdev(String),
 }
 
 /// Converts an array of Strings into the appropriate args type
 /// to construct the children from which we create the nexus.
-pub fn nexus_uri_parse_vec(uris: &[String]) -> Result<Vec<BdevType>, UriError> {
+pub fn nexus_uri_parse_vec(
+    uris: &[String],
+) -> Result<Vec<BdevType>, BdevError> {
     let mut results = Vec::new();
     for target in uris {
         results.push(nexus_parse_uri(target)?);
@@ -34,23 +103,60 @@ pub fn nexus_uri_parse_vec(uris: &[String]) -> Result<Vec<BdevType>, UriError> {
 
     Ok(results)
 }
-/// Parse the given URI into a ChildBdev
-pub fn nexus_parse_uri(uri: &str) -> Result<BdevType, UriError> {
-    if let Ok(uri) = Url::parse(uri) {
-        let bdev_type = match uri.scheme() {
-            "aio" => BdevType::Aio(AioBdev::try_from(&uri)?),
-            "iscsi" => BdevType::Iscsi(IscsiBdev::try_from(&uri)?),
-            "nvmf" => BdevType::Nvmf(NvmfBdev::try_from(&uri)?),
-            // strip the first slash in uri path
-            "bdev" => BdevType::Bdev(uri.path()[1 ..].to_string()),
-            _ => {
-                warn!("Unknown URL scheme {}", uri.to_string());
-                return Err(UriError::Unsupported);
-            }
-        };
 
-        Ok(bdev_type)
-    } else {
-        Err(UriError::InvalidScheme)
+/// Parse the given URI into a ChildBdev
+pub fn nexus_parse_uri(uri: &str) -> Result<BdevType, BdevError> {
+    let parsed_uri = Url::parse(uri).context(UriInvalid {
+        uri: uri.to_owned(),
+    })?;
+    let bdev_type = match parsed_uri.scheme() {
+        "aio" => BdevType::Aio(
+            aio_dev::AioBdev::try_from(&parsed_uri).context(ParseAioUri {
+                uri,
+            })?,
+        ),
+        "iscsi" => BdevType::Iscsi(
+            iscsi_dev::IscsiBdev::try_from(&parsed_uri).context(
+                ParseIscsiUri {
+                    uri,
+                },
+            )?,
+        ),
+        "nvmf" => {
+            BdevType::Nvmf(nvmf_dev::NvmfBdev::try_from(&parsed_uri).context(
+                ParseNvmfUri {
+                    uri,
+                },
+            )?)
+        }
+        // strip the first slash in uri path
+        "bdev" => BdevType::Bdev(parsed_uri.path()[1 ..].to_string()),
+        scheme => {
+            return Err(BdevError::UriSchemeUnsupported {
+                scheme: scheme.to_owned(),
+            })
+        }
+    };
+    Ok(bdev_type)
+}
+
+/// Parse URI and destroy bdev described in the URI.
+pub async fn bdev_destroy(uri: &str, bdev_name: &str) -> Result<(), BdevError> {
+    match nexus_parse_uri(uri)? {
+        BdevType::Aio(args) => args.destroy(bdev_name).await,
+        BdevType::Iscsi(args) => args.destroy(bdev_name).await,
+        BdevType::Nvmf(args) => args.destroy(bdev_name),
+        BdevType::Bdev(_) => Ok(()),
+    }
+}
+
+/// Parse URI and create bdev described in the URI.
+/// Return the bdev name (can be different from URI).
+pub async fn bdev_create(uri: &str) -> Result<String, BdevError> {
+    match nexus_parse_uri(uri)? {
+        BdevType::Aio(args) => args.create().await,
+        BdevType::Iscsi(args) => args.create().await,
+        BdevType::Nvmf(args) => args.create().await,
+        BdevType::Bdev(name) => Ok(name),
     }
 }

--- a/mayastor/src/poller.rs
+++ b/mayastor/src/poller.rs
@@ -1,6 +1,12 @@
-use crate::bdev::nexus::Error;
+use snafu::Snafu;
 use spdk_sys::{spdk_poller, spdk_poller_register, spdk_poller_unregister};
 use std::{ops::Deref, os::raw::c_void};
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display("Failed to create poller"))]
+    CreatePoller {},
+}
 
 /// NewType wrapper around the spdk_poller. NewTypes are preferred over
 /// structure wrappings as they impose no overhead.
@@ -83,7 +89,7 @@ pub fn register_poller<T: Deref + std::fmt::Debug>(
     let poller = unsafe { spdk_poller_register(Some(poll_fn), ptr, usec) };
 
     if poller.is_null() {
-        return Err(Error::Internal("failed to create poller".into()));
+        return Err(Error::CreatePoller {});
     }
 
     std::mem::forget(ctx);

--- a/nix/pkgs/mayastor/default.nix
+++ b/nix/pkgs/mayastor/default.nix
@@ -35,7 +35,7 @@ rec {
 
   mayastor = rustPlatform.buildRustPackage rec {
     name = "mayastor";
-    cargoSha256 = "08v4azj1s189ddlyjplfabz5c9mhcy8a23xb4yv8nvwbm7s40zi7";
+    cargoSha256 = "10yncbdc0p860nj31b1fm8gdgh46g5kb9rz5m9phhdjidnawicaf";
     version = "unstable";
     src = ../../../.;
 


### PR DESCRIPTION
Besides the main group of nexus errors, there are a couple of other
error groups for child bdev, rebuild, labels, nbd, uri parsing, event
and poller modules.