### PR TITLE
nexus: add ability to share through iSCSI

### DIFF
--- a/cli/src/convert.rs
+++ b/cli/src/convert.rs
@@ -1,4 +1,5 @@
 use byte_unit::Byte;
+use rpc::mayastor::ShareProtocolNexus;
 
 /// converts a human string into a blocklen
 #[allow(dead_code)]
@@ -21,5 +22,14 @@ pub(crate) fn parse_size(src: &str) -> Result<u64, String> {
         Ok(val.get_bytes() as u64)
     } else {
         Err(src.to_string())
+    }
+}
+
+pub(crate) fn parse_proto(src: &str) -> Result<ShareProtocolNexus, &str> {
+    match src.to_lowercase().trim() {
+        "nbd" => Ok(ShareProtocolNexus::NexusNbd),
+        "nvmf" => Ok(ShareProtocolNexus::NexusNvmf),
+        "iscsi" => Ok(ShareProtocolNexus::NexusIscsi),
+        _ => Err("Protocol needs be either NVMf, iSCSI or NBD"),
     }
 }

--- a/cli/src/mctl.rs
+++ b/cli/src/mctl.rs
@@ -89,6 +89,13 @@ enum Sub {
         #[structopt(name = "uuid")]
         /// UUID of the nexus to be published
         uuid: String,
+        /// Protocol to use when sharing the nexus.
+        /// Can be NVMf, ISCSI, NBD
+        #[structopt(
+            name = "protocol",
+            parse(try_from_str = "convert::parse_proto")
+        )]
+        protocol: ShareProtocolNexus,
         /// 128 bit encryption key to be used for encrypting the data section
         /// of the nexus.
         #[structopt(name = "key", default_value = "")]
@@ -173,11 +180,15 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
         Sub::Publish {
             uuid,
             key,
+            protocol,
         } => serde_json::to_string_pretty(
             &call::<_, PublishNexusReply>(
                 &opt.socket,
                 "publish_nexus",
-                Some(json!({ "uuid": uuid , "key" : key})),
+                Some(json!({ "uuid": uuid,
+                    "share" : protocol as i32,
+                    "key" : key,
+                })),
             )
             .await?,
         )?,

