### PR TITLE
Rebuild: ensure all state transitions are correct and...

### DIFF
--- a/mayastor/src/bdev/nexus/nexus_bdev_children.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev_children.rs
@@ -241,7 +241,7 @@ impl Nexus {
                 })?;
                 child.state = ChildState::Faulted;
                 let nexus_state = self.set_state(NexusState::Degraded);
-                self.start_rebuild(name).await?;
+                self.start_rebuild_rpc(name).await?;
                 Ok(nexus_state)
             }
         } else {

--- a/mayastor/src/bdev/nexus/nexus_bdev_rebuild.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev_rebuild.rs
@@ -1,4 +1,4 @@
-use crossbeam::channel::Receiver;
+use futures::channel::oneshot::Receiver;
 use rpc::mayastor::RebuildStateReply;
 use snafu::ResultExt;
 
@@ -18,13 +18,14 @@ use crate::{
         nexus_child::ChildState,
     },
     core::Reactors,
-    rebuild::{RebuildJob, RebuildOperations, RebuildState},
+    rebuild::{ClientOperations, RebuildJob, RebuildState},
 };
 
 impl Nexus {
     /// Starts a rebuild job in the background
     pub async fn start_rebuild_rpc(&mut self, name: &str) -> Result<(), Error> {
-        self.start_rebuild(name).await?;
+        // we don't need the rust channel on rpc
+        let _ = self.start_rebuild(name).await?;
         Ok(())
     }
 
@@ -61,24 +62,39 @@ impl Nexus {
             self.bdev.num_blocks() + self.data_ent_offset,
             |nexus, job| {
                 Reactors::current().send_future(async move {
-                    Nexus::complete_rebuild(nexus, job).await;
+                    Nexus::notify_rebuild(nexus, job).await;
                 });
             },
         )
         .context(CreateRebuildError {
-            child: name.to_string(),
+            child: name.to_owned(),
             name: self.name.clone(),
         })?;
 
         dst_child.repairing = true;
 
-        Ok(job.start())
+        job.as_client().start().context(CreateRebuildError {
+            child: name.to_owned(),
+            name: self.name.clone(),
+        })
+    }
+
+    /// Terminates a rebuild in the background
+    /// used for shutdown operations and
+    /// unlike the client operation stop, this command does not fail
+    /// as it overrides the previous client operations
+    fn terminate_rebuild(&self, name: &str) {
+        // If a rebuild job is not found that's ok
+        // as we were just going to remove it anyway.
+        if let Ok(rj) = self.get_rebuild_job(name) {
+            let _ = rj.as_client().terminate();
+        }
     }
 
     /// Stop a rebuild job in the background
     pub async fn stop_rebuild(&self, name: &str) -> Result<(), Error> {
         match self.get_rebuild_job(name) {
-            Ok(rt) => rt.stop().context(RebuildOperationError {}),
+            Ok(rj) => rj.as_client().stop().context(RebuildOperationError {}),
             // If a rebuild task is not found return ok
             // as we were just going to remove it anyway.
             Err(_) => Ok(()),
@@ -87,14 +103,14 @@ impl Nexus {
 
     /// Pause a rebuild job in the background
     pub async fn pause_rebuild(&mut self, name: &str) -> Result<(), Error> {
-        let rt = self.get_rebuild_job(name)?;
-        rt.pause().context(RebuildOperationError {})
+        let rj = self.get_rebuild_job(name)?.as_client();
+        rj.pause().context(RebuildOperationError {})
     }
 
     /// Resume a rebuild job in the background
     pub async fn resume_rebuild(&mut self, name: &str) -> Result<(), Error> {
-        let rt = self.get_rebuild_job(name)?;
-        rt.resume().context(RebuildOperationError {})
+        let rj = self.get_rebuild_job(name)?.as_client();
+        rj.resume().context(RebuildOperationError {})
     }
 
     /// Return the state of a rebuild job
@@ -102,9 +118,9 @@ impl Nexus {
         &mut self,
         name: &str,
     ) -> Result<RebuildStateReply, Error> {
-        let rt = self.get_rebuild_job(name)?;
+        let rj = self.get_rebuild_job(name)?;
         Ok(RebuildStateReply {
-            state: rt.state.to_string(),
+            state: rj.state().to_string(),
         })
     }
 
@@ -117,21 +133,28 @@ impl Nexus {
     pub async fn cancel_child_rebuild_jobs(&mut self, name: &str) {
         let mut src_jobs = self.get_rebuild_job_src(name);
 
-        // Issues a stop to all jobs with the child as a source
-        src_jobs
-            .iter_mut()
-            .for_each(|j| j.stop().unwrap_or_else(|_| {}));
+        let mut replace_jobs = Vec::new();
 
-        // todo: before we can start a new rebuild we need to wait
-        // for the previous rebuild to complete - cas-194
-        for job in src_jobs {
-            if let Err(e) = self.start_rebuild(&job.destination).await {
+        // terminates all jobs with the child as a source
+        src_jobs.iter_mut().for_each(|j| {
+            replace_jobs
+                .push((j.destination.clone(), j.as_client().terminate()));
+        });
+
+        for job in replace_jobs {
+            // before we can start a new rebuild we need to wait
+            // for the previous rebuild to complete
+            if let Err(e) = job.1.await {
+                error!("Error {} when waiting for the job to terminate", e);
+            }
+
+            if let Err(e) = self.start_rebuild(&job.0).await {
                 error!("Failed to recreate rebuild: {}", e);
             }
         }
 
-        // stops the only possible job with the child as a destination
-        self.stop_rebuild(name).await.ok();
+        // terminates the only possible job with the child as a destination
+        self.terminate_rebuild(name);
     }
 
     /// Return rebuild job associated with the src child name.
@@ -142,7 +165,7 @@ impl Nexus {
     ) -> Vec<&'a mut RebuildJob> {
         let jobs = RebuildJob::lookup_src(&name);
 
-        jobs.iter().for_each(|job| assert!(job.nexus == self.name));
+        jobs.iter().for_each(|job| assert_eq!(job.nexus, self.name));
         jobs
     }
 
@@ -157,7 +180,7 @@ impl Nexus {
             name: self.name.clone(),
         })?;
 
-        assert!(job.nexus == self.name);
+        assert_eq!(job.nexus, self.name);
         Ok(job)
     }
 
@@ -171,7 +194,7 @@ impl Nexus {
 
         recovered_child.repairing = false;
 
-        if job.state == RebuildState::Completed {
+        if job.state() == RebuildState::Completed {
             recovered_child.state = ChildState::Open;
 
             // Actually we'd have to check if all other children are healthy
@@ -183,20 +206,22 @@ impl Nexus {
         } else {
             error!(
                 "Rebuild job for child {} of nexus {} failed with state {:?}",
-                &job.destination, &self.name, job.state
+                &job.destination,
+                &self.name,
+                job.state()
             );
         }
 
         Ok(())
     }
 
-    async fn on_rebuild_complete(&mut self, job: String) -> Result<(), Error> {
+    async fn on_rebuild_update(&mut self, job: String) -> Result<(), Error> {
         let j = RebuildJob::lookup(&job).context(RebuildJobNotFound {
             child: job.clone(),
             name: self.name.clone(),
         })?;
 
-        if j.state == RebuildState::Paused {
+        if !j.state().done() {
             // Leave all states as they are
             return Ok(());
         }
@@ -209,12 +234,12 @@ impl Nexus {
         self.on_rebuild_complete_job(&job).await
     }
 
-    /// Rebuild Complete callback when a rebuild job completes
-    async fn complete_rebuild(nexus: String, job: String) {
-        info!("nexus {} received complete_rebuild from job {}", nexus, job);
+    /// Rebuild updated callback when a rebuild job state updates
+    async fn notify_rebuild(nexus: String, job: String) {
+        info!("nexus {} received notify_rebuild from job {}", nexus, job);
 
         if let Some(nexus) = nexus_lookup(&nexus) {
-            if let Err(e) = nexus.on_rebuild_complete(job).await {
+            if let Err(e) = nexus.on_rebuild_update(job).await {
                 error!("Failed to complete the rebuild with error {}", e);
             }
         } else {

--- a/mayastor/src/replicas/mod.rs
+++ b/mayastor/src/replicas/mod.rs
@@ -1,3 +1,10 @@
-/// Rebuild module
-pub mod rebuild;
 pub mod replica;
+
+pub mod rebuild {
+    /// Rebuild api module
+    pub mod rebuild_api;
+    /// Rebuild implementation module
+    pub mod rebuild_impl;
+
+    pub use rebuild_api::*;
+}

--- a/mayastor/src/replicas/rebuild/rebuild_api.rs
+++ b/mayastor/src/replicas/rebuild/rebuild_api.rs
@@ -1,0 +1,169 @@
+#![warn(missing_docs)]
+
+use crate::core::{BdevHandle, CoreError, DmaError};
+use crossbeam::channel::{Receiver, Sender};
+use snafu::Snafu;
+use std::fmt;
+
+use super::rebuild_impl::*;
+
+#[derive(Debug, Snafu)]
+#[snafu(visibility = "pub(crate)")]
+#[allow(missing_docs)]
+/// Various rebuild errors when interacting with a rebuild job or
+/// encountered during a rebuild copy
+pub enum RebuildError {
+    #[snafu(display("Failed to allocate buffer for the rebuild copy"))]
+    NoCopyBuffer { source: DmaError },
+    #[snafu(display("Failed to validate rebuild job creation parameters"))]
+    InvalidParameters {},
+    #[snafu(display("Failed to get a handle for bdev {}", bdev))]
+    NoBdevHandle { source: CoreError, bdev: String },
+    #[snafu(display("IO failed for bdev {}", bdev))]
+    IoError { source: CoreError, bdev: String },
+    #[snafu(display("Failed to find rebuild job {}", job))]
+    JobNotFound { job: String },
+    #[snafu(display("Job {} already exists", job))]
+    JobAlreadyExists { job: String },
+    #[snafu(display("Missing rebuild destination {}", job))]
+    MissingDestination { job: String },
+    #[snafu(display(
+        "{} operation failed because current rebuild state is {}.",
+        operation,
+        state,
+    ))]
+    OpError { operation: String, state: String },
+}
+
+#[derive(Debug, PartialEq, Copy, Clone)]
+/// allowed states for a rebuild job
+pub enum RebuildState {
+    /// Pending when the job is newly created
+    Pending,
+    /// Running when the job is rebuilding
+    Running,
+    /// Stopped when the job is halted as requested through stop
+    /// and pending its removal
+    Stopped,
+    /// Paused when the job is paused as requested through pause
+    Paused,
+    /// Failed when an IO (R/W) operation was failed
+    /// there are no retries as it currently stands
+    Failed,
+    /// Completed when the rebuild was sucessfully completed
+    Completed,
+}
+
+impl fmt::Display for RebuildState {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            RebuildState::Pending => write!(f, "pending"),
+            RebuildState::Running => write!(f, "running"),
+            RebuildState::Stopped => write!(f, "stopped"),
+            RebuildState::Paused => write!(f, "paused"),
+            RebuildState::Failed => write!(f, "failed"),
+            RebuildState::Completed => write!(f, "completed"),
+        }
+    }
+}
+
+/// A rebuild job is responsible for managing a rebuild (copy) which reads
+/// from source_hdl and writes into destination_hdl from specified start to end
+pub struct RebuildJob {
+    /// name of the nexus associated with the rebuild job
+    pub nexus: String,
+    /// source URI of the healthy child to rebuild from
+    pub(super) source: String,
+    pub(super) source_hdl: BdevHandle,
+    /// target URI of the out of sync child in need of a rebuild
+    pub destination: String,
+    pub(super) destination_hdl: BdevHandle,
+    pub(super) block_size: u64,
+    pub(super) start: u64,
+    pub(super) end: u64,
+    pub(super) next: u64,
+    pub(super) segment_size_blks: u64,
+    pub(super) tasks: RebuildTasks,
+    pub(super) complete_fn: fn(String, String) -> (),
+    /// channel used to signal rebuild completion
+    pub complete_chan: (Sender<RebuildState>, Receiver<RebuildState>),
+    /// current state of the rebuild job
+    pub state: RebuildState,
+}
+
+/// Place holder for rebuild statistics
+pub struct RebuildStats {}
+
+/// Public facing operations on a Rebuild Job
+pub trait RebuildOperations {
+    /// Collects statistics from the job
+    fn stats(&self) -> Option<RebuildStats>;
+    /// Schedules the job to start in a future and returns a complete channel
+    /// which can be waited on
+    fn start(&mut self) -> Receiver<RebuildState>;
+    /// Stops the job which then triggers the completion hooks
+    fn stop(&mut self) -> Result<(), RebuildError>;
+    /// pauses the job which can then be later resumed
+    fn pause(&mut self) -> Result<(), RebuildError>;
+    /// Resumes a previously paused job
+    /// this could be used to mitigate excess load on the source bdev, eg
+    /// too much contention with frontend IO
+    fn resume(&mut self) -> Result<(), RebuildError>;
+}
+
+impl RebuildJob {
+    /// Creates a new RebuildJob which rebuilds from source URI to target URI
+    /// from start to end; complete_fn callback is called when the rebuild
+    /// completes with the nexus and destinarion URI as arguments
+    pub fn create<'a>(
+        nexus: &str,
+        source: &str,
+        destination: &'a str,
+        start: u64,
+        end: u64,
+        complete_fn: fn(String, String) -> (),
+    ) -> Result<&'a mut Self, RebuildError> {
+        Self::new(nexus, source, destination, start, end, complete_fn)?
+            .store()?;
+
+        Ok(Self::lookup(destination)?)
+    }
+
+    /// Lookup a rebuild job by its destination uri and return it
+    pub fn lookup(name: &str) -> Result<&mut Self, RebuildError> {
+        if let Some(job) = Self::get_instances().get_mut(name) {
+            Ok(job)
+        } else {
+            Err(RebuildError::JobNotFound {
+                job: name.to_owned(),
+            })
+        }
+    }
+
+    /// Lookup all rebuilds jobs with name as its source
+    pub fn lookup_src(name: &str) -> Vec<&mut Self> {
+        let mut jobs = Vec::new();
+
+        Self::get_instances()
+            .iter_mut()
+            .filter(|j| j.1.source == name)
+            .for_each(|j| jobs.push(j.1));
+
+        jobs
+    }
+
+    /// Lookup a rebuild job by its destination uri then remove and return it
+    pub fn remove(name: &str) -> Result<Self, RebuildError> {
+        match Self::get_instances().remove(name) {
+            Some(job) => Ok(job),
+            None => Err(RebuildError::JobNotFound {
+                job: name.to_owned(),
+            }),
+        }
+    }
+
+    /// Number of rebuild job instances
+    pub fn count() -> usize {
+        Self::get_instances().len()
+    }
+}

--- a/mayastor/tests/common/mod.rs
+++ b/mayastor/tests/common/mod.rs
@@ -8,7 +8,7 @@ use run_script::{self, ScriptOptions};
 use mayastor::{
     core::{MayastorEnvironment, Mthread},
     logger,
-    rebuild::RebuildJob,
+    rebuild::{RebuildJob, RebuildState},
 };
 use spdk_sys::spdk_get_thread;
 
@@ -32,6 +32,12 @@ macro_rules! reactor_poll {
             if $ch.try_recv().is_ok() {
                 break;
             }
+        }
+        mayastor::core::Reactors::current().thread_enter();
+    };
+    ($n:expr) => {
+        for _ in 0 .. $n {
+            mayastor::core::Reactors::current().poll_once();
         }
         mayastor::core::Reactors::current().thread_enter();
     };
@@ -305,19 +311,28 @@ pub fn compare_devices(
     stdout
 }
 
-pub fn wait_for_rebuild(name: String, timeout: Duration) {
+/// Waits for the rebuild to reach `state`, up to `timeout`
+pub fn wait_for_rebuild(name: String, state: RebuildState, timeout: Duration) {
     let (s, r) = unbounded::<()>();
     let job = match RebuildJob::lookup(&name) {
         Ok(job) => job,
         Err(_) => return,
     };
 
-    let ch = job.complete_chan.1.clone();
+    let ch = job.notify_chan.1.clone();
     std::thread::spawn(move || {
-        select! {
-            recv(ch) -> state => info!("rebuild of child {} finished with state {:?}", name, state),
-            recv(after(timeout)) -> _ => panic!("timed out waiting for the rebuild to complete"),
-        }
+        let now = std::time::Instant::now();
+        while {
+            let current_state = select! {
+                recv(ch) -> state => {
+                    info!("rebuild of child {} signalled with state {:?}", name, state);
+                    state.unwrap()
+                },
+                recv(after(timeout - now.elapsed())) -> _ => panic!("timed out waiting for the rebuild to complete after {:?}", timeout),
+            };
+
+            current_state != state
+        } {}
         s.send(())
     });
     reactor_poll!(r);

--- a/mayastor/tests/nexus_rebuild.rs
+++ b/mayastor/tests/nexus_rebuild.rs
@@ -5,6 +5,7 @@ pub mod common;
 use mayastor::{
     bdev::nexus_lookup,
     core::{MayastorCliArgs, MayastorEnvironment, Reactor},
+    replicas::rebuild::RebuildState,
 };
 
 use rpc::mayastor::ShareProtocolNexus;
@@ -79,8 +80,9 @@ fn rebuild_src_removal() {
         nexus.pause_rebuild(&get_dev(new_child)).await.unwrap();
         nexus.remove_child(&get_dev(0)).await.unwrap();
 
-        // todo: test if child was rebuilt sucessfully
-        //nexus_test_child(new_child).await;
+        // tests if new_child which had it's original rebuild src removed
+        // ended up being rebuilt successfully
+        nexus_test_child(new_child).await;
 
         nexus.destroy().await.unwrap();
     });
@@ -122,20 +124,28 @@ async fn nexus_add_child(new_child: u64, wait: bool) {
     let nexus = nexus_lookup(NEXUS_NAME).unwrap();
 
     nexus.add_child(&get_dev(new_child)).await.unwrap();
-    nexus.start_rebuild(&get_dev(new_child)).await.unwrap();
+    let _ = nexus.start_rebuild(&get_dev(new_child)).await.unwrap();
 
     if wait {
         common::wait_for_rebuild(
             get_dev(new_child),
+            RebuildState::Completed,
             std::time::Duration::from_secs(5),
         );
 
         nexus_test_child(new_child).await;
+    } else {
+        // allows for the rebuild to start running (future run by the reactor)
+        reactor_poll!(2);
     }
 }
 
 async fn nexus_test_child(child: u64) {
-    common::wait_for_rebuild(get_dev(child), std::time::Duration::from_secs(5));
+    common::wait_for_rebuild(
+        get_dev(child),
+        RebuildState::Completed,
+        std::time::Duration::from_secs(5),
+    );
 
     let (s, r) = unbounded::<String>();
     std::thread::spawn(move || {

--- a/mayastor/tests/reconfigure.rs
+++ b/mayastor/tests/reconfigure.rs
@@ -11,6 +11,7 @@ use mayastor::{
         MayastorEnvironment,
         Reactor,
     },
+    replicas::rebuild::RebuildState,
 };
 
 static DISKNAME1: &str = "/tmp/disk1.img";
@@ -174,6 +175,7 @@ async fn works() {
 
     common::wait_for_rebuild(
         child2.to_string(),
+        RebuildState::Completed,
         std::time::Duration::from_secs(20),
     );
 


### PR DESCRIPTION
...now we can add the hability to wait for a rebuild state and termination

Commit breakdown:

rebuild: split rebuild module

splits the rebuild module into impl and api
no functional changes
this should help contain the next set of coming changes

-----------------------------------------------------

rebuild: split the rebuild state logic

Fixes the rebuild state by introducing and current and a pending state
the pending state is set by the nexus whenever it wants to perform
an operation on the rebuild. The pending state is reconciled when the
job's runner adjusts to the pending state, eg running -> paused

The states are now fully validated by a state machine. No catch all
"_ => ()", was used so the compiler should complain if a new state is
added.

If a pending state is "pending" then a new operation is rejected until
the previous completes.
Internal operations are allowed to override the pending state

Started to make the trait a first class citizen

bonus: fully implement the child src removal by waiting on the rebuild
job to complete before creating a new job to replace the removed one.
This means we now enable the commented out test
Also fix issues pointed out by semi-standard

CAS-194