### PR TITLE
core: decouple descriptor and io_channel

### DIFF
--- a/jsonrpc/src/test.rs
+++ b/jsonrpc/src/test.rs
@@ -36,7 +36,6 @@ where
     H: FnOnce(Request) -> Vec<u8> + 'static + Send,
     T: FnOnce(Result<R, Error>) -> () + panic::UnwindSafe,
 {
-
     let sock = format!("{}.{:?}", SOCK_PATH, std::thread::current().id());
     let sock_path = Path::new(&sock);
     // Cleanup should be called at all places where we exit from this function
@@ -121,7 +120,8 @@ async fn normal_request_reply() {
             }
             Err(err) => panic!(format!("{}", err)),
         },
-        ).await;
+    )
+    .await;
 }
 
 #[tokio::test]
@@ -144,7 +144,8 @@ async fn invalid_json() {
             Err(Error::ParseError(_)) => (),
             Err(err) => panic!(format!("Wrong error type: {}", err)),
         },
-    ).await;
+    )
+    .await;
 }
 
 #[test]
@@ -187,7 +188,8 @@ async fn invalid_version() {
             Err(Error::InvalidVersion) => (),
             Err(err) => panic!(format!("Wrong error type: {}", err)),
         },
-    ).await;
+    )
+    .await;
 }
 
 #[tokio::test]
@@ -209,7 +211,8 @@ async fn missing_version() {
             Ok(_) => (),
             Err(err) => panic!(format!("{}", err)),
         },
-    ).await;
+    )
+    .await;
 }
 
 #[tokio::test]
@@ -232,7 +235,8 @@ async fn wrong_reply_id() {
             Err(Error::InvalidReplyId) => (),
             Err(err) => panic!(format!("Wrong error type: {}", err)),
         },
-    ).await;
+    )
+    .await;
 }
 
 #[tokio::test]
@@ -255,7 +259,8 @@ async fn empty_result_unexpected() {
             Err(Error::ParseError(_)) => (),
             Err(err) => panic!(format!("Wrong error type: {}", err)),
         },
-    ).await;
+    )
+    .await;
 }
 
 #[tokio::test]
@@ -277,7 +282,8 @@ async fn empty_result_expected() {
             Ok(_) => (),
             Err(err) => panic!(format!("Unexpected error {}", err)),
         },
-    ).await;
+    )
+    .await;
 }
 
 #[tokio::test]
@@ -310,5 +316,6 @@ async fn rpc_error() {
             }
             Err(err) => panic!(format!("Wrong error type: {}", err)),
         },
-        ).await;
+    )
+    .await;
 }

--- a/mayastor/src/bdev/nexus/mod.rs
+++ b/mayastor/src/bdev/nexus/mod.rs
@@ -2,9 +2,9 @@
 use crate::bdev::nexus::{
     nexus_bdev::Nexus,
     nexus_fn_table::NexusFnTable,
-    nexus_module::NexusModule,
     nexus_rpc::register_rpc_methods,
 };
+use spdk_sys::spdk_bdev_module;
 
 pub mod nexus_bdev;
 pub mod nexus_bdev_children;
@@ -27,7 +27,7 @@ pub fn register_module() {
 }
 
 /// get a reference to the module
