### PR TITLE
pool: Return base bdev type in list pools

### DIFF
--- a/mayastor/src/bdev/uring_util.rs
+++ b/mayastor/src/bdev/uring_util.rs
@@ -1,7 +1,8 @@
 use std::{
+    fs,
     fs::{File, OpenOptions},
     io::{BufRead, BufReader, ErrorKind},
-    os::unix::fs::OpenOptionsExt,
+    os::unix::fs::{FileTypeExt, OpenOptionsExt},
 };
 
 pub fn fs_supports_direct_io(path: &str) -> bool {
@@ -59,6 +60,16 @@ fn get_mount_filesystem(path: &str) -> Option<String> {
 }
 
 pub fn fs_type_supported(path: &str) -> bool {
+    let metadata = match fs::metadata(path) {
+        Ok(m) => m,
+        Err(e) => {
+            eprintln!("metadata: {}", e);
+            return false;
+        }
+    };
+    if metadata.file_type().is_block_device() {
+        return true;
+    }
     match get_mount_filesystem(path) {
         None => {
             println!("Skipping uring bdev, unknown fs");

--- a/mayastor/src/bin/uring-support.rs
+++ b/mayastor/src/bin/uring-support.rs
@@ -8,19 +8,16 @@ fn main() {
         .version("0.1.0")
         .author("Jonathan Teh <jonathan.teh@mayadata.io>")
         .about("Determines io_uring support")
-        .arg(
-            Arg::with_name("uring-path")
-                .required(true)
-                .help("Path to file")
-                .index(1),
-        )
+        .arg(Arg::with_name("uring-path").help("Path to file").index(1))
         .get_matches();
 
-    let path = matches.value_of("uring-path").unwrap();
-
-    let supported = uring_util::fs_supports_direct_io(path)
-        && uring_util::fs_type_supported(path)
-        && uring_util::kernel_support();
+    let supported = match matches.value_of("uring-path") {
+        None => true,
+        Some(path) => {
+            uring_util::fs_supports_direct_io(path)
+                && uring_util::fs_type_supported(path)
+        }
+    } && uring_util::kernel_support();
 
     if supported {
         std::process::exit(0);

--- a/mayastor/src/pool.rs
+++ b/mayastor/src/pool.rs
@@ -644,7 +644,11 @@ pub(crate) fn list_pools() -> Vec<jsondata::Pool> {
     for pool in PoolsIter::new() {
         pools.push(jsondata::Pool {
             name: pool.get_name().to_owned(),
-            disks: vec![pool.get_base_bdev().name()],
+            disks: vec![
+                pool.get_base_bdev().driver()
+                    + "://"
+                    + &pool.get_base_bdev().name(),
+            ],
             // TODO: figure out how to detect state of pool
             state: "online".to_owned(),
             capacity: pool.get_capacity(),


### PR DESCRIPTION
Return a URI in the disks field where the URI scheme contains the
base bdev type.

Add a unit test to test creation of pools that use uring bdevs,
though skip the test if the kernel lacks support, which requires
changes to uring-support to only test for kernel support if the
pathname argument is not present.