### PR TITLE
fix NBD and reactor shutdown

### DIFF
--- a/mayastor-test/test_nexus.js
+++ b/mayastor-test/test_nexus.js
@@ -170,7 +170,7 @@ describe('nexus', function() {
       `aio:///${aioFile}?blk_size=4096`,
     ],
   };
-  this.timeout(10000); // for network tests we need long timeouts
+  this.timeout(50000); // for network tests we need long timeouts
 
   before(done => {
     client = createGrpcClient('MayaStor');
@@ -440,41 +440,38 @@ describe('nexus', function() {
     });
   });
 
-  // there is a bug in the NBD driver that will hold one to IO's until the end of times
-  // fix that first and uncomment the test below and increase iterations of the 3 tests above
+  it('should create, publish, un-publish and finally destroy the same nexus', async () => {
+    for (let i = 0; i < 10; i++) {
+      await createNexus(createArgs);
+      await publish({ uuid: UUID });
+      await unpublish({ uuid: UUID });
+      await destroyNexus({ uuid: UUID });
+    }
+  });
 
-  // it('should create, publish, un-publish and finally destroy the same nexus', async () => {
-  //   for (let i = 0; i < 10; i++) {
-  //     await createNexus(createArgs);
-  //     await publish({ uuid: UUID });
-  //     await unpublish({ uuid: UUID });
-  //     await destroyNexus({ uuid: UUID });
-  //   }
-  // });
-  //
-  // it('should create, publish, and destroy but without un-publishing the same nexus', async () => {
-  //   for (let i = 0; i < 10; i++) {
-  //     await createNexus(createArgs);
-  //     await publish({ uuid: UUID });
-  //     await destroyNexus({ uuid: UUID });
-  //   }
-  // });
-  //
-  // it('should create and destroy without publish or un-publishing the same nexus', async () => {
-  //   for (let i = 0; i < 10; i++) {
-  //     await createNexus(createArgs);
-  //     await destroyNexus({ uuid: UUID });
-  //   }
-  // });
+  it('should create, publish, and destroy but without un-publishing the same nexus', async () => {
+    for (let i = 0; i < 10; i++) {
+      await createNexus(createArgs);
+      await publish({ uuid: UUID });
+      await destroyNexus({ uuid: UUID });
+    }
+  });
 
-  // it('should be the case that we do not have any dangling NBD devices left on the system', done => {
-  //   exec('lsblk --json', (err, stdout, stderr) => {
-  //     if (err) return done(err);
-  //     let output = JSON.parse(stdout);
-  //     output.blockdevices.forEach(e => {
-  //       assert(e.name.indexOf('nbd'), -1);
-  //     });
-  //     done();
-  //   });
-  // })
+  it('should create and destroy without publish or un-publishing the same nexus', async () => {
+    for (let i = 0; i < 10; i++) {
+      await createNexus(createArgs);
+      await destroyNexus({ uuid: UUID });
+    }
+  });
+
+  it('should be the case that we do not have any dangling NBD devices left on the system', done => {
+    exec('lsblk --json', (err, stdout, stderr) => {
+      if (err) return done(err);
+      let output = JSON.parse(stdout);
+      output.blockdevices.forEach(e => {
+        assert(e.name.indexOf('nbd'), -1);
+      });
+      done();
+    });
+  });
 });

--- a/mayastor/src/bin/initiator.rs
+++ b/mayastor/src/bin/initiator.rs
@@ -16,12 +16,12 @@ use clap::{App, Arg, SubCommand};
 
 use mayastor::{
     core::{
-        mayastor_env_stop,
         Bdev,
         CoreError,
         DmaError,
+        Reactor,
+        mayastor_env_stop,
         MayastorEnvironment,
-        Reactors,
     },
     jsonrpc::print_error_chain,
     logger,
@@ -182,7 +182,7 @@ fn main() {
                 };
                 mayastor_env_stop(rc)
             };
-            Reactors::current().unwrap().send_future(fut);
+            Reactor::block_on(fut);
         })
         .unwrap();
     info!("{}", rc);

