### PR TITLE
Do not start nvmf/iscsi target on behalf of initiator utility.

### DIFF
--- a/mayastor/src/app.rs
+++ b/mayastor/src/app.rs
@@ -1,0 +1,160 @@
+//! Rust friendly wrappers around SPDK app start stop functions.
+//!
+//! NOTE: Should be used only for test and utility programs which don't
+//! require custom argument parser. Otherwise use mayastor environment
+//! module.
+
+use crate::{developer_delay, executor, logger, pool, replica};
+use spdk_sys::{
+    maya_log,
+    spdk_app_opts,
+    spdk_app_opts_init,
+    spdk_app_parse_args,
+    spdk_app_start,
+    spdk_app_stop,
+};
+use std::{
+    boxed::Box,
+    env,
+    ffi::CString,
+    iter::Iterator,
+    os::raw::{c_char, c_int, c_void},
+    ptr::null_mut,
+    vec::Vec,
+};
+
+/// A callback to print help for extra options that we use.
+/// Mayastor app does not use it because it has it's own code to initialize
+/// spdk env. This is used only by legacy apps, which don't have any extra
+/// options.
+extern "C" fn usage() {
+    // i.e. println!(" -f <path>                 save pid to this file");
+}
+
+/// Rust friendly wrapper around SPDK app start function.
+/// The application code is a closure passed as argument and called
+/// when spdk initialization is done.
+///
+/// This function relies on spdk argument parser. Extra parameters can be
+/// passed in environment variables.
+pub fn start<T, F>(name: &str, mut args: Vec<T>, start_cb: F) -> i32
+where
+    T: Into<Vec<u8>>,
+    F: FnOnce(),
+{
+    // hand over command line args to spdk arg parser
+    let args = args
+        .drain(..)
+        .map(|arg| CString::new(arg).unwrap())
+        .collect::<Vec<CString>>();
+    let mut c_args = args
+        .iter()
+        .map(|arg| arg.as_ptr())
+        .collect::<Vec<*const c_char>>();
+    c_args.push(std::ptr::null());
+
+    let mut opts: spdk_app_opts = Default::default();
+
+    unsafe {
+        spdk_app_opts_init(&mut opts as *mut spdk_app_opts);
+        opts.rpc_addr =
+            CString::new("/var/tmp/mayastor.sock").unwrap().into_raw();
+
+        if let Ok(log_level) = env::var("MAYASTOR_LOGLEVEL") {
+            opts.print_level = match log_level.parse() {
+                Ok(-1) => spdk_sys::SPDK_LOG_DISABLED,
+                Ok(0) => spdk_sys::SPDK_LOG_ERROR,
+                Ok(1) => spdk_sys::SPDK_LOG_WARN,
+                Ok(2) => spdk_sys::SPDK_LOG_NOTICE,
+                Ok(3) => spdk_sys::SPDK_LOG_INFO,
+                Ok(4) => spdk_sys::SPDK_LOG_DEBUG,
+                // default
+                _ => spdk_sys::SPDK_LOG_DEBUG,
+            }
+        } else {
+            opts.print_level = spdk_sys::SPDK_LOG_NOTICE;
+        }
+
+        if spdk_app_parse_args(
+            (c_args.len() as c_int) - 1,
+            c_args.as_ptr() as *mut *mut i8,
+            &mut opts,
+            null_mut(), // extra short options i.e. "f:S:"
+            null_mut(), // extra long options
+            None,       // extra options parse callback
+            Some(usage),
+        ) != spdk_sys::SPDK_APP_PARSE_ARGS_SUCCESS
+        {
+            return -1;
+        }
+    }
+
+    opts.name = CString::new(name).unwrap().into_raw();
+    opts.shutdown_cb = Some(shutdown_cb);
+
+    // set the function pointer to use our maya_log function which is statically
+    // linked into the sys create
+    opts.log = Some(maya_log);
+
+    unsafe {
+        // set the pointer which the maya_log function uses after unpacking the
+        // va_list
+        spdk_sys::logfn = Some(logger::log_impl);
+    }
+
+    unsafe {
+        let rc = spdk_app_start(
+            &mut opts,
+            Some(app_start_cb::<F>),
+            // Double box to convert from fat to thin pointer
+            Box::into_raw(Box::new(Box::new(start_cb))) as *mut c_void,
+        );
+
+        // this will remove shm file in /dev/shm and do other cleanups
+        spdk_sys::spdk_app_fini();
+
+        rc
+    }
+}
+
+/// spdk_all_start callback which starts the future executor and finally calls
+/// user provided start callback.
+extern "C" fn app_start_cb<F>(arg1: *mut c_void)
+where
+    F: FnOnce(),
+{
+    // use in cases when you want to burn less cpu and speed does not matter
+    if let Some(_key) = env::var_os("DELAY") {
+        warn!("*** Delaying reactor every 1000us ***");
+        unsafe {
+            spdk_sys::spdk_poller_register(
+                Some(developer_delay),
+                std::ptr::null_mut(),
+                1000,
+            )
+        };
+    }
+    executor::start();
+    pool::register_pool_methods();
+    replica::register_replica_methods();
+
+    // asynchronous initialization routines
+    let fut = async move {
+        let cb: Box<Box<F>> = unsafe { Box::from_raw(arg1 as *mut Box<F>) };
+        cb();
+    };
+    executor::spawn(fut);
+}
+
+/// Cleanly exit from the program.
+/// NOTE: Use only on programs started by mayastor_start.
+pub fn stop(rc: i32) -> i32 {
+    let fut = async {};
+    executor::stop(fut, Box::new(move || unsafe { spdk_app_stop(rc) }));
+    rc
+}
+
+/// A callback called by spdk when it is shutting down.
+unsafe extern "C" fn shutdown_cb() {
+    stop(0);
+}

