### PR TITLE
Disable "fortify" causing annoying warning when in nix shell.

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -15,6 +15,8 @@ let
   libspdk = pkgs.libspdk.override { enableDebug = true; };
 in
 mkShell {
+  # fortify does not work with -O0 which is used by spdk when --enable-debug
+  hardeningDisable = [ "fortify" ];
 
   buildInputs = [
     figlet


### PR DESCRIPTION
Even better would be to disable fortify conditionally for
libspdk and mayastor package when doing debug build. But that
would need a different solution - this variable works only in
nix shell.