### PR TITLE
nvmeadm: library to connect to remote nvmf targets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,9 +2,9 @@
 # It is not intended for manual editing.
 [[package]]
 name = "aho-corasick"
-version = "0.7.8"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743ad5a418686aad3b87fd14c43badd828cf26e214a00f92a384291cf22e1811"
+checksum = "8716408b8bc624ed7f65d223ddb9ac2d044c0547b6fa4b0d554f3a9540496ada"
 dependencies = [
  "memchr",
 ]
@@ -20,15 +20,15 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7825f6833612eb2414095684fcf6c635becf3ce97fe48cf6421321e93bfbd53c"
+checksum = "013a6e0a2cbe3d20f9c60b65458f7a7f7a5e636c5d0f45a5a6aee5d4b1f01785"
 
 [[package]]
 name = "arc-swap"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7b8a9123b8027467bce0099fe556c628a53c8d83df0507084c31e9ba2e39aff"
+checksum = "d663a8e9a99154b5fb793032533f6328da35e23aac63d5c152279aa8ba356825"
 
 [[package]]
 name = "assert_matches"
@@ -52,9 +52,9 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25f9db3b38af870bf7e5cc649167533b493928e50744e2c30ae350230b414670"
 dependencies = [
- "proc-macro2 1.0.8",
- "quote 1.0.2",
- "syn 1.0.14",
+ "proc-macro2 1.0.9",
+ "quote 1.0.3",
+ "syn 1.0.17",
 ]
 
 [[package]]
@@ -69,13 +69,13 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.24"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "750b1c38a1dfadd108da0f01c08f4cdc7ff1bb39b325f9c82cc972361780a6e1"
+checksum = "21a03abb7c9b93ae229356151a083d26218c0358866a2a59d4280c856e9482e6"
 dependencies = [
- "proc-macro2 1.0.8",
- "quote 1.0.2",
- "syn 1.0.14",
+ "proc-macro2 1.0.9",
+ "quote 1.0.3",
+ "syn 1.0.17",
 ]
 
 [[package]]
@@ -103,9 +103,9 @@ checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 
 [[package]]
 name = "backtrace"
