### PR TITLE
mayastor: add support for JSON config file

### DIFF
--- a/mayastor/src/bin/main.rs
+++ b/mayastor/src/bin/main.rs
@@ -15,10 +15,16 @@ use sysfs;
 mayastor::CPS_INIT!();
 
 fn main() -> Result<(), std::io::Error> {
-    // setup our logger first
-    mayastor_logger_init("TRACE");
-
     let args = MayastorCliArgs::from_args();
+
+    // setup our logger first if -L is passed, raise the log level
+    // automatically. trace maps to debug at FFI level. If RUST_LOG is
+    // passed, we will use it regardless.
+    if !args.log_components.is_empty() {
+        mayastor_logger_init("TRACE");
+    } else {
+        mayastor_logger_init("INFO");
+    }
 
     let hugepage_path = Path::new("/sys/kernel/mm/hugepages/hugepages-2048kB");
     let nr_pages: u32 = sysfs::parse_value(&hugepage_path, "nr_hugepages")?;

--- a/mayastor/src/environment/args.rs
+++ b/mayastor/src/environment/args.rs
@@ -30,6 +30,9 @@ fn parse_mb(src: &str) -> Result<i32, String> {
 )]
 
 pub struct MayastorCliArgs {
+    #[structopt(short = "j")]
+    /// Path to JSON formatted config file
+    pub json: Option<String>,
     #[structopt(short = "c")]
     /// Path to the configuration file if any
     pub config: Option<String>,
@@ -65,6 +68,7 @@ impl Default for MayastorCliArgs {
             no_pci: true,
             log_components: vec![],
             config: None,
+            json: None,
         }
     }
 }

--- a/mayastor/src/event.rs
+++ b/mayastor/src/event.rs
@@ -53,6 +53,7 @@ impl Mthread {
                 done = true
             }
         }
+        unsafe { spdk_set_thread(std::ptr::null_mut()) };
         self
     }
 }

--- a/mayastor/tests/nexus_add_remove.rs
+++ b/mayastor/tests/nexus_add_remove.rs
@@ -31,11 +31,7 @@ fn nexus_add_remove() {
 
     let rc = MayastorEnvironment::new(MayastorCliArgs {
         reactor_mask: "0x3".into(),
-        mem_size: 0,
-        rpc_address: "".to_string(),
-        no_pci: true,
-        config: None,
-        log_components: vec!["thread".into()],
+        ..Default::default()
     })
     .start(|| mayastor::executor::spawn(works()))
     .unwrap();
@@ -246,6 +242,5 @@ async fn works() {
     nexus_remove_5().await;
 
     rebuild_should_error().await;
-    //mayastor_env_stop(0);
     mayastor_stop(0);
 }


### PR DESCRIPTION
This change adds support for a JSON config file. The JSON file are
rpc methods invoked, prior to accepting any other RPC calls.

Additionally, this change auto adjusts the logger when -L is passed.