### PR TITLE
add terraform helpers to construct k8s clusters

### DIFF
--- a/terraform/README.adoc
+++ b/terraform/README.adoc
@@ -1,0 +1,114 @@
+:source-highlighter: highlightjs
+:toc:
+
+== Quick start
+
+. Ensure you have libvirtd running and configured properly
+. Edit `variables.tf` in particular make sure you the public key is correct
+. run `terraform init`
+. run `terraform plan`
+. run `terraform apply`
+
+NOTE: currently the private_key file is also used and is read from the `ssh_user`
+home dir.
+
+== Problem statement
+
+When we want to deploy our "k8s storage" system we want to create and destroy
+k8s clusters very quickly and without any pain regardless of where you deploy it.
+
+So this means we want to deploy it:
+
+1. locally (KVM)
+2. AWS
+3. GCE
+4. Whatever
+
+We however, do not "just" want to deploy k8s, but also we want to be able to
+interact with the hosts itself. For example; verify that we indeed have a new
+nvmf target what have you.
+
+So we need a from of infra management but also - configuration management. These
+scripts are intended to do just that.
+
+== Terraform
+
+Terraform is used to construct the actually cluster and install kubernetes. By default
+only the libvirtd provider is available. However, the code has been structured
+such that we can change the provider module in `main.tf` with any other provider
+and get the same k8s cluster. We can for example add `mod/vbox` which will then
+deploy 3 virtual vbox nodes. The k8s deployment code is decoupled from the actual
+vms. The VMs are assumed to be *Ubuntu* based and makes use of *cloud-init*
+
+After the deployment of the VMs the `k8s` module runs. This module will invoke
+using the output from the previous provider, provisioners to install k8s on the
+master node. 
+
+
+=== Setting up libvirt on Nixos
+
+In order to to use the the libvirt provider you must enable libvirtd
+
+[source,bash]
+----
+boot.extraModprobeConfig = "options kvm_intel nested=1"; // <1>
+virtualisation.libvirtd.enable = true;
+
+users.users.gila = {
+    isNormalUser = true;
+    extraGroups = [ "wheel" "libvirtd" "vboxusers" ]; // <2>
+};
+----
+<1> depends on CPU vendor (intel vs amd)
+<2> make sure you pick the right user name
+
+
+== Main configuration file
+
+The main configuration file is `variables.tf` where all fields **must** be set.
+The `image_path` variable assumes a pre-downloaded image but you can also set it
+to fetch from http. For example:
+
+[source,bash]
+----
+cd /path/to/my/images
+wget https://cloud-images.ubuntu.com/xenial/current/xenial-server-cloudimg-amd64-disk1.img
+----
+
+then change the image path variable to `/path/to/my/images` 
+
+== k8s configuration
+
+K8s is configured by creating a `YAML` file that uses the same variables
+as defined in `variables.tf` but also, it fetches output variables from Terraform.
+
+
+== Terrible
+
+If you want to go terraform can provide you with a basic ansible inventory
+file (hence terrible). This file is printed to the console after `terraform apply` but can also
+be obtained by: 
+[source, bash]
+----
+➜  terraform git:(terraform) ✗ terraform output kluster
+[ks-master]
+ksnode-1 ansible_host=192.168.122.24
+
+[ks-nodes]
+
+ksnode-2 ansible_host=192.168.122.9
+ksnode-3 ansible_host=192.168.122.40
+ssh_user: gila
+----
+
+This nice thing about ansible is that it does not require any SW to be installed
+on the targets.
+
+
+
+[TODO]
+- [ ] auto install mayastor
+- [ ] make the ssh key handeling read all from file or all from vars (right now it does a bit of both)
+- [ ] configure kubectl properly using local-exec provider
+
+

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,25 @@
+module "libvirt" {
+  source = "./mod/libvirt"
+
+  image_path         = var.image_path
+  num_nodes          = var.num_nodes
+  hostname_formatter = var.hostname_formatter
+  ssh_user           = var.ssh_user
+  ssh_key            = var.ssh_key
+  disk_size          = var.disk_size
+
+}
+
+module "k8s" {
+  source = "./mod/k8s"
+
+  num_nodes          = var.num_nodes
+  ssh_user           = var.ssh_user
+  ssh_key            = var.ssh_key
+  node_list          = module.libvirt.node_list
+}
+
+output "kluster" {
+	value =  module.libvirt.ks-cluster-nodes
+}
+

