### PR TITLE
workaround: nix-unstable is not joking

### DIFF
--- a/nix/mayastor-overlay.nix
+++ b/nix/mayastor-overlay.nix
@@ -1,4 +1,17 @@
 self: super: {
+  lcov = super.lcov.overrideAttrs(oldAttrs: rec {
+	  patches =
+    [ (super.fetchpatch {
+        url = https://github.com/linux-test-project/lcov/commit/ebfeb3e179e450c69c3532f98cd5ea1fbf6ccba7.patch;
+        sha256 = "0dalkqbjb6a4vp1lcsxd39dpn5fzdf7ihsjbiviq285s15nxdj1j";
+      })
+      (super.fetchpatch {
+        url = https://github.com/linux-test-project/lcov/commit/75fbae1cfc5027f818a0bb865bf6f96fab3202da.patch;
+        sha256 = "0v1hn0511dxqbf50ppwasc6vmg0m6rns7ydbdy2rdbn0j7gxw30x";
+      })
+    ];
+
+  });
   libiscsi = super.callPackage ./pkgs/libiscsi {};
   nvme-cli = super.callPackage ./pkgs/nvme-cli {};
   nvmet-cli = super.callPackage ./pkgs/nvmet-cli {};


### PR DESCRIPTION
The hashes for the patches used by lcov are not matching
this change overrides the attribute to get us passed that.