--- a/csi/moac/nexus.js
+++ b/csi/moac/nexus.js
@@ -136,6 +136,7 @@ class Nexus {
       res = await this.node.call('publishNexus', {
         uuid: this.uuid,
         key: '',
+        share: 0, // hard-coded to use Nbd for now.
       });
     } catch (err) {
       throw new GrpcError(

--- a/csi/moac/pool.js
+++ b/csi/moac/pool.js
@@ -228,7 +228,7 @@ class Pool {
   async createReplica(uuid, size) {
     let pool = this.name;
     const thin = false;
-    const share = 'NONE';
+    const share = 'REPLICA_NONE';
 
     log.debug(`Creating replica "${uuid}" on the pool "${this}" ...`);
 

--- a/csi/moac/replica.js
+++ b/csi/moac/replica.js
@@ -82,7 +82,9 @@ class Replica {
   async setShare(share) {
     var res;
 
-    assert(['NONE', 'ISCSI', 'NVMF'].indexOf(share) >= 0);
+    assert(
+      ['REPLICA_NONE', 'REPLICA_ISCSI', 'REPLICA_NVMF'].indexOf(share) >= 0
+    );
     log.debug(`Setting share protocol for replica "${this}" ...`);
 
     try {

--- a/csi/moac/test/mayastor_mock.js
+++ b/csi/moac/test/mayastor_mock.js
@@ -117,9 +117,9 @@ class MayastorServer {
           pool.used += args.size;
         }
         var uri;
-        if (args.share == 'NONE') {
+        if (args.share == 'REPLICA_NONE') {
           uri = 'bdev:///' + args.uuid;
-        } else if (args.share == 'ISCSI') {
+        } else if (args.share == 'REPLICA_ISCSI') {
           uri = 'iscsi://192.168.0.1:3800/' + args.uuid;
         } else {
           uri = 'nvmf://192.168.0.1:4020/' + args.uuid;
@@ -181,11 +181,11 @@ class MayastorServer {
           err.code = grpc.status.NOT_FOUND;
           return cb(err);
         }
-        if (args.share == 'NONE') {
+        if (args.share == 'REPLICA_NONE') {
           r.uri = 'bdev:///' + r.uuid;
-        } else if (args.share == 'ISCSI') {
+        } else if (args.share == 'REPLICA_ISCSI') {
           r.uri = 'iscsi://192.168.0.1:3800/' + r.uuid;
-        } else if (args.share == 'NVMF') {
+        } else if (args.share == 'REPLICA_NVMF') {
           r.uri = 'nvmf://192.168.0.1:4020/' + r.uuid;
         } else {
           assert(false, 'Invalid share protocol');
@@ -235,7 +235,8 @@ class MayastorServer {
       },
       publishNexus: (call, cb) => {
         var args = call.request;
-        assertHasKeys(args, ['uuid', 'key'], ['key']);
+        assertHasKeys(args, ['uuid', 'share', 'key'], ['key']);
+        assert.equal(0, args.share); // Must be value of NEXUS_NBD for now
         var idx = self.nexus.findIndex(n => n.uuid == args.uuid);
         if (idx >= 0) {
           self.nexus[idx].devicePath = '/dev/nbd0';

--- a/csi/moac/test/nexus_test.js
+++ b/csi/moac/test/nexus_test.js
@@ -193,6 +193,7 @@ module.exports = function() {
       sinon.assert.calledWith(callStub, 'publishNexus', {
         uuid: UUID,
         key: '',
+        share: 0, // Nbd for now
       });
       expect(nexus.devicePath).to.equal('/dev/nbd0');
       sinon.assert.calledOnce(eventSpy);

--- a/csi/moac/test/node_test.js
+++ b/csi/moac/test/node_test.js
@@ -31,7 +31,7 @@ module.exports = function() {
       pool: 'pool',
       size: 10,
       thin: false,
-      share: 'NONE',
+      share: 'REPLICA_NONE',
       uri: 'bdev:///' + UUID,
     },
   ];
@@ -39,6 +39,7 @@ module.exports = function() {
     {
       uuid: UUID,
       size: 10,
+      share: 0, // value of NEXUS_NBD for now.
       state: 'ONLINE',
       children: [
         {
@@ -129,7 +130,7 @@ module.exports = function() {
           expect(replicaObjects[0].uuid).to.equal(UUID);
           expect(replicaObjects[0].pool.name).to.equal('pool');
           expect(replicaObjects[0].size).to.equal(10);
-          expect(replicaObjects[0].share).to.equal('NONE');
+          expect(replicaObjects[0].share).to.equal('REPLICA_NONE');
           expect(replicaObjects[0].uri).to.equal('bdev:///' + UUID);
 
           expect(nexusObjects).to.have.lengthOf(1);
@@ -185,13 +186,13 @@ module.exports = function() {
         node.once('replica', ev => {
           expect(ev.eventType).to.equal('mod');
           expect(ev.object).to.be.an.instanceof(Replica);
-          expect(ev.object.share).to.equal('NVMF');
+          expect(ev.object.share).to.equal('REPLICA_NVMF');
           expect(ev.object.uri).to.equal('nvmf://blabla');
           done();
         });
         // modify replica property
         let newReplicas = _.cloneDeep(replicas);
-        newReplicas[0].share = 'NVMF';
+        newReplicas[0].share = 'REPLICA_NVMF';
         newReplicas[0].uri = 'nvmf://blabla';
         srv.replicas = newReplicas;
       });
@@ -221,7 +222,7 @@ module.exports = function() {
           pool: 'pool',
           size: 20,
           thin: false,
-          share: 'NONE',
+          share: 'REPLICA_NONE',
           uri: 'bdev:///' + newUuid,
         });
       });
@@ -243,7 +244,7 @@ module.exports = function() {
           pool: 'unknown-pool',
           size: 20,
           thin: false,
-          share: 'NONE',
+          share: 'REPLICA_NONE',
           uri: 'bdev:///' + newUuid,
         });
       });
@@ -315,7 +316,7 @@ module.exports = function() {
           pool: 'new-pool',
           size: 10,
           thin: false,
-          share: 'NONE',
+          share: 'REPLICA_NONE',
           uri: 'bdev:///' + newUuid,
         });
       });
@@ -640,7 +641,7 @@ module.exports = function() {
           pool: 'pool1',
           size: 10,
           thin: false,
-          share: 'NONE',
+          share: 'REPLICA_NONE',
           uri: 'bdev:///' + UUID,
         },
         {
@@ -648,7 +649,7 @@ module.exports = function() {
           pool: 'pool1',
           size: 10,
           thin: false,
-          share: 'NONE',
+          share: 'REPLICA_NONE',
           uri: 'bdev:///' + UUID,
         },
         {
@@ -656,7 +657,7 @@ module.exports = function() {
           pool: 'pool2',
           size: 10,
           thin: false,
-          share: 'NONE',
+          share: 'REPLICA_NONE',
           uri: 'bdev:///' + UUID,
         },
         // this replica does not belong to any pool so should be ignored
@@ -665,7 +666,7 @@ module.exports = function() {
           pool: 'unknown-pool',
           size: 10,
           thin: false,
-          share: 'NONE',
+          share: 'REPLICA_NONE',
           uri: 'bdev:///' + UUID,
         },
       ];

--- a/csi/moac/test/pool_test.js
+++ b/csi/moac/test/pool_test.js
@@ -277,7 +277,7 @@ module.exports = function() {
           pool: 'pool',
           size: 100,
           thin: false,
-          share: 'NONE',
+          share: 'REPLICA_NONE',
           state: 'ONLINE',
           uri: 'bdev://blabla',
         },
@@ -294,7 +294,7 @@ module.exports = function() {
       pool: 'pool',
       size: 100,
       thin: false,
-      share: 'NONE',
+      share: 'REPLICA_NONE',
     });
     sinon.assert.calledWithMatch(stub.secondCall, 'listReplicas', {});
     expect(pool.replicas).to.have.lengthOf(1);
@@ -313,7 +313,7 @@ module.exports = function() {
           pool: 'pool',
           size: 100,
           thin: false,
-          share: 'NONE',
+          share: 'REPLICA_NONE',
           state: 'ONLINE',
           uri: 'bdev://blabla',
         },
@@ -333,7 +333,7 @@ module.exports = function() {
       pool: 'pool',
       size: 100,
       thin: false,
-      share: 'NONE',
+      share: 'REPLICA_NONE',
     });
   });
 

--- a/csi/moac/test/replica_test.js
+++ b/csi/moac/test/replica_test.js
@@ -25,7 +25,7 @@ module.exports = function() {
     uuid: UUID,
     pool: 'pool',
     size: 100,
-    share: 'NONE',
+    share: 'REPLICA_NONE',
     uri: 'bdev:///' + UUID,
     state: 'ONLINE',
   };
@@ -75,7 +75,7 @@ module.exports = function() {
     });
 
     it('should emit event upon change of share and uri property', () => {
-      newProps.share = 'NVMF';
+      newProps.share = 'REPLICA_NVMF';
       newProps.uri = 'nvmf://blabla';
       replica.merge(newProps);
 
@@ -85,7 +85,7 @@ module.exports = function() {
         eventType: 'mod',
         object: replica,
       });
-      expect(replica.share).to.equal('NVMF');
+      expect(replica.share).to.equal('REPLICA_NVMF');
       expect(replica.uri).to.equal('nvmf://blabla');
     });
 
@@ -154,15 +154,15 @@ module.exports = function() {
     let replica = new Replica(props);
     pool.registerReplica(replica);
 
-    let uri = await replica.setShare('NVMF');
+    let uri = await replica.setShare('REPLICA_NVMF');
 
     sinon.assert.calledOnce(stub);
     sinon.assert.calledWith(stub, 'shareReplica', {
       uuid: UUID,
-      share: 'NVMF',
+      share: 'REPLICA_NVMF',
     });
     expect(uri).to.equal('nvmf://blabla');
-    expect(replica.share).to.equal('NVMF');
+    expect(replica.share).to.equal('REPLICA_NVMF');
     expect(replica.uri).to.equal('nvmf://blabla');
   });
 
@@ -176,9 +176,9 @@ module.exports = function() {
     pool.registerReplica(replica);
 
     await shouldFailWith(GrpcCode.INTERNAL, async () => {
-      await replica.setShare('NVMF');
+      await replica.setShare('REPLICA_NVMF');
     });
-    expect(replica.share).to.equal('NONE');
+    expect(replica.share).to.equal('REPLICA_NONE');
   });
 
   it('should destroy the replica', done => {

--- a/csi/moac/test/volumes_test.js
+++ b/csi/moac/test/volumes_test.js
@@ -102,7 +102,7 @@ module.exports = function() {
               pool: 'pool1',
               size: 90,
               thin: false,
-              share: 'NONE',
+              share: 'REPLICA_NONE',
               state: 'ONLINE',
               uri: 'bdev:///' + UUID,
             },
@@ -133,7 +133,7 @@ module.exports = function() {
           pool: 'pool1',
           size: 90,
           thin: false,
-          share: 'NONE',
+          share: 'REPLICA_NONE',
         });
       });
 
@@ -151,7 +151,7 @@ module.exports = function() {
               pool: 'pool1',
               size: 50,
               thin: false,
-              share: 'NONE',
+              share: 'REPLICA_NONE',
               state: 'ONLINE',
               uri: 'bdev:///' + UUID,
             },