--- a/mayastor/src/core/reactor.rs
+++ b/mayastor/src/core/reactor.rs
@@ -1,13 +1,7 @@
-//!
-//! The reactor is the main loop that will run on each core that is available to
-//! use given by the the coremask argument.
-//!The reactor is the main loop that runs on each core that is available to use
-//! given by the core mask argument.
-//!
-//! The first thing that needs to happen is to initialize DPDK, this among others
-//! provides us with lockless queues which we use to send messages between the
-//! cores.  Typically these messages contain simple function pointers and
-//! argument pointers.
+//! The first thing that needs to happen is to initialize DPDK, this among
+//! others provides us with lockless queues which we use to send messages
+//! between the cores.  Typically these messages contain simple function
+//! pointers and argument pointers.
 //!
 //! Per core data structure, there are so-called threads. These threads
 //! represent, not to be confused with OS threads are created dynamically
@@ -16,9 +10,9 @@
 //! and allows us to divide work between cores evenly.
 //!
 //! To summarize, a reactor instance to CPU core is a one-to-one relation. A
-//! reactor, in turn, may have one or more thread objects. The thread objects MAY
-//! hold messages for a specific subsystem. During init, per reactor, we create
-//! one thread which is always thread 0.
+//! reactor, in turn, may have one or more thread objects. The thread objects
+//! MAY hold messages for a specific subsystem. During init, per reactor, we
+//! create one thread which is always thread 0.
 //!
 //! During the poll loop, we traverse all threads and poll each queue of that
 //! thread. The functions executed are all executed within the context of that
@@ -30,11 +24,11 @@
 //! The queue of each thread is unique, but the messages in the queue are all
 //! preallocated from a global pool. This prevents allocations at runtime.
 //!
-//! Alongside that, each reactor (currently) has two additional queues. One queue
-//! is for receiving and sending messages between cores. The other queue is used
-//! for holding on to the messages while it is being processed. Once processed
-//! (or completed) it is dropped from the queue. Unlike the native SPDK messages,
-//! these futures -- are allocated before they execute.
+//! Alongside that, each reactor (currently) has two additional queues. One
+//! queue is for receiving and sending messages between cores. The other queue
+//! is used for holding on to the messages while it is being processed. Once
+//! processed (or completed) it is dropped from the queue. Unlike the native
+//! SPDK messages, these futures -- are allocated before they execute.
 //!
 use std::{cell::Cell, os::raw::c_void, pin::Pin, slice::Iter, time::Duration};
 
@@ -54,11 +48,11 @@ use spdk_sys::{
 
 use crate::core::{Cores, Mthread};
 
-pub(crate) const INIT: usize = 1 << 1;
-pub(crate) const RUNNING: usize = 1 << 2;
-pub(crate) const SHUTDOWN: usize = 1 << 3;
-pub(crate) const SUSPEND: usize = 1 << 4;
-pub(crate) const DEVELOPER_DELAY: usize = 1 << 5;
+pub(crate) const INIT: usize = 1;
+pub(crate) const RUNNING: usize = 1 << 1;
+pub(crate) const SHUTDOWN: usize = 1 << 2;
+pub(crate) const SUSPEND: usize = 1 << 3;
+pub(crate) const DEVELOPER_DELAY: usize = 1 << 4;
 
 #[derive(Debug)]
 pub struct Reactors(Vec<Reactor>);

--- a/mayastor/src/core/reactor.rs
+++ b/mayastor/src/core/reactor.rs
@@ -260,8 +260,6 @@ impl Reactor {
                     return output;
                 }
                 Poll::Pending => {
-                    // should we allow for any other futures to be spawned here?
-                    reactor.receive_futures();
                     reactor.threads[0].with(|| {
                         reactor.run_futures();
                     });

--- a/mayastor/tests/mount_fs.rs
+++ b/mayastor/tests/mount_fs.rs
@@ -4,7 +4,6 @@ use mayastor::{
     bdev::{nexus_create, nexus_lookup},
     core::{mayastor_env_stop, MayastorCliArgs, MayastorEnvironment, Reactor},
 };
-use std::time::Duration;
 
 static DISKNAME1: &str = "/tmp/disk1.img";
 static BDEVNAME1: &str = "aio:///tmp/disk1.img?blk_size=512";
@@ -29,7 +28,6 @@ fn mount_fs() {
 
         let s1 = s.clone();
         std::thread::spawn(move || {
-            std::thread::sleep(Duration::from_secs(5));
             common::mkfs(&device, &fstype);
             let md5 = common::mount_and_write_file(&device);
             s1.send(md5).unwrap();


### PR DESCRIPTION
NBD was hanging when we shutdown as we did not wait for any outstanding IO completed. These IO's where not submitted by us rather by systemd-udev.

Secondly, when we use `block_on` our reactor state is not set to running which implies we need to account for handling this case in the shutdown future. This typically affects testing and not normal mode of operations. 