### PR TITLE
pool: Allow I/O interface to be configured per-pool

### DIFF
--- a/csi/moac/test/mayastor_mock.js
+++ b/csi/moac/test/mayastor_mock.js
@@ -67,7 +67,11 @@ class MayastorServer {
       // capacity to 100 and used to 4.
       createPool: (call, cb) => {
         let args = call.request;
-        assertHasKeys(args, ['name', 'disks', 'blockSize'], ['blockSize']);
+        assertHasKeys(
+          args,
+          ['name', 'disks', 'blockSize', 'ioIf'],
+          ['blockSize', 'ioIf']
+        );
         if (self.pools.find((p) => p.name == args.name)) {
           let err = new Error('already exists');
           err.code = grpc.status.ALREADY_EXISTS;

--- a/csi/src/mayastor_svc.rs
+++ b/csi/src/mayastor_svc.rs
@@ -26,10 +26,11 @@ impl service::mayastor_server::Mayastor for MayastorService {
         }
 
         debug!(
-            "Creating pool {} on {} with block size {}...",
+            "Creating pool {} on {} with block size {}, io_if {}...",
             msg.name,
             msg.disks.join(" "),
             msg.block_size,
+            msg.io_if,
         );
 
         // make a copy of vars used in the closures below
@@ -39,6 +40,7 @@ impl service::mayastor_server::Mayastor for MayastorService {
             name: msg.name,
             disks: msg.disks,
             block_size: Some(msg.block_size),
+            io_if: Some(msg.io_if),
         });
 
         jsonrpc::call::<_, ()>(&self.socket, "create_or_import_pool", args)

--- a/mayastor-test/test_replica.js
+++ b/mayastor-test/test_replica.js
@@ -14,6 +14,7 @@ const { exec } = require('child_process');
 const { createClient } = require('grpc-kit');
 const grpc = require('grpc');
 const common = require('./test_common');
+const enums = require('./grpc_enums');
 
 const POOL = 'tpool';
 const DISK_FILE = '/tmp/mayastor_test_disk';
@@ -196,12 +197,16 @@ describe('replica', function () {
     );
   });
 
-  it('should create a pool', (done) => {
-    client.createPool({ name: POOL, disks: disks }, (err, res) => {
-      if (err) return done(err);
-      assert.lengthOf(Object.keys(res), 0);
-      done();
-    });
+  it('should create a pool with aio bdevs', (done) => {
+    // explicitly specify aio as that always works
+    client.createPool(
+      { name: POOL, disks: disks, io_if: enums.POOL_IO_AIO },
+      (err, res) => {
+        if (err) return done(err);
+        assert.lengthOf(Object.keys(res), 0);
+        done();
+      }
+    );
   });
 
   it('should return error from create when the pool exists', (done) => {

--- a/mayastor/src/bdev/uring_util.rs
+++ b/mayastor/src/bdev/uring_util.rs
@@ -74,15 +74,13 @@ pub fn fs_type_supported(path: &str) -> bool {
     }
 }
 
-pub fn kernel_supports_io_uring() -> bool {
+pub fn kernel_support() -> bool {
     // Match SPDK_URING_QUEUE_DEPTH
     let queue_depth = 512;
     match io_uring::IoUring::new(queue_depth) {
         Ok(_ring) => true,
         Err(e) => {
-            assert_eq!(e.kind(), ErrorKind::Other);
-            assert_eq!(e.raw_os_error().unwrap(), libc::ENOSYS);
-            println!("Skipping uring bdev, IoUring::new: {:?}", e);
+            debug!("IoUring::new: {}", e);
             false
         }
     }

--- a/mayastor/src/bin/main.rs
+++ b/mayastor/src/bin/main.rs
@@ -7,6 +7,7 @@ use structopt::StructOpt;
 
 use git_version::git_version;
 use mayastor::{
+    bdev::uring_util,
     core::{MayastorCliArgs, MayastorEnvironment},
     logger,
 };
@@ -35,8 +36,13 @@ fn main() -> Result<(), std::io::Error> {
 
     let free_pages: u32 = sysfs::parse_value(&hugepage_path, "free_hugepages")?;
     let nr_pages: u32 = sysfs::parse_value(&hugepage_path, "nr_hugepages")?;
+    let uring_supported = uring_util::kernel_support();
 
     info!("Starting Mayastor version {}", git_version!());
+    info!(
+        "kernel io_uring support: {}",
+        if uring_supported { "yes" } else { "no" }
+    );
     info!("free_pages: {} nr_pages: {}", free_pages, nr_pages);
     let env = MayastorEnvironment::new(args);
     env.start(|| {

--- a/mayastor/src/bin/uring-support.rs
+++ b/mayastor/src/bin/uring-support.rs
@@ -20,7 +20,7 @@ fn main() {
 
     let supported = uring_util::fs_supports_direct_io(path)
         && uring_util::fs_type_supported(path)
-        && uring_util::kernel_supports_io_uring();
+        && uring_util::kernel_support();
 
     if supported {
         std::process::exit(0);

--- a/mayastor/tests/core.rs
+++ b/mayastor/tests/core.rs
@@ -31,7 +31,7 @@ fn do_uring() -> bool {
         INIT.call_once(|| {
             DO_URING = uring_util::fs_supports_direct_io(DISKNAME3)
                 && uring_util::fs_type_supported(DISKNAME3)
-                && uring_util::kernel_supports_io_uring();
+                && uring_util::kernel_support();
         });
         DO_URING
     }

--- a/rpc/proto/mayastor.proto
+++ b/rpc/proto/mayastor.proto
@@ -13,12 +13,20 @@ package mayastor;
 // Means no arguments or no return value.
 message Null {}
 
+// I/O interface used for underlying disks in a pool
+enum PoolIoIf {
+  POOL_IO_AUTO = 0;    // prefer uring if supported, falling back to aio
+  POOL_IO_AIO = 1;     // Linux AIO
+  POOL_IO_URING = 2;   // io_uring, requires Linux 5.1
+}
+
 // Create pool arguments.
 // Currently we support only concatenation of disks (RAID-0).
 message CreatePoolRequest {
   string name = 1;           // name of the pool
   repeated string disks = 2; // absolute disk device paths to be claimed by the pool
   uint32 block_size = 3; // when using files, we need to specify the block_size
+  PoolIoIf io_if = 4;        // I/O interface
 }
 
 // State of the storage pool (terminology comes from ZFS).

--- a/rpc/src/jsonrpc.rs
+++ b/rpc/src/jsonrpc.rs
@@ -7,6 +7,8 @@ pub struct CreateOrImportPoolArgs {
     pub disks: Vec<String>,
     /// the block_size of the underlying block devices
     pub block_size: Option<u32>,
+    /// the I/O interface for the underlying block devices
+    pub io_if: Option<i32>,
 }
 
 /// destroy the pool by name


### PR DESCRIPTION
Add io_if to CreatePoolRequest with permissible values of aio, uring and auto (preferring uring if supported by the kernel) and create the appropriate type of bdev.
Show kernel io_uring support status on startup.
Add a unit test to check for valid I/O interfaces values.