-pub fn module() -> Option<NexusModule> {
+pub fn module() -> Option<*mut spdk_bdev_module> {
     nexus_module::NexusModule::current()
 }
 

--- a/mayastor/src/bdev/nexus/nexus_bdev.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev.rs
@@ -301,7 +301,7 @@ impl Nexus {
         b.name = c_str!(name);
         b.product_name = c_str!(NEXUS_PRODUCT_ID);
         b.fn_table = nexus::fn_table().unwrap();
-        b.module = nexus::module().unwrap().as_ptr();
+        b.module = nexus::module().unwrap();
         b.blocklen = 0;
         b.blockcnt = 0;
         b.required_alignment = 9;

--- a/mayastor/src/bdev/nexus/nexus_module.rs
+++ b/mayastor/src/bdev/nexus/nexus_module.rs
@@ -75,7 +75,7 @@ impl NexusModule {
     }
 
     /// obtain a pointer to the raw bdev module
-    pub fn current() -> Option<Self> {
+    pub fn current() -> Option<*mut spdk_bdev_module> {
         let c_name = std::ffi::CString::new(NEXUS_NAME).unwrap();
         let module =
             unsafe { spdk_sys::spdk_bdev_module_list_find(c_name.as_ptr()) };
@@ -83,7 +83,7 @@ impl NexusModule {
         if module.is_null() {
             None
         } else {
-            Some(NexusModule::from(module))
+            Some(module)
         }
     }
 

--- a/mayastor/src/core/bdev.rs
+++ b/mayastor/src/core/bdev.rs
@@ -1,0 +1,206 @@
+use std::{
+    ffi::CStr,
+    fmt::{Debug, Formatter},
+    os::raw::c_void,
+};
+
+use spdk_sys::{
+    spdk_bdev,
+    spdk_bdev_get_aliases,
+    spdk_bdev_get_block_size,
+    spdk_bdev_get_by_name,
+    spdk_bdev_get_name,
+    spdk_bdev_get_num_blocks,
+    spdk_bdev_get_product_name,
+    spdk_bdev_get_uuid,
+    spdk_bdev_io_type_supported,
+    spdk_bdev_open,
+    spdk_uuid_generate,
+};
+
+use crate::core::{uuid::Uuid, Descriptor};
+
+/// new type structure that represents a block device
+pub struct Bdev(pub(crate) *mut spdk_bdev);
+
+impl Debug for Bdev {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
+        writeln!(
+            f,
+            "name: {} driver: {} product: {}",
+            self.name(),
+            self.driver(),
+            self.product_name()
+        )
+    }
+}
+
+impl Bdev {
+    pub fn open(name: &str, read_write: bool) -> Option<Descriptor> {
+        if let Some(bdev) = Self::lookup_by_name(name) {
+            let mut descriptor = std::ptr::null_mut();
+
+            let rc = unsafe {
+                spdk_bdev_open(
+                    bdev.as_ptr(),
+                    read_write,
+                    None,
+                    std::ptr::null_mut(),
+                    &mut descriptor,
+                )
+            };
+
+            return if rc != 0 {
+                None
+            } else {
+                Some(Descriptor(descriptor))
+            };
+        }
+        None
+    }
+
+    pub fn lookup_by_name(name: &str) -> Option<Bdev> {
+        let name = std::ffi::CString::new(name).unwrap();
+
+        let bdev = unsafe { spdk_bdev_get_by_name(name.as_ptr()) };
+        if bdev.is_null() {
+            None
+        } else {
+            Some(Bdev(bdev))
+        }
+    }
+    /// returns the block_size of the underlying device
+    pub fn block_len(&self) -> u32 {
+        unsafe { spdk_bdev_get_block_size(self.0) }
+    }
+
+    /// number of blocks for this device
+    pub fn num_blocks(&self) -> u64 {
+        unsafe { spdk_bdev_get_num_blocks(self.0) }
+    }
+
+    /// set the block count of this device
+    pub fn set_block_count(&self, count: u64) {
+        unsafe {
+            (*self.0).blockcnt = count;
+        }
+    }
+
+    /// set the block length of the device in bytes
+    pub fn set_block_len(&self, len: u32) {
+        unsafe {
+            (*self.0).blocklen = len;
+        }
+    }
+
+    pub fn size_in_bytes(&self) -> u64 {
+        self.num_blocks() * self.block_len() as u64
+    }
+
+    /// whenever the underlying device needs alignment to the page size
+    /// this is typically the case with io_uring and AIO. The value represents
+    /// as a shift/exponent.
+    pub fn alignment(&self) -> u8 {
+        unsafe { (*self.0).required_alignment }
+    }
+
+    /// returns the configured product name
+    pub fn product_name(&self) -> String {
+        unsafe {
+            CStr::from_ptr(spdk_bdev_get_product_name(self.0))
+                .to_str()
+                .unwrap()
+                .to_string()
+        }
+    }
+
+    /// returns the name of driver module for the given bdev
+    pub fn driver(&self) -> String {
+        unsafe {
+            CStr::from_ptr((*(*self.0).module).name)
+                .to_str()
+                .unwrap()
+                .to_string()
+        }
+    }
+
+    /// returns the bdev name
+    pub fn name(&self) -> String {
+        unsafe {
+            CStr::from_ptr(spdk_bdev_get_name(self.0))
+                .to_str()
+                .unwrap()
+                .to_string()
+        }
+    }
+
+    /// the uuid that is set for this bdev, all bdevs should have a UUID set
+    pub fn uuid(&self) -> Uuid {
+        Uuid {
+            0: unsafe { spdk_bdev_get_uuid(self.0) },
+        }
+    }
+
+    /// convert a SPDK UUID into a rust string
+    pub fn uuid_as_string(&self) -> String {
+        let u = Uuid(unsafe { spdk_bdev_get_uuid(self.0) });
+        let uuid = uuid::Uuid::from_bytes(u.as_bytes());
+        uuid.to_hyphenated().to_string()
+    }
+
+    /// Set an alias on the bdev, this alias can be used to find the bdev later
+    /// NOTE: using this before calling spdk_bdev_register() crashes the
+    /// system
+    pub fn add_alias(&self, alias: &str) -> bool {
+        let alias = std::ffi::CString::new(alias).unwrap();
+        let ret =
+            unsafe { spdk_sys::spdk_bdev_alias_add(self.0, alias.as_ptr()) };
+
+        ret == 0
+    }
+
+    /// Get list of bdev aliases
+    pub fn aliases(&self) -> Vec<String> {
+        let mut aliases = Vec::new();
+        let head = unsafe { &*spdk_bdev_get_aliases(self.0) };
+        let mut ent_ptr = head.tqh_first;
+        while !ent_ptr.is_null() {
+            let ent = unsafe { &*ent_ptr };
+            let alias = unsafe { CStr::from_ptr(ent.alias) };
+            aliases.push(alias.to_str().unwrap().to_string());
+            ent_ptr = ent.tailq.tqe_next;
+        }
+        aliases
+    }
+
+    /// returns whenever the bdev supports the requested IO type
+    pub fn io_type_supported(&self, io_type: u32) -> bool {
+        unsafe { spdk_bdev_io_type_supported(self.0, io_type) }
+    }
+
+    /// returns the bdev als a ptr
+    pub fn as_ptr(&self) -> *mut spdk_bdev {
+        self.0
+    }
+
+    /// convert a given UUID into a spdk_bdev_uuid or otherwise, auto generate
+    /// on. Typically the UUID is given however.
+    pub fn set_uuid(&mut self, uuid: Option<String>) {
+        if let Some(uuid) = uuid {
+            if let Ok(this_uuid) = uuid::Uuid::parse_str(&uuid) {
+                unsafe {
+                    std::ptr::copy_nonoverlapping(
+                        this_uuid.as_bytes().as_ptr() as *const _
+                            as *mut c_void,
+                        &mut (*self.0).uuid.u.raw[0] as *const _ as *mut c_void,
+                        (*self.0).uuid.u.raw.len(),
+                    );
+                }
+                return;
+            }
+        }
+
+        unsafe { spdk_uuid_generate(&mut (*self.0).uuid) };
+        info!("No or invalid v4 UUID specified, using self generated one");
+    }
+}

--- a/mayastor/src/core/channel.rs
+++ b/mayastor/src/core/channel.rs
@@ -1,0 +1,9 @@
+use spdk_sys::spdk_io_channel;
+
+pub struct IoChannel(pub(crate) *mut spdk_io_channel);
+
+impl Drop for IoChannel {
+    fn drop(&mut self) {
+        unimplemented!()
+    }
+}

--- a/mayastor/src/core/descriptor.rs
+++ b/mayastor/src/core/descriptor.rs
@@ -1,0 +1,42 @@
+use crate::core::{channel::IoChannel, Bdev};
+use spdk_sys::{
+    spdk_bdev_close,
+    spdk_bdev_desc,
+    spdk_bdev_desc_get_bdev,
+    spdk_bdev_get_io_channel,
+};
+
+/// new type around a descriptor, only one descriptor is typically available as
+/// a bdev is opened only one time. When the last reference to the descriptor is
+/// dropped, we implicitly close the bdev.
+#[derive(Debug, Clone)]
+pub struct Descriptor(pub(crate) *mut spdk_bdev_desc);
+
+impl Drop for Descriptor {
+    fn drop(&mut self) {
+        trace!("closing bdev: {}", self.get_bdev().unwrap().name());
+        unsafe { spdk_bdev_close(self.0) }
+    }
+}
+
+impl Descriptor {
+    pub fn as_ptr(&self) -> *mut spdk_bdev_desc {
+        self.0
+    }
+
+    pub fn get_channel(&self) -> Option<IoChannel> {
+        if self.0.is_null() {
+            None
+        } else {
+            Some(IoChannel(unsafe { spdk_bdev_get_io_channel(self.0) }))
+        }
+    }
+
+    pub fn get_bdev(&self) -> Option<Bdev> {
+        if self.0.is_null() {
+            None
+        } else {
+            Some(Bdev(unsafe { spdk_bdev_desc_get_bdev(self.0) }))
+        }
+    }
+}

--- a/mayastor/src/core/mod.rs
+++ b/mayastor/src/core/mod.rs
@@ -1,0 +1,12 @@
+//!
+//! core contains the primary abstractions around the SPDK primitives.
+
+mod bdev;
+mod channel;
+mod descriptor;
+mod uuid;
+
+pub use ::uuid::Uuid;
+pub use bdev::Bdev;
+pub use channel::IoChannel;
+pub use descriptor::Descriptor;

--- a/mayastor/src/core/uuid.rs
+++ b/mayastor/src/core/uuid.rs
@@ -1,0 +1,12 @@
+use spdk_sys::spdk_uuid;
+/// Muuid provides several From trait implementations for the raw spdk UUIDs
+/// It depends largely, on the bdev, if you can set the uuid in a nice way
+#[derive(Debug)]
+pub struct Uuid(pub(crate) *const spdk_uuid);
+
+impl Uuid {
+    /// For some of reason the uuid is a union
+    pub fn as_bytes(&self) -> [u8; 16] {
+        unsafe { (*self.0).u.raw }
+    }
+}

--- a/mayastor/src/lib.rs
+++ b/mayastor/src/lib.rs
@@ -33,6 +33,7 @@ pub mod rebuild;
 pub mod replica;
 pub mod spdklog;
 
+pub mod core;
 #[macro_export]
 macro_rules! CPS_INIT {
     () => {

--- a/mayastor/tests/core.rs
+++ b/mayastor/tests/core.rs
@@ -1,0 +1,53 @@
+use mayastor::{
+    bdev::nexus::nexus_bdev::nexus_create,
+    core::Bdev,
+    environment::{
+        args::MayastorCliArgs,
+        env::{mayastor_env_stop, MayastorEnvironment},
+    },
+};
+
+static DISKNAME1: &str = "/tmp/disk1.img";
+static BDEVNAME1: &str = "aio:///tmp/disk1.img?blk_size=512";
+
+static DISKNAME2: &str = "/tmp/disk2.img";
+static BDEVNAME2: &str = "aio:///tmp/disk2.img?blk_size=512";
+
+pub mod common;
+#[test]
+fn core() {
+    common::mayastor_test_init();
+
+    common::truncate_file(DISKNAME1, 64 * 1024);
+    common::truncate_file(DISKNAME2, 64 * 1024);
+
+    let rc = MayastorEnvironment::new(MayastorCliArgs::default())
+        .start(|| mayastor::executor::spawn(works()))
+        .unwrap();
+
+    assert_eq!(rc, 0);
+
+    common::compare_files(DISKNAME1, DISKNAME2);
+    common::delete_file(&[DISKNAME1.into(), DISKNAME2.into()]);
+}
+
+async fn create_nexus() {
+    let ch = vec![BDEVNAME1.to_string(), BDEVNAME2.to_string()];
+    nexus_create("core_nexus", 64 * 1024 * 1024, None, &ch)
+        .await
+        .unwrap();
+}
+
+async fn works() {
+    assert_eq!(Bdev::lookup_by_name("core_nexus").is_none(), true);
+    create_nexus().await;
+    let b = Bdev::lookup_by_name("core_nexus").unwrap();
+    assert_eq!(b.name(), "core_nexus");
+
+    let desc = Bdev::open("core_nexus", false).unwrap();
+    let bdev = desc.get_bdev().unwrap();
+    println!("{:?}", bdev);
+    println!("{:?}", bdev.uuid_as_string());
+    assert_eq!(b.name(), bdev.name());
+    mayastor_env_stop(0);
+}


### PR DESCRIPTION
This work is needed in order to dispatch work to other cores (i.e for rebuild).

The nexus has an internal descriptor that is being used for, among others, GPT
labelling. However, using this descriptor on different cores is not allowed as
each core needs to allocate its own IO channels.