-version = "0.3.43"
+version = "0.3.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f80256bc78f67e7df7e36d77366f636ed976895d91fe2ab9efa3973e8fe8c4f"
+checksum = "b1e692897359247cc6bb902933361652380af0f1b7651ae5c5013407f30e109e"
 dependencies = [
  "backtrace-sys",
  "cfg-if",
@@ -115,9 +115,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace-sys"
-version = "0.1.32"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6575f128516de27e3ce99689419835fce9643a9b215a14d2b5b685be018491"
+checksum = "7de8aba10a69c8e8d7622c5710229485ec32e9d55fdad160ea559c086fdcd118"
 dependencies = [
  "cc",
  "libc",
@@ -195,7 +195,7 @@ checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 [[package]]
 name = "blkid"
 version = "0.2.1"
-source = "git+https://github.com/openebs/blkid?branch=blkid-sys#e153bea2c68f4bacf922b6cd3d1915b3b79844f0"
+source = "git+https://github.com/openebs/blkid?branch=blkid-sys#3dc458b001fffeaa4525296b838d1aafd51a7c33"
 dependencies = [
  "blkid-sys",
  "err-derive",
@@ -205,7 +205,7 @@ dependencies = [
 [[package]]
 name = "blkid-sys"
 version = "0.1.4"
-source = "git+https://github.com/openebs/blkid?branch=blkid-sys#e153bea2c68f4bacf922b6cd3d1915b3b79844f0"
+source = "git+https://github.com/openebs/blkid?branch=blkid-sys#3dc458b001fffeaa4525296b838d1aafd51a7c33"
 dependencies = [
  "bindgen 0.48.1",
 ]
@@ -251,15 +251,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "716960a18f978640f25101b5cbf1c6f6b0d3192fab36a2d98ca96f0ecbe41010"
 
 [[package]]
-name = "c2-chacha"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "214238caa1bf3a496ec3392968969cab8549f96ff30652c9e56885329315f6bb"
-dependencies = [
- "ppv-lite86",
-]
-
-[[package]]
 name = "cc"
 version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -282,12 +273,12 @@ checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "chrono"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31850b4a4d6bae316f7a09e691c944c28299298837edc0a03f755618c23cbc01"
+checksum = "80094f509cf8b5ae86a4966a39b3ff66cd7e2a3e594accec3743ff3fabeab5b2"
 dependencies = [
  "num-integer",
- "num-traits",
+ "num-traits 0.2.11",
  "time",
 ]
 
@@ -311,7 +302,7 @@ dependencies = [
  "ansi_term",
  "atty",
  "bitflags",
- "strsim",
+ "strsim 0.8.0",
  "textwrap",
  "unicode-width",
  "vec_map",
@@ -365,35 +356,38 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acec9a3b0b3559f15aee4f90746c4e5e293b701c0f7d3925d24e01645267b68c"
+checksum = "cced8691919c02aac3cb0a1bc2e9b73d89e832bf9a06fc579d4e71b68a2da061"
 dependencies = [
  "crossbeam-utils",
+ "maybe-uninit",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3aa945d63861bfe624b55d153a39684da1e8c0bc8fba932f7ee3a3c16cea3ca"
+checksum = "9f02af974daeee82218205558e51ec8768b48cf524bd01d550abe5573a608285"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
+ "maybe-uninit",
 ]
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.8.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5064ebdbf05ce3cb95e45c8b086f72263f4166b29b97f6baff7ef7fe047b55ac"
+checksum = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
 dependencies = [
- "autocfg 0.1.7",
+ "autocfg 1.0.0",
  "cfg-if",
  "crossbeam-utils",
  "lazy_static",
+ "maybe-uninit",
  "memoffset",
- "scopeguard 1.0.0",
+ "scopeguard 1.1.0",
 ]
 
 [[package]]
@@ -414,11 +408,11 @@ checksum = "3f901f6110b99fdcf0825d0f35e5e26b7ae222ed0d6f2a07c595043e7d5b9429"
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce446db02cdc3165b94ae73111e570793400d0794e46125cc4056c81cbb039f4"
+checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
 dependencies = [
- "autocfg 0.1.7",
+ "autocfg 1.0.0",
  "cfg-if",
  "lazy_static",
 ]
@@ -461,16 +455,87 @@ dependencies = [
 ]
 
 [[package]]
-name = "doc-comment"
-version = "0.3.1"
+name = "darling"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "923dea538cea0aa3025e8685b20d6ee21ef99c4f77e954a30febbaac5ec73a97"
+checksum = "fcfbcb0c5961907597a7d1148e3af036268f2b773886b8bb3eeb1e1281d3d3d6"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6afc018370c3bff3eb51f89256a6bdb18b4fdcda72d577982a14954a7a0b402c"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2 0.4.30",
+ "quote 0.6.13",
+ "strsim 0.7.0",
+ "syn 0.15.44",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6d8dac1c6f1d29a41c4712b4400f878cb4fcc4c7628f298dd75038e024998d1"
+dependencies = [
+ "darling_core",
+ "quote 0.6.13",
+ "syn 0.15.44",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ac53fa6a3cda160df823a9346442525dcaf1e171999a1cf23e67067e4fd64d4"
+dependencies = [
+ "darling",
+ "derive_builder_core",
+ "proc-macro2 0.4.30",
+ "quote 0.6.13",
+ "syn 0.15.44",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0288a23da9333c246bb18c143426074a6ae96747995c5819d2947b64cd942b37"
+dependencies = [
+ "darling",
+ "proc-macro2 0.4.30",
+ "quote 0.6.13",
+ "syn 0.15.44",
+]
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "either"
 version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
+
+[[package]]
+name = "enum-primitive-derive"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2b90e520ec62c1864c8c78d637acbfe8baf5f63240f2fb8165b8325c07812dd"
+dependencies = [
+ "num-traits 0.1.43",
+ "quote 0.3.15",
+ "syn 0.11.11",
+]
 
 [[package]]
 name = "env_logger"
@@ -500,15 +565,15 @@ dependencies = [
 
 [[package]]
 name = "err-derive"
-version = "0.1.6"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b41487fadaa500d02a819eefcde5f713599a01dd51626ef25d2d72d87115667b"
+checksum = "82f46c91bbed409ee74495549acbfcc7fae856e712e1df15afe75d0775eedc6c"
 dependencies = [
  "proc-macro-error",
- "proc-macro2 1.0.8",
- "quote 1.0.2",
- "rustc_version",
- "syn 1.0.14",
+ "proc-macro2 1.0.9",
+ "quote 1.0.3",
+ "rustversion",
+ "syn 1.0.17",
  "synstructure",
 ]
 
@@ -535,11 +600,24 @@ dependencies = [
 
 [[package]]
 name = "failure"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8273f13c977665c5db7eb2b99ae520952fe5ac831ae4cd09d80c4c7042b5ed9"
+checksum = "b8529c2421efa3066a5cbd8063d2244603824daccb6936b079010bb2aa89464b"
 dependencies = [
  "backtrace",
+ "failure_derive",
+]
+
+[[package]]
+name = "failure_derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "030a733c8287d6213886dd487564ff5c8f6aae10278b3588ed177f9d18f8d231"
+dependencies = [
+ "proc-macro2 1.0.9",
+ "quote 1.0.3",
+ "syn 1.0.17",
+ "synstructure",
 ]
 
 [[package]]
@@ -553,6 +631,16 @@ name = "fnv"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
+
+[[package]]
+name = "fsio"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2131cb03096f67334dfba2f0bc46afc5564b08a919d042c6e217e2665741fc54"
+dependencies = [
+ "rand 0.7.3",
+ "users",
+]
 
 [[package]]
 name = "fuchsia-cprng"
@@ -631,9 +719,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a5081aa3de1f7542a794a397cde100ed903b0630152d0973479018fd85423a7"
 dependencies = [
  "proc-macro-hack",
- "proc-macro2 1.0.8",
- "quote 1.0.2",
- "syn 1.0.14",
+ "proc-macro2 1.0.9",
+ "quote 1.0.3",
+ "syn 1.0.17",
 ]
 
 [[package]]
@@ -707,9 +795,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34a97a52fdee1870a34fa6e4b77570cba531b27d1838874fef4429a791a3d657"
 dependencies = [
  "proc-macro-hack",
- "proc-macro2 1.0.8",
- "quote 1.0.2",
- "syn 1.0.14",
+ "proc-macro2 1.0.9",
+ "quote 1.0.3",
+ "syn 1.0.17",
 ]
 
 [[package]]
@@ -726,8 +814,8 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "h2"
-version = "0.2.1"
-source = "git+https://github.com/gila/h2#86845fd165d20cc9d93a422b030aab2dafc1c842"
+version = "0.2.2"
+source = "git+https://github.com/gila/h2?branch=v0.2.2#c81b43a97c8662aa65bdcc28706969cad1423b22"
 dependencies = [
  "bytes 0.5.4",
  "fnv",
@@ -763,9 +851,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eff2656d88f158ce120947499e971d743c05dbcbed62e5bd2f38f1698bbc3772"
+checksum = "1010591b26bbfe835e9faeabeb11866061cc7dcebffd56ad7d0942d0e61aefd8"
 dependencies = [
  "libc",
 ]
@@ -829,9 +917,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.13.2"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa1c527bbc634be72aa7ba31e4e4def9bbb020f5416916279b7c705cd838893e"
+checksum = "ed6081100e960d9d74734659ffc9cc91daf1c0fc7aceb8eaa94ee1a3f5046f2e"
 dependencies = [
  "bytes 0.5.4",
  "futures-channel",
@@ -850,6 +938,12 @@ dependencies = [
  "tower-service",
  "want",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -942,9 +1036,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.66"
+version = "0.2.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d515b1f41455adea1313a4a2ac8a8a477634fbae63cc6100e3aebb207ce61558"
+checksum = "dea0c0405123bba743ee3f91f49b1c7cfb684eef0da0a50110f758ccf24cdff0"
 
 [[package]]
 name = "libloading"
@@ -1018,18 +1112,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "memchr"
-version = "2.3.0"
+name = "maybe-uninit"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3197e20c7edb283f87c071ddfc7a2cca8f8e0b888c242959846a6fce03c72223"
+checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
+
+[[package]]
+name = "memchr"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 
 [[package]]
 name = "memoffset"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75189eb85871ea5c2e2c15abbdd541185f63b408415e5051f5cac122d8c774b9"
+checksum = "b4fc2c02a7e374099d4ee95a193111f72d2110197fe200272371758f6c3643d8"
 dependencies = [
- "rustc_version",
+ "autocfg 1.0.0",
 ]
 
 [[package]]
@@ -1159,7 +1259,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
 dependencies = [
  "memchr",
- "version_check",
+ "version_check 0.1.5",
 ]
 
 [[package]]
@@ -1169,7 +1269,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f6ea62e9d81a77cd3ee9a2a5b9b609447857f3d358704331e4ef39eb247fcba"
 dependencies = [
  "autocfg 1.0.0",
- "num-traits",
+ "num-traits 0.2.11",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
+dependencies = [
+ "num-traits 0.2.11",
 ]
 
 [[package]]
@@ -1192,6 +1301,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "nvmeadm"
+version = "0.1.0"
+dependencies = [
+ "derive_builder",
+ "enum-primitive-derive",
+ "failure",
+ "glob 0.3.0",
+ "ioctl-gen",
+ "libc",
+ "nix 0.14.1",
+ "num-traits 0.1.43",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1200,8 +1323,7 @@ checksum = "b1c601810575c99596d4afc46f78a678c80105117c379eb3650cf99b8a21ce5b"
 [[package]]
 name = "partition-identity"
 version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b33909267193c7babe396e0570d0a12ba997b539edfdb2aea1e767e0ea728f05"
+source = "git+https://github.com/openebs/partition-identity.git#b2625e2f03dbd67820f251ffa1e81e83216c0f72"
 dependencies = [
  "err-derive",
 ]
@@ -1249,9 +1371,9 @@ version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "385322a45f2ecf3410c68d2a549a4a2685e8051d0f278e39743ff4e451cb9b3f"
 dependencies = [
- "proc-macro2 1.0.8",
- "quote 1.0.2",
- "syn 1.0.14",
+ "proc-macro2 1.0.9",
+ "quote 1.0.3",
+ "syn 1.0.17",
 ]
 
 [[package]]
@@ -1274,31 +1396,41 @@ checksum = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
 
 [[package]]
 name = "proc-macro-error"
-version = "0.2.6"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aeccfe4d5d8ea175d5f0e4a2ad0637e0f4121d63bd99d356fb1f39ab2e7c6097"
+checksum = "18f33027081eba0a6d8aba6d1b1c3a3be58cbb12106341c2d5759fcd9b5277e7"
 dependencies = [
- "proc-macro2 1.0.8",
- "quote 1.0.2",
- "syn 1.0.14",
+ "proc-macro-error-attr",
+ "proc-macro2 1.0.9",
+ "quote 1.0.3",
+ "syn 1.0.17",
+ "version_check 0.9.1",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a5b4b77fdb63c1eca72173d68d24501c54ab1269409f6b672c85deb18af69de"
+dependencies = [
+ "proc-macro2 1.0.9",
+ "quote 1.0.3",
+ "syn 1.0.17",
+ "syn-mid",
+ "version_check 0.9.1",
 ]
 
 [[package]]
 name = "proc-macro-hack"
-version = "0.5.11"
+version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecd45702f76d6d3c75a80564378ae228a85f0b59d2f3ed43c91b4a69eb2ebfc5"
-dependencies = [
- "proc-macro2 1.0.8",
- "quote 1.0.2",
- "syn 1.0.14",
-]
+checksum = "fcfdefadc3d57ca21cf17990a28ef4c0f7c61383a28cb7604cf4a18e6ede1420"
 
 [[package]]
 name = "proc-macro-nested"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "369a6ed065f249a159e06c45752c780bda2fb53c995718f9e484d08daa9eb42e"
+checksum = "8e946095f9d3ed29ec38de908c22f95d9ac008e424c7bcae54c75a79c527c694"
 
 [[package]]
 name = "proc-macro2"
@@ -1311,9 +1443,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acb317c6ff86a4e579dfa00fc5e6cca91ecbb4e7eb2df0468805b674eb88548"
+checksum = "6c09721c6781493a2a492a96b5a5bf19b65917fe6728884e7c44dd0c60ca3435"
 dependencies = [
  "unicode-xid 0.2.0",
 ]
@@ -1353,7 +1485,7 @@ dependencies = [
  "prost",
  "prost-types",
  "tempfile",
- "which 3.1.0",
+ "which 3.1.1",
 ]
 
 [[package]]
@@ -1364,9 +1496,9 @@ checksum = "537aa19b95acde10a12fec4301466386f757403de4cd4e5b4fa78fb5ecb18f72"
 dependencies = [
  "anyhow",
  "itertools",
- "proc-macro2 1.0.8",
- "quote 1.0.2",
- "syn 1.0.14",
+ "proc-macro2 1.0.9",
+ "quote 1.0.3",
+ "syn 1.0.17",
 ]
 
 [[package]]
@@ -1387,6 +1519,12 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
+
+[[package]]
+name = "quote"
 version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
@@ -1396,11 +1534,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
+checksum = "2bdc6c187c65bca4260c9011c9e3132efe4909da44726bad24cf7572ae338d7f"
 dependencies = [
- "proc-macro2 1.0.8",
+ "proc-macro2 1.0.9",
 ]
 
 [[package]]
@@ -1430,7 +1568,7 @@ checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
  "getrandom",
  "libc",
- "rand_chacha 0.2.1",
+ "rand_chacha 0.2.2",
  "rand_core 0.5.1",
  "rand_hc 0.2.0",
  "rand_pcg 0.2.1",
@@ -1448,11 +1586,11 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a2a90da8c7523f554344f921aa97283eadf6ac484a6d2a7d0212fa7f8d6853"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
 dependencies = [
- "c2-chacha",
+ "ppv-lite86",
  "rand_core 0.5.1",
 ]
 
@@ -1577,9 +1715,9 @@ checksum = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
 
 [[package]]
 name = "regex"
-version = "1.3.4"
+version = "1.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "322cf97724bea3ee221b78fe25ac9c46114ebb51747ad5babd51a2fc6a8235a8"
+checksum = "7f6946991529684867e47d86474e3a6d0c0ab9b82d5821e314b1ede31fa3a4b3"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1589,9 +1727,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.14"
+version = "0.6.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b28dfe3fe9badec5dbf0a79a9cccad2cfc2ab5484bdb3e44cbd1ae8b3ba2be06"
+checksum = "7fe5bd57d1d7414c6b5ed48563a2c855d995ff777729dcd91c369ec7fea395ae"
 
 [[package]]
 name = "remove_dir_all"
@@ -1619,12 +1757,11 @@ dependencies = [
 
 [[package]]
 name = "run_script"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80a217951e2afacc57d3129bd52aeddc550559f5a82f57529a31fc5675bd6621"
+checksum = "9527b8b68ef929243a3e8ad7471a2d80f6ac23b810aafd3df4a2e5212d8dacc1"
 dependencies = [
- "rand 0.7.3",
- "users",
+ "fsio",
 ]
 
 [[package]]
@@ -1634,19 +1771,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 
 [[package]]
-name = "rustc_version"
-version = "0.2.3"
+name = "rustversion"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+checksum = "b3bba175698996010c4f6dce5e7f173b6eb781fce25d2cfc45e27091ce0b79f6"
 dependencies = [
- "semver",
+ "proc-macro2 1.0.9",
+ "quote 1.0.3",
+ "syn 1.0.17",
 ]
 
 [[package]]
 name = "ryu"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8"
+checksum = "535622e6be132bccd223f4bb2b8ac8d53cda3c7a6394944d3b2b33fb974f9d76"
 
 [[package]]
 name = "scopeguard"
@@ -1656,50 +1795,35 @@ checksum = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
 
 [[package]]
 name = "scopeguard"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42e15e59b18a828bbf5c58ea01debb36b9b096346de35d941dcb89009f24a0d"
-
-[[package]]
-name = "semver"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver-parser"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
-version = "1.0.104"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "414115f25f818d7dfccec8ee535d76949ae78584fc4f79a6f45a904bf8ab4449"
+checksum = "e707fbbf255b8fc8c3b99abb91e7257a622caeb20a9818cbadbeeede4e0932ff"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.104"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "128f9e303a5a29922045a830221b8f78ec74a5f544944f3d5984f8ec3895ef64"
+checksum = "ac5d00fc561ba2724df6758a17de23df5914f20e41cb00f94d5b7ae42fffaff8"
 dependencies = [
- "proc-macro2 1.0.8",
- "quote 1.0.2",
- "syn 1.0.14",
+ "proc-macro2 1.0.9",
+ "quote 1.0.3",
+ "syn 1.0.17",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.47"
+version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15913895b61e0be854afd32fd4163fcd2a3df34142cf2cb961b310ce694cbf90"
+checksum = "9371ade75d4c2d6cb154141b9752cf3781ec9c05e0e5cf35060e1e70ee7b9c25"
 dependencies = [
  "itoa",
  "ryu",
@@ -1730,9 +1854,9 @@ checksum = "5c2fb2ec9bcd216a5b0d0ccf31ab17b5ed1d627960edff65bbe95d3ce221cefc"
 
 [[package]]
 name = "snafu"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "546db9181bce2aa22ed883c33d65603b76335b4c2533a98289f54265043de7a1"
+checksum = "48492e4f51c6e679217e80c11290edfdedf3133e358f4f432a6296f4c820f95b"
 dependencies = [
  "doc-comment",
  "snafu-derive",
@@ -1740,13 +1864,13 @@ dependencies = [
 
 [[package]]
 name = "snafu-derive"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdc75da2e0323f297402fd9c8fdba709bb04e4c627cbe31d19a2c91fc8d9f0e2"
+checksum = "b5d1c41856cbfa99befda5034c72539dd9d7dd6f3e61058bdb804ac40715bc2a"
 dependencies = [
- "proc-macro2 1.0.8",
- "quote 1.0.2",
- "syn 1.0.14",
+ "proc-macro2 1.0.9",
+ "quote 1.0.3",
+ "syn 1.0.17",
 ]
 
 [[package]]
@@ -1768,6 +1892,12 @@ dependencies = [
  "bindgen 0.47.3",
  "cc",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
 
 [[package]]
 name = "strsim"
@@ -1799,6 +1929,17 @@ dependencies = [
 
 [[package]]
 name = "syn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
+dependencies = [
+ "quote 0.3.15",
+ "synom",
+ "unicode-xid 0.0.4",
+]
+
+[[package]]
+name = "syn"
 version = "0.15.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
@@ -1810,13 +1951,33 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.14"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af6f3550d8dff9ef7dc34d384ac6f107e5d31c8f57d9f28e0081503f547ac8f5"
+checksum = "0df0eb663f387145cab623dea85b09c2c5b4b0aef44e945d928e682fce71bb03"
 dependencies = [
- "proc-macro2 1.0.8",
- "quote 1.0.2",
+ "proc-macro2 1.0.9",
+ "quote 1.0.3",
  "unicode-xid 0.2.0",
+]
+
+[[package]]
+name = "syn-mid"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7be3539f6c128a931cf19dcee741c1af532c7fd387baa739c03dd2e96479338a"
+dependencies = [
+ "proc-macro2 1.0.9",
+ "quote 1.0.3",
+ "syn 1.0.17",
+]
+
+[[package]]
+name = "synom"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
+dependencies = [
+ "unicode-xid 0.0.4",
 ]
 
 [[package]]
@@ -1825,9 +1986,9 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
 dependencies = [
- "proc-macro2 1.0.8",
- "quote 1.0.2",
- "syn 1.0.14",
+ "proc-macro2 1.0.9",
+ "quote 1.0.3",
+ "syn 1.0.17",
  "unicode-xid 0.2.0",
 ]
 
@@ -1900,9 +2061,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "0.2.11"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fdd17989496f49cdc57978c96f0c9fe5e4a58a8bddc6813c449a4624f6a030b"
+checksum = "0fa5e81d6bc4e67fe889d5783bd2a128ab2e0cfa487e0be16b6a8d177b101616"
 dependencies = [
  "bytes 0.5.4",
  "fnv",
@@ -1924,13 +2085,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4b1e7ed7d5d4c2af3d999904b0eebe76544897cdbfb2b9684bed2174ab20f7c"
+checksum = "f0c3acc6aa564495a0f2e1d59fab677cd7f81a19994cfc7f3ad0e64301560389"
 dependencies = [
- "proc-macro2 1.0.8",
- "quote 1.0.2",
- "syn 1.0.14",
+ "proc-macro2 1.0.9",
+ "quote 1.0.3",
+ "syn 1.0.17",
 ]
 
 [[package]]
@@ -1983,10 +2144,10 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0436413ba71545bcc6c2b9a0f9d78d72deb0123c6a75ccdfe7c056f9930f5e52"
 dependencies = [
- "proc-macro2 1.0.8",
+ "proc-macro2 1.0.9",
  "prost-build",
- "quote 1.0.2",
- "syn 1.0.14",
+ "quote 1.0.3",
+ "syn 1.0.17",
 ]
 
 [[package]]
@@ -2111,9 +2272,9 @@ dependencies = [
 
 [[package]]
 name = "tower-ready-cache"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2183d0a00b68a41c0af9e281cf51f40c7de2e1d4af4a43f92a5c35bbe7728d7"
+checksum = "4eabb6620e5481267e2ec832c780b31cad0c15dcb14ed825df5076b26b591e1f"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -2156,9 +2317,9 @@ dependencies = [
 
 [[package]]
 name = "tower-util"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5702d7890e35b2aae6ee420e8a762547505dbed30c075fbc84ec069a0aa18314"
+checksum = "d1093c19826d33807c72511e68f73b4a0469a3f22c2bd5f7d5212178b4b89674"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -2168,9 +2329,9 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e213bd24252abeb86a0b7060e02df677d367ce6cb772cef17e9214b8390a8d3"
+checksum = "1721cc8cf7d770cc4257872507180f35a4797272f5962f24c806af9e7faf52ab"
 dependencies = [
  "cfg-if",
  "log",
@@ -2180,28 +2341,28 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cfd395def5a60236e187e1ff905cb55668a59f29928dec05e6e1b1fd2ac1f3"
+checksum = "7fbad39da2f9af1cae3016339ad7f2c7a9e870f12e8fd04c4fd7ef35b30c0d2b"
 dependencies = [
- "quote 1.0.2",
- "syn 1.0.14",
+ "quote 1.0.3",
+ "syn 1.0.17",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13a46f11e372b8bd4b4398ea54353412fdd7fd42a8370c7e543e218cf7661978"
+checksum = "0aa83a9a47081cd522c09c81b31aec2c9273424976f922ad61c053b58350b715"
 dependencies = [
  "lazy_static",
 ]
 
 [[package]]
 name = "tracing-futures"
-version = "0.2.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33848db47a7c848ab48b66aab3293cb9c61ea879a3586ecfcd17302fcea0baf1"
+checksum = "58b0b7fd92dc7b71f29623cc6836dd7200f32161a2313dd78be233a8405694f6"
 dependencies = [
  "pin-project",
  "tracing",
@@ -2242,6 +2403,12 @@ name = "unicode-width"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
+
+[[package]]
+name = "unicode-xid"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
 
 [[package]]
 name = "unicode-xid"
@@ -2297,6 +2464,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 
 [[package]]
+name = "version_check"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce"
+
+[[package]]
 name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2330,9 +2503,9 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "3.1.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5475d47078209a02e60614f7ba5e645ef3ed60f771920ac1906d7c1cc65024c8"
+checksum = "d011071ae14a2f6671d0b74080ae0cd8ebf3a6f8c9589a2cd45f23126fe29724"
 dependencies = [
  "libc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,14 @@
 [patch.crates-io]
-h2 = { git = "https://github.com/gila/h2", branch = "master"}
+h2 = { git = "https://github.com/gila/h2", branch = "v0.2.2"}
+partition-identity = { git = "https://github.com/openebs/partition-identity.git" }
 
 [workspace]
 members = [
-  "cli",
-  "csi",
-  "jsonrpc",
-  "mayastor",
-  "rpc",
-  "sysfs",
+	"cli",
+	"csi",
+	"jsonrpc",
+	"mayastor",
+	"nvmeadm",
+	"rpc",
+	"sysfs",
 ]

--- a/nix/pkgs/mayastor/default.nix
+++ b/nix/pkgs/mayastor/default.nix
@@ -35,7 +35,7 @@ rec {
 
   mayastor = rustPlatform.buildRustPackage rec {
     name = "mayastor";
-    cargoSha256 = "1qxzbgdb3r6frw2x1v8s24ali75lxv1swq9243cxwdnvbbydqlxw";
+    cargoSha256 = "1x1czw1di0m1n1pzqkwmdwyyshn6nbp6sfiy5qzqv7rs23kb75y7";
     version = "unstable";
     src = ../../../.;
 

--- a/nvmeadm/Cargo.toml
+++ b/nvmeadm/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "nvmeadm"
+version = "0.1.0"
+authors = ["Jeffry Molanus <jeffry.molanus@gmail.com>"]
+edition = "2018"
+
+[dependencies]
+failure = "0.1"
+glob = "*"
+derive_builder = "0.7"
+nix = "0.14"
+ioctl-gen = "0.1"
+libc = "0.2"
+enum-primitive-derive = "^0.1"
+num-traits = "^0.1"

--- a/nvmeadm/src/lib.rs
+++ b/nvmeadm/src/lib.rs
@@ -1,0 +1,89 @@
+//!
+//! nvmeadm deals with finding attached, and connecting remote NVMe devices
+//! # Disconnecting all fabric connected devices
+//!
+//! To discover all subsystems on a remote host we can use a discovery builder
+//!
+//! # Discovery builder
+//! ```rust
+//! use nvmeadm::nvmf_discovery::DiscoveryBuilder;
+//!
+//! let mut disc = DiscoveryBuilder::default()
+//!     .transport("tcp".to_string())
+//!     .traddr("127.0.0.1".to_string())
+//!     .trsvcid(4420)
+//!     .build()
+//!     .unwrap();
+//! // connect to an nqn:
+//! let result = disc.connect("mynqn");
+//! ```
+
+#[macro_use]
+extern crate derive_builder;
+#[macro_use]
+extern crate failure;
+extern crate glob;
+#[macro_use]
+extern crate nix;
+#[macro_use]
+extern crate ioctl_gen;
+#[macro_use]
+extern crate enum_primitive_derive;
+use crate::nvme_page::NvmeAdminCmd;
+use std::{
+    fs,
+    io::{self, ErrorKind},
+    path::Path,
+    str::FromStr,
+};
+
+pub mod nvme_namespaces;
+mod nvme_page;
+pub mod nvmf_discovery;
+pub mod nvmf_subsystem;
+
+/// the device entry in /dev for issuing ioctls to the kernels nvme driver
+const NVME_FABRICS_PATH: &str = "/dev/nvme-fabrics";
+/// ioctl for passing any NVMe command to the kernel
+const NVME_ADMIN_CMD_IOCLT: u32 =
+    iowr!(b'N', 0x41, std::mem::size_of::<NvmeAdminCmd>());
+
+#[derive(Debug, Fail)]
+pub enum NvmeError {
+    #[fail(display = "IO error: {}", error)]
+    IoError { error: io::Error },
+    #[fail(display = "nqn: {} not found", _0)]
+    NqnNotFound(String),
+    #[fail(display = "controller with nqn: {} not found", _0)]
+    CtlNotFound(String),
+    #[fail(display = "no nvmf subsystems found")]
+    NoSubsystems,
+}
+impl From<io::Error> for NvmeError {
+    fn from(err: io::Error) -> NvmeError {
+        NvmeError::IoError {
+            error: err,
+        }
+    }
+}
+/// Read and parse value from a sysfs file
+pub fn parse_value<T>(dir: &Path, file: &str) -> Result<T, std::io::Error>
+where
+    T: FromStr,
+{
+    let path = dir.join(file);
+    let s = fs::read_to_string(&path)?;
+    let s = s.trim();
+
+    match s.parse() {
+        Ok(v) => Ok(v),
+        Err(_) => Err(std::io::Error::new(
+            ErrorKind::InvalidData,
+            format!(
+                "Failed to parse {}: {}",
+                path.as_path().to_str().unwrap(),
+                s
+            ),
+        )),
+    }
+}

--- a/nvmeadm/src/nvme_namespaces.rs
+++ b/nvmeadm/src/nvme_namespaces.rs
@@ -1,0 +1,93 @@
+use crate::parse_value;
+use failure::Error;
+use glob::glob;
+use std::{os::unix::fs::FileTypeExt, path::Path};
+
+/// NvmeDevices are devices that are already connected to the kernel
+/// they have not interaction with the fabric itself. Notice that a
+/// nvme device, for the post part is a subsystem + nsid.
+
+#[derive(Debug, Default)]
+pub struct NvmeDevice {
+    /// device path of the device
+    path: String,
+    /// the device model defined by the manufacturer
+    model: String,
+    /// serial number of the device
+    serial: String,
+    /// the size in bytes
+    size: u64,
+    /// the UUID for the device
+    uuid: String,
+    /// the world wide name of the device typically wwn.uuid
+    wwid: String,
+    /// the namespace id
+    nsid: u64,
+    /// firmware revision
+    fw_rev: String,
+    /// the nqn of the subsystem this device instance is connected to
+    subsysnqn: String,
+}
+
+impl NvmeDevice {
+    /// Construct a new NVMe device from a given path. The [struct.NvmeDevice]
+    /// will fill in all the details defined within the structure or return an
+    /// error if the value for the structure could not be found.
+    fn new(p: &Path) -> Result<Self, Error> {
+        let name = p.file_name().unwrap().to_str().unwrap();
+        let devpath = format!("/sys/block/{}", name);
+        let subsyspath = format!("/sys/block/{}/device", name);
+        let source = Path::new(devpath.as_str());
+        let subsys = Path::new(subsyspath.as_str());
+
+        Ok(NvmeDevice {
+            path: p.display().to_string(),
+            fw_rev: parse_value(&subsys, "firmware_rev")?,
+            subsysnqn: parse_value(&subsys, "subsysnqn")?,
+            model: parse_value(&subsys, "model")?,
+            serial: parse_value(&subsys, "serial")?,
+            size: parse_value(&source, "size")?,
+            // NOTE: during my testing, it seems that NON fabric devices
+            // do not have a UUID, this means that local PCIe devices will
+            // be filtered out automatically. We should not depend on this
+            // feature or, bug until we gather more data
+            uuid: parse_value(&source, "uuid")?,
+            wwid: parse_value(&source, "wwid")?,
+            nsid: parse_value(&source, "nsid")?,
+        })
+    }
+}
+/// The DeviceList of all NVMe devices found that provide all properties as
+/// defined in the [struct.NvmeDevice]
+#[derive(Debug, Default)]
+pub struct NvmeDeviceList {
+    devices: Vec<String>,
+}
+
+impl Iterator for NvmeDeviceList {
+    type Item = Result<NvmeDevice, Error>;
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some(e) = self.devices.pop() {
+            return Some(NvmeDevice::new(Path::new(&e)));
+        }
+        None
+    }
+}
+
+impl NvmeDeviceList {
+    /// glob sysfs and filter out all devices that start with /dev/nvme
+    pub fn new() -> Self {
+        let mut list = NvmeDeviceList::default();
+        let path_entries = glob("/dev/nvme*").unwrap();
+        for entry in path_entries {
+            if let Ok(path) = entry {
+                if let Ok(meta) = std::fs::metadata(&path) {
+                    if meta.file_type().is_block_device() {
+                        list.devices.push(path.display().to_string());
+                    }
+                }
+            }
+        }
+        list
+    }
+}

--- a/nvmeadm/src/nvme_page.rs
+++ b/nvmeadm/src/nvme_page.rs
@@ -1,0 +1,123 @@
+use crate::nvme_page;
+use libc::{c_char, c_uchar};
+use std::fmt;
+
+#[repr(C)]
+#[derive(Default)]
+pub struct ZeroSizeArray<T>(::core::marker::PhantomData<T>, [T; 0]);
+
+impl<T> ZeroSizeArray<T> {
+    pub unsafe fn as_ptr(&self) -> *const T {
+        self as *const nvme_page::ZeroSizeArray<T> as *const T
+    }
+    pub unsafe fn as_slice(&self, len: usize) -> &[T] {
+        ::core::slice::from_raw_parts(self.as_ptr(), len)
+    }
+}
+
+impl<T> ::core::fmt::Debug for ZeroSizeArray<T> {
+    fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+        fmt.write_str("ZeroSizeArray")
+    }
+}
+
+#[repr(C)]
+pub struct NvmfDiscRspPageHdr {
+    pub genctr: u64,
+    pub numrec: u64,
+    pub recfmt: u16,
+    pub resv14: [c_uchar; 1006usize],
+    pub entries: ZeroSizeArray<NvmfDiscRspPageEntry>,
+}
+
+impl fmt::Debug for NvmfDiscRspPageHdr {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("NvmfDiscRspPageHdr")
+            .field("genctr", &self.genctr)
+            .field("numrec", &self.numrec)
+            .field("recfmt", &self.recfmt)
+            .finish()
+    }
+}
+
+impl Default for NvmfDiscRspPageHdr {
+    fn default() -> Self {
+        NvmfDiscRspPageHdr {
+            ..unsafe { std::mem::zeroed() }
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Default, Clone, Copy)]
+pub struct NvmeAdminCmd {
+    pub opcode: c_uchar,
+    pub flags: c_uchar, // fuse, rsvd1,psdt,cid
+    pub cid: u16,
+    pub nsid: u32,
+    pub cdw2: u32,
+    pub cdw3: u32,
+    pub mptr: u64,
+    pub dptr: u64,
+    pub mptr_len: u32,
+    pub dptr_len: u32,
+    pub cdw10: u32,
+    pub cdw11: u32,
+    pub cdw12: u32,
+    pub cdw13: u32,
+    pub cdw14: u32,
+    pub cdw15: u32,
+    pub timeout_ms: u32,
+    pub result: u32,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct NvmfDiscRspPageEntry {
+    pub trtype: c_uchar,
+    pub adrfam: c_uchar,
+    pub subtype: c_uchar,
+    pub treq: c_uchar, // 0:2 secure channel, reserved
+    pub portid: u16,
+    pub cntlid: u16,
+    pub asqsz: u16, // admin queue size
+    pub resv8: [c_uchar; 22usize],
+    pub trsvcid: [c_char; 32usize],
+    pub resv64: [c_uchar; 192usize],
+    pub subnqn: [c_char; 256usize],
+    pub traddr: [c_char; 256usize],
+    pub tsas: NvmfDiscRspPageEntryTsas,
+}
+impl Default for NvmfDiscRspPageEntry {
+    fn default() -> Self {
+        NvmfDiscRspPageEntry {
+            ..unsafe { std::mem::zeroed() }
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union NvmfDiscRspPageEntryTsas {
+    pub common: [::std::os::raw::c_char; 256usize],
+    pub rdma: nvmf_disc_rsp_page_entry_tsas_rdma,
+    pub tcp: NvmfDiscRspPageEntryTsasTcp,
+    __union_align: [u16; 128usize],
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct NvmfDiscRspPageEntryTsasTcp {
+    pub sectype: c_uchar,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct nvmf_disc_rsp_page_entry_tsas_rdma {
+    pub qptype: c_uchar,
+    pub prtype: c_uchar,
+    pub cms: c_uchar,
+    pub resv3: [c_uchar; 5usize],
+    pub pkey: u16,
+    pub resv10: [c_uchar; 246usize],
+}

--- a/nvmeadm/src/nvmf_discovery.rs
+++ b/nvmeadm/src/nvmf_discovery.rs
@@ -1,0 +1,405 @@
+use crate::nvme_page::{
+    NvmeAdminCmd,
+    NvmfDiscRspPageEntry,
+    NvmfDiscRspPageHdr,
+};
+use std::{convert::TryInto, fmt};
+
+use nix::libc::ioctl as nix_ioctl;
+
+/// when connecting to a NVMF target, we MAY send a NQN that we want to be
+/// referred as.
+const MACHINE_UUID_PATH: &str = "/sys/class/dmi/id/product_uuid";
+
+use crate::{NvmeError, NVME_ADMIN_CMD_IOCLT, NVME_FABRICS_PATH};
+use failure::Error;
+use std::{
+    fs::OpenOptions,
+    io::{Read, Write},
+    path::Path,
+    str::FromStr,
+};
+
+use num_traits::FromPrimitive;
+use std::{net::IpAddr, os::unix::io::AsRawFd};
+
+/// The TrType struct for all known transports types note: we are missing loop
+#[derive(Debug, Primitive)]
+#[allow(non_camel_case_types)]
+pub enum TrType {
+    rdma = 1,
+    fc = 2,
+    tcp = 3,
+}
+
+impl fmt::Display for TrType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+/// AddressFamily, in case of TCP and RDMA we use IPv6 or IPc4 only
+#[derive(Debug, Primitive)]
+pub enum AddressFamily {
+    PCI = 0,
+    IPv4 = 1,
+    IPv6 = 2,
+    IB = 3,
+    FC = 4,
+}
+
+impl fmt::Display for AddressFamily {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+/// There are two built in subsystems available normal, i.e an NVMe device
+/// or a discovery controller. We are always exporting a discovery controller
+/// even when we are not actively serving out any devices
+#[derive(Debug, Primitive)]
+pub enum SubType {
+    DISCOVERY = 1,
+    NVME = 2,
+}
+
+#[derive(Debug)]
+pub struct DiscoveryLogEntry {
+    pub tr_type: TrType,
+    pub adr_fam: AddressFamily,
+    pub subtype: SubType,
+    pub port_id: u32,
+    pub trsvcid: String,
+    pub traddr: String,
+    pub subnqn: String,
+}
+
+/// Creates a new Disovery struct to find new NVMe devices
+///
+///
+/// # Example
+/// ```
+/// use nvmeadm::nvmf_discovery::DiscoveryBuilder;
+///
+/// let mut disc = DiscoveryBuilder::default()
+///     .transport("tcp".to_string())
+///     .traddr("127.0.0.1".to_string())
+///     .trsvcid(4420)
+///     .build()
+///     .unwrap();
+///
+/// let pages = disc.discover();
+/// pages.iter().map(|e| println!("{:#?}", e)).for_each(drop);
+/// ```
+#[derive(Default, Debug, Builder)]
+#[builder(build_fn(validate = "Self::validate"))]
+pub struct Discovery {
+    transport: String,
+    traddr: String,
+    trsvcid: u32,
+    #[builder(setter(skip))]
+    ctl_id: u32,
+    #[builder(setter(skip))]
+    arg_string: String,
+    #[builder(setter(skip))]
+    entries: Vec<DiscoveryLogEntry>,
+}
+
+impl fmt::Display for Discovery {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+impl Discovery {
+    ///
+    /// Runs the actual discovery process and returns a vector of found
+    /// [struct.DiscoveryLogEntry]. Through the pages we can connect to the
+    /// targets.
+    ///
+    /// The pages are iteratable so you can filter exactly what you are looing
+    /// for
+    pub fn discover(&mut self) -> Result<&Vec<DiscoveryLogEntry>, Error> {
+        self.arg_string = format!(
+            "nqn=nqn.2014-08.org.nvmexpress.discovery,transport={},traddr={},trsvcid={}",
+            self.transport, self.traddr, self.trsvcid
+        );
+        let p = Path::new(NVME_FABRICS_PATH);
+
+        let mut file = OpenOptions::new().write(true).read(true).open(&p)?;
+
+        file.write_all(self.arg_string.as_bytes())?;
+        let mut buf = String::new();
+        file.read_to_string(&mut buf)?;
+        // get the ctl=value from the controller
+        let v = buf.split(',').collect::<Vec<_>>()[0]
+            .split('=')
+            .collect::<Vec<_>>()[1];
+
+        let ctl_id = u32::from_str(v).unwrap();
+        self.ctl_id = ctl_id;
+        self.get_discovery_response_pages()?;
+        Ok(&self.entries)
+    }
+
+    // private function that retrieves number of records
+    fn get_discovery_response_page_entries(&self) -> Result<u64, Error> {
+        let f = OpenOptions::new()
+            .read(true)
+            .open(Path::new(&format!("/dev/nvme{}", self.ctl_id)))?;
+
+        // See NVM-Express1_3d 5.14
+        let hdr_len = std::mem::size_of::<NvmfDiscRspPageHdr>() as u32;
+        let h = NvmfDiscRspPageHdr::default();
+        let mut cmd = NvmeAdminCmd::default();
+        cmd.opcode = 0x02;
+        cmd.nsid = 0;
+        cmd.dptr_len = hdr_len;
+        cmd.dptr = &h as *const _ as u64;
+
+        // bytes to dwords, devide by 4. Spec says 0's value
+
+        let dword_count = (hdr_len >> 2) - 1;
+        let numdl = dword_count & 0xFFFF;
+
+        // 0x70 is the discovery OP code see
+        // NVMe_over_Fabrics_1_0_Gold_20160605-1.pdf  5.3
+        cmd.cdw10 = 0x70 | numdl << 16;
+
+        let _ret = unsafe {
+            convert_ioctl_res!(nix_ioctl(
+                f.as_raw_fd(),
+                u64::from(NVME_ADMIN_CMD_IOCLT).try_into().unwrap(),
+                &cmd
+            ))?
+        };
+
+        Ok(h.numrec)
+    }
+
+    // note we can only transfer max_io size. This means that if the number of
+    // controllers
+    // is larger we have to do {] while() we control the size for our
+    // controllers not others! This means in the future we will have to come
+    // back to this
+    //
+    // What really want is a stream of pages where we can filter process them
+    // one by one.
+
+    fn get_discovery_response_pages(&mut self) -> Result<usize, Error> {
+        let f = OpenOptions::new()
+            .read(true)
+            .open(Path::new(&format!("/dev/nvme{}", self.ctl_id)))?;
+
+        let count = self.get_discovery_response_page_entries()?;
+
+        let hdr_len = std::mem::size_of::<NvmfDiscRspPageHdr>();
+        let response_len = std::mem::size_of::<NvmfDiscRspPageEntry>();
+        let total_length = hdr_len + (response_len * count as usize);
+        let buffer = unsafe { libc::calloc(1, total_length) };
+
+        let mut cmd = NvmeAdminCmd::default();
+
+        cmd.opcode = 0x02;
+        cmd.nsid = 0;
+        cmd.dptr_len = total_length as u32;
+        cmd.dptr = buffer as *const _ as u64;
+
+        let dword_count = ((total_length >> 2) - 1) as u32;
+        let numdl: u16 = (dword_count & 0xFFFF) as u16;
+        let numdu: u16 = (dword_count >> 16) as u16;
+
+        cmd.cdw10 = 0x70 | u32::from(numdl) << 16 as u32;
+        cmd.cdw11 = u32::from(numdu);
+
+        let _ret = unsafe {
+            convert_ioctl_res!(nix_ioctl(
+                f.as_raw_fd(),
+                u64::from(NVME_ADMIN_CMD_IOCLT).try_into().unwrap(),
+                &cmd
+            ))?
+        };
+
+        let hdr = unsafe { &mut *(buffer as *mut NvmfDiscRspPageHdr) };
+        let entries = unsafe { hdr.entries.as_slice(hdr.numrec as usize) };
+
+        for e in entries {
+            let tr_type = TrType::from_u8(e.trtype);
+            let adr_fam = AddressFamily::from_u8(e.adrfam);
+            let subtype = SubType::from_u8(e.subtype);
+
+            if tr_type.is_none() || adr_fam.is_none() || subtype.is_none() {
+                eprintln!("Invalid discovery record, skipping");
+                continue;
+            }
+
+            let record = DiscoveryLogEntry {
+                tr_type: tr_type.unwrap(),
+                adr_fam: adr_fam.unwrap(),
+                port_id: u32::from(e.portid),
+                subtype: subtype.unwrap(),
+
+                trsvcid: unsafe {
+                    std::ffi::CStr::from_ptr(&e.trsvcid[0])
+                        .to_string_lossy()
+                        .into_owned()
+                        .trim()
+                        .into()
+                },
+                traddr: unsafe {
+                    std::ffi::CStr::from_ptr(&e.traddr[0])
+                        .to_string_lossy()
+                        .into_owned()
+                        .trim()
+                        .into()
+                },
+                subnqn: unsafe {
+                    std::ffi::CStr::from_ptr(&e.subnqn[0])
+                        .to_string_lossy()
+                        .into_owned()
+                        .trim()
+                        .into()
+                },
+            };
+            self.entries.push(record);
+        }
+
+        self.remove_controller()?;
+        unsafe { libc::free(buffer) };
+        Ok(self.entries.len())
+    }
+
+    // we need to close the discovery controller when we are done and before we
+    // connect
+    fn remove_controller(&self) -> Result<(), Error> {
+        let target =
+            format!("/sys/class/nvme/nvme{}/delete_controller", self.ctl_id);
+        let path = Path::new(&target);
+        let mut file = OpenOptions::new().write(true).open(&path)?;
+        file.write_all(b"1")?;
+        Ok(())
+    }
+
+    /// Connect to all discovery log page entries found during the discovery
+    /// phase
+    pub fn connect_all(&mut self) -> Result<(), Error> {
+        if self.entries.is_empty() {
+            return Err(Error::from(NvmeError::NoSubsystems));
+        }
+        let p = Path::new(NVME_FABRICS_PATH);
+
+        let mut file = OpenOptions::new().write(true).read(true).open(&p)?;
+        // we are ignoring errors here, and connect to all possible devices
+        if let Err(connections) = self
+            .entries
+            .iter_mut()
+            .map(|e| {
+                file.write_all(e.build_connect_args().unwrap().as_bytes())
+                    .and_then(|_e| {
+                        let mut buf = String::new();
+                        file.read_to_string(&mut buf)?;
+                        Ok(buf)
+                    })
+            })
+            .collect::<Result<Vec<_>, _>>()
+        {
+            return Err(connections.into());
+        }
+
+        Ok(())
+    }
+
+    ///
+    /// This method the actual thing we care about. We want to connect to
+    /// something and all we have is the name of the node we are supposed to
+    /// connect to a port this port in our case may vary depending on which
+    /// side of the fabric we are but in general, this will be either 4420
+    /// or 4421.
+    ///
+    /// When we are already connected to the same host we will get back
+    /// connection in progress. These errors are propagated back to use as
+    /// we use the ? marker
+    ///
+    ///  # Example
+    ///  ```rust
+    ///  use nvmeadm::nvmf_discovery::DiscoveryBuilder;
+    ///
+    ///  let mut discovered_targets = DiscoveryBuilder::default()
+    ///          .transport("tcp".to_string())
+    ///          .traddr("127.0.0.1".to_string())
+    ///          .trsvcid(4420)
+    ///          .build()
+    ///          .unwrap();
+    ///
+    ///  let result = discovered_targets.connect("mynqn");
+    /// ```
+    ///
+
+    pub fn connect(&mut self, nqn: &str) -> Result<String, Error> {
+        let p = Path::new(NVME_FABRICS_PATH);
+
+        if let Some(ss) = self.entries.iter_mut().find(|p| p.subnqn == nqn) {
+            let mut file =
+                OpenOptions::new().write(true).read(true).open(&p)?;
+            file.write_all(ss.build_connect_args().unwrap().as_bytes())?;
+            let mut buf = String::new();
+            file.read_to_string(&mut buf)?;
+            Ok(buf)
+        } else {
+            Err(NvmeError::NqnNotFound(nqn.into()).into())
+        }
+    }
+}
+
+impl DiscoveryBuilder {
+    fn validate(&self) -> Result<(), String> {
+        if let Some(transport) = &self.transport {
+            if transport != "tcp" && transport != "rdma" {
+                return Err("invalid transport specified".into());
+            }
+        }
+
+        if let Some(traddr) = &self.traddr {
+            if let Err(ip) = IpAddr::from_str(&traddr) {
+                return Err(format!("Invalid IP address: {}", ip.to_string()));
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl DiscoveryLogEntry {
+    fn read_file(&self, file_path: &str) -> Result<String, Error> {
+        let mut fd = std::fs::File::open(file_path)?;
+        let mut content = String::new();
+        fd.read_to_string(&mut content)?;
+        Ok(content.trim().to_string())
+    }
+
+    fn get_host_id(&self) -> Result<String, Error> {
+        let id = self.read_file(MACHINE_UUID_PATH)?;
+        Ok(id)
+    }
+
+    //TODO: we need to pass in the HOSTNAME suggestion is to use env::
+
+    fn my_nqn_name(&self) -> Result<String, Error> {
+        let hostid = self.get_host_id()?;
+        Ok(format!("nqn.2019-05.io.openebs.mayastor:{}", hostid))
+    }
+
+    pub fn build_connect_args(&mut self) -> Result<String, Error> {
+        let mut connect_args = String::new();
+
+        connect_args.push_str(&format!("nqn={},", self.subnqn));
+        connect_args.push_str(&format!("hostnqn={},", self.my_nqn_name()?));
+        connect_args.push_str(&format!("hostid={},", self.get_host_id()?));
+
+        connect_args.push_str(&format!("transport={},", self.tr_type));
+        connect_args.push_str(&format!("traddr={},", self.traddr));
+        connect_args.push_str(&format!("trsvcid={}", self.trsvcid));
+
+        Ok(connect_args)
+    }
+}

--- a/nvmeadm/src/nvmf_subsystem.rs
+++ b/nvmeadm/src/nvmf_subsystem.rs
@@ -1,0 +1,125 @@
+use crate::{parse_value, NvmeError};
+use failure::Error;
+use glob::glob;
+use std::{fs::OpenOptions, io::Write, path::Path};
+
+use std::str::FromStr;
+/// Subsystem struct shows us all the connect fabrics. This does not include
+/// NVMe devices that are connected by trtype=PCIe
+#[derive(Default, Clone, Debug)]
+pub struct Subsystem {
+    /// name of the subsystem
+    pub name: String,
+    /// instance number of the subsystem (controller)
+    pub instance: u32,
+    /// NVme Qualified Name (NQN)
+    pub nqn: String,
+    /// state of the connection, will contain live if online
+    pub state: String,
+    /// the transport type being used (tcp or RDMA)
+    pub transport: String,
+    /// address contains traddr=X,trsvcid=Y
+    pub address: String,
+    /// serial number
+    pub serial: String,
+    /// model number
+    pub model: String,
+}
+
+impl Subsystem {
+    /// scans the sysfs directory for attached subsystems skips any transport
+    /// that does not contain a value that is being read in the implementation
+    pub fn new(source: &Path) -> Result<Self, Error> {
+        let name = source
+            .strip_prefix("/sys/devices/virtual/nvme-fabrics/ctl")?
+            .display()
+            .to_string();
+        let instance = u32::from_str(name.trim_start_matches("nvme")).unwrap();
+        let nqn = parse_value::<String>(&source, "subsysnqn")?;
+        let state = parse_value::<String>(&source, "state")?;
+        let transport = parse_value::<String>(&source, "transport")?;
+        let address = parse_value::<String>(&source, "address")?;
+        let serial = parse_value::<String>(&source, "serial")?;
+        let model = parse_value::<String>(&source, "model")?;
+
+        if serial == "" || model == "" {
+            return Err(
+                NvmeError::CtlNotFound("discovery controller".into()).into()
+            );
+        }
+
+        // if it does not have a serial and or model -- its a discovery
+        // controller so we skip it
+
+        let model = parse_value::<String>(&source, "model")?;
+        Ok(Subsystem {
+            name,
+            instance,
+            nqn,
+            state,
+            transport,
+            address,
+            serial,
+            model,
+        })
+    }
+    /// issue a rescan to the controller to find new namespaces
+    pub fn rescan(&self) -> Result<(), Error> {
+        let target = format!("/sys/class/nvme/{}/rescan_controller", self.name);
+        let path = Path::new(&target);
+
+        let mut file = OpenOptions::new().write(true).open(&path)?;
+        file.write_all(b"1")?;
+        Ok(())
+    }
+    /// disconnects the transport dropping all namespaces
+    pub fn disconnect(&self) -> Result<(), Error> {
+        let target = format!("/sys/class/nvme/{}/delete_controller", self.name);
+        let path = Path::new(&target);
+
+        let mut file = OpenOptions::new().write(true).open(&path)?;
+        file.write_all(b"1")?;
+        Ok(())
+    }
+    /// resets the nvme controller
+    pub fn reset(&self) -> Result<(), Error> {
+        let target = format!("/sys/class/nvme/{}/reset_controller", self.name);
+        let path = Path::new(&target);
+
+        let mut file = OpenOptions::new().write(true).open(&path)?;
+        file.write_all(b"1")?;
+        Ok(())
+    }
+}
+
+/// list of subsystems found on the system
+#[derive(Default, Debug)]
+pub struct NvmeSubsystems {
+    entries: Vec<String>,
+}
+
+impl Iterator for NvmeSubsystems {
+    type Item = Result<Subsystem, Error>;
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some(e) = self.entries.pop() {
+            return Some(Subsystem::new(Path::new(&e)));
+        }
+        None
+    }
+}
+
+impl NvmeSubsystems {
+    /// Construct a new list of subsystems
+    pub fn new() -> Result<Self, Error> {
+        let path_entries = glob("/sys/devices/virtual/nvme-fabrics/ctl/nvme*")?;
+        let mut entries = Vec::new();
+        for entry in path_entries {
+            if let Ok(path) = entry {
+                entries.push(path.display().to_string())
+            }
+        }
+        Ok(NvmeSubsystems {
+            entries,
+        })
+    }
+}

--- a/nvmeadm/tests/discovery_test.rs
+++ b/nvmeadm/tests/discovery_test.rs
@@ -1,0 +1,14 @@
+use nvmeadm::nvmf_discovery::DiscoveryBuilder;
+
+#[test]
+fn disovery_test() {
+    let mut explorer = DiscoveryBuilder::default()
+        .transport("tcp".to_string())
+        .traddr("127.0.0.01".to_string())
+        .trsvcid(4420)
+        .build()
+        .unwrap();
+
+    // only root can discover
+    let _ = explorer.discover();
+}


### PR DESCRIPTION
This library will be used within the CSI driver to connect, discover
and perhaps other functionality that we might need. This is to avoid
the need of external binaries (like with iSCSI).

This touches Cargo.lock and so we also take the opportunity to
upgrade the dependencies.