### PR TITLE
moac: Strip URI scheme from disks when constructing Pool 

### DIFF
--- a/terraform/mod/k8s/node.sh
+++ b/terraform/mod/k8s/node.sh
@@ -8,4 +8,4 @@ done
 
 sudo kubeadm join --token=${token} ${master_ip}:6443 \
   --discovery-token-unsafe-skip-ca-verification \
-  --ignore-preflight-errors=Swap
+  --ignore-preflight-errors=Swap,SystemVerification


### PR DESCRIPTION
Since bcb1cc2 the disks field in the listPools reply contains a URI.
Strip that back to the path only for consistency within moac.

For mayastor-mock, have listPools store a URI to match mayastor's
behaviour.

Reviewed by Jan.