### PR TITLE
build: fix prettier linting and make hooks read-only

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
     -   id: rust-style
         name: Rust style
         description: Run cargo fmt on files included in the commit. rustfmt should be installed before-hand.
-        entry: cargo fmt --all --
+        entry: cargo fmt --all -- --check
         pass_filenames: true
         types: [file, rust]
         language: system
@@ -26,7 +26,7 @@ repos:
     -   id: js-style
         name: JS style
         description: Run prettier on files included in the commit. prettier npm module should be installed before-hand.
-        entry: prettier --config=.prettierrc --write
+        entry: prettier --config=.prettierrc --check
         pass_filenames: true
         types: [file, javascript]
         language: system

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,5 @@
 {
-  allowParens: always
+  "arrowParens": always,
   "singleQuote": true,
   "trailingComma": "es5"
 }

--- a/csi/moac/logger.js
+++ b/csi/moac/logger.js
@@ -24,10 +24,10 @@ const monthShortNames = [
 // Oct 10 19:49:29.027
 function toLocalTime(isoTs) {
   var dt = new Date(Date.parse(isoTs));
-  var pad = function (num) {
+  var pad = function(num) {
     return (num < 10 ? '0' : '') + num;
   };
-  var pad2 = function (num) {
+  var pad2 = function(num) {
     if (num < 10) {
       return '00' + num;
     } else if (num < 100) {
@@ -95,7 +95,7 @@ function Logger(component) {
 
 var levels = ['debug', 'info', 'warn', 'error'];
 levels.forEach((lvl) => {
-  Logger.prototype[lvl] = function (msg) {
+  Logger.prototype[lvl] = function(msg) {
     logger[lvl].call(logger, {
       label: this.component,
       message: msg,
@@ -103,7 +103,7 @@ levels.forEach((lvl) => {
   };
 });
 // rename trace to silly
-Logger.prototype.trace = function (msg) {
+Logger.prototype.trace = function(msg) {
   logger.silly.call(logger, {
     component: this.component,
     message: msg,

--- a/csi/moac/test/csi_test.js
+++ b/csi/moac/test/csi_test.js
@@ -25,7 +25,7 @@ function getCsiClient(svc) {
   return client;
 }
 
-module.exports = function () {
+module.exports = function() {
   it('should start even if there is stale socket file', async () => {
     await fs.writeFile(SOCKPATH, 'blabla');
     var server = new CsiServer(SOCKPATH);
@@ -42,7 +42,7 @@ module.exports = function () {
     throw new Error('Server did not clean up the socket file');
   });
 
-  describe('identity', function () {
+  describe('identity', function() {
     var server;
     var client;
 
@@ -94,7 +94,7 @@ module.exports = function () {
     });
   });
 
-  describe('controller', function () {
+  describe('controller', function() {
     var client;
     var registry, volumes;
     var getCapacityStub, createVolumeStub, getVolumesStub, destroyVolumeStub;
@@ -124,7 +124,7 @@ module.exports = function () {
       }
     });
 
-    describe('generic', function () {
+    describe('generic', function() {
       var server;
 
       afterEach(async () => {
@@ -191,7 +191,7 @@ module.exports = function () {
       });
     });
 
-    describe('CreateVolume', function () {
+    describe('CreateVolume', function() {
       var server;
       // place-holder for return value from createVolume when we don't care
       // about the data (i.e. when testing error cases).
@@ -456,7 +456,7 @@ module.exports = function () {
       });
     });
 
-    describe('DeleteVolume', function () {
+    describe('DeleteVolume', function() {
       var server;
 
       beforeEach(async () => {
@@ -492,7 +492,7 @@ module.exports = function () {
       });
     });
 
-    describe('ListVolumes', function () {
+    describe('ListVolumes', function() {
       var server;
       // uuid except the last two digits
       var uuidBase = '4334cc8a-2fed-45ed-866f-3716639db5';
@@ -570,7 +570,7 @@ module.exports = function () {
       });
     });
 
-    describe('ControllerPublishVolume', function () {
+    describe('ControllerPublishVolume', function() {
       var server;
 
       before(async () => {
@@ -766,7 +766,7 @@ module.exports = function () {
       });
     });
 
-    describe('ControllerUnpublishVolume', function () {
+    describe('ControllerUnpublishVolume', function() {
       var server;
 
       before(async () => {
@@ -848,7 +848,7 @@ module.exports = function () {
       });
     });
 
-    describe('ValidateVolumeCapabilities', function () {
+    describe('ValidateVolumeCapabilities', function() {
       var server;
 
       before(async () => {
@@ -929,7 +929,7 @@ module.exports = function () {
       });
     });
 
-    describe('GetCapacity', function () {
+    describe('GetCapacity', function() {
       var server;
 
       before(async () => {

--- a/csi/moac/test/event_stream_test.js
+++ b/csi/moac/test/event_stream_test.js
@@ -13,7 +13,7 @@ const Volume = require('../volume');
 const Volumes = require('../volumes');
 const EventStream = require('../event_stream');
 
-module.exports = function () {
+module.exports = function() {
   // Easy generator of a test node with fake pools, replicas and nexus
   // omitting all properties that are not necessary for the event stream.
   class FakeNode {

--- a/csi/moac/test/grpc_client_test.js
+++ b/csi/moac/test/grpc_client_test.js
@@ -10,7 +10,7 @@ const { shouldFailWith } = require('./utils');
 
 const EGRESS_ENDPOINT = '127.0.0.1:12345';
 
-module.exports = function () {
+module.exports = function() {
   var srv;
   var client;
 

--- a/csi/moac/test/index.js
+++ b/csi/moac/test/index.js
@@ -23,7 +23,7 @@ const csiTest = require('./csi_test.js');
 
 logger.setLevel('debug');
 
-describe('moac', function () {
+describe('moac', function() {
   describe('workq', workqTest);
   describe('grpc client', grpcTest);
   describe('watcher', watcherTest);

--- a/csi/moac/test/nexus_test.js
+++ b/csi/moac/test/nexus_test.js
@@ -13,7 +13,7 @@ const { GrpcCode, GrpcError } = require('../grpc_client');
 
 const UUID = 'ba5e39e9-0c0e-4973-8a3a-0dccada09cbb';
 
-module.exports = function () {
+module.exports = function() {
   var props = {
     uuid: UUID,
     size: 100,

--- a/csi/moac/test/node_operator_test.js
+++ b/csi/moac/test/node_operator_test.js
@@ -15,7 +15,7 @@ const sinon = require('sinon');
 const NodeOperator = require('../node_operator');
 const Watcher = require('./watcher_stub');
 
-module.exports = function () {
+module.exports = function() {
   var filterFunc = NodeOperator.prototype.filterMayastorNode;
 
   describe('node filtering', () => {
@@ -197,9 +197,9 @@ module.exports = function () {
     // and customizable return value from getNode method.
     function createFakeRegistry(getNodeReturn) {
       let registry = {
-        addNode: function () {},
-        removeNode: function () {},
-        getNode: function () {},
+        addNode: function() {},
+        removeNode: function() {},
+        getNode: function() {},
       };
       addNodeSpy = sinon.spy(registry, 'addNode');
       removeNodeSpy = sinon.spy(registry, 'removeNode');
@@ -280,7 +280,7 @@ module.exports = function () {
       let node = {
         name: 'node-name',
         endpoint: '127.0.0.1:123',
-        connect: function () {},
+        connect: function() {},
       };
       let connectSpy = sinon.spy(node, 'connect');
       let registry = createFakeRegistry(node);

--- a/csi/moac/test/node_test.js
+++ b/csi/moac/test/node_test.js
@@ -14,7 +14,7 @@ const enums = require('./grpc_enums');
 const UUID = 'ba5e39e9-0c0e-4973-8a3a-0dccada09cbb';
 const EGRESS_ENDPOINT = '127.0.0.1:12345';
 
-module.exports = function () {
+module.exports = function() {
   var srv;
   var node;
   var pools = [
@@ -56,7 +56,7 @@ module.exports = function () {
     expect(node.toString()).to.equal('node-name');
   });
 
-  describe('node events', function () {
+  describe('node events', function() {
     this.timeout(500);
 
     // start a fake mayastor server
@@ -524,7 +524,7 @@ module.exports = function () {
     });
   });
 
-  describe('object create', function () {
+  describe('object create', function() {
     var replica;
     var pool;
     var nexus;
@@ -612,7 +612,7 @@ module.exports = function () {
     });
   });
 
-  describe('object list', function () {
+  describe('object list', function() {
     const UUID1 = 'ba5e39e9-0c0e-4973-8a3a-0dccada09cb1';
     const UUID2 = 'ba5e39e9-0c0e-4973-8a3a-0dccada09cb2';
     const UUID3 = 'ba5e39e9-0c0e-4973-8a3a-0dccada09cb3';

--- a/csi/moac/test/pool_operator_test.js
+++ b/csi/moac/test/pool_operator_test.js
@@ -30,7 +30,7 @@ const Node = require('./node_stub');
 
 const NAMESPACE = 'mayastor';
 
-module.exports = function () {
+module.exports = function() {
   var msStub, putStub;
 
   // Create k8s pool resource object
@@ -76,8 +76,8 @@ module.exports = function () {
   // endpoint to update the status of resource. Fake watcher that is used
   // in the tests does not use this client stub.
   function createK8sClient(watcher) {
-    let mayastorpools = { mayastorpools: function (name) {} };
-    let namespaces = function (ns) {
+    let mayastorpools = { mayastorpools: function(name) {} };
+    let namespaces = function(ns) {
       expect(ns).to.equal(NAMESPACE);
       return mayastorpools;
     };
@@ -94,7 +94,7 @@ module.exports = function () {
         // the tricky thing here is that we have to update watcher's cache
         // if we use this fake k8s client to change the object in order to
         // mimic real behaviour.
-        put: async function (payload) {
+        put: async function(payload) {
           watcher.objects[payload.body.metadata.name].status =
             payload.body.status;
           // simulate the asynchronicity of the put
@@ -564,7 +564,7 @@ module.exports = function () {
           state: 'POOL_DEGRADED',
           capacity: 100,
           used: 10,
-          destroy: async function () {},
+          destroy: async function() {},
         });
         let destroyStub = sinon.stub(pool, 'destroy');
         destroyStub.rejects(new GrpcError(GrpcCode.INTERNAL, 'destroy failed'));
@@ -804,7 +804,7 @@ module.exports = function () {
         state: 'POOL_ONLINE',
         capacity: 100,
         used: 4,
-        destroy: async function () {},
+        destroy: async function() {},
       });
       let destroyStub = sinon.stub(pool, 'destroy');
       destroyStub.resolves();

--- a/csi/moac/test/pool_test.js
+++ b/csi/moac/test/pool_test.js
@@ -11,7 +11,7 @@ const Replica = require('../replica');
 const { shouldFailWith } = require('./utils');
 const { GrpcCode, GrpcError } = require('../grpc_client');
 
-module.exports = function () {
+module.exports = function() {
   let props = {
     name: 'pool',
     disks: ['/dev/sda'],

--- a/csi/moac/test/registry_test.js
+++ b/csi/moac/test/registry_test.js
@@ -11,7 +11,7 @@ const Nexus = require('../nexus');
 const Node = require('../node');
 const NodeStub = require('./node_stub');
 
-module.exports = function () {
+module.exports = function() {
   it('should add a node to the registry and look up the node', () => {
     let registry = new Registry();
     registry.Node = NodeStub;
@@ -201,7 +201,7 @@ module.exports = function () {
     expect(cap).to.equal(75);
   });
 
-  describe('pool selection', function () {
+  describe('pool selection', function() {
     it('should prefer ONLINE pool', () => {
       // has more free space but is degraded
       let pool1 = new Pool({

--- a/csi/moac/test/replica_test.js
+++ b/csi/moac/test/replica_test.js
@@ -13,7 +13,7 @@ const { GrpcCode, GrpcError } = require('../grpc_client');
 
 const UUID = 'ba5e39e9-0c0e-4973-8a3a-0dccada09cbb';
 
-module.exports = function () {
+module.exports = function() {
   var poolProps = {
     name: 'pool',
     disks: ['/dev/sda'],

--- a/csi/moac/test/rest_api_test.js
+++ b/csi/moac/test/rest_api_test.js
@@ -17,7 +17,7 @@ const UUID1 = '02de3df9-ce18-4164-89e1-b1cbf7a88e51';
 const UUID2 = '02de3df9-ce18-4164-89e1-b1cbf7a88e52';
 const UUID3 = '02de3df9-ce18-4164-89e1-b1cbf7a88e53';
 
-module.exports = function () {
+module.exports = function() {
   var apiServer;
   var call1, call2, call3, call4;
 

--- a/csi/moac/test/volume_operator_test.js
+++ b/csi/moac/test/volume_operator_test.js
@@ -34,7 +34,7 @@ function defaultMeta(uuid) {
   };
 }
 
-module.exports = function () {
+module.exports = function() {
   var msStub, putStub, putStatusStub, deleteStub, postStub;
   var defaultSpec = {
     replicaCount: 1,
@@ -76,8 +76,8 @@ module.exports = function () {
   // endpoint to update the status of resource. Fake watcher that is used
   // in the tests does not use this client stub.
   function createK8sClient(watcher) {
-    let mayastorvolumes = { mayastorvolumes: function (name) {} };
-    let namespaces = function (ns) {
+    let mayastorvolumes = { mayastorvolumes: function(name) {} };
+    let namespaces = function(ns) {
       expect(ns).to.equal(NAMESPACE);
       return mayastorvolumes;
     };
@@ -90,7 +90,7 @@ module.exports = function () {
     };
 
     msStub = sinon.stub(mayastorvolumes, 'mayastorvolumes');
-    msStub.post = async function (payload) {
+    msStub.post = async function(payload) {
       watcher.objects[payload.body.metadata.name] = payload.body;
       // simulate the asynchronicity of the put
       await sleep(1);
@@ -102,12 +102,12 @@ module.exports = function () {
       // the tricky thing here is that we have to update watcher's cache
       // if we use this fake k8s client to change the object in order to
       // mimic real behaviour.
-      put: async function (payload) {
+      put: async function(payload) {
         watcher.objects[payload.body.metadata.name].spec = payload.body.spec;
       },
-      delete: async function () {},
+      delete: async function() {},
       status: {
-        put: async function (payload) {
+        put: async function(payload) {
           watcher.objects[payload.body.metadata.name].status =
             payload.body.status;
         },

--- a/csi/moac/test/volume_test.js
+++ b/csi/moac/test/volume_test.js
@@ -23,7 +23,7 @@ const defaultOpts = {
   limitBytes: 100,
 };
 
-module.exports = function () {
+module.exports = function() {
   it('should stringify volume name', () => {
     let registry = new Registry();
     let volume = new Volume(UUID, registry, defaultOpts);

--- a/csi/moac/test/volumes_test.js
+++ b/csi/moac/test/volumes_test.js
@@ -20,7 +20,7 @@ const { shouldFailWith } = require('./utils');
 
 const UUID = 'ba5e39e9-0c0e-4973-8a3a-0dccada09cbb';
 
-module.exports = function () {
+module.exports = function() {
   describe('ensure', () => {
     var registry, volumes;
     var node1, node2, node3;
@@ -79,7 +79,7 @@ module.exports = function () {
     }
 
     // Each test creates a volume so the setup needs to run for each case.
-    describe('create volume', function () {
+    describe('create volume', function() {
       beforeEach(createTestEnv);
 
       afterEach(() => {
@@ -293,7 +293,7 @@ module.exports = function () {
     });
 
     // Volume is created once in the first test and then all tests use it
-    describe('misc', function () {
+    describe('misc', function() {
       before(createTestEnv);
 
       afterEach(() => {

--- a/csi/moac/test/watcher_test.js
+++ b/csi/moac/test/watcher_test.js
@@ -169,7 +169,7 @@ class StreamMockTracker {
   }
 }
 
-module.exports = function () {
+module.exports = function() {
   // Basic watcher operations grouped in describe to avoid repeating watcher
   // initialization & tear down for each test case.
   describe('watch events', () => {

--- a/csi/moac/test/workq_test.js
+++ b/csi/moac/test/workq_test.js
@@ -29,7 +29,7 @@ class Task {
   }
 }
 
-module.exports = function () {
+module.exports = function() {
   var clock;
 
   beforeEach(() => {

--- a/csi/moac/volumes.js
+++ b/csi/moac/volumes.js
@@ -21,7 +21,7 @@ class Volumes extends EventEmitter {
   start() {
     var self = this;
     this.events = new EventStream({ registry: this.registry });
-    this.events.on('data', async function (ev) {
+    this.events.on('data', async function(ev) {
       if (ev.kind != 'replica' && ev.kind != 'nexus') {
         // not interesed in node and pool events
         return;

--- a/mayastor-test/sudo.js
+++ b/mayastor-test/sudo.js
@@ -33,7 +33,7 @@ function sudo(command, options, nameInPs) {
     if (pid || child.exitCode !== null) {
       child.emit('started');
     } else {
-      setTimeout(function () {
+      setTimeout(function() {
         pidof(nameInPs, waitForStartup);
       }, 100);
     }
@@ -43,9 +43,12 @@ function sudo(command, options, nameInPs) {
   pidof(nameInPs, waitForStartup);
 
   // FIXME: Remove this handler when the child has successfully started
-  child.stderr.on('data', function (data) {
-    var lines = data.toString().trim().split('\n');
-    lines.forEach(function (line) {
+  child.stderr.on('data', function(data) {
+    var lines = data
+      .toString()
+      .trim()
+      .split('\n');
+    lines.forEach(function(line) {
       if (line === prompt) {
         if (++prompts > 1) {
           // The previous entry must have been incorrect, since sudo asks again.
@@ -60,7 +63,7 @@ function sudo(command, options, nameInPs) {
               prompt: options.prompt || 'sudo requires your password: ',
               silent: true,
             },
-            function (error, answer) {
+            function(error, answer) {
               child.stdin.write(answer + '\n');
               if (options.cachePassword) {
                 cachedPassword = answer;

--- a/mayastor-test/test_cli.js
+++ b/mayastor-test/test_cli.js
@@ -53,8 +53,8 @@ function runMockServer(rules) {
   mayastorMockServer.listen('127.0.0.1:' + EGRESS_PORT);
 }
 
-describe('cli', function () {
-  describe('success', function () {
+describe('cli', function() {
+  describe('success', function() {
     before(() => {
       process.env.RUST_BACKTRACE = '1';
       runMockServer([
@@ -195,7 +195,7 @@ describe('cli', function () {
       }
     });
 
-    it('should create a pool', function (done) {
+    it('should create a pool', function(done) {
       const cmd = util.format(
         '%s pool create -b 512 %s %s',
         EGRESS_CMD,
@@ -213,7 +213,7 @@ describe('cli', function () {
       });
     });
 
-    it('should list pools', function (done) {
+    it('should list pools', function(done) {
       const cmd = util.format('%s -q pool list', EGRESS_CMD);
 
       exec(cmd, (err, stdout, stderr) => {
@@ -267,7 +267,7 @@ describe('cli', function () {
       });
     });
 
-    it('should destroy a pool', function (done) {
+    it('should destroy a pool', function(done) {
       const cmd = util.format('%s pool destroy %s', EGRESS_CMD, POOL);
 
       exec(cmd, (err, stdout, stderr) => {
@@ -280,7 +280,7 @@ describe('cli', function () {
       });
     });
 
-    it('should create a replica', function (done) {
+    it('should create a replica', function(done) {
       const cmd = util.format(
         '%s replica create %s %s --size=1000 --thin --protocol=nvmf',
         EGRESS_CMD,
@@ -298,7 +298,7 @@ describe('cli', function () {
       });
     });
 
-    it('should share the replica', function (done) {
+    it('should share the replica', function(done) {
       const cmd = util.format('%s replica share %s iscsi', EGRESS_CMD, UUID);
 
       exec(cmd, (err, stdout, stderr) => {
@@ -311,7 +311,7 @@ describe('cli', function () {
       });
     });
 
-    it('should list replicas', function (done) {
+    it('should list replicas', function(done) {
       const cmd = util.format('%s -q replica list', EGRESS_CMD);
 
       exec(cmd, (err, stdout, stderr) => {
@@ -373,7 +373,7 @@ describe('cli', function () {
       });
     });
 
-    it('should stat replicas', function (done) {
+    it('should stat replicas', function(done) {
       const cmd = util.format('%s -q replica stats', EGRESS_CMD);
 
       exec(cmd, (err, stdout, stderr) => {
@@ -424,7 +424,7 @@ describe('cli', function () {
       });
     });
 
-    it('should destroy a replica', function (done) {
+    it('should destroy a replica', function(done) {
       const cmd = util.format('%s replica destroy %s', EGRESS_CMD, UUID);
 
       exec(cmd, (err, stdout, stderr) => {
@@ -439,7 +439,7 @@ describe('cli', function () {
   });
 
   // these cases test typical failures which might happen
-  describe('failures', function () {
+  describe('failures', function() {
     before(() => {
       runMockServer([
         {
@@ -530,7 +530,7 @@ describe('cli', function () {
       }
     });
 
-    it('should not create a pool if it already exists', function (done) {
+    it('should not create a pool if it already exists', function(done) {
       const cmd = util.format('%s pool create %s %s', EGRESS_CMD, POOL, DISK);
 
       exec(cmd, (err, stdout, stderr) => {
@@ -541,7 +541,7 @@ describe('cli', function () {
       });
     });
 
-    it('should not list the pools in case of internal error', function (done) {
+    it('should not list the pools in case of internal error', function(done) {
       const cmd = util.format('%s -q pool list', EGRESS_CMD);
 
       exec(cmd, (err, stdout, stderr) => {
@@ -552,7 +552,7 @@ describe('cli', function () {
       });
     });
 
-    it('should not destroy a pool if it does not exist', function (done) {
+    it('should not destroy a pool if it does not exist', function(done) {
       const cmd = util.format('%s pool destroy %s', EGRESS_CMD, POOL);
 
       exec(cmd, (err, stdout, stderr) => {
@@ -563,7 +563,7 @@ describe('cli', function () {
       });
     });
 
-    it('should not create a replica if it already exists', function (done) {
+    it('should not create a replica if it already exists', function(done) {
       const cmd = util.format(
         '%s replica create %s %s --size=1000 --thin',
         EGRESS_CMD,
@@ -579,7 +579,7 @@ describe('cli', function () {
       });
     });
 
-    it('should not share the replica if it does not exist', function (done) {
+    it('should not share the replica if it does not exist', function(done) {
       const cmd = util.format('%s replica share %s nvmf', EGRESS_CMD, UUID);
 
       exec(cmd, (err, stdout, stderr) => {
@@ -590,7 +590,7 @@ describe('cli', function () {
       });
     });
 
-    it('should not list replicas in case of internal error', function (done) {
+    it('should not list replicas in case of internal error', function(done) {
       const cmd = util.format('%s -q replica list', EGRESS_CMD);
 
       exec(cmd, (err, stdout, stderr) => {
@@ -601,7 +601,7 @@ describe('cli', function () {
       });
     });
 
-    it('should not stat replicas in case of internal error', function (done) {
+    it('should not stat replicas in case of internal error', function(done) {
       const cmd = util.format('%s -q replica stats', EGRESS_CMD);
 
       exec(cmd, (err, stdout, stderr) => {
@@ -612,7 +612,7 @@ describe('cli', function () {
       });
     });
 
-    it('should not destroy a replica if it does not exist', function (done) {
+    it('should not destroy a replica if it does not exist', function(done) {
       const cmd = util.format('%s replica destroy %s', EGRESS_CMD, UUID);
 
       exec(cmd, (err, stdout, stderr) => {

--- a/mayastor-test/test_common.js
+++ b/mayastor-test/test_common.js
@@ -68,10 +68,10 @@ function execAsRoot(cmd, args, done) {
   let stderr = '';
   let stdout = '';
 
-  child.stderr.on('data', data => {
+  child.stderr.on('data', (data) => {
     stderr += data;
   });
-  child.stdout.on('data', data => {
+  child.stdout.on('data', (data) => {
     stdout += data;
   });
   child.on('close', (code, signal) => {
@@ -100,12 +100,12 @@ function waitFor(ping, done) {
   let iters = 0;
 
   async.whilst(
-    cb => {
+    (cb) => {
       cb(null, iters < 10);
     },
-    next => {
+    (next) => {
       iters++;
-      ping(err => {
+      ping((err) => {
         if (err) {
           last_error = err;
           setTimeout(next, 1000);
@@ -127,7 +127,7 @@ function getMyIp() {
   let externIp = _.map(
     _.flatten(Object.values(os.networkInterfaces())),
     'address'
-  ).find(addr => addr.indexOf(':') < 0 && !addr.match(/^127\./));
+  ).find((addr) => addr.indexOf(':') < 0 && !addr.match(/^127\./));
   assert(externIp, 'Cannot determine external IP address of the system');
   return externIp;
 }
@@ -138,10 +138,10 @@ function startProcess(command, args, env, closeCb, psName) {
   let proc = runAsRoot(getCmdPath(command), args, env, psName);
   proc.output = [];
 
-  proc.stdout.on('data', data => {
+  proc.stdout.on('data', (data) => {
     proc.output.push(data);
   });
-  proc.stderr.on('data', data => {
+  proc.stderr.on('data', (data) => {
     proc.output.push(data);
   });
   proc.once('close', (code, signal) => {
@@ -230,19 +230,19 @@ function startMayastorGrpc() {
 }
 
 function killSudoedProcess(name, pid, done) {
-  find('name', name).then(res => {
+  find('name', name).then((res) => {
     var whichPid;
     if (process.geteuid() === 0) {
       whichPid = 'pid';
     } else {
       whichPid = 'ppid';
     }
-    res = res.filter(ent => ent[whichPid] == pid);
+    res = res.filter((ent) => ent[whichPid] == pid);
     if (res.length == 0) {
       return done();
     }
     let child = runAsRoot('kill', ['-s', 'SIGTERM', res[0].pid.toString()]);
-    child.stderr.on('data', data => {
+    child.stderr.on('data', (data) => {
       console.log('kill', name, 'error:', data.toString());
     });
     child.once('close', () => {
@@ -262,7 +262,7 @@ function stopAll(done) {
     (name, cb) => {
       let proc = procs[name];
       console.log(`Stopping ${name} with pid ${proc.pid} ...`);
-      killSudoedProcess(name, proc.pid, err => {
+      killSudoedProcess(name, proc.pid, (err) => {
         if (err) return cb(null, err);
         // let other close event handlers on the process run
         setTimeout(cb, 0);
@@ -272,7 +272,7 @@ function stopAll(done) {
       assert(!err);
       procs = {};
       // return the first found error
-      done(errors.find(e => !!e));
+      done(errors.find((e) => !!e));
     }
   );
 }
@@ -287,8 +287,8 @@ function restartMayastor(ping, done) {
 
   async.series(
     [
-      next => {
-        killSudoedProcess('mayastor', proc.pid, err => {
+      (next) => {
+        killSudoedProcess('mayastor', proc.pid, (err) => {
           if (err) return next(err);
           if (procs.mayastor) {
             procs.mayastor.once('close', next);
@@ -297,11 +297,11 @@ function restartMayastor(ping, done) {
           }
         });
       },
-      next => {
+      (next) => {
         // let other close event handlers on the process run
         setTimeout(next, 0);
       },
-      next => {
+      (next) => {
         startMayastor();
         waitFor(ping, next);
       },
@@ -320,8 +320,8 @@ function restartMayastorGrpc(ping, done) {
 
   async.series(
     [
-      next => {
-        killSudoedProcess('mayastor-agent', proc.pid, err => {
+      (next) => {
+        killSudoedProcess('mayastor-agent', proc.pid, (err) => {
           if (err) return next(err);
           if (procs['mayastor-agent']) {
             procs['mayastor-agent'].once('close', next);
@@ -330,11 +330,11 @@ function restartMayastorGrpc(ping, done) {
           }
         });
       },
-      next => {
+      (next) => {
         // let other close event handlers on the process run
         setTimeout(next, 0);
       },
-      next => {
+      (next) => {
         startMayastorGrpc();
         waitFor(ping, next);
       },
@@ -369,7 +369,7 @@ function dumbCommand(method, args, done) {
 function ensureNbdWritable(done) {
   if (process.geteuid() != 0) {
     let child = runAsRoot('sh', ['-c', 'chmod o+rw /dev/nbd*']);
-    child.stderr.on('data', data => {
+    child.stderr.on('data', (data) => {
       console.log(data.toString());
     });
     child.on('close', (code, signal) => {
@@ -388,10 +388,10 @@ function ensureNbdWritable(done) {
 // the socket to everyone.
 function fixSocketPerms(done) {
   let child = runAsRoot('chmod', ['a+rw', CSI_ENDPOINT]);
-  child.stderr.on('data', data => {
+  child.stderr.on('data', (data) => {
     //console.log('chmod', 'error:', data.toString());
   });
-  child.on('close', code => {
+  child.on('close', (code) => {
     if (code != 0) {
       done('Failed to chmod the socket' + code);
     } else {

--- a/mayastor-test/test_csi.js
+++ b/mayastor-test/test_csi.js
@@ -86,7 +86,7 @@ function createPublishDir(mountTarget) {
 
 // Returns a callback which verifies that method ended with given grpc error.
 function shouldFailWith(code, done) {
-  return function (err, res) {
+  return function(err, res) {
     if (err) {
       assert.equal(err.code, code);
       done();
@@ -98,7 +98,10 @@ function shouldFailWith(code, done) {
 
 // Get filesystem type for given mount point.
 function getFsType(mp) {
-  let lines = execSync('mount').toString().trim().split('\n');
+  let lines = execSync('mount')
+    .toString()
+    .trim()
+    .split('\n');
   for (let i = 0; i < lines.length; i++) {
     let cols = lines[i].split(' ');
     if (mp === cols[2]) {
@@ -107,7 +110,7 @@ function getFsType(mp) {
   }
 }
 
-describe('csi', function () {
+describe('csi', function() {
   this.timeout(10000); // for network tests we need long timeouts
 
   // Start mayastor and create the lvol configuration needed for testing.
@@ -153,7 +156,7 @@ describe('csi', function () {
         (next) => {
           async.times(
             5,
-            function (n, next) {
+            function(n, next) {
               let uuid = BASE_UUID + n;
               common.dumbCommand(
                 'create_replica',
@@ -173,7 +176,7 @@ describe('csi', function () {
         (next) => {
           async.times(
             5,
-            function (n, next) {
+            function(n, next) {
               let uuid = BASE_UUID + n;
               common.dumbCommand(
                 'create_nexus',
@@ -191,7 +194,7 @@ describe('csi', function () {
         (next) => {
           async.times(
             5,
-            function (n, next) {
+            function(n, next) {
               let uuid = BASE_UUID + n;
               common.dumbCommand(
                 'publish_nexus',
@@ -221,11 +224,11 @@ describe('csi', function () {
         (next) => {
           async.times(
             5,
-            function (n, next) {
+            function(n, next) {
               let uuid = BASE_UUID + n;
               common.dumbCommand('unpublish_nexus', { uuid: uuid }, next);
             },
-            function (err, res) {
+            function(err, res) {
               next();
             }
           );
@@ -238,7 +241,7 @@ describe('csi', function () {
     );
   });
 
-  describe('general', function () {
+  describe('general', function() {
     it('should start even if there is a stale csi socket file', (done) => {
       var client = createCsiClient('Identity');
 
@@ -263,7 +266,7 @@ describe('csi', function () {
     });
   });
 
-  describe('identity', function () {
+  describe('identity', function() {
     var client;
 
     before(() => {
@@ -312,7 +315,7 @@ describe('csi', function () {
     });
   });
 
-  describe('node', function () {
+  describe('node', function() {
     var client;
 
     before(() => {
@@ -354,7 +357,7 @@ describe('csi', function () {
     });
   });
 
-  describe('stage and unstage xfs volume', function () {
+  describe('stage and unstage xfs volume', function() {
     var client;
     var mountTarget = '/tmp/target0';
 
@@ -521,7 +524,7 @@ describe('csi', function () {
     });
   });
 
-  describe('stage and unstage ext4 volume', function () {
+  describe('stage and unstage ext4 volume', function() {
     var client;
     var mountTarget = '/tmp/target1';
 
@@ -584,7 +587,7 @@ describe('csi', function () {
     });
   });
 
-  describe('stage misc', function () {
+  describe('stage misc', function() {
     var client;
     var mountTarget = '/tmp/target2';
 
@@ -625,7 +628,7 @@ describe('csi', function () {
 
   // The combinations of ro/rw and access mode flags are quite confusing.
   // See the source code for more info on how this should work.
-  describe('publish and unpublish', function () {
+  describe('publish and unpublish', function() {
     var client;
 
     before(() => {
@@ -638,7 +641,7 @@ describe('csi', function () {
       }
     });
 
-    describe('MULTI_NODE_READER_ONLY staged volume', function () {
+    describe('MULTI_NODE_READER_ONLY staged volume', function() {
       var mountTarget = '/tmp/target3';
       var bindTarget1 = '/tmp/bind1';
       var bindTarget2 = '/tmp/bind2';
@@ -815,7 +818,7 @@ describe('csi', function () {
       });
     });
 
-    describe('MULTI_NODE_SINGLE_WRITER staged volume', function () {
+    describe('MULTI_NODE_SINGLE_WRITER staged volume', function() {
       var mountTarget = '/tmp/target4';
       var bindTarget1 = '/tmp/bind1';
       var bindTarget2 = '/tmp/bind2';

--- a/mayastor-test/test_nexus.js
+++ b/mayastor-test/test_nexus.js
@@ -126,10 +126,10 @@ function createGrpcClient(service) {
   );
 }
 
-var doUring = (function () {
+var doUring = (function() {
   var executed = false;
   var supportsUring = false;
-  return function () {
+  return function() {
     if (!executed) {
       executed = true;
       const { exec } = require('child_process');
@@ -152,7 +152,7 @@ var doUring = (function () {
   };
 })();
 
-describe('nexus', function () {
+describe('nexus', function() {
   var client;
   var nbd_device;
   var iscsi_uri;

--- a/mayastor-test/test_rebuild.js
+++ b/mayastor-test/test_rebuild.js
@@ -130,7 +130,7 @@ function createGrpcClient() {
   return client;
 }
 
-describe('rebuild tests', function () {
+describe('rebuild tests', function() {
   var client;
 
   this.timeout(10000); // for network tests we need long timeouts
@@ -254,7 +254,7 @@ describe('rebuild tests', function () {
     );
   });
 
-  describe('running rebuild', function () {
+  describe('running rebuild', function() {
     beforeEach(async () => {
       await client.addChildNexus().sendMessage(rebuildArgs);
       await client.startRebuild().sendMessage(rebuildArgs);
@@ -278,7 +278,7 @@ describe('rebuild tests', function () {
     });
   });
 
-  describe('stopping rebuild', function () {
+  describe('stopping rebuild', function() {
     beforeEach(async () => {
       await client.addChildNexus().sendMessage(rebuildArgs);
       await client.startRebuild().sendMessage(rebuildArgs);

--- a/mayastor-test/test_replica.js
+++ b/mayastor-test/test_replica.js
@@ -83,7 +83,7 @@ function createGrpcClient(service) {
   );
 }
 
-describe('replica', function () {
+describe('replica', function() {
   var client;
 
   this.timeout(10000); // for network tests we need long timeouts
@@ -482,7 +482,7 @@ describe('replica', function () {
   it('should create 5 replicas', (done) => {
     async.times(
       5,
-      function (n, next) {
+      function(n, next) {
         client.createReplica(
           {
             uuid: BASE_UUID + n,
@@ -527,7 +527,7 @@ describe('replica', function () {
     });
   });
 
-  describe('nvmf', function () {
+  describe('nvmf', function() {
     let uri; // URI of the created nvmf replica
     let blockFile = '/tmp/test_block'; // file with contents of a data block
 
@@ -705,7 +705,7 @@ describe('replica', function () {
     });
   });
 
-  describe('import', function () {
+  describe('import', function() {
     before(() => {
       // For testing import we need to restart mayastor which is possible only
       // if testing local instance of mayastor.


### PR DESCRIPTION
Correct a spelling mistake in .prettierrc, and commit the changes
now necessary to have the precommit hooks pass against all of our
files.

I've also altered the precommit hooks so that they no longer alter
code in the repository when they run. This should minimise the effort
required to repair any damage from teething problems with these tools.