### PR TITLE
build: remove rdma-core

### DIFF
--- a/nix/pkgs/libspdk/default.nix
+++ b/nix/pkgs/libspdk/default.nix
@@ -40,12 +40,11 @@ stdenv.mkDerivation rec {
     numactl
     openssl
     python
-    rdma-core
-  ] ++ stdenv.lib.optionals enableDebug [cunit lcov];
+  ] ++ stdenv.lib.optionals enableDebug [ cunit lcov ];
 
   CONFIGURE_OPTS = ''
     ${enableFeature enableDebug "debug"}
-    --without-isal --with-iscsi-initiator --with-rdma
+    --without-isal --with-iscsi-initiator
     --with-internal-vhost-lib --disable-tests --with-dpdk-machine=native
     --with-crypto
     --with-uring
@@ -79,7 +78,7 @@ stdenv.mkDerivation rec {
     find . -type f -name 'librte_vhost.a' -delete
 
     $CC -shared -o libspdk_fat.so \
-    -lc -lrdmacm -laio -libverbs -liscsi -lnuma -ldl -lrt -luuid -lpthread -lcrypto -luring \
+    -lc -laio -liscsi -lnuma -ldl -lrt -luuid -lpthread -lcrypto -luring \
     -Wl,--whole-archive \
     $(find build/lib -type f -name 'libspdk_*.a*' -o -name 'librte_*.a*') \
     $(find dpdk/build/lib -type f -name 'librte_*.a*') \

--- a/nix/pkgs/mayastor/default.nix
+++ b/nix/pkgs/mayastor/default.nix
@@ -57,7 +57,6 @@ rec {
       openssl
       pkg-config
       protobuf
-      rdma-core
       utillinux
       xfsprogs
     ];

--- a/spdk-sys/build.rs
+++ b/spdk-sys/build.rs
@@ -84,8 +84,6 @@ fn main() {
         .expect("Couldn't write bindings!");
 
     println!("cargo:rustc-link-lib=spdk_fat");
-    println!("cargo:rustc-link-lib=ibverbs");
-    println!("cargo:rustc-link-lib=rdmacm");
     println!("cargo:rustc-link-lib=aio");
     println!("cargo:rustc-link-lib=iscsi");
     println!("cargo:rustc-link-lib=numa");


### PR DESCRIPTION
We need to clean up some of the packages and start pinning
to a stable nix-pkgs. This should also mean we remove any stuff we
don't use currently.