--- a/terraform/mod/k8s/kubeadm_config.yaml
+++ b/terraform/mod/k8s/kubeadm_config.yaml
@@ -1,0 +1,28 @@
+apiVersion: kubeadm.k8s.io/v1beta2
+bootstrapTokens:
+  - groups:
+      - system:bootstrappers:kubeadm:default-node-token
+    token: ${token}
+    ttl: 24h0m0s
+    usages:
+      - signing
+      - authentication
+kind: InitConfiguration
+localAPIEndpoint:
+  advertiseAddress: ${master_ip}
+  bindPort: 6443
+---
+apiVersion: kubeadm.k8s.io/v1beta2
+apiServer:
+  timeoutForControlPlane: 4m0s
+  certSANs:
+    - ${cert_sans}
+clusterName: gilanetes
+kind: ClusterConfiguration
+networking:
+  serviceSubnet: "10.96.0.0/12"
+  podSubnet: ${pod_cidr}
+---
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+cgroupDriver: "systemd"

--- a/terraform/mod/k8s/main.tf
+++ b/terraform/mod/k8s/main.tf
@@ -1,0 +1,76 @@
+variable "k8s_cluster_token" {
+  default = "abcdef.1234567890abcdef"
+}
+variable "overlay_cidr" {
+  default = "10.244.0.0/16"
+}
+
+variable "num_nodes" {
+
+}
+
+variable "ssh_user" {
+
+}
+
+variable "ssh_key" {
+
+}
+variable "node_list" {
+
+}
+
+resource "null_resource" "k8s" {
+  count = var.num_nodes
+
+  connection {
+    host        = element(var.node_list, count.index)
+    user        = var.ssh_user
+    private_key = file(format("/home/%s/.ssh/id_rsa", var.ssh_user))
+
+  }
+
+  provisioner "file" {
+    content     = data.template_file.master-configuration.rendered
+    destination = "/tmp/kubeadm_config.yaml"
+  }
+
+
+  provisioner "remote-exec" {
+    inline = [element(data.template_file.install.*.rendered, count.index)]
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      count.index == 0 ? data.template_file.master.rendered : data.template_file.node.rendered
+    ]
+  }
+}
+
+data "template_file" "master-configuration" {
+  template = file("${path.module}/kubeadm_config.yaml")
+
+  vars = {
+    master_ip = element(var.node_list, 0)
+    token     = var.k8s_cluster_token
+    cert_sans = element(var.node_list, 0)
+    pod_cidr  = var.overlay_cidr
+  }
+}
+
+data "template_file" "install" {
+  count    = var.num_nodes
+  template = file("${path.module}/repo.sh")
+}
+
+data "template_file" "master" {
+  template = file("${path.module}/master.sh")
+}
+
+data "template_file" "node" {
+  template = file("${path.module}/node.sh")
+  vars = {
+    master_ip = element(var.node_list, 0)
+    token     = var.k8s_cluster_token
+  }
+}

--- a/terraform/mod/k8s/master.sh
+++ b/terraform/mod/k8s/master.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+sudo kubeadm init --config /tmp/kubeadm_config.yaml \
+  --ignore-preflight-errors=Swap,NumCPU
+
+[ -d "$HOME"/.kube ] || mkdir -p "$HOME"/.kube
+ln -s /etc/kubernetes/admin.conf "$HOME"/.kube/config
+
+while ! nc -z localhost 6443; do
+  echo "...Waiting on k8s API server to give a sign of life"
+  sleep 5
+done
+
+sudo kubectl apply -f https://raw.githubusercontent.com/cloudnativelabs/kube-router/master/daemonset/kubeadm-kuberouter.yaml

--- a/terraform/mod/k8s/node.sh
+++ b/terraform/mod/k8s/node.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+until $(nc -z ${master_ip} 6443); do
+  echo "Waiting for API server to respond"
+  sleep 5
+done
+
+sudo kubeadm join --token=${token} ${master_ip}:6443 \
+  --discovery-token-unsafe-skip-ca-verification \
+  --ignore-preflight-errors=Swap

