### PR TITLE
terraform: Fix lxd provider to allow k8s to start

### DIFF
--- a/terraform/README.adoc
+++ b/terraform/README.adoc
@@ -4,7 +4,7 @@
 == Quick start
 
 . Ensure you have libvirtd or lxd running and configured **correctly**
-. Edit `variables.tf` in particular make sure you the public key is correct
+. Edit `variables.tf` in particular make sure the public key is correct
 . Edit `main.tf` and comment out either the LXD section or the libvirtd section
 . run `terraform init`
 . run `terraform plan`
@@ -23,13 +23,13 @@ So this means we want to deploy it:
 
 1. locally (KVM)
 2. locally (LXD)
-2. AWS
-3. GCE
-4. Whatever
+3. AWS
+4. GCE
+5. Whatever
 
-We, however, do not "just" want to deploy k8s, but also we want to be able to
-interact with the hosts itself. For example; verify that we indeed have a new
-nvmf target what have you.
+We, however, do not "just" want to deploy k8s, but also want to be able to
+interact with the hosts themsleves. For example; verify that we indeed have a
+new nvmf target or what have you.
 
 So we need a form of infra management but also - configuration management.
 These scripts are intended to do just that.
@@ -40,10 +40,10 @@ Terraform is used to construct the actual cluster and install Kubernetes. By
 default only the libvirtd and lxd providers are available.
 
 However, the code has been structured such that we can change the provider
-module in `main.tf` with any other provider and get the same k8s cluster.
+module in `main.tf` to any other provider and get the same k8s cluster.
 
 We can, for example, add `mod/vbox` which will then deploy 3 virtual vbox nodes.
-The k8s deployment code is decoupled from the actual VMS. The VMs are assumed to
+The k8s deployment code is decoupled from the actual VMs. The VMs are assumed to
 be *Ubuntu* based and makes use of *cloud-init*
 
 After the deployment of the VMs, the `k8s` module runs. This module will invoke
@@ -118,6 +118,11 @@ WARNING: do not use btrfs or ZFS as a storage pool.
 Now comes a somewhat tricky part. We need to install the terraform lxd provider,
 but it does not exist in nixpkgs. I'll create a PR to NixOS shortly.
 
+On other distributions, manually install the lxd provider from
+https://github.com/sl1pm4t/terraform-provider-lxd by downloading a release,
+extracting it to ~/.terraform.d/plugins then renaming the binary, dropping
+the version.
+
 The way the terraform plugin works is not -- default. All plugins are evaluated
 in the terraform-providers expression, which reads other files from disks. So a
 simple override -- as far as I know,  won't work in this case more so, because
@@ -140,7 +145,7 @@ And you are all set to deploy mayastor.
 === Private docker repo
 
 If you want to use a private docker repo you should edit the docker daemon
-config file to suite your needs.
+config file to suit your needs.
 
 An example configuration could be something like the following:
 

--- a/terraform/mod/k8s/repo.sh
+++ b/terraform/mod/k8s/repo.sh
@@ -8,7 +8,7 @@ cat <<EOF | sudo tee /etc/apt/sources.list.d/kubernetes.list
 deb https://apt.kubernetes.io/ kubernetes-xenial main
 EOF
 
-sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu xenial stable"
+sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
 
 sudo apt-get update
 sudo apt-get install -y -o Options::=--force-confdef \
@@ -16,6 +16,10 @@ sudo apt-get install -y -o Options::=--force-confdef \
   containerd.io docker-ce-cli
 
 sudo apt-mark hold kubelet kubeadm kubectl
+
+# if you wish to use a private docker repo uncomment this the line below
+# and add it to daemon.json
+# "insecure-registries" : ["192.168.1.4:5000"]
 
 sudo tee /etc/docker/daemon.json >/dev/null <<EOF
 {
@@ -25,8 +29,6 @@ sudo tee /etc/docker/daemon.json >/dev/null <<EOF
     "max-size": "100m"
   },
   "storage-driver": "overlay2"
-  # if you wish to use a private docker repo uncomment this the line below
-  # "insecure-registries" : ["192.168.1.4:5000"]
 }
 EOF
 

--- a/terraform/mod/lxd/main.tf
+++ b/terraform/mod/lxd/main.tf
@@ -8,7 +8,7 @@ variable "num_nodes" {
 
 resource "lxd_cached_image" "ubuntu" {
   source_remote = "ubuntu"
-  source_image  = "disco/amd64"
+  source_image  = "bionic/amd64"
 }
 
 variable "ssh_key" {
@@ -34,11 +34,11 @@ resource "lxd_container" "c8s" {
   image     = lxd_cached_image.ubuntu.fingerprint
   ephemeral = false
 
-  # be carefull with raw.lxc it has to be key=value\nkey=value
+  # be careful with raw.lxc it has to be key=value\nkey=value
 
   config = {
     "boot.autostart"       = true
-    "raw.lxc"              = "lxc.mount.auto = proc:rw cgroup:rw sys:rw\nlxc.apparmor.profile = unconfined\nlxc.cgroup.devices.allow = a\nlxc.cap.drop="
+    "raw.lxc"              = "lxc.mount.auto = proc:rw cgroup:rw sys:rw\nlxc.mount.entry = /lib/modules lib/modules none bind,ro 0 0\nlxc.mount.entry = /boot boot none bind.ro 0 0\nlxc.apparmor.profile = unconfined\nlxc.cgroup.devices.allow = a\nlxc.cap.drop="
     "linux.kernel_modules" = "ip_tables,ip6_tables,nf_nat,overlay,netlink_diag,br_netfilter"
     "security.nesting"     = true
     "security.privileged"  = true

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -7,6 +7,7 @@ variable "image_path" {
 variable "ssh_key" {
   type        = string
   description = "SSH pub key to use"
+  default     = "<contents of ~/.ssh/id_rsa.pub>"
 }
 
 # this variable is used in two different ways. One is to create the user


### PR DESCRIPTION
Downgrade the lxd image to Ubuntu 18.04/bionic, making it consistent
with the libvirt provider, as 19.04/disco is no longer supported.
Fixes failed package installation from the Ubuntu repositories.

Mount /lib/modules and /boot from the host into the container to allow
kubeadm's pre-flight checks to pass and hence start.

For the k8s installation, install the Docker from a repository that
matches the version of Ubuntu instead of using 16.04/xenial. Move
the comment out of daemon.json as it was causing parse failure and
preventing Docker from starting.

Finally, update the documentation to smooth out some roadblocks.