### PR TITLE
CI: Use 8192 huge pages throughout the test

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -55,7 +55,7 @@ jobs:
       - run: ln -s /host/bin/kmod /bin/modprobe
       - run: /bin/modprobe nbd
       - run: /bin/modprobe xfs
-      - run: echo 2048 | tee /sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages
+      - run: echo 8192 | tee /sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages
       - run: ( cd mayastor-test && npm install)
       - run: ( cd mayastor-test && ./node_modules/mocha/bin/mocha test_cli.js )
       - run: ( cd mayastor-test && ./node_modules/mocha/bin/mocha test_replica.js )


### PR DESCRIPTION
Switching from 8192 hugepages in the unit tests to 2048 hugepages in the mocha tests causes problems. Solve this by using 8192 in both tests.