### PR TITLE
mayastor-test: Test uring bdevs in test_nexus

### DIFF
--- a/mayastor-test/test_nexus.js
+++ b/mayastor-test/test_nexus.js
@@ -125,10 +125,10 @@ function createGrpcClient(service) {
   );
 }
 
-var doUring = (function () {
+var doUring = (function() {
   var executed = false;
   var supportsUring = false;
-  return function () {
+  return function() {
     if (!executed) {
       executed = true;
       const { exec } = require('child_process');
@@ -140,7 +140,7 @@ var doUring = (function () {
         'uring-support'
       );
       const CMD = URING_SUPPORT_CMD + ' ' + uringFile;
-      exec(CMD, (error) => {
+      exec(CMD, error => {
         if (error) {
           return;
         }
@@ -148,7 +148,7 @@ var doUring = (function () {
       });
     }
     return supportsUring;
-  }
+  };
 })();
 
 describe('nexus', function() {
@@ -263,10 +263,8 @@ describe('nexus', function() {
           fs.unlink(aioFile, err => next());
         },
         next => {
-          if (doUring())
-            fs.unlink(uringFile, err => next());
-          else
-            next();
+          if (doUring()) fs.unlink(uringFile, err => next());
+          else next();
         },
       ],
       err => {
@@ -289,8 +287,7 @@ describe('nexus', function() {
         `nvmf://127.0.0.1:8420/nqn.2019-05.io.openebs:disk2`,
       ],
     };
-    if (doUring())
-      args.children.push(`uring:///${uringFile}?blk_size=4096`);
+    if (doUring()) args.children.push(`uring:///${uringFile}?blk_size=4096`);
 
     client.CreateNexus(args, done);
   });
@@ -321,7 +318,10 @@ describe('nexus', function() {
       );
       assert.equal(nexus.children[3].state, 'open');
       if (doUring()) {
-        assert.equal(nexus.children[4].uri, `uring:///${uringFile}?blk_size=4096`);
+        assert.equal(
+          nexus.children[4].uri,
+          `uring:///${uringFile}?blk_size=4096`
+        );
         assert.equal(nexus.children[4].state, 'open');
       }
       done();

--- a/mayastor/Cargo.toml
+++ b/mayastor/Cargo.toml
@@ -16,6 +16,10 @@ path = "src/bin/spdk.rs"
 name = "initiator"
 path = "src/bin/initiator.rs"
 
+[[bin]]
+name = "uring-support"
+path = "src/bin/uring-support.rs"
+
 [dev-dependencies]
 assert_matches = "1.2"
 run_script = "*"

--- a/mayastor/src/bdev/mod.rs
+++ b/mayastor/src/bdev/mod.rs
@@ -23,6 +23,7 @@ mod iscsi_dev;
 pub(crate) mod nexus;
 mod nvmf_dev;
 mod uring_dev;
+pub mod uring_util;
 
 unsafe fn parse_config_param<T>(
     sp: *mut spdk_conf_section,

--- a/mayastor/src/bdev/uring_util.rs
+++ b/mayastor/src/bdev/uring_util.rs
@@ -5,8 +5,10 @@ use std::{
 };
 
 pub fn fs_supports_direct_io(path: &str) -> bool {
-    // SPDK uring bdev uses IORING_SETUP_IOPOLL which requires O_DIRECT
-    // which works on at least XFS filesystems
+    // SPDK uring bdev uses IORING_SETUP_IOPOLL which is usable only on a file
+    // descriptor opened with O_DIRECT. The file system or block device must
+    // also support polling.
+    // This works on at least XFS filesystems
     match OpenOptions::new()
         .read(true)
         .write(true)

--- a/mayastor/src/bdev/uring_util.rs
+++ b/mayastor/src/bdev/uring_util.rs
@@ -1,0 +1,87 @@
+use std::{
+    fs::{File, OpenOptions},
+    io::{BufRead, BufReader, ErrorKind},
+    os::unix::fs::OpenOptionsExt,
+};
+
+pub fn fs_supports_direct_io(path: &str) -> bool {
+    // SPDK uring bdev uses IORING_SETUP_IOPOLL which requires O_DIRECT
+    // which works on at least XFS filesystems
+    match OpenOptions::new()
+        .read(true)
+        .write(true)
+        .custom_flags(libc::O_DIRECT)
+        .open(path)
+    {
+        Ok(_f) => true,
+        Err(e) => {
+            assert_eq!(e.kind(), ErrorKind::InvalidInput);
+            println!("Skipping uring bdev, open: {:?}", e);
+            false
+        }
+    }
+}
+
+fn get_mount_filesystem(path: &str) -> Option<String> {
+    let mut path = std::path::Path::new(path);
+    loop {
+        let f = match File::open("/etc/mtab") {
+            Ok(f) => f,
+            Err(e) => {
+                eprintln!("open: {}", e);
+                return None;
+            }
+        };
+        let reader = BufReader::new(f);
+
+        let d = path.to_str().unwrap();
+        for line in reader.lines() {
+            let l = match line {
+                Ok(l) => l,
+                Err(e) => {
+                    eprintln!("line: {}", e);
+                    return None;
+                }
+            };
+            let parts: Vec<&str> = l.split_whitespace().collect();
+            if !parts.is_empty() && parts[1] == d {
+                return Some(parts[2].to_string());
+            }
+        }
+
+        path = match path.parent() {
+            None => return None,
+            Some(p) => p,
+        }
+    }
+}
+
+pub fn fs_type_supported(path: &str) -> bool {
+    match get_mount_filesystem(path) {
+        None => {
+            println!("Skipping uring bdev, unknown fs");
+            false
+        }
+        Some(d) => match d.as_str() {
+            "xfs" => true,
+            _ => {
+                println!("Skipping uring bdev, fs: {}", d);
+                false
+            }
+        },
+    }
+}
+
+pub fn kernel_supports_io_uring() -> bool {
+    // Match SPDK_URING_QUEUE_DEPTH
+    let queue_depth = 512;
+    match io_uring::IoUring::new(queue_depth) {
+        Ok(_ring) => true,
+        Err(e) => {
+            assert_eq!(e.kind(), ErrorKind::Other);
+            assert_eq!(e.raw_os_error().unwrap(), libc::ENOSYS);
+            println!("Skipping uring bdev, IoUring::new: {:?}", e);
+            false
+        }
+    }
+}

--- a/mayastor/src/bin/uring-support.rs
+++ b/mayastor/src/bin/uring-support.rs
@@ -1,6 +1,6 @@
 extern crate clap;
 
-use clap::{Arg, App};
+use clap::{App, Arg};
 use mayastor::bdev::uring_util;
 
 fn main() {
@@ -8,10 +8,12 @@ fn main() {
         .version("0.1.0")
         .author("Jonathan Teh <jonathan.teh@mayadata.io>")
         .about("Determines io_uring support")
-        .arg(Arg::with_name("uring-path")
-                 .required(true)
-                 .help("Path to file")
-                 .index(1))
+        .arg(
+            Arg::with_name("uring-path")
+                .required(true)
+                .help("Path to file")
+                .index(1),
+        )
         .get_matches();
 
     let path = matches.value_of("uring-path").unwrap();

--- a/mayastor/src/bin/uring-support.rs
+++ b/mayastor/src/bin/uring-support.rs
@@ -1,0 +1,28 @@
+extern crate clap;
+
+use clap::{Arg, App};
+use mayastor::bdev::uring_util;
+
+fn main() {
+    let matches = App::new("io_uring support")
+        .version("0.1.0")
+        .author("Jonathan Teh <jonathan.teh@mayadata.io>")
+        .about("Determines io_uring support")
+        .arg(Arg::with_name("uring-path")
+                 .required(true)
+                 .help("Path to file")
+                 .index(1))
+        .get_matches();
+
+    let path = matches.value_of("uring-path").unwrap();
+
+    let supported = uring_util::fs_supports_direct_io(path)
+        && uring_util::fs_type_supported(path)
+        && uring_util::kernel_supports_io_uring();
+
+    if supported {
+        std::process::exit(0);
+    } else {
+        std::process::exit(1);
+    }
+}

--- a/mayastor/tests/core.rs
+++ b/mayastor/tests/core.rs
@@ -10,9 +10,7 @@ use mayastor::{
     },
     nexus_uri::{bdev_create, bdev_destroy},
 };
-use std::{
-    sync::Once,
-};
+use std::sync::Once;
 
 static DISKNAME1: &str = "/tmp/disk1.img";
 static BDEVNAME1: &str = "aio:///tmp/disk1.img?blk_size=512";


### PR DESCRIPTION
Only test uring bdevs if the filesystem and kernel support it.
Move the functions testing for io_uring support from the core unit test to bdev::uring_util. Add a CLI tool that calls these functions given a path so that it can be called from test_nexus.