### PR TITLE
Test utility for reading/writing to/from nexus child - replica

### DIFF
--- a/mayastor/Cargo.toml
+++ b/mayastor/Cargo.toml
@@ -12,6 +12,10 @@ path = "src/bin/main.rs"
 name = "spdk"
 path = "src/bin/spdk.rs"
 
+[[bin]]
+name = "initiator"
+path = "src/bin/initiator.rs"
+
 [dependencies]
 assert_matches = "1.3.0"
 bincode = "1.2.0"

--- a/mayastor/src/bdev/nexus/nexus_bdev.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev.rs
@@ -32,7 +32,7 @@
 //!
 //! // only use DMA buffers to issue IO, as its a member of the opened device
 //! // alignment is handled implicitly
-//! let mut buf = bd.dma_zmalloc(4096).unwrap();
+//! let mut buf = bd.dma_malloc(4096).unwrap();
 //!
 //! // fill the buffer with a know value
 //! buf.fill(0xff);
@@ -75,7 +75,7 @@ use crate::{
         },
         Bdev,
     },
-    descriptor::{DmaBuf, DmaError},
+    dma::{DmaBuf, DmaError},
     executor::errno_result_from_i32,
     jsonrpc::{Code, RpcErrorCode},
     nexus_uri::BdevError,

