### PR TITLE
As a developer I want to trigger CI/CD pipeline when I update my PR

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,12 +7,6 @@ stages:
   - image
   - publish
 
-.only-default: &only-default
-  only:
-    - master
-    - external_pull_requests
-    - web
-
 # Check code style and common programming errors in JS and rust
 # source code. Do this in parallel to the build of the product,
 # because cargo clippy takes time and we don't want to wait for it.
@@ -27,14 +21,10 @@ lint:
     - nix-shell --run 'jshint --config .jshintrc csi/moac/*.js mayastor-test/*.js'
     - nix-shell --run 'cargo fmt --all'
     - nix-shell --run 'cargo clippy --all --all-targets -- -D warnings'
-  only:
-    - external_pull_requests
-    - web
 
 # Build mayastor and grpc gateway (rust source code) and run rust unit tests.
 # Save built binaries for API tests done in the next stage.
 build-mayastor:
-  <<: *only-default
   stage: build
   image: mayadata/ms-buildenv:latest
   cache:
@@ -72,7 +62,6 @@ build-mayastor:
 
 # Test mayastor grpc & cli interfaces using JS mocha test framework.
 test-mayastor:
-  <<: *only-default
   stage: test
   image: mayadata/ms-buildenv:latest
   dependencies:
@@ -101,7 +90,6 @@ test-mayastor:
 # Build moac which comprises installation of npm dependencies and run
 # the tests on it.
 build-moac:
-  <<: *only-default
   stage: build
   image: mayadata/ms-buildenv:latest
   cache:
@@ -114,7 +102,6 @@ build-moac:
 
 # Build moac docker image using the NIX.
 image-moac:
-  <<: *only-default
   stage: image
   image: mayadata/ms-buildenv:latest
   script:
@@ -127,7 +114,6 @@ image-moac:
 
 # Build mayastor docker images using the NIX.
 image-mayastor:
-  <<: *only-default
   stage: image
   image: mayadata/ms-buildenv:latest
   before_script:


### PR DESCRIPTION
Sadly this reverts most of the a1304d05d (CI/CD pipeline was spawned
twice for each PR), however external_pull_requests gitlab feature is
so buggy that we have no other option. The long term solution will be
to migrate from gitlab to something else.