### PR TITLE
mayastor: switch to upstream tonic-rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,6 +19,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7b8a9123b8027467bce0099fe556c628a53c8d83df0507084c31e9ba2e39aff"
+
+[[package]]
 name = "assert_matches"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -30,8 +36,18 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb6fa015ebe961e9908ca4c1854e7dc7aabd4417da77b6a0466e4dfb4c8f6f69"
 dependencies = [
- "async-stream-impl",
+ "async-stream-impl 0.1.1",
  "futures-core-preview",
+]
+
+[[package]]
+name = "async-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58982858be7540a465c790b95aaea6710e5139bf8956b1d1344d014fa40100b0"
+dependencies = [
+ "async-stream-impl 0.2.0",
+ "futures-core",
 ]
 
 [[package]]
@@ -40,28 +56,40 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f0d8c5b411e36dcfb04388bacfec54795726b1f0148adcb0f377a96d6747e0e"
 dependencies = [
- "proc-macro2 1.0.6",
+ "proc-macro2 1.0.7",
  "quote 1.0.2",
- "syn 1.0.11",
+ "syn 1.0.13",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "393356ed99aa7bff0ac486dde592633b83ab02bd254d8c209d5b9f1d0f533480"
+dependencies = [
+ "proc-macro2 1.0.7",
+ "quote 1.0.2",
+ "syn 1.0.13",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6dd385bb33043b833ba049048d57bdbb4d654a121ed68c71871ca51ff67070"
+checksum = "c8df72488e87761e772f14ae0c2480396810e51b2c2ade912f97f0f7e5b95e3c"
 dependencies = [
- "proc-macro2 1.0.6",
+ "proc-macro2 1.0.7",
  "quote 1.0.2",
- "syn 1.0.11",
+ "syn 1.0.13",
 ]
 
 [[package]]
 name = "atty"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
+ "hermit-abi",
  "libc",
  "winapi 0.3.8",
 ]
@@ -73,10 +101,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
 
 [[package]]
-name = "backtrace"
-version = "0.3.40"
+name = "autocfg"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "924c76597f0d9ca25d762c25a4d369d51267536465dc5064bdf0eb073ed477ea"
+checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
+
+[[package]]
+name = "backtrace"
+version = "0.3.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ed64ae6d9ebfd9893193c4b2532b1292ec97bd8271c9d7d0fa90cd78a34cba"
 dependencies = [
  "backtrace-sys",
  "cfg-if",
@@ -210,6 +244,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytes"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10004c15deb332055f7a4a208190aed362cf9a7c2f6ab70a305fba50e1105f38"
+
+[[package]]
 name = "bytesize"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -226,9 +266,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.48"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52a465a666ca3d838ebbf08b241383421412fe7ebb463527bba275526d89f76"
+checksum = "95e28fa049fda1c330bcf9d723be7663a899c4679724b34c81e9f5a326aab8cd"
 
 [[package]]
 name = "cexpr"
@@ -316,48 +356,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-channel"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ec7fcd21571dc78f96cc96243cab8d8f035247c3efd16c687be154c3fa9efa"
-dependencies = [
- "crossbeam-utils 0.6.6",
-]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3aa945d63861bfe624b55d153a39684da1e8c0bc8fba932f7ee3a3c16cea3ca"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils 0.7.0",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5064ebdbf05ce3cb95e45c8b086f72263f4166b29b97f6baff7ef7fe047b55ac"
-dependencies = [
- "autocfg",
- "cfg-if",
- "crossbeam-utils 0.7.0",
- "lazy_static",
- "memoffset",
- "scopeguard 1.0.0",
-]
-
-[[package]]
-name = "crossbeam-queue"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c979cd6cfe72335896575c6b5688da489e420d36a27a0b9eb0c73db574b4a4b"
-dependencies = [
- "crossbeam-utils 0.6.6",
-]
-
-[[package]]
 name = "crossbeam-utils"
 version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -368,38 +366,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-utils"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce446db02cdc3165b94ae73111e570793400d0794e46125cc4056c81cbb039f4"
-dependencies = [
- "autocfg",
- "cfg-if",
- "lazy_static",
-]
-
-[[package]]
 name = "csi"
 version = "0.1.0"
 dependencies = [
- "async-stream",
+ "async-stream 0.1.2",
  "blkid",
- "bytes",
+ "bytes 0.4.12",
  "bytesize",
  "chrono",
  "clap",
  "env_logger 0.7.1",
- "futures-preview",
- "futures-util-preview",
+ "futures",
  "git-version",
  "glob 0.3.0",
- "http",
- "http-body",
+ "http 0.1.21",
+ "http-body 0.2.0",
  "jsonrpc",
  "libc",
  "log",
  "loopdev",
- "nix 0.16.0",
+ "nix 0.16.1",
  "proc-mounts",
  "prost",
  "prost-build",
@@ -411,13 +397,10 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sys-mount",
- "sysfs",
  "tokio",
- "tokio-net",
  "tonic",
  "tonic-build",
  "tower",
- "tracing-log",
 ]
 
 [[package]]
@@ -465,10 +448,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b41487fadaa500d02a819eefcde5f713599a01dd51626ef25d2d72d87115667b"
 dependencies = [
  "proc-macro-error",
- "proc-macro2 1.0.6",
+ "proc-macro2 1.0.7",
  "quote 1.0.2",
  "rustc_version",
- "syn 1.0.11",
+ "syn 1.0.13",
  "synstructure",
 ]
 
@@ -537,14 +520,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
+name = "futures"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f16056ecbb57525ff698bb955162d0cd03bee84e6241c27ff75c08d8ca5987"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcae98ca17d102fd8a3603727b9259fcf7fa4239b603d2142926189bc8999b86"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
 name = "futures-channel-preview"
 version = "0.3.0-alpha.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5e5f4df964fa9c1c2f8bddeb5c3611631cacd93baf810fc8bb2fb4b495c263a"
 dependencies = [
  "futures-core-preview",
- "futures-sink-preview",
 ]
+
+[[package]]
+name = "futures-core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79564c427afefab1dfb3298535b21eda083ef7935b4f0ecbfcb121f0aec10866"
 
 [[package]]
 name = "futures-core-preview"
@@ -553,35 +566,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b35b6263fb1ef523c3056565fa67b1d16f0a8604ff12b11b08c25f28a734c60a"
 
 [[package]]
-name = "futures-executor-preview"
-version = "0.3.0-alpha.19"
+name = "futures-executor"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75236e88bd9fe88e5e8bfcd175b665d0528fe03ca4c5207fabc028c8f9d93e98"
+checksum = "1e274736563f686a837a0568b478bdabfeaec2dca794b5649b04e2fe1627c231"
 dependencies = [
- "futures-core-preview",
- "futures-util-preview",
- "num_cpus",
+ "futures-core",
+ "futures-task",
+ "futures-util",
 ]
 
 [[package]]
-name = "futures-io-preview"
-version = "0.3.0-alpha.19"
+name = "futures-io"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4914ae450db1921a56c91bde97a27846287d062087d4a652efc09bb3a01ebda"
+checksum = "e676577d229e70952ab25f3945795ba5b16d63ca794ca9d2c860e5595d20b5ff"
 
 [[package]]
-name = "futures-preview"
-version = "0.3.0-alpha.19"
+name = "futures-macro"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b1dce2a0267ada5c6ff75a8ba864b4e679a9e2aa44262af7a3b5516d530d76e"
+checksum = "52e7c56c15537adb4f76d0b7a76ad131cb4d2f4f32d3b0bcabcbe1c7c5e87764"
 dependencies = [
- "futures-channel-preview",
- "futures-core-preview",
- "futures-executor-preview",
- "futures-io-preview",
- "futures-sink-preview",
- "futures-util-preview",
+ "proc-macro-hack",
+ "proc-macro2 1.0.7",
+ "quote 1.0.2",
+ "syn 1.0.13",
 ]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "171be33efae63c2d59e6dbba34186fe0d6394fb378069a76dfd80fdcffd43c16"
 
 [[package]]
 name = "futures-sink-preview"
@@ -590,14 +607,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86f148ef6b69f75bb610d4f9a2336d4fc88c4b5b67129d1a340dd0fd362efeec"
 
 [[package]]
-name = "futures-timer"
-version = "0.4.0"
+name = "futures-task"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "878f1d2fc31355fa02ed2372e741b0c17e58373341e6a122569b4623a14a7d33"
+checksum = "0bae52d6b29cf440e298856fec3965ee6fa71b06aa7495178615953fd669e5f9"
+
+[[package]]
+name = "futures-timer"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1de7508b218029b0f01662ed8f61b1c964b3ae99d6f25462d0f55a595109df6"
+
+[[package]]
+name = "futures-util"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0d66274fb76985d3c62c886d1da7ac4c0903a8c9f754e8fe0f35a6a6cc39e76"
 dependencies = [
- "futures-core-preview",
- "futures-util-preview",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
  "pin-utils",
+ "proc-macro-hack",
+ "proc-macro-nested",
+ "slab",
 ]
 
 [[package]]
@@ -608,9 +645,6 @@ checksum = "5ce968633c17e5f97936bd2797b6e38fb56cf16a7422319f7ec2e30d3c470e8d"
 dependencies = [
  "futures-channel-preview",
  "futures-core-preview",
- "futures-io-preview",
- "futures-sink-preview",
- "memchr",
  "pin-utils",
  "slab",
 ]
@@ -623,9 +657,9 @@ checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 
 [[package]]
 name = "getrandom"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7db7ca94ed4cd01190ceee0d8a8052f08a247aa1b469a7f68c6a3b71afcf407"
+checksum = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
 dependencies = [
  "cfg-if",
  "libc",
@@ -634,9 +668,9 @@ dependencies = [
 
 [[package]]
 name = "git-version"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ec7e5984df8e27b2387a44b442376e72f7cf779dd61a94cf73f876fe39964ac"
+checksum = "94918e83f1e01dedc2e361d00ce9487b14c58c7f40bab148026fa39d42cb41e2"
 dependencies = [
  "git-version-macro",
  "proc-macro-hack",
@@ -644,14 +678,14 @@ dependencies = [
 
 [[package]]
 name = "git-version-macro"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3e3ccc888320973ac873ca5068b1126726d5ad7c034188ca086d74be5ff34fa"
+checksum = "34a97a52fdee1870a34fa6e4b77570cba531b27d1838874fef4429a791a3d657"
 dependencies = [
  "proc-macro-hack",
- "proc-macro2 1.0.6",
+ "proc-macro2 1.0.7",
  "quote 1.0.2",
- "syn 1.0.11",
+ "syn 1.0.13",
 ]
 
 [[package]]
@@ -668,22 +702,20 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "h2"
-version = "0.2.0-alpha.3"
-source = "git+https://github.com/gila/h2#8a35f9f793dffc47f53ad95c89124b024a5d13a4"
+version = "0.2.1"
+source = "git+https://github.com/gila/h2#86845fd165d20cc9d93a422b030aab2dafc1c842"
 dependencies = [
- "bytes",
+ "bytes 0.5.3",
  "fnv",
- "futures-core-preview",
- "futures-sink-preview",
- "futures-util-preview",
- "http",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 0.2.0",
  "indexmap",
  "log",
  "slab",
- "string",
- "tokio-codec",
- "tokio-io",
- "tokio-sync",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -707,9 +739,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f629dc602392d3ec14bfc8a09b5e644d7ffd725102b48b81e59f90f2633621d7"
+checksum = "eff2656d88f158ce120947499e971d743c05dbcbed62e5bd2f38f1698bbc3772"
 dependencies = [
  "libc",
 ]
@@ -720,19 +752,40 @@ version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6ccf5ede3a895d8856620237b2f02972c1bbc78d2965ad7fe8838d4a0ed41f0"
 dependencies = [
- "bytes",
+ "bytes 0.4.12",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b708cc7f06493459026f53b9a61a7a121a5d1ec6238dee58ea4941132b30156b"
+dependencies = [
+ "bytes 0.5.3",
  "fnv",
  "itoa",
 ]
 
 [[package]]
 name = "http-body"
-version = "0.2.0-alpha.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3aef6f3de2bd8585f5b366f3f550b5774500b4764d00cf00f903c95749eec3"
+checksum = "d4908999be8b408e507d4148f3374a6f9e34e941f2d8c3928b1d565f1453291d"
 dependencies = [
- "bytes",
- "http",
+ "bytes 0.5.3",
+ "http 0.2.0",
+]
+
+[[package]]
+name = "http-body"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b"
+dependencies = [
+ "bytes 0.5.3",
+ "http 0.2.0",
 ]
 
 [[package]]
@@ -752,44 +805,26 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.13.0-alpha.4"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d05aa523087ac0b9d8b93dd80d5d482a697308ed3b0dca7b0667511a7fa7cdc"
+checksum = "8bf49cfb32edee45d890537d9057d1b02ed55f53b7b6a30bae83a38c9231749e"
 dependencies = [
- "bytes",
- "futures-channel-preview",
- "futures-core-preview",
- "futures-util-preview",
+ "bytes 0.5.3",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
  "h2",
- "http",
- "http-body",
+ "http 0.2.0",
+ "http-body 0.3.1",
  "httparse",
- "iovec",
  "itoa",
  "log",
  "net2",
  "pin-project",
  "time",
  "tokio",
- "tokio-executor",
- "tokio-io",
- "tokio-net",
- "tokio-sync",
- "tokio-timer",
- "tower-make",
  "tower-service",
  "want",
-]
-
-[[package]]
-name = "idna"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
-dependencies = [
- "matches",
- "unicode-bidi",
- "unicode-normalization",
 ]
 
 [[package]]
@@ -809,7 +844,7 @@ version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712d7b3ea5827fcb9d4fda14bf4da5f136f0db2ae9c8f4bd4e2d1c6fde4e6db2"
 dependencies = [
- "autocfg",
+ "autocfg 0.1.7",
 ]
 
 [[package]]
@@ -846,14 +881,12 @@ checksum = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 name = "jsonrpc"
 version = "0.1.0"
 dependencies = [
- "futures-preview",
  "log",
  "nix 0.14.1",
  "serde",
  "serde_derive",
  "serde_json",
  "tokio",
- "tokio-net",
  "tonic",
 ]
 
@@ -872,9 +905,6 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-dependencies = [
- "spin",
-]
 
 [[package]]
 name = "libc"
@@ -894,18 +924,18 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e57b3997725d2b60dbec1297f6c2e2957cc383db1cebd6be812163f969c7d586"
+checksum = "79b2de95ecb4691949fea4716ca53cdbcfccb2c612e19644a8bad05edcf9f47b"
 dependencies = [
  "scopeguard 1.0.0",
 ]
 
 [[package]]
 name = "log"
-version = "0.4.10"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ad466a945c9c40f6f9a449c55675547e59bc75a2722d4689042ab3ae80c9c"
+checksum = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 dependencies = [
  "cfg-if",
 ]
@@ -933,18 +963,18 @@ dependencies = [
  "assert_matches",
  "bincode",
  "byte-unit",
- "bytes",
+ "bytes 0.4.12",
  "clap",
  "crc",
  "env_logger 0.7.1",
- "futures-preview",
+ "futures",
  "futures-timer",
  "git-version",
  "ioctl-gen",
  "lazy_static",
  "libc",
  "log",
- "nix 0.16.0",
+ "nix 0.16.1",
  "rpc",
  "run_script",
  "serde",
@@ -953,8 +983,7 @@ dependencies = [
  "spdk-sys",
  "structopt",
  "sysfs",
- "url 2.1.0",
- "url_serde",
+ "url",
  "uuid",
 ]
 
@@ -966,18 +995,9 @@ checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 
 [[package]]
 name = "memchr"
-version = "2.2.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
-
-[[package]]
-name = "memoffset"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75189eb85871ea5c2e2c15abbdd541185f63b408415e5051f5cac122d8c774b9"
-dependencies = [
- "rustc_version",
-]
+checksum = "3197e20c7edb283f87c071ddfc7a2cca8f8e0b888c242959846a6fce03c72223"
 
 [[package]]
 name = "mio"
@@ -992,10 +1012,22 @@ dependencies = [
  "kernel32-sys",
  "libc",
  "log",
- "miow",
+ "miow 0.2.1",
  "net2",
  "slab",
  "winapi 0.2.8",
+]
+
+[[package]]
+name = "mio-named-pipes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5e374eff525ce1c5b7687c4cef63943e7686524a387933ad27ca7ec43779cb3"
+dependencies = [
+ "log",
+ "mio",
+ "miow 0.3.3",
+ "winapi 0.3.8",
 ]
 
 [[package]]
@@ -1019,6 +1051,16 @@ dependencies = [
  "net2",
  "winapi 0.2.8",
  "ws2_32-sys",
+]
+
+[[package]]
+name = "miow"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "396aa0f2003d7df8395cb93e09871561ccc3e785f0acb369170e8cc74ddf9226"
+dependencies = [
+ "socket2",
+ "winapi 0.3.8",
 ]
 
 [[package]]
@@ -1053,9 +1095,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19a8300bf427d432716764070ff70d5b2b7801c958b9049686e6cbd8b06fad92"
+checksum = "dd0eaf8df8bab402257e0a5c17a254e4cc1f72a93588a1ddfb5d356c801aa7cb"
 dependencies = [
  "bitflags",
  "cc",
@@ -1076,21 +1118,21 @@ dependencies = [
 
 [[package]]
 name = "num-integer"
-version = "0.1.41"
+version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b85e541ef8255f6cf42bbfe4ef361305c6c135d10919ecc26126c4e5ae94bc09"
+checksum = "3f6ea62e9d81a77cd3ee9a2a5b9b609447857f3d358704331e4ef39eb247fcba"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.0",
  "num-traits",
 ]
 
 [[package]]
 name = "num-traits"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4c81ffc11c212fa327657cb19dd85eb7419e163b5b076bede2bdb5c974c07e4"
+checksum = "c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.0",
 ]
 
 [[package]]
@@ -1180,10 +1222,16 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44ca92f893f0656d3cba8158dd0f2b99b94de256a4a54e870bd6922fcc6c8355"
 dependencies = [
- "proc-macro2 1.0.6",
+ "proc-macro2 1.0.7",
  "quote 1.0.2",
- "syn 1.0.11",
+ "syn 1.0.13",
 ]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8822eb8bb72452f038ebf6048efa02c3fe22bf83f76519c9583e47fc194a422"
 
 [[package]]
 name = "pin-utils"
@@ -1203,9 +1251,9 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aeccfe4d5d8ea175d5f0e4a2ad0637e0f4121d63bd99d356fb1f39ab2e7c6097"
 dependencies = [
- "proc-macro2 1.0.6",
+ "proc-macro2 1.0.7",
  "quote 1.0.2",
- "syn 1.0.11",
+ "syn 1.0.13",
 ]
 
 [[package]]
@@ -1214,10 +1262,16 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ecd45702f76d6d3c75a80564378ae228a85f0b59d2f3ed43c91b4a69eb2ebfc5"
 dependencies = [
- "proc-macro2 1.0.6",
+ "proc-macro2 1.0.7",
  "quote 1.0.2",
- "syn 1.0.11",
+ "syn 1.0.13",
 ]
+
+[[package]]
+name = "proc-macro-nested"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "369a6ed065f249a159e06c45752c780bda2fb53c995718f9e484d08daa9eb42e"
 
 [[package]]
 name = "proc-macro2"
@@ -1230,9 +1284,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9e470a8dc4aeae2dee2f335e8f533e2d4b347e1434e5671afc49b054592f27"
+checksum = "0319972dcae462681daf4da1adeeaa066e3ebd29c69be96c6abb1259d2ee2bcc"
 dependencies = [
  "unicode-xid 0.2.0",
 ]
@@ -1254,7 +1308,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d14b1c185652833d24aaad41c5832b0be5616a590227c1fbff57c616754b23"
 dependencies = [
  "byteorder",
- "bytes",
+ "bytes 0.4.12",
  "prost-derive",
 ]
 
@@ -1264,7 +1318,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb788126ea840817128183f8f603dce02cb7aea25c2a0b764359d8e20010702e"
 dependencies = [
- "bytes",
+ "bytes 0.4.12",
  "heck",
  "itertools",
  "log",
@@ -1295,15 +1349,15 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1de482a366941c8d56d19b650fac09ca08508f2a696119ee7513ad590c8bac6f"
 dependencies = [
- "bytes",
+ "bytes 0.4.12",
  "prost",
 ]
 
 [[package]]
 name = "quick-error"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
@@ -1320,7 +1374,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
 dependencies = [
- "proc-macro2 1.0.6",
+ "proc-macro2 1.0.7",
 ]
 
 [[package]]
@@ -1329,7 +1383,7 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
 dependencies = [
- "autocfg",
+ "autocfg 0.1.7",
  "libc",
  "rand_chacha 0.1.1",
  "rand_core 0.4.2",
@@ -1337,22 +1391,23 @@ dependencies = [
  "rand_isaac",
  "rand_jitter",
  "rand_os",
- "rand_pcg",
+ "rand_pcg 0.1.2",
  "rand_xorshift",
  "winapi 0.3.8",
 ]
 
 [[package]]
 name = "rand"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae1b169243eaf61759b8475a998f0a385e42042370f3a7dbaf35246eacc8412"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
  "getrandom",
  "libc",
  "rand_chacha 0.2.1",
  "rand_core 0.5.1",
  "rand_hc 0.2.0",
+ "rand_pcg 0.2.1",
 ]
 
 [[package]]
@@ -1361,7 +1416,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
 dependencies = [
- "autocfg",
+ "autocfg 0.1.7",
  "rand_core 0.3.1",
 ]
 
@@ -1457,8 +1512,17 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
 dependencies = [
- "autocfg",
+ "autocfg 0.1.7",
  "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
+dependencies = [
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -1487,9 +1551,9 @@ checksum = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
 
 [[package]]
 name = "regex"
-version = "1.3.1"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc220bd33bdce8f093101afe22a037b8eb0e5af33592e6a9caafff0d4cb81cbd"
+checksum = "b5508c1941e4e7cb19965abef075d35a9a8b5cdf0846f30b4050e9b55dc55e87"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1499,9 +1563,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.12"
+version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11a7e20d1cce64ef2fed88b66d347f88bd9babb82845b2b858f3edbf59a4f716"
+checksum = "e734e891f5b408a29efbf8309e656876276f49ab6a6ac208600b4419bd893d90"
 
 [[package]]
 name = "remove_dir_all"
@@ -1516,11 +1580,10 @@ dependencies = [
 name = "rpc"
 version = "0.1.0"
 dependencies = [
- "bytes",
+ "bytes 0.4.12",
  "prost",
  "prost-build",
  "prost-derive",
- "prost-types",
  "serde",
  "serde_derive",
  "serde_json",
@@ -1530,11 +1593,11 @@ dependencies = [
 
 [[package]]
 name = "run_script"
-version = "0.3.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61b3a5ed82e15afc3e238178e2d22113af69ac88bd64a04499f025478853937f"
+checksum = "7c0159ae870920e692ef9226b56b831d50abca091e588e43972f3e099b40ca7f"
 dependencies = [
- "rand 0.7.2",
+ "rand 0.7.3",
  "users",
 ]
 
@@ -1601,9 +1664,9 @@ version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "128f9e303a5a29922045a830221b8f78ec74a5f544944f3d5984f8ec3895ef64"
 dependencies = [
- "proc-macro2 1.0.6",
+ "proc-macro2 1.0.7",
  "quote 1.0.2",
- "syn 1.0.11",
+ "syn 1.0.13",
 ]
 
 [[package]]
@@ -1615,6 +1678,16 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f478ede9f64724c5d173d7bb56099ec3e2d9fc2774aac65d34b8b890405f41"
+dependencies = [
+ "arc-swap",
+ "libc",
 ]
 
 [[package]]
@@ -1634,15 +1707,15 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ecf3b85f68e8abaa7555aa5abdb1153079387e60b718283d732f03897fcfc86"
+checksum = "44e59e0c9fa00817912ae6e4e6e3c4fe04455e75699d06eedc7d85917ed8e8f4"
 
 [[package]]
 name = "snafu"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41207ca11f96a62cd34e6b7fdf73d322b25ae3848eb9d38302169724bb32cf27"
+checksum = "65929384f863545b67a696ce36499cd045e5dca834aca85c929401d99a920bad"
 dependencies = [
  "doc-comment",
  "snafu-derive",
@@ -1650,13 +1723,25 @@ dependencies = [
 
 [[package]]
 name = "snafu-derive"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c5e338c8b0577457c9dda8e794b6ad7231c96e25b1b0dd5842d52249020c1c0"
+checksum = "c6d2b1d1afd31abf5e72cc8d21e51443e3eb6b24dcda99ad3c048df5524eae80"
 dependencies = [
- "proc-macro2 1.0.6",
+ "proc-macro2 1.0.7",
  "quote 1.0.2",
- "syn 1.0.11",
+ "syn 1.0.13",
+]
+
+[[package]]
+name = "socket2"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8b74de517221a2cb01a53349cf54182acdc31a074727d3079068448c0676d85"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "winapi 0.3.8",
 ]
 
 [[package]]
@@ -1665,21 +1750,6 @@ version = "0.1.0"
 dependencies = [
  "bindgen 0.47.3",
  "cc",
-]
-
-[[package]]
-name = "spin"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
-
-[[package]]
-name = "string"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d24114bfcceb867ca7f71a0d3fe45d45619ec47a6fbfa98cb14e14250bfa5d6d"
-dependencies = [
- "bytes",
 ]
 
 [[package]]
@@ -1723,11 +1793,11 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.11"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dff0acdb207ae2fe6d5976617f887eb1e35a2ba52c13c7234c790960cdad9238"
+checksum = "1e4ff033220a41d1a57d8125eab57bf5263783dfdcc18688b1dacc6ce9651ef8"
 dependencies = [
- "proc-macro2 1.0.6",
+ "proc-macro2 1.0.7",
  "quote 1.0.2",
  "unicode-xid 0.2.0",
 ]
@@ -1738,9 +1808,9 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
 dependencies = [
- "proc-macro2 1.0.6",
+ "proc-macro2 1.0.7",
  "quote 1.0.2",
- "syn 1.0.11",
+ "syn 1.0.13",
  "unicode-xid 0.2.0",
 ]
 
@@ -1767,7 +1837,7 @@ checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 dependencies = [
  "cfg-if",
  "libc",
- "rand 0.7.2",
+ "rand 0.7.3",
  "redox_syscall",
  "remove_dir_all",
  "winapi 0.3.8",
@@ -1775,11 +1845,11 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.0.5"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96d6098003bde162e4277c70665bd87c326f5a0c3f3fbfb285787fa482d54e6e"
+checksum = "bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f"
 dependencies = [
- "wincolor",
+ "winapi-util",
 ]
 
 [[package]]
@@ -1793,9 +1863,9 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "0.3.6"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
+checksum = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
 dependencies = [
  "lazy_static",
 ]
@@ -1813,24 +1883,26 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "0.2.0-alpha.6"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f17f5d6ab0f35c1506678b28fb1798bdf74fcb737e9843c7b17b73e426eba38"
+checksum = "ffa2fdcfa937b20cb3c822a635ceecd5fc1a27a6a474527e5516aa24b8c8820a"
 dependencies = [
- "bytes",
- "futures-core-preview",
- "futures-sink-preview",
- "futures-util-preview",
+ "bytes 0.5.3",
+ "fnv",
+ "futures-core",
+ "iovec",
+ "lazy_static",
+ "libc",
+ "memchr",
+ "mio",
+ "mio-named-pipes",
+ "mio-uds",
  "num_cpus",
- "tokio-codec",
- "tokio-executor",
- "tokio-fs",
- "tokio-io",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "slab",
  "tokio-macros",
- "tokio-net",
- "tokio-sync",
- "tokio-timer",
- "tracing-core",
+ "winapi 0.3.8",
 ]
 
 [[package]]
@@ -1839,7 +1911,7 @@ version = "0.2.0-alpha.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f5d22fd1e84bd4045d28813491cb7d7caae34d45c80517c2213f09a85e8787a"
 dependencies = [
- "bytes",
+ "bytes 0.4.12",
  "futures-core-preview",
  "futures-sink-preview",
  "log",
@@ -1852,30 +1924,8 @@ version = "0.2.0-alpha.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ee9ceecf69145923834ea73f32ba40c790fd877b74a7817dd0b089f1eb9c7c8"
 dependencies = [
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-queue",
- "crossbeam-utils 0.6.6",
- "futures-core-preview",
  "futures-util-preview",
  "lazy_static",
- "num_cpus",
- "slab",
- "tokio-sync",
- "tracing",
-]
-
-[[package]]
-name = "tokio-fs"
-version = "0.2.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf85e16971e06e680c622e0c1b455be94b086275c5ddcd6d4a83a2bfbb83cda"
-dependencies = [
- "futures-core-preview",
- "futures-util-preview",
- "lazy_static",
- "tokio-executor",
- "tokio-io",
  "tokio-sync",
 ]
 
@@ -1885,21 +1935,19 @@ version = "0.2.0-alpha.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112784d5543df30660b04a72ca423bfbd90e8bb32f94dcf610f15401218b22c5"
 dependencies = [
- "bytes",
+ "bytes 0.4.12",
  "futures-core-preview",
  "log",
- "memchr",
- "pin-project",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "0.2.0-alpha.6"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b616374bcdadd95974e1f0dfca07dc913f1163c53840c0d664aca35114964e"
+checksum = "50a61f268a3db2acee8dcab514efc813dc6dbe8a00e86076f935f94304b59a7a"
 dependencies = [
  "quote 1.0.2",
- "syn 1.0.11",
+ "syn 1.0.13",
 ]
 
 [[package]]
@@ -1908,16 +1956,11 @@ version = "0.2.0-alpha.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a441682cd32f3559383112c4a7f372f5c9fa1950c5cf8c8dd05274a2ce8c2654"
 dependencies = [
- "bytes",
- "crossbeam-utils 0.6.6",
+ "crossbeam-utils",
  "futures-core-preview",
- "futures-sink-preview",
  "futures-util-preview",
- "iovec",
  "lazy_static",
- "libc",
  "mio",
- "mio-uds",
  "num_cpus",
  "parking_lot",
  "slab",
@@ -1936,71 +1979,72 @@ checksum = "4f1aaeb685540f7407ea0e27f1c9757d258c7c6bf4e3eb19da6fc59b747239d2"
 dependencies = [
  "fnv",
  "futures-core-preview",
- "futures-sink-preview",
  "futures-util-preview",
 ]
 
 [[package]]
-name = "tokio-timer"
-version = "0.3.0-alpha.6"
+name = "tokio-util"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97c1587fe71018eb245a4a9daa13a5a3b681bbc1f7fdadfe24720e141472c13"
+checksum = "571da51182ec208780505a32528fc5512a8fe1443ab960b3f2f3ef093cd16930"
 dependencies = [
- "crossbeam-utils 0.6.6",
- "futures-core-preview",
- "futures-util-preview",
- "slab",
- "tokio-executor",
- "tokio-sync",
+ "bytes 0.5.3",
+ "futures-core",
+ "futures-sink",
+ "log",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
 name = "tonic"
-version = "0.1.0-alpha.6"
-source = "git+https://github.com/gila/tonic#b394a3973931ef1b50a36cccd2d8963bb154b2d7"
+version = "0.1.0-beta.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e856eb0eaaf2d71ccde5de981ab09aced2ca4acf397fe33c0a8df67326cb968"
 dependencies = [
- "async-stream",
+ "async-stream 0.2.0",
  "async-trait",
  "base64",
- "bytes",
- "futures-core-preview",
- "futures-util-preview",
- "http",
- "http-body",
+ "bytes 0.5.3",
+ "futures-core",
+ "futures-util",
+ "http 0.2.0",
+ "http-body 0.3.1",
  "hyper",
  "percent-encoding 1.0.1",
  "pin-project",
  "prost",
  "prost-derive",
  "tokio",
- "tokio-codec",
+ "tokio-util",
  "tower",
  "tower-balance",
  "tower-load",
  "tower-make",
  "tower-service",
  "tracing",
+ "tracing-futures",
 ]
 
 [[package]]
 name = "tonic-build"
-version = "0.1.0-alpha.6"
+version = "0.1.0-beta.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a2f25663b822568d660f64a4a9b6af17f51d11a6175781fa2391786a224665"
+checksum = "3fd6e2f53c54cd28efefa13cd081160a85eb913d280beee99b1bd3f9ca219048"
 dependencies = [
- "proc-macro2 1.0.6",
+ "proc-macro2 1.0.7",
  "prost-build",
  "quote 1.0.2",
- "syn 1.0.11",
+ "syn 1.0.13",
 ]
 
 [[package]]
 name = "tower"
-version = "0.3.0-alpha.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05ce6a5913c351c65d5538545302eceaf3f84e8257654370d298c3ea1a97935"
+checksum = "4b299df54795e6f72bca45063b5803d1f9a1ba9b11a3c7c64d0b84519b451fdd"
 dependencies = [
- "futures-core-preview",
+ "futures-core",
  "tower-buffer",
  "tower-discover",
  "tower-layer",
@@ -2014,36 +2058,35 @@ dependencies = [
 
 [[package]]
 name = "tower-balance"
-version = "0.3.0-alpha.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38dce028671196b8e89965a7b057b8e4bc99206185c0418ce8d164fe674c9d72"
+checksum = "a792277613b7052448851efcf98a2c433e6f1d01460832dc60bef676bc275d4c"
 dependencies = [
- "futures-core-preview",
- "futures-util-preview",
+ "futures-core",
+ "futures-util",
  "indexmap",
  "pin-project",
- "rand 0.6.5",
+ "rand 0.7.3",
  "slab",
- "tokio-sync",
- "tokio-timer",
+ "tokio",
  "tower-discover",
  "tower-layer",
  "tower-load",
  "tower-make",
+ "tower-ready-cache",
  "tower-service",
  "tracing",
 ]
 
 [[package]]
 name = "tower-buffer"
-version = "0.3.0-alpha.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb66caab441682c3eac396617cbc1c2bd8962589468d08be3b05cb6875200694"
+checksum = "c4887dc2a65d464c8b9b66e0e4d51c2fd6cf5b3373afc72805b0a60bce00446a"
 dependencies = [
- "futures-core-preview",
+ "futures-core",
  "pin-project",
- "tokio-executor",
- "tokio-sync",
+ "tokio",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -2051,56 +2094,55 @@ dependencies = [
 
 [[package]]
 name = "tower-discover"
-version = "0.3.0-alpha.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fba86e21286ce7aa7735c9a12801384a34493ae0fae6a9767fafc22b3968a2e9"
+checksum = "0f6b5000c3c54d269cc695dff28136bb33d08cbf1df2c48129e143ab65bf3c2a"
 dependencies = [
- "futures-core-preview",
+ "futures-core",
  "pin-project",
  "tower-service",
 ]
 
 [[package]]
 name = "tower-layer"
-version = "0.3.0-alpha.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44458625be64d57b07579ddf7408ba5111853474893980ad81c2e9c56ad2d2e2"
+checksum = "a35d656f2638b288b33495d1053ea74c40dc05ec0b92084dd71ca5566c4ed1dc"
 
 [[package]]
 name = "tower-limit"
-version = "0.3.0-alpha.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f630ef814d59b52ea79f37ad78d9d88669d11ff29b92eb72d36b3a32af80681a"
+checksum = "0a4030a1dc1ab99ec6fc9475fc18c62f6cc4da035d370fcbd22fe342f9dd16cd"
 dependencies = [
- "futures-core-preview",
+ "futures-core",
  "pin-project",
- "tokio-sync",
- "tokio-timer",
+ "tokio",
  "tower-layer",
  "tower-service",
 ]
 
 [[package]]
 name = "tower-load"
-version = "0.3.0-alpha.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87335a79d9928ea6353ff6cc12470584ff16229783c738fbb169c3a13698a5bc"
+checksum = "8cc79fc3afd07492b7966d7efa7c6c50f8ed58d768a6075dd7ae6591c5d2017b"
 dependencies = [
- "futures-core-preview",
+ "futures-core",
  "log",
  "pin-project",
- "tokio-timer",
+ "tokio",
  "tower-discover",
  "tower-service",
 ]
 
 [[package]]
 name = "tower-load-shed"
-version = "0.3.0-alpha.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2da88d27937d6960520fdfcfbc52c35f7535e65bcb2ddeda3f2246b70eb2de1"
+checksum = "9f021e23900173dc315feb4b6922510dae3e79c689b74c089112066c11f0ae4e"
 dependencies = [
- "futures-core-preview",
+ "futures-core",
  "pin-project",
  "tower-layer",
  "tower-service",
@@ -2108,101 +2150,110 @@ dependencies = [
 
 [[package]]
 name = "tower-make"
-version = "0.3.0-alpha.2a"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "316d47dd40cde4ac5d88110eaf9a10a4e2a68612d9c056cd2aa24e37dcb484cd"
+checksum = "ce50370d644a0364bf4877ffd4f76404156a248d104e2cc234cd391ea5cdc965"
 dependencies = [
- "tokio-io",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-ready-cache"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2183d0a00b68a41c0af9e281cf51f40c7de2e1d4af4a43f92a5c35bbe7728d7"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap",
+ "log",
+ "tokio",
  "tower-service",
 ]
 
 [[package]]
 name = "tower-retry"
-version = "0.3.0-alpha.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bb37b898570d5a50c10c50ee254563853f8445fc23e261cffc747beb1a84618"
+checksum = "e6727956aaa2f8957d4d9232b308fe8e4e65d99db30f42b225646e86c9b6a952"
 dependencies = [
- "futures-core-preview",
+ "futures-core",
  "pin-project",
- "tokio-timer",
+ "tokio",
  "tower-layer",
  "tower-service",
 ]
 
 [[package]]
 name = "tower-service"
-version = "0.3.0-alpha.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63ff37396cd966ce43bea418bfa339f802857495f797dafa00bea5b7221ebdfa"
+checksum = "e987b6bf443f4b5b3b6f38704195592cca41c5bb7aedd3c3693c7081f8289860"
 
 [[package]]
 name = "tower-timeout"
-version = "0.3.0-alpha.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a43f7de8a757264c7949c3cb109a89e4ec9f2a3dd938804d3a0cb521862b35ff"
+checksum = "127b8924b357be938823eaaec0608c482d40add25609481027b96198b2e4b31e"
 dependencies = [
  "pin-project",
- "tokio-timer",
+ "tokio",
  "tower-layer",
  "tower-service",
 ]
 
 [[package]]
 name = "tower-util"
-version = "0.3.0-alpha.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aef810d487f4d67df42064a69f58572413b9cb37b177d363921762ac5a9eb76b"
+checksum = "5702d7890e35b2aae6ee420e8a762547505dbed30c075fbc84ec069a0aa18314"
 dependencies = [
- "futures-core-preview",
- "futures-util-preview",
+ "futures-core",
+ "futures-util",
  "pin-project",
- "tower-layer",
  "tower-service",
 ]
 
 [[package]]
 name = "tracing"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff4e4f59e752cb3beb5b61c6d5e11191c7946231ba84faec2902c9efdd8691c5"
+checksum = "6de6a8590a29d3f401eab60470c699efa0adf7b4f0352055bf24df2b69849b40"
 dependencies = [
  "cfg-if",
  "log",
- "spin",
  "tracing-attributes",
  "tracing-core",
 ]
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4263b12c3d3c403274493eb805966093b53214124796552d674ca1dd5d27c2b"
+checksum = "04cfd395def5a60236e187e1ff905cb55668a59f29928dec05e6e1b1fd2ac1f3"
 dependencies = [
  "quote 1.0.2",
- "syn 1.0.11",
+ "syn 1.0.13",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.7"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc913647c520c959b6d21e35ed8fa6984971deca9f0a2fcb8c51207e0c56af1d"
+checksum = "13a46f11e372b8bd4b4398ea54353412fdd7fd42a8370c7e543e218cf7661978"
 dependencies = [
  "lazy_static",
- "spin",
 ]
 
 [[package]]
-name = "tracing-log"
-version = "0.1.1"
+name = "tracing-futures"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e0f8c7178e13481ff6765bd169b33e8d554c5d2bbede5e32c356194be02b9b9"
+checksum = "107ae59580d2a1d994b6b965b16fe94c969fe86d3f7fd2572a1ee243bcaf7f09"
 dependencies = [
- "env_logger 0.6.2",
- "lazy_static",
- "log",
- "tracing-core",
+ "pin-project",
+ "tracing",
 ]
 
 [[package]]
@@ -2226,7 +2277,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b561e267b2326bb4cebfc0ef9e68355c7abe6c6f522aeac2f5bf95d56c59bdcf"
 dependencies = [
- "smallvec 1.0.0",
+ "smallvec 1.1.0",
 ]
 
 [[package]]
@@ -2255,34 +2306,13 @@ checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 
 [[package]]
 name = "url"
-version = "1.7.2"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
+checksum = "829d4a8476c35c9bf0bbce5a3b23f4106f79728039b726d292bb93bc106787cb"
 dependencies = [
- "idna 0.1.5",
- "matches",
- "percent-encoding 1.0.1",
-]
-
-[[package]]
-name = "url"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b414f6c464c879d7f9babf951f23bc3743fb7313c081b2e6ca719067ea9d61"
-dependencies = [
- "idna 0.2.0",
+ "idna",
  "matches",
  "percent-encoding 2.1.0",
-]
-
-[[package]]
-name = "url_serde"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74e7d099f1ee52f823d4bdd60c93c3602043c728f5db3b97bdb548467f7bddea"
-dependencies = [
- "serde",
- "url 1.7.2",
 ]
 
 [[package]]
@@ -2333,9 +2363,9 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.7.0"
+version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b89c3ce4ce14bdc6fb6beaf9ec7928ca331de5df7e5ea278375642a2f478570d"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "which"
@@ -2377,9 +2407,9 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7168bab6e1daee33b4557efd0e95d5ca70a03706d39fa5f3fe7a236f584b03c9"
+checksum = "4ccfbf554c6ad11084fb7517daca16cfdcaccbdadba4fc336f032a8b12c2ad80"
 dependencies = [
  "winapi 0.3.8",
 ]
@@ -2389,16 +2419,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "wincolor"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96f5016b18804d24db43cebf3c77269e7569b8954a8464501c216cc5e070eaa9"
-dependencies = [
- "winapi 0.3.8",
- "winapi-util",
-]
 
 [[package]]
 name = "ws2_32-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,5 @@
 [patch.crates-io]
 h2 = { git = "https://github.com/gila/h2", branch = "master"}
-tonic = { git = "https://github.com/gila/tonic", branch = "master"}
 
 [workspace]
 members = [

--- a/csi/Cargo.toml
+++ b/csi/Cargo.toml
@@ -13,7 +13,8 @@ name = "mayastor-client"
 path = "src/client.rs"
 
 [build-dependencies]
-tonic-build = "0.1.0-alpha.3"
+bytes = "0.4"
+tonic-build = "0.1.0-beta.1"
 prost-build = "0.5.0"
 
 [dependencies]
@@ -23,34 +24,30 @@ bytesize = "1.0.0"
 chrono = "0.4.9"
 clap = "2.32"
 env_logger = "0.7"
-futures-preview = "=0.3.0-alpha.19"
-futures-util-preview = "=0.3.0-alpha.19"
+futures = { version = "0.3", default-features = false }
 git-version = "0.3.1"
 
 glob = "*"
-http = "0.1.19"
-http-body = "=0.2.0-alpha.3"
+http = "0.1"
+http-body = "0.2"
 jsonrpc = { path = "../jsonrpc" }
 libc = "0.2"
 log = "0.4"
 loopdev = "*"
 nix = "*"
-proc-mounts = "0.2.2"
+proc-mounts = "0.2"
 prost = "0.5"
 prost-derive = "0.5"
 prost-types = "0.5"
 rpc = { path = "../rpc" }
 serde = { version = "1.0", features = ["derive"] }
-serde_derive = "1.0.98"
-serde_json = "1.0.36"
-sys-mount = "1.2.0"
-sysfs = { path = "../sysfs"}
-tokio = "0.2.0-alpha.6"
+serde_derive = "1.0"
+serde_json = "1.0"
+sys-mount = "1.2"
+tokio = { version = "0.2.8", features = ["full"] }
 run_script = "*"
-tokio-net = "0.2.0-alpha.6"
-tonic = "0.1.0-alpha.3"
-tower = "=0.3.0-alpha.2"
-tracing-log = {version = "0.1.1", features = ["env_logger"] }
+tonic = "0.1.0-beta.1"
+tower = "0.3"
 [dependencies.blkid]
 branch = "blkid-sys"
 git = "https://github.com/openebs/blkid"

--- a/csi/src/client.rs
+++ b/csi/src/client.rs
@@ -12,7 +12,7 @@ use clap::{App, AppSettings, Arg, ArgMatches, SubCommand};
 use tokio;
 use tonic::{transport::Channel, Code, Request, Status};
 
-use rpc::service::client::MayastorClient;
+use rpc::service::mayastor_client::MayastorClient;
 
 fn parse_share_protocol(pcol: Option<&str>) -> Result<i32, Status> {
     match pcol {

--- a/csi/src/identity.rs
+++ b/csi/src/identity.rs
@@ -19,7 +19,7 @@ pub struct Identity {
 
 impl Identity {}
 #[tonic::async_trait]
-impl server::Identity for Identity {
+impl identity_server::Identity for Identity {
     async fn get_plugin_info(
         &self,
         _request: Request<GetPluginInfoRequest>,

--- a/csi/src/mayastor_svc.rs
+++ b/csi/src/mayastor_svc.rs
@@ -13,7 +13,7 @@ pub struct MayastorService {
 }
 impl MayastorService {}
 #[tonic::async_trait]
-impl service::server::Mayastor for MayastorService {
+impl service::mayastor_server::Mayastor for MayastorService {
     async fn create_pool(
         &self,
         request: Request<CreatePoolRequest>,

--- a/csi/src/node.rs
+++ b/csi/src/node.rs
@@ -86,7 +86,7 @@ async fn lookup_nexus(
 
 impl Node {}
 #[tonic::async_trait]
-impl server::Node for Node {
+impl node_server::Node for Node {
     async fn node_get_info(
         &self,
         _request: Request<NodeGetInfoRequest>,

--- a/jsonrpc/Cargo.toml
+++ b/jsonrpc/Cargo.toml
@@ -10,7 +10,6 @@ nix = "0.14.1"
 serde = "1.0.84"
 serde_derive = "1.0.84"
 serde_json = "1.0.36"
-tokio = "0.2.0-alpha.6"
-tokio-net = "0.2.0-alpha.6"
-tonic = "0.1.0-alpha.3"
-futures-preview = "=0.3.0-alpha.19"
+tonic = "0.1.0-beta.1"
+tokio = { version = "0.2", features =  ["full"]  }
+

--- a/mayastor/Cargo.toml
+++ b/mayastor/Cargo.toml
@@ -16,30 +16,31 @@ path = "src/bin/spdk.rs"
 name = "initiator"
 path = "src/bin/initiator.rs"
 
+[dev-dependencies]
+assert_matches = "1.2"
+run_script = "*"
+
 [dependencies]
-assert_matches = "1.3.0"
-bincode = "1.2.0"
+bincode = "1.2"
 bytes = "0.4.12"
 byte-unit = "3.0.1"
 clap = "2.33.0"
 crc = "1.8.1"
 env_logger = "0.7"
-futures-preview = "=0.3.0-alpha.19"
-futures-timer = "0.4.0"
-git-version = "0.3.1"
+futures = "0.3"
+futures-timer = "2.0"
+git-version = "0.3"
 ioctl-gen = "0.1.1"
-lazy_static = "1.3.0"
+lazy_static = "1.3"
 libc = "0.2"
-log = "0.4.6"
-nix = "0.16.0"
+log = "0.4"
+nix = "0.16"
 rpc = { path = "../rpc"}
-run_script = "0.3.2"
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0.39"
-snafu = "0.6.0"
+serde_json = "1.0"
+snafu = "0.6"
 spdk-sys = { path = "../spdk-sys" }
-url = "2.1.0"
-url_serde = "0.2.0"
+url = "2.1"
 uuid = { version = "0.7", features = ["v4"] }
 structopt = "0.2.18"
 sysfs = { path = "../sysfs"}

--- a/mayastor/src/bdev/nexus/nexus_nbd.rs
+++ b/mayastor/src/bdev/nexus/nexus_nbd.rs
@@ -41,7 +41,7 @@ async fn wait_until_ready(path: &str) -> Result<(), ()> {
     let device_size: u32 = 0;
     // each iteration sleeps 100ms => total time out is 10s
     for _i in 1i32 .. 100 {
-        let _ = Delay::new(Duration::from_millis(100)).await;
+        Delay::new(Duration::from_millis(100)).await;
 
         let f = OpenOptions::new().read(true).open(Path::new(&path));
         if f.is_err() {

--- a/mayastor/tests/common/mod.rs
+++ b/mayastor/tests/common/mod.rs
@@ -103,7 +103,6 @@ pub fn mount_umount(device: &str) -> String {
 
 pub fn mount_and_write_file(device: &str) -> String {
     let mut options = ScriptOptions::new();
-    options.capture_output = true;
     options.exit_on_error = true;
     options.print_commands = false;
 

--- a/nix/lib/rust.nix
+++ b/nix/lib/rust.nix
@@ -11,7 +11,7 @@ let
 in
 rec {
   nightly = overlay.rustChannelOf {
-    date = "2019-11-25";
+    date = "2019-12-19";
     channel = "nightly";
   };
 

--- a/nix/pkgs/mayastor/default.nix
+++ b/nix/pkgs/mayastor/default.nix
@@ -35,7 +35,7 @@ rec {
 
   mayastor = rustPlatform.buildRustPackage rec {
     name = "mayastor";
-    cargoSha256 = "03gfmk3zmcn6ihbknc7jpi6i5yxxlw9c40mdiaxlb0b9cbp5i0qd";
+    cargoSha256 = "0b2zxvnkvbvn11nvms9fhrwy8mhqrnq1s18agd120wc2vr43zm98";
     version = "unstable";
     src = ../../../.;
 

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -13,7 +13,6 @@ tonic = "0.1.0-alpha.3"
 bytes = "0.4"
 prost = "0.5"
 prost-derive = "0.5"
-prost-types = "0.5.0"
 serde = { version = "1.0.98", features = ["derive"] }
 serde_derive = "1.0.99"
 serde_json = "1.0.40"


### PR DESCRIPTION
tonic-rs has recently added support for UDS so we do not need to make use of our
fork anymore. Also, while here, removed some unused dependencies and bump the
versions.