### PR TITLE
nix: Use mayastor-overlay to build liburing

### DIFF
--- a/nix/mayastor-overlay.nix
+++ b/nix/mayastor-overlay.nix
@@ -1,5 +1,6 @@
 self: super: {
   libiscsi = super.callPackage ./pkgs/libiscsi {};
+  liburing = super.callPackage ./pkgs/liburing {};
   nvme-cli = super.callPackage ./pkgs/nvme-cli {};
   nvmet-cli = super.callPackage ./pkgs/nvmet-cli {};
   libspdk = super.callPackage ./pkgs/libspdk {};

--- a/nix/pkgs/liburing/default.nix
+++ b/nix/pkgs/liburing/default.nix
@@ -1,0 +1,44 @@
+{ stdenv, fetchgit
+, fetchpatch
+}:
+
+stdenv.mkDerivation rec {
+  pname = "liburing";
+  version = "0.5";
+
+  src = fetchgit {
+    url    = "http://git.kernel.dk/${pname}";
+    rev    = "3be13f40c02f245ac03a8b3500736e657f04920a";
+    sha256 = "09q33iw0y5xb2237k0px5s54kbk0ch20nr4j2c050nzss3fmsg2f";
+  };
+
+  separateDebugInfo = true;
+  enableParallelBuilding = true;
+
+  outputs = [ "out" "lib" "dev" "man" ];
+
+  configurePhase = ''
+    ./configure \
+      --prefix=$out \
+      --includedir=$dev/include \
+      --libdir=$lib/lib \
+      --libdevdir=$lib/lib \
+      --mandir=$man/share/man \
+  '';
+
+  # Copy the examples into $out.
+  postInstall = ''
+    mkdir -p $out/bin
+    cp ./examples/io_uring-cp examples/io_uring-test $out/bin
+    cp ./examples/link-cp $out/bin/io_uring-link-cp
+    cp ./examples/ucontext-cp $out/bin/io_uring-ucontext-cp
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Userspace library for the Linux io_uring API";
+    homepage    = https://git.kernel.dk/cgit/liburing/;
+    license     = licenses.lgpl21;
+    platforms   = platforms.linux;
+    maintainers = with maintainers; [ thoughtpolice ];
+  };
+}


### PR DESCRIPTION
Upstream nix-unstable moved from liburing 0.2 to 0.4pre, which introduced libdevdir in the configure script. This was not set as part of the build so libspdk_fat.so ended up being linked to liburing.so.1 without a full path, breaking the build of Mayastor.

Override upstream's nix expression by setting libdevdir to libdir, and also moving up to the current 0.5 release.