--- a/mayastor/src/bdev/nexus/nexus_channel.rs
+++ b/mayastor/src/bdev/nexus/nexus_channel.rs
@@ -92,9 +92,14 @@ impl NexusChannelInner {
             .map(|c| {
                 info!(
                     "{}: Getting new channel for child {} desc {:p}",
-                    c.parent, c.name, c.desc
+                    c.parent,
+                    c.name,
+                    c.descriptor.as_ref().unwrap().as_ptr()
                 );
-                self.ch.push((c.desc, c.get_io_channel()))
+                self.ch.push((
+                    c.descriptor.as_ref().unwrap().as_ptr(),
+                    c.get_io_channel().unwrap(),
+                ))
             })
             .for_each(drop);
 
@@ -126,7 +131,12 @@ impl NexusChannel {
             .children
             .iter_mut()
             .filter(|c| c.state == ChildState::Open)
-            .map(|c| channels.ch.push((c.desc, c.get_io_channel())))
+            .map(|c| {
+                channels.ch.push((
+                    c.descriptor.as_ref().unwrap().as_ptr(),
+                    c.get_io_channel().unwrap(),
+                ))
+            })
             .for_each(drop);
         ch.inner = Box::into_raw(channels);
         0

--- a/mayastor/src/bdev/nexus/nexus_label.rs
+++ b/mayastor/src/bdev/nexus/nexus_label.rs
@@ -72,7 +72,7 @@ use crate::{
         nexus_bdev::Nexus,
         nexus_child::{ChildError, ChildIoError},
     },
-    descriptor::{DmaBuf, DmaError},
+    dma::{DmaBuf, DmaError},
 };
 
 #[derive(Debug, Snafu)]

--- a/mayastor/src/bin/initiator.rs
+++ b/mayastor/src/bin/initiator.rs
@@ -1,0 +1,178 @@
+//! Command line test utility to copy bytes to/from a replica which can be any
+//! target type understood by the nexus.
+
+extern crate clap;
+#[macro_use]
+extern crate log;
+
+use clap::{App, Arg, SubCommand};
+use mayastor::{
+    bdev::{bdev_lookup_by_name, Bdev},
+    descriptor::{DescError, Descriptor},
+    dma::{DmaBuf, DmaError},
+    executor,
+    jsonrpc::print_error_chain,
+    mayastor_logger_init,
+    mayastor_start,
+    mayastor_stop,
+    nexus_uri::{bdev_create, BdevError},
+};
+use std::{
+    fmt,
+    fs,
+    io::{self, Write},
+    process,
+};
+
+/// The errors from this utility are not supposed to be parseable by machine,
+/// so all we need is a string with unfolded error messages from all nested
+/// errors, which will be printed to stderr.
+struct Error {
+    msg: String,
+}
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.msg)
+    }
+}
+impl From<DescError> for Error {
+    fn from(err: DescError) -> Self {
+        Self {
+            msg: print_error_chain(&err),
+        }
+    }
+}
+impl From<DmaError> for Error {
+    fn from(err: DmaError) -> Self {
+        Self {
+            msg: print_error_chain(&err),
+        }
+    }
+}
+impl From<BdevError> for Error {
+    fn from(err: BdevError) -> Self {
+        Self {
+            msg: print_error_chain(&err),
+        }
+    }
+}
+impl From<io::Error> for Error {
+    fn from(err: io::Error) -> Self {
+        Self {
+            msg: err.to_string(),
+        }
+    }
+}
+
+type Result<T, E = Error> = std::result::Result<T, E>;
+
+mayastor::CPS_INIT!();
+
+/// Create initiator bdev.
+async fn create_bdev(uri: &str) -> Result<Bdev> {
+    let bdev_name = bdev_create(uri).await?;
+    let bdev = bdev_lookup_by_name(&bdev_name)
+        .expect("Failed to lookup the created bdev");
+    Ok(bdev)
+}
+
+/// Allocate IO buffer suitable for given bdev with the bdev descriptor.
+fn alloc_buf(bdev: &Bdev, desc: &Descriptor) -> Result<DmaBuf> {
+    let len = bdev.block_len() as usize;
+    desc.dma_malloc(len).map_err(|err| err.into())
+}
+
+/// Read block of data from bdev at given offset to a file.
+async fn read(uri: &str, offset: u64, file: &str) -> Result<()> {
+    let bdev = create_bdev(uri).await?;
+    let desc = Descriptor::open(&bdev, false)?;
+    let mut buf = alloc_buf(&bdev, &desc)?;
+    let n = desc.read_at(offset, &mut buf).await?;
+    fs::write(file, buf.as_slice())?;
+    info!("{} bytes read", n);
+    Ok(())
+}
+
+/// Write block of data from file to bdev at given offset.
+async fn write(uri: &str, offset: u64, file: &str) -> Result<()> {
+    let bdev = create_bdev(uri).await?;
+    let bytes = fs::read(file)?;
+    let desc = Descriptor::open(&bdev, true)?;
+    let mut buf = alloc_buf(&bdev, &desc)?;
+    let mut n = buf.as_mut_slice().write(&bytes[..]).unwrap();
+    if n < buf.len() {
+        warn!("Writing a buffer which was not fully initialized from a file");
+    }
+    n = desc.write_at(offset, &buf).await?;
+    info!("{} bytes written", n);
+    Ok(())
+}
+
+/// Connect to the target.
+async fn connect(uri: &str) -> Result<()> {
+    let _bdev = create_bdev(uri).await?;
+    info!("Connected!");
+    Ok(())
+}
+
+fn main() {
+    let matches = App::new("Test initiator for nexus replica")
+        .about("Connect, read or write a block to a nexus replica using its URI")
+        .arg(Arg::with_name("URI")
+            .help("URI of the replica to connect to")
+            .required(true)
+            .index(1))
+        .arg(Arg::with_name("offset")
+            .short("o")
+            .long("offset")
+            .value_name("NUMBER")
+            .help("Offset of IO operation on the replica in bytes (default 0)")
+            .takes_value(true))
+        .subcommand(SubCommand::with_name("connect")
+            .about("Connect to and disconnect from the replica"))
+        .subcommand(SubCommand::with_name("read")
+            .about("Read bytes from the replica")
+            .arg(Arg::with_name("FILE")
+                .help("File to write data that were read from the replica")
+                .required(true)
+                .index(1)))
+        .subcommand(SubCommand::with_name("write")
+            .about("Write bytes to the replica")
+            .arg(Arg::with_name("FILE")
+                .help("File to read data from that will be written to the replica")
+                .required(true)
+                .index(1)))
+        .get_matches();
+
+    mayastor_logger_init("INFO");
+
+    let uri = matches.value_of("URI").unwrap().to_owned();
+    let offset: u64 = match matches.value_of("offset") {
+        Some(val) => val.parse().expect("Offset must be a number"),
+        None => 0,
+    };
+
+    let rc = mayastor_start("initiator", ["-s", "128"].to_vec(), move || {
+        let fut = async move {
+            let res = if let Some(matches) = matches.subcommand_matches("read")
+            {
+                read(&uri, offset, matches.value_of("FILE").unwrap()).await
+            } else if let Some(matches) = matches.subcommand_matches("write") {
+                write(&uri, offset, matches.value_of("FILE").unwrap()).await
+            } else {
+                connect(&uri).await
+            };
+            let rc = if let Err(err) = res {
+                error!("{}", err);
+                -1
+            } else {
+                0
+            };
+            mayastor_stop(rc);
+        };
+        executor::spawn(fut);
+    });
+    info!("{}", rc);
+
+    process::exit(rc);
+}