--- a/terraform/mod/k8s/repo.sh
+++ b/terraform/mod/k8s/repo.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+sudo apt-get update && sudo apt-get install -y apt-transport-https curl \
+  ca-certificates software-properties-common
+
+curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+cat <<EOF | sudo tee /etc/apt/sources.list.d/kubernetes.list
+deb https://apt.kubernetes.io/ kubernetes-xenial main
+EOF
+
+sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu xenial stable"
+
+sudo apt-get update
+sudo apt-get install -y kubelet kubeadm kubectl docker-ce containerd.io docker-ce-cli
+sudo apt-mark hold kubelet kubeadm kubectl
+
+sudo tee /etc/docker/daemon.json >/dev/null <<EOF
+{
+  "exec-opts": ["native.cgroupdriver=systemd"],
+  "log-driver": "json-file",
+  "log-opts": {
+    "max-size": "100m"
+  },
+  "storage-driver": "overlay2"
+}
+EOF
+
+sudo mkdir -p /etc/systemd/system/docker.service.d
+
+# Restart docker.
+sudo systemctl daemon-reload
+sudo systemctl restart docker
+
+sudo tee /etc/modules-load.d/containerd.conf >/dev/null <<EOF
+overlay
+br_netfilter
+EOF
+
+sudo modprobe overlay
+sudo modprobe br_netfilter
+
+# Setup required sysctl params, these persist across reboots.
+sudo sysctl --system
+sudo mkdir -p /etc/containerd
+sudo containerd config default | sudo tee /etc/containerd/config.toml
+
+# Restart containerd
+sudo systemctl restart containerd

--- a/terraform/mod/libvirt/cloud_init.tmpl
+++ b/terraform/mod/libvirt/cloud_init.tmpl
@@ -1,0 +1,22 @@
+#cloud-config
+system_info:
+  default_user:
+    name: ${ssh_user}
+    sudo: ALL=(ALL) NOPASSWD:ALL
+users:
+  - name: ${ssh_user}
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    shell: /bin/bash
+    groups: users, wheel
+    ssh_authorized_keys:
+      - ${ssh_key}
+ssh_pwauth: True
+chpasswd:
+  list: |
+    root:mayastor
+  expire: False
+growpart:
+  mode: auto
+  devices: ["/"]
+  ignore_growroot_disabled: false
+hostname: ${hostname}

