### PR TITLE
CI issues: mkfs/dd fails randomly on CI

### DIFF
--- a/mayastor-test/test_nexus.js
+++ b/mayastor-test/test_nexus.js
@@ -697,7 +697,7 @@ describe('nexus', function () {
   });
 
   it('should be the case that we do not have any dangling NBD devices left on the system', (done) => {
-    exec('sleep 1; lsblk --json', (err, stdout, stderr) => {
+    exec('sleep 3; lsblk --json', (err, stdout, stderr) => {
       if (err) return done(err);
       let output = JSON.parse(stdout);
       output.blockdevices.forEach((e) => {

--- a/mayastor/src/bdev/nexus/nexus_nbd.rs
+++ b/mayastor/src/bdev/nexus/nexus_nbd.rs
@@ -203,7 +203,7 @@ impl NbdDisk {
             convert_ioctl_res!(libc::ioctl(
                 f.unwrap().as_raw_fd(),
                 SET_TIMEOUT as u64,
-                1,
+                3,
             ))
         }
         .unwrap();


### PR DESCRIPTION
Speculating that the root cause is actually the nexus taking "too long"
to complete an IO. Currently, we set the NBD timeout to 1s and it seems
that when we hit this timeout the NBD socket is actually shutdown...

After some testing 3s seems to be enough to keep things happy (at least
on github actions)