### PR TITLE
nexus: fix signal handling during shutdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,7 +54,7 @@ checksum = "393356ed99aa7bff0ac486dde592633b83ab02bd254d8c209d5b9f1d0f533480"
 dependencies = [
  "proc-macro2 1.0.8",
  "quote 1.0.2",
- "syn 1.0.13",
+ "syn 1.0.14",
 ]
 
 [[package]]
@@ -65,7 +65,7 @@ checksum = "c8df72488e87761e772f14ae0c2480396810e51b2c2ade912f97f0f7e5b95e3c"
 dependencies = [
  "proc-macro2 1.0.8",
  "quote 1.0.2",
- "syn 1.0.13",
+ "syn 1.0.14",
 ]
 
 [[package]]
@@ -424,7 +424,7 @@ dependencies = [
  "proc-macro2 1.0.8",
  "quote 1.0.2",
  "rustc_version",
- "syn 1.0.13",
+ "syn 1.0.14",
  "synstructure",
 ]
 
@@ -549,7 +549,7 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro2 1.0.8",
  "quote 1.0.2",
- "syn 1.0.13",
+ "syn 1.0.14",
 ]
 
 [[package]]
@@ -625,7 +625,7 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro2 1.0.8",
  "quote 1.0.2",
- "syn 1.0.13",
+ "syn 1.0.14",
 ]
 
 [[package]]
