### PR TITLE
rebuild: run n copy tasks at a time (async tasks)

### DIFF
--- a/mayastor/tests/common/mod.rs
+++ b/mayastor/tests/common/mod.rs
@@ -94,6 +94,15 @@ pub fn truncate_file(path: &str, size: u64) {
     assert_eq!(output.status.success(), true);
 }
 
+pub fn truncate_file_bytes(path: &str, size: u64) {
+    let output = Command::new("truncate")
+        .args(&["-s", &format!("{}", size), path])
+        .output()
+        .expect("failed exec truncate");
+
+    assert_eq!(output.status.success(), true);
+}
+
 pub fn fscheck(device: &str) {
     let output = Command::new("fsck")
         .args(&[device, "-n"])

--- a/mayastor/tests/nexus_rebuild.rs
+++ b/mayastor/tests/nexus_rebuild.rs
@@ -23,8 +23,8 @@ static NEXUS_SIZE: u64 = 10 * 1024 * 1024; // 10MiB
 #[test]
 fn rebuild_test() {
     common::delete_file(&[DISKNAME1.into(), DISKNAME2.into()]);
-    common::truncate_file(DISKNAME1, NEXUS_SIZE / 1024);
-    common::truncate_file(DISKNAME2, NEXUS_SIZE / 1024);
+    common::truncate_file_bytes(DISKNAME1, NEXUS_SIZE);
+    common::truncate_file_bytes(DISKNAME2, NEXUS_SIZE);
 
     test_init!();
 


### PR DESCRIPTION
a management async tasks schedules all copy tasks, awaits them and schedules enough tasks until the bdev is fully rebuilt
(still using a single reactor this time)