### PR TITLE
CAS-225. Handling for reset IO in nexus function table.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,7 +25,7 @@ jobs:
       - run: /bin/modprobe nbd
       - run: /bin/modprobe xfs
       - run: /bin/modprobe nvme_tcp
-      - run: echo 2048 | tee /sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages
+      - run: echo 8192 | tee /sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages
       - run: rm mayastor/.cargo/config
       - run: rm nvmeadm/.cargo/config
       - run: cargo build --all

--- a/mayastor/src/bdev/nexus/nexus_bdev.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev.rs
@@ -698,7 +698,7 @@ impl Nexus {
         }
     }
 
-    /// reset underlying children.
+    /// send reset IO to the underlying children.
     pub(crate) fn reset(
         &self,
         pio: *mut spdk_bdev_io,
@@ -712,6 +712,7 @@ impl Nexus {
             .iter()
             .map(|c| unsafe {
                 let (bdev, chan) = c.io_tuple();
+                trace!("Dispatched RESET");
                 spdk_bdev_reset(
                     bdev,
                     chan,

--- a/mayastor/src/bdev/nexus/nexus_fn_table.rs
+++ b/mayastor/src/bdev/nexus/nexus_fn_table.rs
@@ -114,7 +114,10 @@ impl NexusFnTable {
                         nio.fail();
                     }
                 }
-                _ => panic!("{} Received unsupported IO!", nexus.name),
+                _ => panic!(
+                    "{} Received unsupported IO! type {}",
+                    nexus.name, io_type
+                ),
             };
         } else {
             // something is very wrong ...

--- a/mayastor/src/core/mod.rs
+++ b/mayastor/src/core/mod.rs
@@ -67,6 +67,10 @@ pub enum CoreError {
         offset: u64,
         len: usize,
     },
+    #[snafu(display("Failed to dispatch reset",))]
+    ResetDispatch {
+        source: Errno,
+    },
     #[snafu(display("Write failed at offset {} length {}", offset, len))]
     WriteFailed {
         offset: u64,
@@ -77,4 +81,6 @@ pub enum CoreError {
         offset: u64,
         len: usize,
     },
+    #[snafu(display("Reset failed"))]
+    ResetFailed {},
 }

--- a/mayastor/tests/reset.rs
+++ b/mayastor/tests/reset.rs
@@ -1,0 +1,100 @@
+pub mod common;
+use common::ms_exec::MayastorProcess;
+use mayastor::{
+    bdev::nexus_create,
+    core::{
+        mayastor_env_stop,
+        BdevHandle,
+        MayastorCliArgs,
+        MayastorEnvironment,
+        Reactor,
+    },
+    subsys,
+    subsys::Config,
+};
+
+static DISKNAME1: &str = "/tmp/disk1.img";
+static BDEVNAME1: &str = "aio:///tmp/disk1.img?blk_size=512";
+
+static DISKNAME2: &str = "/tmp/disk2.img";
+static BDEVNAME2: &str = "aio:///tmp/disk2.img?blk_size=512";
+
+fn generate_config() {
+    let uri1 = BDEVNAME1.into();
+    let uri2 = BDEVNAME2.into();
+    let mut config = Config::default();
+
+    let child1_bdev = subsys::BaseBdev {
+        uri: uri1,
+        uuid: Some("00000000-76b6-4fcf-864d-1027d4038756".into()),
+    };
+
+    let child2_bdev = subsys::BaseBdev {
+        uri: uri2,
+        uuid: Some("11111111-76b6-4fcf-864d-1027d4038756".into()),
+    };
+
+    config.base_bdevs = Some(vec![child1_bdev]);
+    config.implicit_share_base = true;
+    config.nexus_opts.iscsi_enable = false;
+    config.nexus_opts.replica_port = 8430;
+    config.write("/tmp/child1.yaml").unwrap();
+
+    config.base_bdevs = Some(vec![child2_bdev]);
+    config.nexus_opts.replica_port = 8431;
+    config.write("/tmp/child2.yaml").unwrap();
+}
+
+#[test]
+fn nexus_reset_mirror() {
+    generate_config();
+
+    common::truncate_file(DISKNAME1, 64 * 1024);
+    common::truncate_file(DISKNAME2, 64 * 1024);
+
+    let args = vec![
+        "-s".to_string(),
+        "128".to_string(),
+        "-y".to_string(),
+        "/tmp/child1.yaml".to_string(),
+        "-p".into(),
+        "10126".into(),
+    ];
+
+    let _ms1 = MayastorProcess::new(Box::from(args)).unwrap();
+
+    let args = vec![
+        "-s".to_string(),
+        "128".to_string(),
+        "-y".to_string(),
+        "/tmp/child2.yaml".to_string(),
+        "-p".into(),
+        "10127".into(),
+    ];
+
+    let _ms2 = MayastorProcess::new(Box::from(args)).unwrap();
+
+    test_init!();
+
+    Reactor::block_on(async {
+        create_nexus().await;
+        reset().await;
+    });
+    mayastor_env_stop(0);
+}
+
+async fn create_nexus() {
+    let ch = vec![
+        "nvmf://127.0.0.1:8431/nqn.2019-05.io.openebs:11111111-76b6-4fcf-864d-1027d4038756".to_string(),
+        "nvmf://127.0.0.1:8430/nqn.2019-05.io.openebs:00000000-76b6-4fcf-864d-1027d4038756".into()
+    ];
+
+    nexus_create("reset_test", 64 * 1024 * 1024, None, &ch)
+        .await
+        .unwrap();
+}
+
+async fn reset() {
+    let bdev = BdevHandle::open("reset_test", true, true).unwrap();
+    bdev.reset().await.unwrap();
+}


### PR DESCRIPTION
The code this commit refers to has already been included in
cas-79 but this commit adds explicit testing of those changes.
Includes gila's rust-based testing of reset functionality in a
new unit test plus support for the reset IO in the core handle
code.
Also included is a command-line option to pass addition options
to the EAL environment to aid debugging.
The number of huge pages available was increased from 2048 to 8192
to avoid memory issues seen in the reset test.