--- a/mayastor/src/dma.rs
+++ b/mayastor/src/dma.rs
@@ -1,0 +1,105 @@
+//! The buffers written to the bdev must be allocated by the provided allocation
+//! methods. These buffers are allocated from mem pools and huge pages and allow
+//! for DMA transfers in the case of, for example, NVMe devices.
+
+use std::{
+    ffi::c_void,
+    ops::{Deref, DerefMut},
+    slice::{from_raw_parts, from_raw_parts_mut},
+};
+
+use snafu::Snafu;
+use spdk_sys::{spdk_dma_free, spdk_dma_zmalloc};
+
+#[derive(Debug, Snafu)]
+pub enum DmaError {
+    #[snafu(display("Failed to allocate DMA buffer"))]
+    Alloc {},
+}
+
+/// DmaBuf that is allocated from the memory pool
+#[derive(Debug)]
+pub struct DmaBuf {
+    /// a raw pointer to the buffer
+    buf: *mut c_void,
+    /// the length of the allocated buffer
+    length: usize,
+}
+
+impl DmaBuf {
+    /// convert the buffer to a slice
+    pub fn as_slice(&self) -> &[u8] {
+        unsafe { from_raw_parts(self.buf as *mut u8, self.length as usize) }
+    }
+
+    /// convert the buffer to a mutable slice
+    pub fn as_mut_slice(&mut self) -> &mut [u8] {
+        unsafe { from_raw_parts_mut(self.buf as *mut u8, self.length as usize) }
+    }
+
+    /// fill the buffer with the given value
+    pub fn fill(&mut self, val: u8) {
+        unsafe {
+            std::ptr::write_bytes(
+                self.as_mut_slice().as_ptr() as *mut u8,
+                val,
+                self.length,
+            )
+        }
+    }
+
+    /// Allocate a buffer suitable for IO (wired and backed by huge page memory)
+    pub fn new(size: usize, alignment: u8) -> Result<Self, DmaError> {
+        let buf;
+        unsafe {
+            buf = spdk_dma_zmalloc(
+                size,
+                1 << alignment as usize,
+                std::ptr::null_mut(),
+            )
+        };
+
+        if buf.is_null() {
+            Err(DmaError::Alloc {})
+        } else {
+            Ok(DmaBuf {
+                buf,
+                length: size,
+            })
+        }
+    }
+
+    /// Return length of the allocated buffer.
+    pub fn len(&self) -> usize {
+        self.length
+    }
+
+    /// Returns if the length of the allocated buffer is empty.
+    /// Pretty useless but the best friends len and is_empty cannot be parted.
+    pub fn is_empty(&self) -> bool {
+        self.length == 0
+    }
+}
+
+impl Deref for DmaBuf {
+    type Target = *mut c_void;
+
+    fn deref(&self) -> &Self::Target {
+        &self.buf
+    }
+}
+
+impl DerefMut for DmaBuf {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.buf
+    }
+}
+
+impl Drop for DmaBuf {
+    fn drop(&mut self) {
+        if cfg!(debug_assertions) {
+            trace!("dropping Dmabuf {:?}", self);
+        }
+        unsafe { spdk_dma_free(self.buf as *mut c_void) }
+    }
+}

--- a/mayastor/src/jsonrpc.rs
+++ b/mayastor/src/jsonrpc.rs
@@ -114,7 +114,7 @@ impl std::error::Error for JsonRpcError {}
 
 pub type Result<T, E = JsonRpcError> = std::result::Result<T, E>;
 
