### PR TITLE
Fix race condition in pool operator when moac starts.

### DIFF
--- a/csi/moac/test/node_stub.js
+++ b/csi/moac/test/node_stub.js
@@ -48,6 +48,10 @@ class Node extends EventEmitter {
   async createPool(name, disks) {
     // this method should typically be replaced by a sinon stub for testing
   }
+
+  isSynced() {
+    return true;
+  }
 }
 
 module.exports = Node;


### PR DESCRIPTION
The problem happens when a pool resource is checked and the node operator
has not finished sync of nodes. In that case pools haven't been read
from the storage node and pool operator thinks they don't exist and
starts to create them. It fails to create the pools and it prints
disturbing messages to the log and makes the moac behave a bit wacky.
The fix is to defer pool creation until the node has been synced.