@@ -902,10 +902,10 @@ dependencies = [
  "futures-timer",
  "git-version",
  "ioctl-gen",
- "lazy_static",
  "libc",
  "log",
  "nix 0.16.1",
+ "once_cell",
  "rpc",
  "run_script",
  "serde",
@@ -1071,6 +1071,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c601810575c99596d4afc46f78a678c80105117c379eb3650cf99b8a21ce5b"
+
+[[package]]
 name = "partition-identity"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1109,29 +1115,29 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b90146c7216e4cb534069fb91366de4ea0ea353105ee45ed297e2d1619e469"
+checksum = "75fca1c4ff21f60ca2d37b80d72b63dab823a9d19d3cda3a81d18bc03f0ba8c5"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44ca92f893f0656d3cba8158dd0f2b99b94de256a4a54e870bd6922fcc6c8355"
+checksum = "6544cd4e4ecace61075a6ec78074beeef98d58aa9a3d07d053d993b2946a90d6"
 dependencies = [
  "proc-macro2 1.0.8",
  "quote 1.0.2",
- "syn 1.0.13",
+ "syn 1.0.14",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8822eb8bb72452f038ebf6048efa02c3fe22bf83f76519c9583e47fc194a422"
+checksum = "237844750cfbb86f67afe27eee600dfbbcb6188d734139b534cbfbf4f96792ae"
 
 [[package]]
 name = "pin-utils"
@@ -1153,7 +1159,7 @@ checksum = "aeccfe4d5d8ea175d5f0e4a2ad0637e0f4121d63bd99d356fb1f39ab2e7c6097"
 dependencies = [
  "proc-macro2 1.0.8",
  "quote 1.0.2",
- "syn 1.0.13",
+ "syn 1.0.14",
 ]
 
 [[package]]
@@ -1164,7 +1170,7 @@ checksum = "ecd45702f76d6d3c75a80564378ae228a85f0b59d2f3ed43c91b4a69eb2ebfc5"
 dependencies = [
  "proc-macro2 1.0.8",
  "quote 1.0.2",
- "syn 1.0.13",
+ "syn 1.0.14",
 ]
 
 [[package]]
@@ -1239,7 +1245,7 @@ dependencies = [
  "itertools",
  "proc-macro2 1.0.8",
  "quote 1.0.2",
- "syn 1.0.13",
+ "syn 1.0.14",
 ]
 
 [[package]]
@@ -1559,14 +1565,14 @@ checksum = "128f9e303a5a29922045a830221b8f78ec74a5f544944f3d5984f8ec3895ef64"
 dependencies = [
  "proc-macro2 1.0.8",
  "quote 1.0.2",
- "syn 1.0.13",
+ "syn 1.0.14",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c575e0cc52bdd09b47f330f646cf59afc586e9c4e3ccd6fc1f625b8ea1dad7"
+checksum = "eab8f15f15d6c41a154c1b128a22f2dfabe350ef53c40953d84e36155c91192b"
 dependencies = [
  "itoa",
  "ryu",
@@ -1613,7 +1619,7 @@ checksum = "bdc75da2e0323f297402fd9c8fdba709bb04e4c627cbe31d19a2c91fc8d9f0e2"
 dependencies = [
  "proc-macro2 1.0.8",
  "quote 1.0.2",
- "syn 1.0.13",
+ "syn 1.0.14",
 ]
 
 [[package]]
@@ -1677,9 +1683,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e4ff033220a41d1a57d8125eab57bf5263783dfdcc18688b1dacc6ce9651ef8"
+checksum = "af6f3550d8dff9ef7dc34d384ac6f107e5d31c8f57d9f28e0081503f547ac8f5"
 dependencies = [
  "proc-macro2 1.0.8",
  "quote 1.0.2",
@@ -1694,7 +1700,7 @@ checksum = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
 dependencies = [
  "proc-macro2 1.0.8",
  "quote 1.0.2",
- "syn 1.0.13",
+ "syn 1.0.14",
  "unicode-xid 0.2.0",
 ]
 
@@ -1767,9 +1773,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffa2fdcfa937b20cb3c822a635ceecd5fc1a27a6a474527e5516aa24b8c8820a"
+checksum = "c1fc73332507b971a5010664991a441b5ee0de92017f5a0e8b00fd684573045b"
 dependencies = [
  "bytes 0.5.3",
  "fnv",
@@ -1796,7 +1802,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50a61f268a3db2acee8dcab514efc813dc6dbe8a00e86076f935f94304b59a7a"
 dependencies = [
  "quote 1.0.2",
- "syn 1.0.13",
+ "syn 1.0.14",
 ]
 
 [[package]]
@@ -1815,9 +1821,9 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "796bf8f5c49c0a50835f4dc0baff7abe0773c7c53abc2b2a76cc012328cca027"
+checksum = "08283643b1d483eb7f3fc77069e63b5cba3e4db93514b3d45470e67f123e4e48"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1845,14 +1851,14 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae1da859b1c093ce54a130fbb8c94c920133d0937035e8004610263785aba9e"
+checksum = "0436413ba71545bcc6c2b9a0f9d78d72deb0123c6a75ccdfe7c056f9930f5e52"
 dependencies = [
  "proc-macro2 1.0.8",
  "prost-build",
  "quote 1.0.2",
- "syn 1.0.13",
+ "syn 1.0.14",
 ]
 
 [[package]]
@@ -2051,7 +2057,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04cfd395def5a60236e187e1ff905cb55668a59f29928dec05e6e1b1fd2ac1f3"
 dependencies = [
  "quote 1.0.2",
- "syn 1.0.13",
+ "syn 1.0.14",
 ]
 
 [[package]]
@@ -2090,9 +2096,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b561e267b2326bb4cebfc0ef9e68355c7abe6c6f522aeac2f5bf95d56c59bdcf"
+checksum = "5479532badd04e128284890390c1e876ef7a993d0570b3597ae43dfa1d59afa4"
 dependencies = [
  "smallvec",
 ]

--- a/jsonrpc/src/test.rs
+++ b/jsonrpc/src/test.rs
@@ -36,7 +36,6 @@ where
     H: FnOnce(Request) -> Vec<u8> + 'static + Send,
     T: FnOnce(Result<R, Error>) -> () + panic::UnwindSafe,
 {
-
     let sock = format!("{}.{:?}", SOCK_PATH, std::thread::current().id());
     let sock_path = Path::new(&sock);
     // Cleanup should be called at all places where we exit from this function
@@ -121,7 +120,8 @@ async fn normal_request_reply() {
             }
             Err(err) => panic!(format!("{}", err)),
         },
-        ).await;
+    )
+    .await;
 }
 
 #[tokio::test]
@@ -144,7 +144,8 @@ async fn invalid_json() {
             Err(Error::ParseError(_)) => (),
             Err(err) => panic!(format!("Wrong error type: {}", err)),
         },
-    ).await;
+    )
+    .await;
 }
 
 #[test]