-fn print_error_chain(err: &dyn std::error::Error) -> String {
+pub fn print_error_chain(err: &dyn std::error::Error) -> String {
     let mut msg = format!("{}", err);
     let mut opt_source = err.source();
     while let Some(source) = opt_source {

--- a/mayastor/src/nexus_uri.rs
+++ b/mayastor/src/nexus_uri.rs
@@ -105,7 +105,7 @@ pub fn nexus_uri_parse_vec(
 }
 
 /// Parse the given URI into a ChildBdev
-pub fn nexus_parse_uri(uri: &str) -> Result<BdevType, BdevError> {
+fn nexus_parse_uri(uri: &str) -> Result<BdevType, BdevError> {
     let parsed_uri = Url::parse(uri).context(UriInvalid {
         uri: uri.to_owned(),
     })?;

--- a/mayastor/src/rebuild.rs
+++ b/mayastor/src/rebuild.rs
@@ -14,7 +14,8 @@ use crate::{
         nexus_bdev::{nexus_lookup, NexusState},
         nexus_io::Bio,
     },
-    descriptor::{Descriptor, DmaBuf, DmaError},
+    descriptor::Descriptor,
+    dma::{DmaBuf, DmaError},
     event::MayaCtx,
     executor::errno_result_from_i32,
     poller::{register_poller, PollTask},
@@ -331,9 +332,9 @@ impl RebuildTask {
     ) -> Result<RebuildState, Error> {
         let errno = unsafe {
             spdk_bdev_read_blocks(
-                self.source.desc,
-                self.source.ch,
-                self.buf.buf,
+                self.source.as_ptr(),
+                self.source.channel(),
+                *self.buf,
                 self.current_lba,
                 num_blocks as u64,
                 Some(Self::read_complete),
@@ -366,9 +367,9 @@ impl RebuildTask {
         let bio = Bio(io);
         let errno = unsafe {
             spdk_bdev_write_blocks(
-                self.target.desc,
-                self.target.ch,
-                self.buf.buf,
+                self.target.as_ptr(),
+                self.target.channel(),
+                *self.buf,
                 bio.offset(),
                 bio.num_blocks(),
                 Some(Self::write_complete),

--- a/mayastor/tests/io.rs
+++ b/mayastor/tests/io.rs
@@ -1,10 +1,13 @@
 use std::process::Command;
 
 use mayastor::{
+    bdev::bdev_lookup_by_name,
     descriptor::Descriptor,
-    environment::{args::MayastorCliArgs, env::MayastorEnvironment},
-    mayastor_stop,
-    nexus_uri::{nexus_parse_uri, BdevType},
+    environment::{
+        args::MayastorCliArgs,
+        env::{mayastor_env_stop, MayastorEnvironment},
+    },
+    nexus_uri::bdev_create,
 };
 
 static DISKNAME: &str = "/tmp/disk.img";
@@ -37,39 +40,29 @@ fn io_test() {
 // The actual work here is completely driven by the futures. We
 // only execute one future per reactor loop.
 async fn start() {
-    make_bdev().await;
+    bdev_create(BDEVNAME).await.expect("failed to create bdev");
     write_some().await;
     read_some().await;
-    mayastor_stop(0);
-}
-
-async fn make_bdev() {
-    match nexus_parse_uri(BDEVNAME) {
-        Ok(BdevType::Aio(args)) => {
-            let _ = args.create().await.expect("failed to create");
-        }
-        _ => {
-            panic!("invalid test configuration");
-        }
-    }
+    mayastor_env_stop(0);
 }
 
 async fn write_some() {
-    let d = Descriptor::open(BDEVNAME, true).expect("failed open bdev");
-    let mut buf = d.dma_zmalloc(512).expect("failed to allocate buffer");
+    let bdev = bdev_lookup_by_name(BDEVNAME).expect("failed to lookup bdev");
+    let d = Descriptor::open(&bdev, true).expect("failed open bdev");
+    let mut buf = d.dma_malloc(512).expect("failed to allocate buffer");
     buf.fill(0xff);
 
     let s = buf.as_slice();
     assert_eq!(s[0], 0xff);
 
     d.write_at(0, &buf).await.unwrap();
-    d.close();
 }
 
 async fn read_some() {
-    let d = Descriptor::open(BDEVNAME, false);
+    let bdev = bdev_lookup_by_name(BDEVNAME).expect("failed to lookup bdev");
+    let d = Descriptor::open(&bdev, false);
     let d = d.unwrap();
-    let mut buf = d.dma_zmalloc(1024).expect("failed to allocate buffer");
+    let mut buf = d.dma_malloc(1024).expect("failed to allocate buffer");
     let slice = buf.as_mut_slice();
 
     assert_eq!(slice[0], 0);
@@ -77,7 +70,6 @@ async fn read_some() {
     assert_eq!(slice[513], 0xff);
 
     d.read_at(0, &mut buf).await.unwrap();
-    d.close();
 
     let slice = buf.as_slice();
 

--- a/mayastor/tests/mount_fs.rs
+++ b/mayastor/tests/mount_fs.rs
@@ -6,8 +6,10 @@ use mayastor::{
         nexus_bdev::{nexus_create, nexus_lookup},
         nexus_io,
     },
-    environment::{args::MayastorCliArgs, env::MayastorEnvironment},
-    mayastor_stop,
+    environment::{
+        args::MayastorCliArgs,
+        env::{mayastor_env_stop, MayastorEnvironment},
+    },
 };
 
 static DISKNAME1: &str = "/tmp/disk1.img";
@@ -160,5 +162,5 @@ async fn works() {
     mount_unmount().await;
     run_fio_on_nexus().await;
 
-    mayastor_stop(0);
+    mayastor_env_stop(0);
 }

--- a/mayastor/tests/nexus_add_remove.rs
+++ b/mayastor/tests/nexus_add_remove.rs
@@ -6,8 +6,10 @@ use mayastor::{
         instances,
         nexus_bdev::{nexus_create, nexus_lookup, Error, NexusState},
     },
-    environment::{args::MayastorCliArgs, env::MayastorEnvironment},
-    mayastor_stop,
+    environment::{
+        args::MayastorCliArgs,
+        env::{mayastor_env_stop, MayastorEnvironment},
+    },
     rebuild::RebuildState,
 };
 
@@ -242,5 +244,5 @@ async fn works() {
     nexus_remove_5().await;
 
     rebuild_should_error().await;
-    mayastor_stop(0);
+    mayastor_env_stop(0);
 }

--- a/mayastor/tests/nexus_label.rs
+++ b/mayastor/tests/nexus_label.rs
@@ -10,9 +10,11 @@ use mayastor::{
         nexus_bdev::{nexus_create, nexus_lookup},
         nexus_label::{GPTHeader, GptEntry},
     },
-    descriptor::DmaBuf,
-    environment::{args::MayastorCliArgs, env::MayastorEnvironment},
-    mayastor_stop,
+    dma::DmaBuf,
+    environment::{
+        args::MayastorCliArgs,
+        env::{mayastor_env_stop, MayastorEnvironment},
+    },
 };
 
 const HDR_GUID: &str = "322974ae-5711-874b-bfbd-1a74df4dd714";
@@ -60,7 +62,7 @@ async fn start() {
     test_known_label();
     make_nexus().await;
     label_child().await;
-    mayastor_stop(0);
+    mayastor_env_stop(0);
 }
 
 /// Test that we can deserialize a known good gpt label and parse it. After

--- a/mayastor/tests/rebuild.rs
+++ b/mayastor/tests/rebuild.rs
@@ -1,7 +1,9 @@
 use mayastor::{
     bdev::nexus::nexus_bdev::{nexus_create, nexus_lookup, NexusState},
-    environment::{args::MayastorCliArgs, env::MayastorEnvironment},
-    mayastor_stop,
+    environment::{
+        args::MayastorCliArgs,
+        env::{mayastor_env_stop, MayastorEnvironment},
+    },
     poller::SetTimeout,
 };
 
@@ -52,7 +54,7 @@ async fn works() {
         |nexus: String| {
             let n = nexus_lookup(&nexus).unwrap();
             assert_eq!(n.status(), NexusState::Online);
-            mayastor_stop(0);
+            mayastor_env_stop(0);
         },
         5_000_000,
     );


### PR DESCRIPTION
* Refactor the code around bdev descriptor object to feel more rusty
  and to avoid code duplication with spdk_bdev_open().
* Rust wrapper object for DMA buffer lives in its own file now.
* Remove dma_zmalloc() in favour of dma_malloc() - both methods
  returned zero initialized memory.
* Fix bug when return code from mayastor_stop wasn't properly
  propagated to mayastor_start caller.
* Fix default log expression which filtered out all messages not coming
  from the mayastor lib (i.e. messages from the binaries using the lib).
* Remove "deprecated" tag from mayastor_start() as it's preferred
  alternative to mayastor env lib for simple test & utility programs.

Help message for the new tool:
```
Test initiator for nexus replica
Connect, read or write a block to a nexus replica using its URI

USAGE:
    initiator [OPTIONS] <URI> [SUBCOMMAND]

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

OPTIONS:
    -o, --offset <NUMBER>    Offset of IO operation on the replica in bytes (default 0)

ARGS:
    <URI>    URI of the replica to connect to

SUBCOMMANDS:
    connect    Connect to and disconnect from the replica
    help       Prints this message or the help of the given subcommand(s)
    read       Read bytes from the replica
    write      Write bytes to the replica
```

Example usage (all three major subcommands):
```
  initiator nvmf://127.0.0.1:8420/nqn.2019-05.io.openebs:disk2 connect
  initiator nvmf://127.0.0.1:8420/nqn.2019-05.io.openebs:disk2 read /tmp/out
  initiator nvmf://127.0.0.1:8420/nqn.2019-05.io.openebs:disk2 write /tmp/out
```

TODO:
 * Make starting nvmf and iscsi target in mayastor lib optional. We don't
   need those in initiator utility. We need to squeeze mem requirements
   and the targets conflict with a mayastor instance running on the same
   host (workaround is MY_POD_IP=<extern-IP>).
 * Use the new utility in JS unit tests to test the IO on replica.