### PR TITLE
bors: update configuration

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,1 +1,9 @@
+# must pass befor merge in master
 status = ["Build", "Clippy"]
+# must pass before staging
+pr_status = ["Clippy"]
+# dont want merge commits do we?
+use_squash_merge = true
+required_approvals = 2
+# add issue key behind this and it wont show in the commit
+cut_body_after = "!!!"


### PR DESCRIPTION
 - we require 2 reviewers
 - we do not want merge commits
 - clippy in a PR must always pass before we stage it

Not 100% sure yet if this is is final but I think it is.
!!!

Below here things are ignored CAS-1