### PR TITLE
Rebuild: Start rebuild when setting child online

### DIFF
--- a/csi/src/mayastor_svc.rs
+++ b/csi/src/mayastor_svc.rs
@@ -414,9 +414,9 @@ fn get_child_method_string(action: i32) -> Result<String, Status> {
     match action {
         0 => Ok("offline_child".to_string()),
         1 => Ok("online_child".to_string()),
-        _ => {
-            let msg = action.to_string() + " is an invalid operation.";
-            Err(Status::invalid_argument(msg))
-        }
+        _ => Err(Status::invalid_argument(format!(
+            "{} is an invalid operation",
+            action
+        ))),
     }
 }

--- a/csi/src/mayastor_svc.rs
+++ b/csi/src/mayastor_svc.rs
@@ -309,8 +309,8 @@ impl service::mayastor_server::Mayastor for MayastorService {
     ) -> Result<Response<Null>, Status> {
         let msg = request.into_inner();
         trace!("{:?}", msg);
-        jsonrpc::call::<_, ()>(&self.socket, "offline_child", Some(msg))
-            .await?;
+        let method = get_child_method_string(msg.action)?;
+        jsonrpc::call::<_, ()>(&self.socket, &method, Some(msg)).await?;
         Ok(Response::new(Null {}))
     }
 
@@ -407,5 +407,16 @@ impl service::mayastor_server::Mayastor for MayastorService {
         )
         .await?;
         Ok(Response::new(r))
+    }
+}
+
+fn get_child_method_string(action: i32) -> Result<String, Status> {
+    match action {
+        0 => Ok("offline_child".to_string()),
+        1 => Ok("online_child".to_string()),
+        _ => {
+            let msg = action.to_string() + " is an invalid operation.";
+            Err(Status::invalid_argument(msg))
+        }
     }
 }

--- a/mayastor-test/test_rebuild.js
+++ b/mayastor-test/test_rebuild.js
@@ -107,6 +107,18 @@ const rebuildArgs = {
   uri: `aio:///${child2}?blk_size=4096`,
 };
 
+const childOnlineArgs = {
+  uuid: UUID,
+  uri: `aio:///${child2}?blk_size=4096`,
+  action: 1,
+};
+
+const childOfflineArgs = {
+  uuid: UUID,
+  uri: `aio:///${child2}?blk_size=4096`,
+  action: 0,
+};
+
 function createGrpcClient() {
   const PROTO_PATH = __dirname + '/../rpc/proto/mayastor_service.proto';
 
@@ -403,6 +415,67 @@ describe('rebuild tests', function () {
 
     it('check number of rebuilds', async () => {
       await checkNumRebuilds('1');
+    });
+  });
+
+  describe('set child online', function () {
+    beforeEach(async () => {
+      await client.addChildNexus().sendMessage(rebuildArgs);
+      await client.childOperation().sendMessage(childOfflineArgs);
+      await client.childOperation().sendMessage(childOnlineArgs);
+    });
+
+    afterEach(async () => {
+      await client.stopRebuild().sendMessage(rebuildArgs);
+      await client.removeChildNexus().sendMessage(rebuildArgs);
+    });
+
+    it('check nexus state', async () => {
+      await checkState(ObjectType.NEXUS, 'degraded');
+    });
+
+    it('check source state', async () => {
+      await checkState(ObjectType.SOURCE_CHILD, 'open');
+    });
+
+    it('check destination state', async () => {
+      await checkState(ObjectType.DESTINATION_CHILD, 'faulted');
+    });
+
+    it('check rebuild state', async () => {
+      await checkRebuildState('running');
+    });
+
+    it('check number of rebuilds', async () => {
+      await checkNumRebuilds('1');
+    });
+  });
+
+  describe('set child offline', function () {
+    beforeEach(async () => {
+      await client.addChildNexus().sendMessage(rebuildArgs);
+      await client.startRebuild().sendMessage(rebuildArgs);
+      await client.childOperation().sendMessage(childOfflineArgs);
+    });
+
+    afterEach(async () => {
+      await client.removeChildNexus().sendMessage(rebuildArgs);
+    });
+
+    it('check nexus state', async () => {
+      await checkState(ObjectType.NEXUS, 'degraded');
+    });
+
+    it('check source state', async () => {
+      await checkState(ObjectType.SOURCE_CHILD, 'open');
+    });
+
+    it('check destination state', async () => {
+      await checkState(ObjectType.DESTINATION_CHILD, 'closed');
+    });
+
+    it('check number of rebuilds', async () => {
+      await checkNumRebuilds('0');
     });
   });
 });

--- a/mayastor/src/bdev/nexus/nexus_bdev_children.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev_children.rs
@@ -207,6 +207,7 @@ impl Nexus {
             });
         }
 
+        self.stop_rebuild(name).await?;
         self.reconfigure(DREvent::ChildOffline).await;
         Ok(self.set_state(NexusState::Degraded))
     }
@@ -231,9 +232,10 @@ impl Nexus {
                     child: name.to_owned(),
                     name: self.name.clone(),
                 })?;
