### PR TITLE
nvmeadm: improve test coverage.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,6 +27,7 @@ jobs:
       - run: pushd mayastor-test && ./node_modules/mocha/bin/mocha test_csi.js && popd
       - run: pushd mayastor-test && ./node_modules/mocha/bin/mocha test_nexus.js && popd
       - run: pushd mayastor-test && ./node_modules/mocha/bin/mocha test_rebuild.js && popd
+      - run: pushd nvmeadm && cargo test && popd
   Image:
     # dont image if the build fails
     needs: Build

--- a/nvmeadm/src/nvmf_discovery.rs
+++ b/nvmeadm/src/nvmf_discovery.rs
@@ -409,7 +409,7 @@ impl DiscoveryLogEntry {
 ///
 ///  # Example
 ///  ```rust
-///  let num_disconnects = nvmeadm::nvmf_discovery::disconnect(nqn);
+///  let num_disconnects = nvmeadm::nvmf_discovery::disconnect("mynqn");
 ///  ```
 
 pub fn disconnect(nqn: &str) -> Result<usize, Error> {

--- a/nvmeadm/tests/discovery_test.rs
+++ b/nvmeadm/tests/discovery_test.rs
@@ -14,6 +14,20 @@ fn disovery_test() {
 }
 
 #[test]
+fn connect_test() {
+    let mut explorer = DiscoveryBuilder::default()
+        .transport("tcp".to_string())
+        .traddr("127.0.0.01".to_string())
+        .trsvcid(4420)
+        .build()
+        .unwrap();
+
+    // only root can discover and connect
+    let _ = explorer.discover();
+    let _ = explorer.connect("mynqn");
+}
+
+#[test]
 fn disconnect_test() {
     let _ = disconnect("mynqn");
 }

--- a/test.sh
+++ b/test.sh
@@ -9,3 +9,4 @@ pushd mayastor-test && ./node_modules/mocha/bin/mocha test_replica.js && popd
 pushd mayastor-test && ./node_modules/mocha/bin/mocha test_csi.js && popd
 pushd mayastor-test && ./node_modules/mocha/bin/mocha test_nexus.js && popd
 pushd mayastor-test && ./node_modules/mocha/bin/mocha test_rebuild.js && popd
+pushd nvmeadm && cargo test && popd


### PR DESCRIPTION
Make sure 'cargo test' includes nvmeadm in CI.

Add test to .github/workflows/build.yaml and test.sh.
Fix a commonent in nvmeadm/src/nvmf_discovery.rs.
Add a test for connect in nvmeadm/tests/discovery_test.rs.