@@ -182,7 +182,7 @@ module.exports = function() {
           pool: 'pool1',
           size: 50,
           thin: false,
-          share: 'NONE',
+          share: 'REPLICA_NONE',
         });
       });
 
@@ -228,7 +228,7 @@ module.exports = function() {
               pool: 'pool1',
               size: 96,
               thin: false,
-              share: 'NONE',
+              share: 'REPLICA_NONE',
               state: 'ONLINE',
               uri: 'bdev:///' + UUID,
             },
@@ -268,7 +268,7 @@ module.exports = function() {
               pool: 'pool2',
               size: 96,
               thin: false,
-              share: 'NONE',
+              share: 'REPLICA_NONE',
               state: 'ONLINE',
               uri: 'bdev:///' + UUID,
             },
@@ -285,7 +285,7 @@ module.exports = function() {
               pool: 'pool3',
               size: 96,
               thin: false,
-              share: 'NONE',
+              share: 'REPLICA_NONE',
               state: 'ONLINE',
               uri: 'bdev:///' + UUID,
             },
@@ -302,7 +302,7 @@ module.exports = function() {
           pool: 'pool1',
           size: 96,
           thin: false,
-          share: 'NONE',
+          share: 'REPLICA_NONE',
         });
         sinon.assert.calledWithMatch(stub1.secondCall, 'listReplicas', {});
         sinon.assert.calledWithMatch(stub1.thirdCall, 'createNexus', {
@@ -318,12 +318,12 @@ module.exports = function() {
           pool: 'pool2',
           size: 96,
           thin: false,
-          share: 'NONE',
+          share: 'REPLICA_NONE',
         });
         sinon.assert.calledWithMatch(stub2.secondCall, 'listReplicas', {});
         sinon.assert.calledWithMatch(stub2.thirdCall, 'shareReplica', {
           uuid: UUID,
-          share: 'NVMF',
+          share: 'REPLICA_NVMF',
         });
 
         expect(stub3.callCount).to.equal(3);
@@ -332,12 +332,12 @@ module.exports = function() {
           pool: 'pool3',
           size: 96,
           thin: false,
-          share: 'NONE',
+          share: 'REPLICA_NONE',
         });
         sinon.assert.calledWithMatch(stub3.secondCall, 'listReplicas', {});
         sinon.assert.calledWithMatch(stub3.thirdCall, 'shareReplica', {
           uuid: UUID,
-          share: 'NVMF',
+          share: 'REPLICA_NVMF',
         });
 
         expect(volumes.get(UUID)).to.equal(volume);
@@ -392,7 +392,7 @@ module.exports = function() {
               pool: 'pool3',
               size: 96,
               thin: false,
-              share: 'NONE',
+              share: 'REPLICA_NONE',
               state: 'ONLINE',
               uri: 'bdev:///' + UUID,
             },
@@ -417,12 +417,12 @@ module.exports = function() {
           pool: 'pool3',
           size: 96,
           thin: false,
-          share: 'NONE',
+          share: 'REPLICA_NONE',
         });
         sinon.assert.calledWithMatch(stub3.secondCall, 'listReplicas', {});
         sinon.assert.calledWithMatch(stub3.thirdCall, 'shareReplica', {
           uuid: UUID,
-          share: 'NVMF',
+          share: 'REPLICA_NVMF',
         });
       });
 
@@ -430,9 +430,9 @@ module.exports = function() {
         // We switch one of the remote replicas to local and vice versa
         let local = node1.pools[0].replicas[0];
         let remote = node2.pools[0].replicas[0];
-        local.share = 'NVMF';
+        local.share = 'REPLICA_NVMF';
         local.uri = 'nvmf://remote-replica';
-        remote.share = 'NONE';
+        remote.share = 'REPLICA_NONE';
         remote.uri = 'bdev:///' + UUID;
 
         stub1.onCall(0).resolves({ uri: 'bdev:///' + UUID });
@@ -445,12 +445,12 @@ module.exports = function() {
         expect(stub1.callCount).to.equal(1);
         sinon.assert.calledWithMatch(stub1.firstCall, 'shareReplica', {
           uuid: UUID,
-          share: 'NONE',
+          share: 'REPLICA_NONE',
         });
         expect(stub2.callCount).to.equal(1);
         sinon.assert.calledWithMatch(stub2.firstCall, 'shareReplica', {
           uuid: UUID,
-          share: 'NVMF',
+          share: 'REPLICA_NVMF',
         });
       });
 