@@ -187,7 +188,8 @@ async fn invalid_version() {
             Err(Error::InvalidVersion) => (),
             Err(err) => panic!(format!("Wrong error type: {}", err)),
         },
-    ).await;
+    )
+    .await;
 }
 
 #[tokio::test]
@@ -209,7 +211,8 @@ async fn missing_version() {
             Ok(_) => (),
             Err(err) => panic!(format!("{}", err)),
         },
-    ).await;
+    )
+    .await;
 }
 
 #[tokio::test]
@@ -232,7 +235,8 @@ async fn wrong_reply_id() {
             Err(Error::InvalidReplyId) => (),
             Err(err) => panic!(format!("Wrong error type: {}", err)),
         },
-    ).await;
+    )
+    .await;
 }
 
 #[tokio::test]
@@ -255,7 +259,8 @@ async fn empty_result_unexpected() {
             Err(Error::ParseError(_)) => (),
             Err(err) => panic!(format!("Wrong error type: {}", err)),
         },
-    ).await;
+    )
+    .await;
 }
 
 #[tokio::test]
@@ -277,7 +282,8 @@ async fn empty_result_expected() {
             Ok(_) => (),
             Err(err) => panic!(format!("Unexpected error {}", err)),
         },
-    ).await;
+    )
+    .await;
 }
 
 #[tokio::test]
@@ -310,5 +316,6 @@ async fn rpc_error() {
             }
             Err(err) => panic!(format!("Wrong error type: {}", err)),
         },
-        ).await;
+    )
+    .await;
 }

--- a/mayastor/Cargo.toml
+++ b/mayastor/Cargo.toml
@@ -31,10 +31,10 @@ futures = "0.3"
 futures-timer = "2.0"
 git-version = "0.3"
 ioctl-gen = "0.1.1"
-lazy_static = "1.3"
 libc = "0.2"
 log = "0.4"
 nix = "0.16"
+once_cell = "1.3"
 rpc = { path = "../rpc"}
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/mayastor/src/bdev/nexus/nexus_child.rs
+++ b/mayastor/src/bdev/nexus/nexus_child.rs
@@ -182,7 +182,7 @@ impl NexusChild {
                 spdk_bdev_module_claim_bdev(
                     bdev.inner,
                     desc.as_ptr(),
-                    &NEXUS_MODULE.module as *const _ as *mut _,
+                    &NEXUS_MODULE.as_ptr() as *const _ as *mut _,
                 )
             };
             if let Err(err) = errno_result_from_i32((), errno) {

--- a/mayastor/src/bdev/nexus/nexus_module.rs
+++ b/mayastor/src/bdev/nexus/nexus_module.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::vec_box)]
-use lazy_static;
 use spdk_sys::{
     spdk_bdev_module,
     spdk_bdev_module_examine_done,
@@ -14,27 +12,20 @@ use crate::bdev::{
     },
     Bdev,
 };
+use once_cell::sync::{Lazy, OnceCell};
 use std::{cell::UnsafeCell, ffi::CString};
 
 const NEXUS_NAME: &str = "NEXUS_CAS_MODULE";
-lazy_static! {
-    pub(crate) static ref NEXUS_MODULE: NexusModule = NexusModule::new();
-    static ref NEXUS_INSTANCES: NexusInstances = NexusInstances {
-        inner: UnsafeCell::new(Vec::new()),
-    };
-}
+
+pub(crate) static NEXUS_MODULE: Lazy<NexusModule> = Lazy::new(NexusModule::new);
 
 #[derive(Default, Debug)]
 pub struct NexusInstances {
     inner: UnsafeCell<Vec<Box<Nexus>>>,
 }
 