--- a/terraform/mod/libvirt/main.tf
+++ b/terraform/mod/libvirt/main.tf
@@ -1,0 +1,143 @@
+# variables are declared in the top level variable file
+
+variable "image_path" {
+}
+
+variable "num_nodes" {
+}
+
+variable "hostname_formatter" {
+}
+
+variable "ssh_user" {
+}
+
+variable "ssh_key" {
+}
+
+variable "disk_size" {
+}
+
+provider "libvirt" {
+  uri = "qemu:///system"
+}
+
+# a pool is where we store all images and cloud-init iso's
+resource "libvirt_pool" "ubuntu-pool" {
+  name = "ubuntu-pool"
+  type = "dir"
+  path = var.image_path
+}
+
+# our base image from ubuntu, that includes by default cloud-init
+resource "libvirt_volume" "ubuntu-qcow2" {
+  name   = "ubuntu-base"
+  pool   = libvirt_pool.ubuntu-pool.name
+  source = "/code/ubuntu-18.04-server-cloudimg-amd64.img"
+  format = "qcow2"
+}
+
+# we want to, based of the first image, create 3 separate images each with their own
+# cloud-init settings
+resource "libvirt_volume" "ubuntu-qcow2-resized" {
+  name           = format(var.hostname_formatter, count.index + 1)
+  count          = var.num_nodes
+  base_volume_id = libvirt_volume.ubuntu-qcow2.id
+  pool           = libvirt_pool.ubuntu-pool.name
+  size           = var.disk_size
+}
+
+# user data that we pass to cloud init that reads variables from variables.tf and
+# passes them to a template file to be filled in.
+
+data "template_file" "user_data" {
+  count = var.num_nodes
+  template = templatefile("${path.module}/cloud_init.tmpl",
+    { ssh_user = var.ssh_user, ssh_key = var.ssh_key,
+  hostname = format(var.hostname_formatter, count.index + 1) })
+}
+
+# likewise for networking
+data "template_file" "network_config" {
+  template = file("${path.module}/network_config.cfg")
+}
+
+# our cloud-init disk resource
+resource "libvirt_cloudinit_disk" "commoninit" {
+  name           = format("commoninit-%d.iso", count.index + 1)
+  count          = var.num_nodes
+  user_data      = data.template_file.user_data[count.index].rendered
+  network_config = data.template_file.network_config.rendered
+  pool           = libvirt_pool.ubuntu-pool.name
+}
+
+# create the actual VMs for the cluster
+resource "libvirt_domain" "ubuntu-domain" {
+  count     = var.num_nodes
+  name      = format(var.hostname_formatter, count.index + 1)
+  memory    = 4096
+  vcpu      = 2
+  autostart = true
+
+  cloudinit = libvirt_cloudinit_disk.commoninit[count.index].id
+
+  disk {
+    volume_id = libvirt_volume.ubuntu-qcow2-resized[count.index].id
+    scsi      = "true"
+  }
+
+  console {
+    type        = "pty"
+    target_type = "serial"
+    target_port = "0"
+  }
+
+  network_interface {
+    network_name   = "default"
+    hostname       = format(var.hostname_formatter, count.index + 1)
+    wait_for_lease = true
+  }
+
+  console {
+    type        = "pty"
+    target_type = "virtio"
+    target_port = "1"
+  }
+
+  # as each nodes comes online, grab the DHCP assigned IP and call cloud-init status --wait
+  # this will keep running until SSH allows access and thus, we know by then, the system
+  # is ready for business as it would return only when cloud-init has completed. We do not however
+  # know the outcome of cloud-init but we have faith, and will now soon enough if it failed
+
+  provisioner "remote-exec" {
+    inline = ["cloud-init status --wait"]
+    connection {
+      type        = "ssh"
+      user        = var.ssh_user
+      host        = self.network_interface.0.addresses.0
+      private_key = file(format("/home/%s/.ssh/id_rsa", var.ssh_user))
+    }
+  }
+}
+
+# generate the inventory template for ansible
+output "ks-cluster-nodes" {
+  value = <<EOT
+[ks-master]
+${libvirt_domain.ubuntu-domain.0.name} ansible_host=${libvirt_domain.ubuntu-domain.0.network_interface.0.addresses.0}
+
+[ks-nodes]
+%{for ip in libvirt_domain.ubuntu-domain.*~}
+%{if ip.name != "${format(var.hostname_formatter, 1)}"}${ip.name} ansible_host=${ip.network_interface.0.addresses.0}%{endif}
+%{endfor~}
+ssh_user: ${var.ssh_user}
+EOT
+}
+
+output "node_list" {
+  value = libvirt_domain.ubuntu-domain.*.network_interface.0.addresses.0
+}
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/mod/libvirt/network_config.cfg
+++ b/terraform/mod/libvirt/network_config.cfg
@@ -1,0 +1,4 @@
+version: 2
+ethernets:
+  ens3:
+    dhcp4: true

--- a/terraform/shell.nix
+++ b/terraform/shell.nix
@@ -1,0 +1,7 @@
+with import <nixpkgs> { };
+
+let t = terraform.withPlugins (p: [ p.libvirt p.null p.template ]);
+in mkShell {
+  buildInputs = [ t tflint ];
+}
+

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,37 @@
+variable "image_path" {
+  type        = string
+  description = "Where the images will be stored"
+  default     = "/code/ubuntu-pool"
+}
+
+variable "ssh_key" {
+  type        = string
+  description = "SSH pub key to use"
+}
+
+# this variable is used in two different ways. One is to create the user
+# but we also use the ~/$user/.ssh path to grab the private_key to connect
+# to the VMs.
+
+variable "ssh_user" {
+  type        = string
+  description = "The user that should be created and who has sudo power"
+  default     = "gila"
+}
+
+variable "disk_size" {
+  type        = number
+  description = "The size of the root disk in bytes"
+  default     = 5361393664
+}
+
+variable "hostname_formatter" {
+  type    = string
+  default = "ksnode-%d"
+}
+
+variable "num_nodes" {
+  type        = number
+  default     = 3
+  description = "The number of nodes to create"
+}


### PR DESCRIPTION
This is an initial pass to providing automated setup of a k8s cluster. We can extend this as we need to for other providers. The purpose of this is to get something "fast but working" and not delve into the more sophisticated systems like KOPS and/or Kubespray. 

Some notes:

 - it might be useful to build an ISO to avoid pkg installing which consumes the most time 
- installing mayastor on this cluster automatically is not done yet the intent is to use terraform for this as well
- the setup of the OS, ie huge pages and kubelet config is purposely not setup. the reason for this is that we must provide an easy way to do this with a system that is not configured correctly yet
- we always grab the latest release we can pin the exact release in the YAML files if we want