--- a/csi/moac/volume.js
+++ b/csi/moac/volume.js
@@ -165,7 +165,7 @@ class Volume {
     if (!nexus) {
       // create a new nexus
       let localReplica = Object.values(this.replicas).find(
-        r => r.share == 'NONE'
+        r => r.share == 'REPLICA_NONE'
       );
       if (!localReplica) {
         // should not happen but who knows ..
@@ -367,11 +367,14 @@ class Volume {
       let replica = replicaSet[i];
       let share;
       // make sure that replica which is local to the nexus is accessed locally
-      if (replica.pool.node == localNode && replica.share != 'NONE') {
-        share = 'NONE';
-      } else if (replica.pool.node != localNode && replica.share == 'NONE') {
+      if (replica.pool.node == localNode && replica.share != 'REPLICA_NONE') {
+        share = 'REPLICA_NONE';
+      } else if (
+        replica.pool.node != localNode &&
+        replica.share == 'REPLICA_NONE'
+      ) {
         // make sure that replica which is remote to nexus can be accessed
-        share = 'NVMF';
+        share = 'REPLICA_NVMF';
       }
       if (share) {
         try {

--- a/csi/src/client.rs
+++ b/csi/src/client.rs
@@ -16,10 +16,16 @@ use rpc::service::mayastor_client::MayastorClient;
 
 fn parse_share_protocol(pcol: Option<&str>) -> Result<i32, Status> {
     match pcol {
-        None => Ok(rpc::mayastor::ShareProtocol::None as i32),
-        Some("nvmf") => Ok(rpc::mayastor::ShareProtocol::Nvmf as i32),
-        Some("iscsi") => Ok(rpc::mayastor::ShareProtocol::Iscsi as i32),
-        Some("none") => Ok(rpc::mayastor::ShareProtocol::None as i32),
+        None => Ok(rpc::mayastor::ShareProtocolReplica::ReplicaNone as i32),
+        Some("nvmf") => {
+            Ok(rpc::mayastor::ShareProtocolReplica::ReplicaNvmf as i32)
+        }
+        Some("iscsi") => {
+            Ok(rpc::mayastor::ShareProtocolReplica::ReplicaIscsi as i32)
+        }
+        Some("none") => {
+            Ok(rpc::mayastor::ShareProtocolReplica::ReplicaNone as i32)
+        }
         Some(_) => Err(Status::new(
             Code::Internal,
             "Invalid value of share protocol".to_owned(),
@@ -219,14 +225,14 @@ async fn list_replicas(
                 r.pool,
                 r.uuid,
                 r.thin,
-                match rpc::mayastor::ShareProtocol::from_i32(r.share) {
-                    Some(rpc::mayastor::ShareProtocol::None) => {
+                match rpc::mayastor::ShareProtocolReplica::from_i32(r.share) {
+                    Some(rpc::mayastor::ShareProtocolReplica::ReplicaNone) => {
                         "none"
                     }
-                    Some(rpc::mayastor::ShareProtocol::Nvmf) => {
+                    Some(rpc::mayastor::ShareProtocolReplica::ReplicaNvmf) => {
                         "nvmf"
                     }
-                    Some(rpc::mayastor::ShareProtocol::Iscsi) => {
+                    Some(rpc::mayastor::ShareProtocolReplica::ReplicaIscsi) => {
                         "iscsi"
                     }
                     None => "unknown",

--- a/deploy/fiotest.sh
+++ b/deploy/fiotest.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+kubectl exec -it fio -- fio --name=benchtest --size=50m --filename=/volume/test --direct=1 --rw=randrw --ioengine=libaio --bs=4k --iodepth=16 --numjobs=1 --time_based --runtime=60

--- a/mayastor-test/mayastor_proto.js
+++ b/mayastor-test/mayastor_proto.js
@@ -1,0 +1,55 @@
+'use strict';
+
+const path = require('path');
+const protoLoader = require('@grpc/proto-loader');
+// we can't use grpc-kit because we need to connect to UDS and that's currently
+// possible only with grpc-uds.
+const grpc = require('grpc-uds');
+
+function getConstants() {
+  const pkgDef = grpc.loadPackageDefinition(
+    protoLoader.loadSync(
+      path.join(__dirname, '..', 'rpc', 'proto', 'mayastor.proto'),
+      {
+        // this is to load google/descriptor.proto
+        includeDirs: ['./node_modules/protobufjs'],
+        keepCase: true,
+        longs: String,
+        enums: String,
+        defaults: true,
+        oneofs: true,
+      }
+    )
+  );
+
+  //FIXME: the correct way to do this is to enumerate all the members,
+  // and create the map from that. This will do for now.
+  return {
+    ShareProtocolReplica: {
+      REPLICA_NONE: pkgDef.mayastor.ShareProtocolReplica.type.value.find(
+        ent => ent.name == 'REPLICA_NONE'
+      ).number,
+      REPLICA_NVMF: pkgDef.mayastor.ShareProtocolReplica.type.value.find(
+        ent => ent.name == 'REPLICA_NVMF'
+      ).number,
+      REPLICA_ISCSI: pkgDef.mayastor.ShareProtocolReplica.type.value.find(
+        ent => ent.name == 'REPLICA_ISCSI'
+      ).number,
+    },
+    ShareProtocolNexus: {
+      NEXUS_NBD: pkgDef.mayastor.ShareProtocolNexus.type.value.find(
+        ent => ent.name == 'NEXUS_NBD'
+      ).number,
+      NEXUS_NVMF: pkgDef.mayastor.ShareProtocolNexus.type.value.find(
+        ent => ent.name == 'NEXUS_NVMF'
+      ).number,
+      NEXUS_ISCSI: pkgDef.mayastor.ShareProtocolNexus.type.value.find(
+        ent => ent.name == 'NEXUS_ISCSI'
+      ).number,
+    },
+  };
+}
+
+module.exports = {
+  getConstants,
+};

--- a/mayastor-test/test_csi.js
+++ b/mayastor-test/test_csi.js
@@ -24,6 +24,7 @@ const protoLoader = require('@grpc/proto-loader');
 // possible only with grpc-uds.
 const grpc = require('grpc-uds');
 const common = require('./test_common');
+const mayastorProto = require('./mayastor_proto');
 // Without requiring wtf module the ts hangs at the end. It seems that it is
 // waiting for sudo'd mayastor progress which has already exited!?
 const wtfnode = require('wtfnode');
@@ -197,7 +198,12 @@ describe('csi', function() {
               let uuid = BASE_UUID + n;
               common.dumbCommand(
                 'publish_nexus',
-                { uuid: uuid, key: '' },
+                {
+                  uuid: uuid,
+                  key: '',
+                  share: mayastorProto.getConstants().ShareProtocolNexus
+                    .NEXUS_NBD,
+                },
                 next
               );
             },

--- a/mayastor-test/test_replica.js
+++ b/mayastor-test/test_replica.js
@@ -238,7 +238,7 @@ describe('replica', function() {
         uuid: UUID,
         pool: POOL,
         thin: true,
-        share: 'ISCSI',
+        share: 'REPLICA_ISCSI',
         size: 8 * (1024 * 1024), // keep this multiple of cluster size (4MB)
       },
       (err, res) => {
@@ -262,7 +262,7 @@ describe('replica', function() {
       assert.equal(res.pool, POOL);
       assert.equal(res.thin, true);
       assert.equal(res.size, 8 * 1024 * 1024);
-      assert.equal(res.share, 'ISCSI');
+      assert.equal(res.share, 'REPLICA_ISCSI');
       assert.match(res.uri, ISCSI_URI);
       assert.equal(res.uri.match(ISCSI_URI)[1], common.getMyIp());
 
@@ -330,7 +330,7 @@ describe('replica', function() {
       assert.equal(res.pool, POOL);
       assert.equal(res.thin, true);
       assert.equal(res.size, 8 * 1024 * 1024);
-      assert.equal(res.share, 'NONE');
+      assert.equal(res.share, 'REPLICA_NONE');
       assert.match(res.uri, /^bdev:\/\/\//);
       done();
     });
@@ -340,7 +340,7 @@ describe('replica', function() {
     client.shareReplica(
       {
         uuid: UUID,
-        share: 'NVMF',
+        share: 'REPLICA_NVMF',
       },
       (err, res) => {
         if (err) return done(err);
@@ -354,7 +354,7 @@ describe('replica', function() {
           });
           assert.lengthOf(res, 1);
           res = res[0];
-          assert.equal(res.share, 'NVMF');
+          assert.equal(res.share, 'REPLICA_NVMF');
           assert.match(res.uri, NVMF_URI);
           done();
         });
@@ -366,7 +366,7 @@ describe('replica', function() {
     client.shareReplica(
       {
         uuid: UUID,
-        share: 'NVMF',
+        share: 'REPLICA_NVMF',
       },
       (err, res) => {
         if (err) return done(err);
@@ -380,7 +380,7 @@ describe('replica', function() {
     client.shareReplica(
       {
         uuid: UUID,
-        share: 'ISCSI',
+        share: 'REPLICA_ISCSI',
       },
       (err, res) => {
         if (err) return done(err);
@@ -394,7 +394,7 @@ describe('replica', function() {
           });
           assert.lengthOf(res, 1);
           res = res[0];
-          assert.equal(res.share, 'ISCSI');
+          assert.equal(res.share, 'REPLICA_ISCSI');
           assert.match(res.uri, ISCSI_URI);
           done();
         });
@@ -419,7 +419,7 @@ describe('replica', function() {
           });
           assert.lengthOf(res, 1);
           res = res[0];
-          assert.equal(res.share, 'NONE');
+          assert.equal(res.share, 'REPLICA_NONE');
           assert.match(res.uri, /^bdev:\/\/\//);
           done();
         });
@@ -559,7 +559,7 @@ describe('replica', function() {
           uuid: UUID,
           pool: POOL,
           thin: true,
-          share: 'NVMF',
+          share: 'REPLICA_NVMF',
           // Keep this multiple of cluster size (4MB).
           // Fill the entire pool so that we can test data reset
           // upon replica recreate.
@@ -587,7 +587,7 @@ describe('replica', function() {
         assert.equal(res.pool, POOL);
         assert.equal(res.thin, true);
         assert.equal(res.size, 96 * 1024 * 1024);
-        assert.equal(res.share, 'NVMF');
+        assert.equal(res.share, 'REPLICA_NVMF');
         assert.equal(res.uri, uri);
         done();
       });
@@ -649,7 +649,7 @@ describe('replica', function() {
           uuid: UUID,
           pool: POOL,
           thin: true,
-          share: 'NVMF',
+          share: 'REPLICA_NVMF',
           size: 8 * (1024 * 1024), // keep this multiple of cluster size (4MB)
         },
         (err, res) => {

--- a/mayastor/src/bdev/nexus/mod.rs
+++ b/mayastor/src/bdev/nexus/mod.rs
@@ -15,6 +15,7 @@ pub(crate) mod nexus_child;
 mod nexus_config;
 pub mod nexus_fn_table;
 pub mod nexus_io;
+pub mod nexus_iscsi;
 pub mod nexus_label;
 pub mod nexus_module;
 pub mod nexus_nbd;

--- a/mayastor/src/bdev/nexus/nexus_bdev.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev.rs
@@ -5,6 +5,7 @@
 //! application needs synchronous mirroring may be required.
 
 use std::{
+    fmt,
     fmt::{Display, Formatter},
     os::raw::c_void,
 };
@@ -39,8 +40,9 @@ use crate::{
             nexus_channel::{DREvent, NexusChannel, NexusChannelInner},
             nexus_child::{ChildError, ChildState, NexusChild},
             nexus_io::{io_status, Bio},
+            nexus_iscsi::{NexusIscsiError, NexusIscsiTarget},
             nexus_label::LabelError,
-            nexus_nbd::{Disk, NbdError},
+            nexus_nbd::{NbdDisk, NbdError},
         },
     },
     core::{Bdev, DmaBuf, DmaError},
@@ -65,12 +67,20 @@ pub enum Error {
     CreateCryptoBdev { source: Errno, name: String },
     #[snafu(display("Failed to destroy crypto bdev for nexus {}", name))]
     DestroyCryptoBdev { source: Errno, name: String },
-    #[snafu(display("The nexus {} has been already shared", name))]
+    #[snafu(display(
+        "The nexus {} has been already shared with a different protocol",
+        name
+    ))]
     AlreadyShared { name: String },
     #[snafu(display("The nexus {} has not been shared", name))]
     NotShared { name: String },
-    #[snafu(display("Failed to share nexus {}", name))]
-    ShareNexus { source: NbdError, name: String },
+    #[snafu(display("Failed to share nexus over NBD {}", name))]
+    ShareNbdNexus { source: NbdError, name: String },
+    #[snafu(display("Failed to share iscsi nexus {}", name))]
+    ShareIscsiNexus {
+        source: NexusIscsiError,
+        name: String,
+    },
     #[snafu(display("Failed to allocate label of nexus {}", name))]
     AllocLabel { source: DmaError, name: String },
     #[snafu(display("Failed to write label of nexus {}", name))]
@@ -145,6 +155,8 @@ pub enum Error {
         name: String,
         reason: String,
     },
+    #[snafu(display("Invalid ShareProtocol value {}", sp_value))]
+    InvalidShareProtocol { sp_value: i32 },
 }
 
 impl RpcErrorCode for Error {
@@ -183,12 +195,29 @@ impl RpcErrorCode for Error {
             Error::ChildNotFound {
                 ..
             } => Code::NotFound,
+            Error::InvalidShareProtocol {
+                ..
+            } => Code::InvalidParams,
             _ => Code::InternalError,
         }
     }
 }
 
 pub(crate) static NEXUS_PRODUCT_ID: &str = "Nexus CAS Driver v0.0.1";
+
+pub enum NexusTarget {
+    NbdDisk(NbdDisk),
+    NexusIscsiTarget(NexusIscsiTarget),
+}
+
+impl fmt::Debug for NexusTarget {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            NexusTarget::NbdDisk(disk) => fmt::Debug::fmt(&disk, f),
+            NexusTarget::NexusIscsiTarget(tgt) => fmt::Debug::fmt(&tgt, f),
+        }
+    }
+}
 
 /// The main nexus structure
 #[derive(Debug)]
@@ -211,13 +240,13 @@ pub struct Nexus {
     pub dr_complete_notify: Option<oneshot::Sender<i32>>,
     /// the offset in num blocks where the data partition starts
     pub data_ent_offset: u64,
-    /// nbd device which the nexus is exposed through
-    pub(crate) nbd_disk: Option<Disk>,
     /// the handle to be used when sharing the nexus, this allows for the bdev
     /// to be shared with vbdevs on top
     pub(crate) share_handle: Option<String>,
     /// vector of rebuild tasks
     pub rebuilds: Vec<RebuildTask>,
+    /// enum containing the protocol-specific target used to publish the nexus
+    pub nexus_target: Option<NexusTarget>,
 }
 
 unsafe impl core::marker::Sync for Nexus {}
@@ -291,10 +320,10 @@ impl Nexus {
             bdev_raw: Box::into_raw(b),
             dr_complete_notify: None,
             data_ent_offset: 0,
-            nbd_disk: None,
             share_handle: None,
             size,
             rebuilds: Vec::new(),
+            nexus_target: None,
         });
 
         n.bdev.set_uuid(match uuid {

--- a/mayastor/src/bdev/nexus/nexus_iscsi.rs
+++ b/mayastor/src/bdev/nexus/nexus_iscsi.rs
@@ -1,0 +1,81 @@
+//! Utility functions and wrappers for working with iSCSI devices in SPDK.
+
+use std::fmt;
+
+use snafu::Snafu;
+
+use crate::{
+    core::Bdev,
+    target::{
+        iscsi::{create_uri, share, target_name, unshare},
+        Side,
+    },
+};
+
+#[derive(Debug, Snafu)]
+pub enum NexusIscsiError {
+    #[snafu(display("Bdev not found {}", dev))]
+    BdevNotFound { dev: String },
+    #[snafu(display(
+        "Failed to create iscsi target for bdev uuid {}, error {}",
+        dev,
+        err
+    ))]
+    CreateTargetFailed { dev: String, err: String },
+}
+
+/// Iscsi target representation.
+pub struct NexusIscsiTarget {
+    bdev_name: String, /* logically we might store a spdk_iscsi_tgt_node here but ATM the bdev name is all we actually need */
+}
+
+impl NexusIscsiTarget {
+    /// Allocate iscsi device for the bdev and start it.
+    /// When the function returns the iscsi target is ready for IO.
+    pub fn create(bdev_name: &str) -> Result<Self, NexusIscsiError> {
+        let bdev = match Bdev::lookup_by_name(bdev_name) {
+            None => {
+                return Err(NexusIscsiError::BdevNotFound {
+                    dev: bdev_name.to_string(),
+                })
+            }
+            Some(bd) => bd,
+        };
+
+        match share(bdev_name, &bdev, Side::Nexus) {
+            Ok(_) => Ok(Self {
+                bdev_name: bdev_name.to_string(),
+            }),
+            Err(e) => Err(NexusIscsiError::CreateTargetFailed {
+                dev: bdev_name.to_string(),
+                err: e.to_string(),
+            }),
+        }
+    }
+
+    pub async fn destroy(self) {
+        info!("Destroying iscsi frontend target");
+        match unshare(&self.bdev_name).await {
+            Ok(()) => (),
+            Err(e) => {
+                error!("Failed to destroy iscsi frontend target, error {}", e)
+            }
+        }
+    }
+
+    pub fn as_uri(&self) -> String {
+        create_uri(Side::Nexus, &target_name(&self.bdev_name))
+    }
+}
+
+impl fmt::Debug for NexusIscsiTarget {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}@{:?}", self.as_uri(), self.bdev_name)
+    }
+}
+
+impl fmt::Display for NexusIscsiTarget {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.as_uri())
+    }
+}

--- a/mayastor/src/bdev/nexus/nexus_nbd.rs
+++ b/mayastor/src/bdev/nexus/nexus_nbd.rs
@@ -182,11 +182,11 @@ pub async fn start(
 }
 
 /// NBD disk representation.
-pub struct Disk {
+pub struct NbdDisk {
     nbd_ptr: *mut spdk_nbd_disk,
 }
 
-impl Disk {
+impl NbdDisk {
     /// Allocate nbd device for the bdev and start it.
     /// When the function returns the nbd disk is ready for IO.
     pub async fn create(bdev_name: &str) -> Result<Self, NbdError> {
@@ -255,13 +255,13 @@ impl Disk {
     }
 }
 
-impl fmt::Debug for Disk {
+impl fmt::Debug for NbdDisk {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}@{:?}", self.get_path(), self.nbd_ptr)
     }
 }
 
-impl fmt::Display for Disk {
+impl fmt::Display for NbdDisk {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.get_path())
     }

--- a/mayastor/src/bdev/nexus/nexus_rpc.rs
+++ b/mayastor/src/bdev/nexus/nexus_rpc.rs
@@ -14,6 +14,7 @@ use rpc::mayastor::{
     RebuildProgressRequest,
     RebuildStateRequest,
     RemoveChildNexusRequest,
+    ShareProtocolNexus,
     StartRebuildRequest,
     UnpublishNexusRequest,
 };
@@ -133,9 +134,21 @@ pub(crate) fn register_rpc_methods() {
             let key: Option<String> =
                 if args.key == "" { None } else { Some(args.key) };
 
+            let share_protocol = match ShareProtocolNexus::from_i32(args.share)
+            {
+                Some(protocol) => protocol,
+                None => {
+                    return Err(Error::InvalidShareProtocol {
+                        sp_value: args.share as i32,
+                    })
+                }
+            };
+
             let nexus = nexus_lookup(&args.uuid)?;
-            nexus.share(key).await.map(|device_path| PublishNexusReply {
-                device_path,
+            nexus.share(share_protocol, key).await.map(|device_path| {
+                PublishNexusReply {
+                    device_path,
+                }
             })
         };
         fut.boxed_local()

--- a/mayastor/src/bdev/nexus/nexus_share.rs
+++ b/mayastor/src/bdev/nexus/nexus_share.rs
@@ -12,29 +12,57 @@ use crate::{
             DestroyCryptoBdev,
             Error,
             Nexus,
-            ShareNexus,
+            NexusTarget,
+            ShareIscsiNexus,
+            ShareNbdNexus,
         },
-        nexus_nbd::Disk,
+        nexus_iscsi::NexusIscsiTarget,
+        nexus_nbd::NbdDisk,
     },
     core::Bdev,
     ffihelper::{cb_arg, done_errno_cb, errno_result_from_i32, ErrnoResult},
 };
+
+use rpc::mayastor::ShareProtocolNexus;
 
 /// we are using the multi buffer encryption implementation using CBC as the
 /// algorithm
 const CRYPTO_FLAVOUR: &str = "crypto_aesni_mb";
 
 impl Nexus {
-    /// Publish the nexus to system using nbd device and return the path to
-    /// nbd device.
     pub async fn share(
         &mut self,
+        share_protocol: ShareProtocolNexus,
         key: Option<String>,
     ) -> Result<String, Error> {
-        if self.nbd_disk.is_some() {
-            return Err(Error::AlreadyShared {
-                name: self.name.clone(),
-            });
+        // We could already be shared -- as CSI is idempotent chances are we get
+        // called for some odd reason. Validate indeed -- that we are
+        // shared by walking the target. If so, and the protocol is
+        // correct simply return Ok(). If so, and the protocol is
+        // incorrect, return Error(). If we are not shared but the
+        // variant says we should be, carry on to correct the state.
+        match self.nexus_target {
+            Some(NexusTarget::NbdDisk(ref nbd_disk)) => {
+                if share_protocol != ShareProtocolNexus::NexusNbd {
+                    return Err(Error::AlreadyShared {
+                        name: self.name.clone(),
+                    });
+                } else {
+                    warn!("{} is already shared", self.name);
+                    return Ok(nbd_disk.get_path());
+                }
+            }
+            Some(NexusTarget::NexusIscsiTarget(ref iscsi_target)) => {
+                if share_protocol != ShareProtocolNexus::NexusIscsi {
+                    return Err(Error::AlreadyShared {
+                        name: self.name.clone(),
+                    });
+                } else {
+                    warn!("{} is already shared", self.name);
+                    return Ok(iscsi_target.as_uri());
+                }
+            }
+            None => (),
         }
 
         assert_eq!(self.share_handle, None);
@@ -69,13 +97,40 @@ impl Nexus {
         debug!("creating share handle for {}", name);
         // The share handle is the actual bdev that is shared through the
         // various protocols.
-        let disk = Disk::create(&name).await.context(ShareNexus {
-            name: self.name.clone(),
-        })?;
-        let device_path = disk.get_path();
+
+        let device_id = match share_protocol {
+            ShareProtocolNexus::NexusNbd => {
+                // Publish the nexus to system using nbd device and return the
+                // path to nbd device.
+                let nbd_disk =
+                    NbdDisk::create(&name).await.context(ShareNbdNexus {
+                        name: self.name.clone(),
+                    })?;
+                let device_path = nbd_disk.get_path();
+                self.nexus_target = Some(NexusTarget::NbdDisk(nbd_disk));
+                device_path
+            }
+            ShareProtocolNexus::NexusIscsi => {
+                // Publish the nexus to system using an iscsi target and return
+                // the IQN
+                let iscsi_target = NexusIscsiTarget::create(&name).context(
+                    ShareIscsiNexus {
+                        name: self.name.clone(),
+                    },
+                )?;
+                let uri = iscsi_target.as_uri();
+                self.nexus_target =
+                    Some(NexusTarget::NexusIscsiTarget(iscsi_target));
+                uri
+            }
+            ShareProtocolNexus::NexusNvmf => {
+                return Err(Error::InvalidShareProtocol {
+                    sp_value: share_protocol as i32,
+                })
+            }
+        };
         self.share_handle = Some(name);
-        self.nbd_disk = Some(disk);
-        Ok(device_path)
+        Ok(device_id)
     }
 
     /// Undo share operation on nexus. To the chain of bdevs are all claimed
@@ -83,46 +138,51 @@ impl Nexus {
     /// bdev. As such, we must first destroy the share and move our way down
     /// from there.
     pub async fn unshare(&mut self) -> Result<(), Error> {
-        match self.nbd_disk.take() {
-            Some(disk) => {
+        match self.nexus_target.take() {
+            Some(NexusTarget::NbdDisk(disk)) => {
                 disk.destroy();
-                let bdev_name = self.share_handle.take().unwrap();
-                if let Some(bdev) = Bdev::lookup_by_name(&bdev_name) {
-                    // if the share handle is the same as bdev name it
-                    // implies there is no top level bdev, and we are done
-                    if self.name != bdev.name() {
-                        let (s, r) = oneshot::channel::<ErrnoResult<()>>();
-                        // currently, we only have the crypto vbdev
-                        unsafe {
-                            spdk_sys::delete_crypto_disk(
-                                bdev.as_ptr(),
-                                Some(done_errno_cb),
-                                cb_arg(s),
-                            );
-                        }
-                        r.await
-                            .expect("crypto delete sender is gone")
-                            .context(DestroyCryptoBdev {
-                                name: self.name.clone(),
-                            })?;
-                    }
-                } else {
-                    warn!("Missing bdev for a shared device");
-                }
-                Ok(())
             }
-            None => Err(Error::NotShared {
-                name: self.name.clone(),
-            }),
+            Some(NexusTarget::NexusIscsiTarget(iscsi_target)) => {
+                iscsi_target.destroy().await;
+            }
+            None => {
+                warn!("{} was not shared", self.name);
+                return Ok(());
+            }
+        };
+
+        let bdev_name = self.share_handle.take().unwrap();
+        if let Some(bdev) = Bdev::lookup_by_name(&bdev_name) {
+            // if the share handle is the same as bdev name it
+            // implies there is no top level bdev, and we are done
+            if self.name != bdev.name() {
+                let (s, r) = oneshot::channel::<ErrnoResult<()>>();
+                // currently, we only have the crypto vbdev
+                unsafe {
+                    spdk_sys::delete_crypto_disk(
+                        bdev.as_ptr(),
+                        Some(done_errno_cb),
+                        cb_arg(s),
+                    );
+                }
+                r.await.expect("crypto delete sender is gone").context(
+                    DestroyCryptoBdev {
+                        name: self.name.clone(),
+                    },
+                )?;
+            }
+        } else {
+            warn!("Missing bdev for a shared device");
         }
+        Ok(())
     }
 
     /// Return path /dev/... under which the nexus is shared or None if not
-    /// shared.
+    /// shared as nbd.
     pub fn get_share_path(&self) -> Option<String> {
-        match self.nbd_disk {
-            Some(ref disk) => Some(disk.get_path()),
-            None => None,
+        match self.nexus_target {
+            Some(NexusTarget::NbdDisk(ref disk)) => Some(disk.get_path()),
+            _ => None,
         }
     }
 }

--- a/mayastor/src/target/mod.rs
+++ b/mayastor/src/target/mod.rs
@@ -1,2 +1,8 @@
 pub mod iscsi;
 pub mod nvmf;
+
+// Which kind of target interface to use for a bdev
+pub enum Side {
+    Nexus,
+    Replica,
+}

--- a/mayastor/tests/mount_fs.rs
+++ b/mayastor/tests/mount_fs.rs
@@ -5,6 +5,8 @@ use mayastor::{
     core::{mayastor_env_stop, MayastorCliArgs, MayastorEnvironment, Reactor},
 };
 
+use rpc::mayastor::ShareProtocolNexus;
+
 static DISKNAME1: &str = "/tmp/disk1.img";
 static BDEVNAME1: &str = "aio:///tmp/disk1.img?blk_size=512";
 
@@ -20,7 +22,11 @@ fn mount_fs() {
         create_nexus().await;
         let nexus = nexus_lookup("nexus").unwrap();
 
-        let device = nexus.share(None).await.unwrap();
+        //TODO: repeat this test for NVMF and ISCSI
+        let device = nexus
+            .share(ShareProtocolNexus::NexusNbd, None)
+            .await
+            .unwrap();
         let (s, r) = unbounded();
 
         // create an XFS filesystem on the nexus device, mount it, create a file
@@ -46,8 +52,15 @@ fn mount_fs() {
         let right = nexus_lookup("right").unwrap();
 
         // share both nexuses
-        let left_device = left.share(None).await.unwrap();
-        let right_device = right.share(None).await.unwrap();
+        //TODO: repeat this test for NVMF and ISCSI, and permutations?
+        let left_device = left
+            .share(ShareProtocolNexus::NexusNbd, None)
+            .await
+            .unwrap();
+        let right_device = right
+            .share(ShareProtocolNexus::NexusNbd, None)
+            .await
+            .unwrap();
 
         let s1 = s.clone();
         std::thread::spawn(move || {
@@ -92,7 +105,11 @@ fn mount_fs_1() {
         create_nexus().await;
         let nexus = nexus_lookup("nexus").unwrap();
 
-        let device = nexus.share(None).await.unwrap();
+        //TODO: repeat this test for NVMF and ISCSI
+        let device = nexus
+            .share(ShareProtocolNexus::NexusNbd, None)
+            .await
+            .unwrap();
 
         std::thread::spawn(move || {
             for _i in 0 .. 10 {
@@ -113,7 +130,11 @@ fn mount_fs_2() {
         create_nexus().await;
         let nexus = nexus_lookup("nexus").unwrap();
 
-        let device = nexus.share(None).await.unwrap();
+        //TODO: repeat this test for NVMF and ISCSI
+        let device = nexus
+            .share(ShareProtocolNexus::NexusNbd, None)
+            .await
+            .unwrap();
         let (s, r) = unbounded::<String>();
 
         std::thread::spawn(move || s.send(common::fio_run_verify(&device)));

--- a/mayastor/tests/nexus_rebuild.rs
+++ b/mayastor/tests/nexus_rebuild.rs
@@ -9,6 +9,8 @@ use mayastor::{
     core::{mayastor_env_stop, MayastorCliArgs, MayastorEnvironment, Reactor},
 };
 
+use rpc::mayastor::ShareProtocolNexus;
+
 static DISKNAME1: &str = "/tmp/disk1.img";
 static BDEVNAME1: &str = "aio:///tmp/disk1.img?blk_size=512";
 
@@ -35,7 +37,10 @@ async fn rebuild_test_start() {
     create_nexus().await;
 
     let nexus = nexus_lookup(NEXUS_NAME).unwrap();
-    let device = nexus.share(None).await.unwrap();
+    let device = nexus
+        .share(ShareProtocolNexus::NexusNbd, None)
+        .await
+        .unwrap();
 
     let nexus_device = device.clone();
     let (s, r) = unbounded::<String>();

--- a/nix/mayastor-overlay.nix
+++ b/nix/mayastor-overlay.nix
@@ -15,15 +15,15 @@ self: super: {
 
   });
 
-  terraform-provider-lxd = super.callPackage ./pkgs/terraform-provider-lxd { };
-  libiscsi = super.callPackage ./pkgs/libiscsi { };
-  liburing = super.callPackage ./pkgs/liburing { };
-  nvme-cli = super.callPackage ./pkgs/nvme-cli { };
-  nvmet-cli = super.callPackage ./pkgs/nvmet-cli { };
-  libspdk = super.callPackage ./pkgs/libspdk { };
-  mayastor = (super.callPackage ./pkgs/mayastor { }).mayastor;
-  mayastorImage = (super.callPackage ./pkgs/mayastor { }).mayastorImage;
-  mayastorCSIImage = (super.callPackage ./pkgs/mayastor { }).mayastorCSIImage;
+  terraform-provider-lxd = super.callPackage ./pkgs/terraform-provider-lxd {};
+  libiscsi = super.callPackage ./pkgs/libiscsi {};
+  liburing = super.callPackage ./pkgs/liburing {};
+  nvme-cli = super.callPackage ./pkgs/nvme-cli {};
+  nvmet-cli = super.callPackage ./pkgs/nvmet-cli {};
+  libspdk = super.callPackage ./pkgs/libspdk {};
+  mayastor = (super.callPackage ./pkgs/mayastor {}).mayastor;
+  mayastorImage = (super.callPackage ./pkgs/mayastor {}).mayastorImage;
+  mayastorCSIImage = (super.callPackage ./pkgs/mayastor {}).mayastorCSIImage;
   node-moac = (import ./../csi/moac { pkgs = super; }).package;
   node-moacImage = (import ./../csi/moac { pkgs = super; }).buildImage;
 }

--- a/rpc/proto/mayastor.proto
+++ b/rpc/proto/mayastor.proto
@@ -48,10 +48,19 @@ message ListPoolsReply {
 }
 
 // Protocol for remote storage access which exposes a replica.
-enum ShareProtocol {
-  NONE = 0;   // not exposed
-  NVMF = 1;   // NVMe over Fabrics (TCP)
-  ISCSI = 2;  // iSCSI
+enum ShareProtocolReplica {
+  REPLICA_NONE = 0;   // not exposed
+  REPLICA_NVMF = 1;   // NVMe over Fabrics (TCP)
+  REPLICA_ISCSI = 2;  // iSCSI
+}
+
+// Note that enum values use C++ scoping rules, meaning that enum values are siblings of their type,
+// not children of it.
+// So cannot use NBD, NVMF, and ISCSI as symbols for ShareProtocolNexus
+enum ShareProtocolNexus {
+  NEXUS_NBD = 0;    // local
+  NEXUS_NVMF = 1;   // NVMe over Fabrics (TCP)
+  NEXUS_ISCSI = 2;  // iSCSI
 }
 
 // Create replica arguments.
@@ -60,7 +69,7 @@ message CreateReplicaRequest {
   string pool = 2;  // name of the pool
   uint64 size = 3;  // size of the replica in bytes
   bool thin = 4;    // thin provisioning
-  ShareProtocol share = 5;  // protocol to expose the replica over
+  ShareProtocolReplica share = 5;  // protocol to expose the replica over
 }
 
 // Create replica response.
@@ -79,7 +88,7 @@ message Replica {
   string pool = 2;  // name of the pool
   bool thin = 3;    // thin provisioning
   uint64 size = 4;  // size of the replica in bytes
-  ShareProtocol share = 5;  // protocol used for exposing the replica
+  ShareProtocolReplica share = 5;  // protocol used for exposing the replica
   string uri = 6;   // uri usable by nexus to access it
 }
 
@@ -113,7 +122,7 @@ message StatReplicasReply {
 // Share replica request.
 message ShareReplicaRequest {
   string uuid = 1;  // uuid of the replica
-  ShareProtocol share = 2;  // protocol used for exposing the replica
+  ShareProtocolReplica share = 2;  // protocol used for exposing the replica
                             // Use "NONE" to disable remote access.
 }
 
@@ -171,6 +180,7 @@ message RemoveChildNexusRequest {
 message PublishNexusRequest {
   string uuid = 1; // uuid of the nexus which to create device for
   string key = 2; // encryption key
+  ShareProtocolNexus share = 3;  // protocol used for the front end.
 }
 
 message PublishNexusReply {


### PR DESCRIPTION
Make it possible to specify the nexus front-end protocol for use with CSI and add support for  iSCSI. 

See task CAS-54.
The set of supported interfaces is planned to be nbd, iSCSI and nvmf.
Of these, nbd is implemented. This change adds iSCSI, Nvmf is still to be implemented.
A publish nexus request now takes an additional parameter to specify which protocol to use. Specifying "iscsi" now results in the creation of an iSCSI target to act as the front-end for the specified nexus. 
To separate the domain of the front-end iscsi target from that of the existing iscsi targets used for the back-end replicas, two portal groups are now created, which differ in the choice of TCP port used.

The choice of ports for the two portal groups are likely to change as a result of CAS-97.

(Changes by @chriswldenyer and @blaisedias to allow a nexus to be shared via iSCSI.)

Changes have been made resulting from the first code reviews.
Iscsi nexus tests have been added to test_nexus.js, as requested and as required by CAS-65.
The publish nexus request now returns the URI of the created iSCSI target.
Repeated publish requests and now handled correctly, a repeated request with a different protocol returns an error.