--- a/mayastor/src/bin/initiator.rs
+++ b/mayastor/src/bin/initiator.rs
@@ -7,14 +7,13 @@ extern crate log;
 
 use clap::{App, Arg, SubCommand};
 use mayastor::{
+    app,
     bdev::{bdev_lookup_by_name, Bdev},
     descriptor::{DescError, Descriptor},
     dma::{DmaBuf, DmaError},
     executor,
     jsonrpc::print_error_chain,
-    mayastor_logger_init,
-    mayastor_start,
-    mayastor_stop,
+    logger,
     nexus_uri::{bdev_create, BdevError},
 };
 use std::{
@@ -144,7 +143,7 @@ fn main() {
                 .index(1)))
         .get_matches();
 
-    mayastor_logger_init("INFO");
+    logger::init("INFO");
 
     let uri = matches.value_of("URI").unwrap().to_owned();
     let offset: u64 = match matches.value_of("offset") {
@@ -152,7 +151,7 @@ fn main() {
         None => 0,
     };
 
-    let rc = mayastor_start("initiator", ["-s", "128"].to_vec(), move || {
+    let rc = app::start("initiator", ["-s", "128"].to_vec(), move || {
         let fut = async move {
             let res = if let Some(matches) = matches.subcommand_matches("read")
             {
@@ -168,7 +167,7 @@ fn main() {
             } else {
                 0
             };
-            mayastor_stop(rc);
+            app::stop(rc);
         };
         executor::spawn(fut);
     });

--- a/mayastor/src/bin/main.rs
+++ b/mayastor/src/bin/main.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 use git_version::git_version;
 use mayastor::{
     environment::{args::MayastorCliArgs, env::MayastorEnvironment},
-    mayastor_logger_init,
+    logger,
 };
 
 use structopt::StructOpt;
@@ -21,9 +21,9 @@ fn main() -> Result<(), std::io::Error> {
     // automatically. trace maps to debug at FFI level. If RUST_LOG is
     // passed, we will use it regardless.
     if !args.log_components.is_empty() {
-        mayastor_logger_init("TRACE");
+        logger::init("TRACE");
     } else {
-        mayastor_logger_init("INFO");
+        logger::init("INFO");
     }
 
     let hugepage_path = Path::new("/sys/kernel/mm/hugepages/hugepages-2048kB");

--- a/mayastor/src/environment/env.rs
+++ b/mayastor/src/environment/env.rs
@@ -50,7 +50,7 @@ use crate::{
     event::Mthread,
     executor,
     iscsi_target,
-    log_impl,
+    logger,
     nvmf_target,
     pool,
     replica,
@@ -469,7 +469,7 @@ impl MayastorEnvironment {
             // open our log implementation which is implemented in the wrapper
             spdk_log_open(Some(maya_log));
             // our callback called defined in rust called by our wrapper
-            spdk_sys::logfn = Some(log_impl);
+            spdk_sys::logfn = Some(logger::log_impl);
         }
         Ok(())
     }

--- a/mayastor/src/lib.rs
+++ b/mayastor/src/lib.rs
@@ -11,32 +11,10 @@ extern crate serde_json;
 extern crate snafu;
 extern crate spdk_sys;
 
-use env_logger::{Builder, Env};
-use log::{logger, Level, Record};
-use spdk_sys::{
-    maya_log,
-    spdk_app_opts,
-    spdk_app_opts_init,
-    spdk_app_parse_args,
-    spdk_app_start,
-    spdk_app_stop,
-    spdk_log_get_print_level,
-};
-use std::{
-    boxed::Box,
-    env,
-    ffi::{CStr, CString},
-    io::Write,
-    iter::Iterator,
-    net::Ipv4Addr,
-    os::raw::{c_char, c_int, c_void},
-    path::Path,
-    ptr::null_mut,
-    time::Duration,
-    vec::Vec,
-};
+use std::{os::raw::c_void, time::Duration};
 
 pub mod aio_dev;
+pub mod app;
 pub mod bdev;
 pub mod descriptor;
 pub mod dma;
@@ -46,6 +24,7 @@ pub mod executor;
 pub mod iscsi_dev;
 pub mod iscsi_target;
 pub mod jsonrpc;
+pub mod logger;
 pub mod nexus_uri;
 pub mod nvmf_dev;
 pub mod nvmf_target;
@@ -54,6 +33,7 @@ pub mod pool;
 pub mod rebuild;
 pub mod replica;
 pub mod spdklog;
+
 #[macro_export]
 macro_rules! CPS_INIT {
     () => {
@@ -67,251 +47,9 @@ pub extern "C" fn cps_init() {
     bdev::nexus::register_module();
 }
 
-extern "C" fn log_impl(
-    level: i32,
-    file: *const c_char,
-    line: u32,
-    _func: *const c_char,
-    buf: *const c_char,
-    _n: i32, // the number of bytes written into buf
-) {
-    unsafe {
-        // remove new line characters from the log messages if any
-        let fmt = CStr::from_ptr(buf).to_str().unwrap().trim_end();
-        let filename = CStr::from_ptr(file).to_str().unwrap();
-
-        if spdk_log_get_print_level() < level {
-            return;
-        }
-
-        let lvl = match level {
-            spdk_sys::SPDK_LOG_DISABLED => return,
-            spdk_sys::SPDK_LOG_ERROR => Level::Error,
-            spdk_sys::SPDK_LOG_WARN => Level::Warn,
-            // the default level for now
-            spdk_sys::SPDK_LOG_INFO => Level::Info,
-            spdk_sys::SPDK_LOG_NOTICE => Level::Debug,
-            spdk_sys::SPDK_LOG_DEBUG => Level::Trace,
-            // if the error level is unknown to us we log it as an error by
-            // default
-            _ => Level::Error,
-        };
-
-        logger().log(
-            &Record::builder()
-                .args(format_args!("{}", fmt))
-                .target(module_path!())
-                .file(Some(filename))
-                .line(Some(line))
-                .level(lvl)
-                .build(),
-        );
-    }
-}
-
-/// This function configures the logging format. The loglevel is also processed
-/// here i.e `RUST_LOG=mayastor=TRACE` will print all trace!() and higher
-/// messages to the console.
-///
-/// Log messages originating from SPDK, are processed in `log_impl` the log
-/// levels don not exactly match. See `log_impl` for the exact mapping.
-///
-/// We might want to suppress certain messages, as some of them are redundant,
-/// in particular, the NOTICE messages as such, they are mapped to debug.
-pub fn mayastor_logger_init(level: &str) {
-    let mut builder =
-        Builder::from_env(Env::default().default_filter_or(level.to_string()));
-
-    builder.format(|buf, record| {
-        let mut level_style = buf.default_level_style(record.level());
-        level_style.set_intense(true);
-        writeln!(
-            buf,
-            "[{} {} {}:{}] {}",
-            buf.timestamp_nanos(),
-            level_style.value(record.level()),
-            Path::new(record.file().unwrap())
-                .file_name()
-                .unwrap()
-                .to_str()
-                .unwrap(),
-            record.line().unwrap(),
-            record.args()
-        )
-    });
-    builder.init();
-}
-
-/// A callback to print help for extra options that we use.
-/// Mayastor app does not use it because it has it's own code to initialize
-/// spdk env. This is used only by legacy apps, which don't have any extra
-/// options.
-extern "C" fn usage() {
-    // i.e. println!(" -f <path>                 save pid to this file");
-}
-
-/// Rust friendly wrapper around SPDK app start function.
-/// The application code is a closure passed as argument and called
-/// when spdk initialization is done.
-///
-/// This function relies on spdk argument parser. Extra parameters can be
-/// passed in environment variables.
-///
-/// NOTE: Should be used only for test and utility programs which don't
-/// require custom argument parser. Otherwise use mayastor environment
-/// module.
-pub fn mayastor_start<T, F>(name: &str, mut args: Vec<T>, start_cb: F) -> i32
-where
-    T: Into<Vec<u8>>,
-    F: FnOnce(),
-{
-    // hand over command line args to spdk arg parser
-    let args = args
-        .drain(..)
-        .map(|arg| CString::new(arg).unwrap())
-        .collect::<Vec<CString>>();
-    let mut c_args = args
-        .iter()
-        .map(|arg| arg.as_ptr())
-        .collect::<Vec<*const c_char>>();
-    c_args.push(std::ptr::null());
-
-    let mut opts: spdk_app_opts = Default::default();
-
-    unsafe {
-        spdk_app_opts_init(&mut opts as *mut spdk_app_opts);
-        opts.rpc_addr =
-            CString::new("/var/tmp/mayastor.sock").unwrap().into_raw();
-
-        if let Ok(log_level) = env::var("MAYASTOR_LOGLEVEL") {
-            opts.print_level = match log_level.parse() {
-                Ok(-1) => spdk_sys::SPDK_LOG_DISABLED,
-                Ok(0) => spdk_sys::SPDK_LOG_ERROR,
-                Ok(1) => spdk_sys::SPDK_LOG_WARN,
-                Ok(2) => spdk_sys::SPDK_LOG_NOTICE,
-                Ok(3) => spdk_sys::SPDK_LOG_INFO,
-                Ok(4) => spdk_sys::SPDK_LOG_DEBUG,
-                // default
-                _ => spdk_sys::SPDK_LOG_DEBUG,
-            }
-        } else {
-            opts.print_level = spdk_sys::SPDK_LOG_NOTICE;
-        }
-
-        if spdk_app_parse_args(
-            (c_args.len() as c_int) - 1,
-            c_args.as_ptr() as *mut *mut i8,
-            &mut opts,
-            null_mut(), // extra short options i.e. "f:S:"
-            null_mut(), // extra long options
-            None,       // extra options parse callback
-            Some(usage),
-        ) != spdk_sys::SPDK_APP_PARSE_ARGS_SUCCESS
-        {
-            return -1;
-        }
-    }
-
-    opts.name = CString::new(name).unwrap().into_raw();
-    opts.shutdown_cb = Some(mayastor_shutdown_cb);
-
-    // set the function pointer to use our maya_log function which is statically
-    // linked into the sys create
-    opts.log = Some(maya_log);
-
-    unsafe {
-        // set the pointer which the maya_log function uses after unpacking the
-        // va_list
-        spdk_sys::logfn = Some(log_impl);
-    }
-
-    unsafe {
-        let rc = spdk_app_start(
-            &mut opts,
-            Some(app_start_cb::<F>),
-            // Double box to convert from fat to thin pointer
-            Box::into_raw(Box::new(Box::new(start_cb))) as *mut c_void,
-        );
-
-        // this will remove shm file in /dev/shm and do other cleanups
-        spdk_sys::spdk_app_fini();
-
-        rc
-    }
-}
-
+/// Delay function called from the spdk poller to prevent draining of cpu
+/// in cases when performance is not a priority (i.e. unit tests).
 extern "C" fn developer_delay(_ctx: *mut c_void) -> i32 {
     std::thread::sleep(Duration::from_millis(1));
     0
-}
-
-/// spdk_all_start callback which starts the future executor and finally calls
-/// user provided start callback.
-extern "C" fn app_start_cb<F>(arg1: *mut c_void)
-where
-    F: FnOnce(),
-{
-    // use in cases when you want to burn less cpu and speed does not matter
-    if let Some(_key) = env::var_os("DELAY") {
-        warn!("*** Delaying reactor every 1000us ***");
-        unsafe {
-            spdk_sys::spdk_poller_register(
-                Some(developer_delay),
-                std::ptr::null_mut(),
-                1000,
-            )
-        };
-    }
-    let address = match env::var("MY_POD_IP") {
-        Ok(val) => {
-            let _ipv4: Ipv4Addr = match val.parse() {
-                Ok(val) => val,
-                Err(_) => {
-                    error!("Invalid IP address: MY_POD_IP={}", val);
-                    mayastor_stop(-1);
-                    return;
-                }
-            };
-            val
-        }
-        Err(_) => "127.0.0.1".to_owned(),
-    };
-    executor::start();
-    pool::register_pool_methods();
-    replica::register_replica_methods();
-    if let Err(msg) = iscsi_target::init_iscsi(&address) {
-        error!("Failed to initialize Mayastor iscsi: {}", msg);
-        mayastor_stop(-1);
-        return;
-    }
-
-    // asynchronous initialization routines
-    let fut = async move {
-        if let Err(msg) = nvmf_target::init_nvmf(&address).await {
-            error!("Failed to initialize Mayastor nvmf target: {}", msg);
-            mayastor_stop(-1);
-            return;
-        }
-        let cb: Box<Box<F>> = unsafe { Box::from_raw(arg1 as *mut Box<F>) };
-        cb();
-    };
-    executor::spawn(fut);
-}
-
-/// Cleanly exit from the program.
-/// NOTE: Use only on programs started by mayastor_start.
-pub fn mayastor_stop(rc: i32) -> i32 {
-    iscsi_target::fini_iscsi();
-    let fut = async move {
-        if let Err(msg) = nvmf_target::fini_nvmf().await {
-            error!("Failed to finalize nvmf target: {}", msg);
-        }
-    };
-    executor::stop(fut, Box::new(move || unsafe { spdk_app_stop(rc) }));
-    rc
-}
-
-/// A callback called by spdk when it is shutting down.
-unsafe extern "C" fn mayastor_shutdown_cb() {
-    mayastor_stop(0);
 }

--- a/mayastor/src/logger.rs
+++ b/mayastor/src/logger.rs
@@ -1,0 +1,81 @@
+use env_logger::{Builder, Env};
+use log::{logger, Level, Record};
+use spdk_sys::spdk_log_get_print_level;
+use std::{ffi::CStr, io::Write, os::raw::c_char, path::Path};
+
+/// Log messages originating from SPDK, are processed by this function.
+/// Note that the log levels between spdk and rust do not exactly match.
+///
+/// The function should have been unsafe because we dereference raw pointer
+/// arguments, but the pointer in spdk_sys where this fn is assigned expects
+/// a safe function.
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+pub extern "C" fn log_impl(
+    level: i32,
+    file: *const c_char,
+    line: u32,
+    _func: *const c_char,
+    buf: *const c_char,
+    _n: i32, // the number of bytes written into buf
+) {
+    // remove new line characters from the log messages if any
+    let fmt = unsafe { CStr::from_ptr(buf).to_str().unwrap().trim_end() };
+    let filename = unsafe { CStr::from_ptr(file).to_str().unwrap() };
+
+    if unsafe { spdk_log_get_print_level() } < level {
+        return;
+    }
+
+    let lvl = match level {
+        spdk_sys::SPDK_LOG_DISABLED => return,
+        spdk_sys::SPDK_LOG_ERROR => Level::Error,
+        spdk_sys::SPDK_LOG_WARN => Level::Warn,
+        // the default level for now
+        spdk_sys::SPDK_LOG_INFO => Level::Info,
+        spdk_sys::SPDK_LOG_NOTICE => Level::Debug,
+        spdk_sys::SPDK_LOG_DEBUG => Level::Trace,
+        // if the error level is unknown to us we log it as an error by
+        // default
+        _ => Level::Error,
+    };
+
+    logger().log(
+        &Record::builder()
+            .args(format_args!("{}", fmt))
+            .target(module_path!())
+            .file(Some(filename))
+            .line(Some(line))
+            .level(lvl)
+            .build(),
+    );
+}
+
+/// This function configures the logging format. The loglevel is also processed
+/// here i.e `RUST_LOG=mayastor=TRACE` will print all trace!() and higher
+/// messages to the console.
+///
+/// We might want to suppress certain messages, as some of them are redundant,
+/// in particular, the NOTICE messages as such, they are mapped to debug.
+pub fn init(level: &str) {
+    let mut builder =
+        Builder::from_env(Env::default().default_filter_or(level.to_string()));
+
+    builder.format(|buf, record| {
+        let mut level_style = buf.default_level_style(record.level());
+        level_style.set_intense(true);
+        writeln!(
+            buf,
+            "[{} {} {}:{}] {}",
+            buf.timestamp_nanos(),
+            level_style.value(record.level()),
+            Path::new(record.file().unwrap())
+                .file_name()
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            record.line().unwrap(),
+            record.args()
+        )
+    });
+    builder.init();
+}

--- a/mayastor/src/spdklog.rs
+++ b/mayastor/src/spdklog.rs
@@ -1,5 +1,9 @@
 //! Logger implementation for standard rust log module piping all log messages
 //! to spdk logger. Some code here has been borrowed from stderr rust logger.
+//!
+//! NOTE: It is not used anymore as instead of sending log messages to spdk
+//! we send them from spdk to rust which has greater capabilities (i.e. colored
+//! output).
 
 use log::{Level, LevelFilter, Log, Metadata, Record};
 use std::ffi::CString;

--- a/mayastor/tests/common/mod.rs
+++ b/mayastor/tests/common/mod.rs
@@ -1,9 +1,9 @@
-use mayastor::mayastor_logger_init;
+use mayastor::logger;
 use run_script::{self, ScriptOptions};
 use std::{env, io, io::Write, process::Command};
 
 pub fn mayastor_test_init() {
-    mayastor_logger_init("TRACE");
+    logger::init("DEBUG");
     env::set_var("MAYASTOR_LOGLEVEL", "4");
     mayastor::CPS_INIT!();
 }


### PR DESCRIPTION
Move legacy mayastor start/stop functions to app module.
Move log related functions to logger module.
Set log level for rust unit tests to debug (instead of trace).
spdklog module is not used but left in the source tree just in case.

PS: This eliminates the need for MY_POD_IP workaround when running the initiator on the same host with mayastor. It moves legacy start code from a sight not to confuse it with new mayastor env code. I assume that it lowers the required hp memory by a bit but still not enough to run mayastor on the same host with initiator while having 1G of memory in hugepages. The main culprit is iscsi initiator/target in spdk which reserves large memory pools for IO. This could be solved by tuning the IO depth etc, which is possible to do with a configuration file. This PR does not aim to solve this problem.