### PR TITLE
build: add sudo to build image

### DIFF
--- a/nix/pkgs/ms-buildenv/default.nix
+++ b/nix/pkgs/ms-buildenv/default.nix
@@ -56,6 +56,7 @@
 , python
 , rdma-core
 , rustup
+, sudo
 , stdenv
 , utillinux
 , xfsprogs
@@ -67,11 +68,9 @@ let
   # the same binaries. Remember, a profile is symling A/bin and B/bin into a
   # profile. If both A and B have /bin/foo -- we have a collision.
   #
-
   bintools = binutils.overrideAttrs (o: rec { meta.priority = 9; });
   libclang =
     llvmPackages.libclang.overrideAttrs (o: rec { meta.priority = 4; });
-
   libc = glibc.overrideAttrs (o: rec { meta.priority = 4; });
   # useful things to be included within the container
   core = [
@@ -91,6 +90,7 @@ let
     procps
     stdenv.cc
     stdenv.cc.cc.lib
+    sudo
     xz
   ];
 
@@ -117,7 +117,6 @@ let
       xfsprogs
     ] ++ core ++ rust ++ node;
   };
-
   image = dockerTools.buildImage {
     name = "mayadata/ms-buildenv";
     tag = "nix";

--- a/nix/pkgs/ms-buildenv/root/etc/sudoers
+++ b/nix/pkgs/ms-buildenv/root/etc/sudoers
@@ -1,0 +1,5 @@
+Defaults env_keep+=SSH_AUTH_SOCK
+root  ALL=(ALL:ALL) SETENV: ALL
+Defaults:root,%wheel env_keep+=TERMINFO_DIRS
+Defaults:root,%wheel env_keep+=TERMINFO
+


### PR DESCRIPTION
We really don't need sudo, however, some of the GH actions require it.
The reason that some of them need/assume that, is that they can be run
on the host directly or within a container.