-                self.reconfigure(DREvent::ChildOnline).await;
-                //TODO should be rebuilding
-                Ok(self.set_state(NexusState::Degraded))
+                child.state = ChildState::Faulted;
+                let nexus_state = self.set_state(NexusState::Degraded);
+                self.start_rebuild(name).await?;
+                Ok(nexus_state)
             }
         } else {
             Err(Error::ChildNotFound {

--- a/mayastor/src/bdev/nexus/nexus_bdev_rebuild.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev_rebuild.rs
@@ -76,8 +76,12 @@ impl Nexus {
 
     /// Stop a rebuild job in the background
     pub async fn stop_rebuild(&mut self, name: &str) -> Result<(), Error> {
-        let rt = self.get_rebuild_job(name)?;
-        rt.stop().context(RebuildOperationError {})
+        match self.get_rebuild_job(name) {
+            Ok(rt) => rt.stop().context(RebuildOperationError {}),
+            // If a rebuild task is not found return ok
+            // as we were just going to remove it anyway.
+            Err(_) => Ok(()),
+        }
     }
 
     /// Pause a rebuild job in the background

--- a/mayastor/src/bdev/nexus/nexus_rpc.rs
+++ b/mayastor/src/bdev/nexus/nexus_rpc.rs
@@ -167,21 +167,29 @@ pub(crate) fn register_rpc_methods() {
         fut.boxed_local()
     });
 
-    jsonrpc_register("offline_child", |args: ChildNexusRequest| {
-        let fut = async move {
-            let nexus = nexus_lookup(&args.uuid)?;
-            nexus.offline_child(&args.uri).await
-        };
-        fut.boxed_local()
-    });
+    jsonrpc_register::<rpc::mayastor::ChildNexusRequest, _, _, Error>(
+        "offline_child",
+        |args: ChildNexusRequest| {
+            let fut = async move {
+                let nexus = nexus_lookup(&args.uuid)?;
+                nexus.offline_child(&args.uri).await?;
+                Ok(())
+            };
+            fut.boxed_local()
+        },
+    );
 
-    jsonrpc_register("online_child", |args: ChildNexusRequest| {
-        let fut = async move {
-            let nexus = nexus_lookup(&args.uuid)?;
-            nexus.online_child(&args.uri).await
-        };
-        fut.boxed_local()
-    });
+    jsonrpc_register::<rpc::mayastor::ChildNexusRequest, _, _, Error>(
+        "online_child",
+        |args: ChildNexusRequest| {
+            let fut = async move {
+                let nexus = nexus_lookup(&args.uuid)?;
+                nexus.online_child(&args.uri).await?;
+                Ok(())
+            };
+            fut.boxed_local()
+        },
+    );
 
     jsonrpc_register("add_child_nexus", |args: AddChildNexusRequest| {
         let fut = async move {

--- a/mayastor/tests/nexus_rebuild.rs
+++ b/mayastor/tests/nexus_rebuild.rs
@@ -1,6 +1,4 @@
-use crossbeam::channel::{after, select, unbounded};
-use log::info;
-use std::time::Duration;
+use crossbeam::channel::unbounded;
 
 pub mod common;
 
@@ -71,16 +69,11 @@ async fn rebuild_test_start() {
     nexus.add_child(BDEVNAME2).await.unwrap();
 
     // kick's off the rebuild (NOWAIT) so we have to wait on a channel
-    let rebuild_complete = nexus.start_rebuild(BDEVNAME2).await.unwrap();
-    let (s, r) = unbounded::<()>();
-    std::thread::spawn(move || {
-        select! {
-            recv(rebuild_complete) -> state => info!("rebuild of child {} finished with state {:?}", BDEVNAME2, state),
-            recv(after(Duration::from_secs(5))) -> _ => panic!("timed out waiting for the rebuild to complete"),
-        }
-        s.send(())
-    });
-    reactor_poll!(r);
+    nexus.start_rebuild(BDEVNAME2).await.unwrap();
+    common::wait_for_rebuild(
+        BDEVNAME2.to_string(),
+        std::time::Duration::from_secs(5),
+    );
 
     let (s, r) = unbounded::<String>();
     std::thread::spawn(move || {

--- a/mayastor/tests/reconfigure.rs
+++ b/mayastor/tests/reconfigure.rs
@@ -172,6 +172,11 @@ async fn works() {
     nexus.online_child(&child2).await.unwrap();
     assert_eq!(nexus.status(), NexusState::Degraded);
 
+    common::wait_for_rebuild(
+        child2.to_string(),
+        std::time::Duration::from_secs(20),
+    );
+
     buf.fill(0xAA);
     // write 0xAA to the nexus
     for i in 0 .. 10 {


### PR DESCRIPTION
- When a child is set offline, stop any ongoing rebuilds for that child
- When setting a child online, set its state to faulted and initiate a rebuild
    - The reconfigure tests had to be updated to wait for the rebuild to complete before carrying out   some checks.
- Create a common "wait_for_rebuild" utility function


Fixes:
- Add support for offline and online operations to the "child_operation"
- Do not return anything from rpc calls to offline_child and online_child. This prevents error messages being output by rpc clients like mctl. This is because return values were not expected.