-#[derive(Default, Debug)]
-pub struct NexusModule {
-    /// inner reference to the bdev module that is registered to SPDK
-    /// note that SPDK changes this module internally
-    pub(crate) module: spdk_bdev_module,
-}
+#[derive(Debug)]
+pub struct NexusModule(*mut spdk_bdev_module);
 
 unsafe impl Sync for NexusModule {}
 unsafe impl Sync for NexusInstances {}
@@ -42,20 +33,17 @@ unsafe impl Sync for NexusInstances {}
 unsafe impl Send for NexusModule {}
 unsafe impl Send for NexusInstances {}
 
-impl From<*mut spdk_bdev_module> for NexusModule {
-    // cant silence
-    #![allow(clippy::not_unsafe_ptr_arg_deref)]
-    fn from(m: *mut spdk_bdev_module) -> Self {
-        NexusModule {
-            module: unsafe { *m },
-        }
+impl Default for NexusModule {
+    fn default() -> Self {
+        Self::new()
     }
 }
+
 impl NexusModule {
     /// construct a new NexusModule instance and setup main properties
     /// as well as the function table and json-rpc methods if any
     pub fn new() -> Self {
-        let mut module: spdk_bdev_module = Default::default();
+        let mut module = Box::new(spdk_bdev_module::default());
         module.name = c_str!(NEXUS_NAME);
 
         module.async_init = false;
@@ -65,13 +53,19 @@ impl NexusModule {
         module.get_ctx_size = Some(Self::nexus_ctx_size);
         module.examine_config = Some(Self::examine);
         module.examine_disk = None;
-        NexusModule {
-            module,
-        }
+        NexusModule(Box::into_raw(module))
     }
 
     pub fn as_ptr(&self) -> *mut spdk_bdev_module {
-        &self as *const _ as *mut _
+        self.0
+    }
+
+    pub fn from_null_checked(b: *mut spdk_bdev_module) -> Option<Self> {
+        if b.is_null() {
+            None
+        } else {
+            Some(NexusModule(b))
+        }
     }
 
     /// obtain a pointer to the raw bdev module
@@ -79,29 +73,30 @@ impl NexusModule {
         let c_name = std::ffi::CString::new(NEXUS_NAME).unwrap();
         let module =
             unsafe { spdk_sys::spdk_bdev_module_list_find(c_name.as_ptr()) };
-
-        if module.is_null() {
-            None
-        } else {
-            Some(NexusModule::from(module))
-        }
+        NexusModule::from_null_checked(module)
     }
 
     /// return instances, we ensure that this can only ever be called on a
     /// properly allocated thread
     pub fn get_instances() -> &'static mut Vec<Box<Nexus>> {
         let thread = unsafe { spdk_get_thread() };
-
         if thread.is_null() {
-            panic!("not on spdk thread");
+            panic!("not called from SPDK thread")
         }
-        unsafe { &mut (*NEXUS_INSTANCES.inner.get()) }
+
+        static NEXUS_INSTANCES: OnceCell<NexusInstances> = OnceCell::new();
+
+        let global_instances = NEXUS_INSTANCES.get_or_init(|| NexusInstances {
+            inner: UnsafeCell::new(Vec::new()),
+        });
+
+        unsafe { &mut *global_instances.inner.get() }
     }
 
     /// return the name of the module
     pub fn name(&self) -> String {
         unsafe {
-            std::ffi::CStr::from_ptr(self.module.name)
+            std::ffi::CStr::from_ptr((*self.0).name)
                 .to_str()
                 .unwrap()
                 .to_string()
@@ -119,7 +114,7 @@ impl NexusModule {
 
     extern "C" fn nexus_mod_fini() {
         info!("Unloading Nexus CAS Module");
-        let _ = unsafe { CString::from_raw(NEXUS_MODULE.module.name as _) };
+        let _ = unsafe { CString::from_raw((*(NEXUS_MODULE.0)).name as _) };
         Self::get_instances().clear();
     }
 
@@ -132,7 +127,7 @@ impl NexusModule {
         if instances.iter().any(|n| n.name() == name) {
             unsafe {
                 spdk_bdev_module_examine_done(
-                    &NEXUS_MODULE.module as *const _ as *mut _,
+                    NEXUS_MODULE.0 as *const _ as *mut _,
                 )
             }
             return;
@@ -151,9 +146,7 @@ impl NexusModule {
             });
 
         unsafe {
-            spdk_bdev_module_examine_done(
-                &NEXUS_MODULE.module as *const _ as *mut _,
-            )
+            spdk_bdev_module_examine_done(NEXUS_MODULE.0 as *const _ as *mut _)
         }
     }
 
@@ -164,6 +157,6 @@ impl NexusModule {
 
 pub fn register_module() {
     unsafe {
-        spdk_bdev_module_list_add((&NEXUS_MODULE.module) as *const _ as *mut _);
+        spdk_bdev_module_list_add((NEXUS_MODULE.0) as *const _ as *mut _);
     }
 }

--- a/mayastor/src/event.rs
+++ b/mayastor/src/event.rs
@@ -29,7 +29,10 @@ pub type EventFn = extern "C" fn(*mut c_void, *mut c_void);
 /// should not be confused with an actual thread. Consider it more to be
 /// analogous to a container to which you can submit work and poll it to drive
 /// the submitted work to completion.
-pub struct Mthread(pub *mut spdk_thread);
+pub struct Mthread(*mut spdk_thread);
+
+unsafe impl Send for Mthread {}
+unsafe impl Sync for Mthread {}
 
 impl Mthread {
     ///
@@ -55,6 +58,22 @@ impl Mthread {
         }
         unsafe { spdk_set_thread(std::ptr::null_mut()) };
         self
+    }
+
+    pub fn inner(self) -> *const spdk_thread {
+        self.0
+    }
+
+    pub fn inner_mut(self) -> *mut spdk_thread {
+        self.0
+    }
+
+    pub fn from_null_checked(t: *mut spdk_thread) -> Option<Self> {
+        if t.is_null() {
+            None
+        } else {
+            Some(Mthread(t))
+        }
     }
 }
 

--- a/mayastor/src/lib.rs
+++ b/mayastor/src/lib.rs
@@ -1,7 +1,5 @@
 #[macro_use]
 extern crate ioctl_gen;
-#[macro_use]
-extern crate lazy_static;
 extern crate nix;
 #[macro_use]
 extern crate log;

--- a/nix/pkgs/mayastor/default.nix
+++ b/nix/pkgs/mayastor/default.nix
@@ -35,7 +35,7 @@ rec {
 
   mayastor = rustPlatform.buildRustPackage rec {
     name = "mayastor";
-    cargoSha256 = "1hv5iqp5501y7013p71nc53j645f0m0js2r2cpah65l7px2d7xks";
+    cargoSha256 = "166hk96hkzr1wqhndw02hflpchwmrq8sazcrdj0d82bvzl017pdf";
     version = "unstable";
     src = ../../../.;
 


### PR DESCRIPTION
# TL;DR

No functional changes; just want to upstream this early before the other wad of changes as it touches Cargo.lock

During tests (that is #[test]) the signal handling results in a crash.
The culprit here is the fact that the test framework starts Mayastor
on a different thread. To avoid this we make the management thread global instead
of store it thread-local.

While here, I've also removed the lazy_static!() and switched us over to
OnceCell and, some minor cleanup in the CAS bdev module. As this requires
a change in Cargo.lock, we might as well updated the dependencies too.

Lastly, the callback to env::start() was called without the proper context.