### PR TITLE
Fix warning message re registered poller when ms, initiator and spdk exits

### DIFF
--- a/mayastor-test/test_common.js
+++ b/mayastor-test/test_common.js
@@ -170,7 +170,7 @@ function startSpdk(config, args, env) {
     args,
     _.assign(
       {
-        DELAY: '1',
+        MAYASTOR_DELAY: '1',
       },
       env
     ),
@@ -199,7 +199,7 @@ function startMayastor(config, args, env) {
     _.assign(
       {
         MY_POD_IP: getMyIp(),
-        DELAY: '1',
+        MAYASTOR_DELAY: '1',
       },
       env
     ),

--- a/mayastor/src/delay.rs
+++ b/mayastor/src/delay.rs
@@ -1,0 +1,41 @@
+use spdk_sys::{spdk_poller, spdk_poller_register, spdk_poller_unregister};
+use std::{cell::RefCell, os::raw::c_void, time::Duration};
+
+thread_local! {
+    /// Delay poller pointer for unregistering the poller at the end
+    static DELAY_POLLER: RefCell<Option<*mut spdk_poller>> = RefCell::new(None);
+}
+
+/// Delay function called from the spdk poller to prevent draining of cpu
+/// in cases when performance is not a priority (i.e. unit tests).
+extern "C" fn sleep(_ctx: *mut c_void) -> i32 {
+    std::thread::sleep(Duration::from_millis(1));
+    0
+}
+
+/// Start delaying reactor every 1ms by 1ms. It blocks the thread for a
+/// short moment so it is not able to perform any useful work when sleeping.
+pub fn register() {
+    warn!("*** Delaying reactor every 1ms by 1ms ***");
+    let delay_poller = unsafe {
+        spdk_poller_register(Some(sleep), std::ptr::null_mut(), 1000)
+    };
+    DELAY_POLLER.with(move |poller_cell| {
+        let mut poller_maybe = poller_cell.try_borrow_mut().unwrap();
+        if poller_maybe.is_some() {
+            panic!("Delay poller registered twice");
+        }
+        *poller_maybe = Some(delay_poller);
+    });
+}
+
+// By unregistering the delay poller we avoid a warning about unregistered
+// poller at the end.
+pub fn unregister() {
+    DELAY_POLLER.with(move |poller_cell| {
+        let poller_maybe = poller_cell.try_borrow_mut().unwrap().take();
+        if let Some(mut poller) = poller_maybe {
+            unsafe { spdk_poller_unregister(&mut poller) };
+        }
+    });
+}

--- a/mayastor/src/lib.rs
+++ b/mayastor/src/lib.rs
@@ -11,11 +11,10 @@ extern crate serde_json;
 extern crate snafu;
 extern crate spdk_sys;
 
-use std::{os::raw::c_void, time::Duration};
-
 pub mod aio_dev;
 pub mod app;
 pub mod bdev;
+pub mod delay;
 pub mod descriptor;
 pub mod dma;
 pub mod environment;
@@ -45,11 +44,4 @@ macro_rules! CPS_INIT {
 
 pub extern "C" fn cps_init() {
     bdev::nexus::register_module();
-}
-
-/// Delay function called from the spdk poller to prevent draining of cpu
-/// in cases when performance is not a priority (i.e. unit tests).
-extern "C" fn developer_delay(_ctx: *mut c_void) -> i32 {
-    std::thread::sleep(Duration::from_millis(1));
-    0
 }


### PR DESCRIPTION
The annoying message was caused by forgetting to unregister the delay
poller at the end. Other changes:

* DELAY was renamed to MAYASTOR_DELAY to avoid accidental name clash
* The delay code was repeated at three places -> single reusable module