### PR TITLE
Fix CSI volume provisioning for NBD devices

### DIFF
--- a/csi/src/node/iscsiutil.rs
+++ b/csi/src/node/iscsiutil.rs
@@ -66,7 +66,7 @@ fn attach_disk(
         "-t",
         "sendtargets",
         "-p",
-        "{}:{}",
+        &tp,
         "-I",
         "default",
         "-o",
@@ -187,24 +187,6 @@ pub fn detach_disk(ip_addr: &str, port: &str, iqn: &str) -> Result<(), String> {
         return Err(String::from_utf8(output.stderr).unwrap());
     }
 
-    let args_discoverydb_del = [
-        "-m",
-        "discoverydb",
-        "-t",
-        "sendtargets",
-        "-p",
-        &tp,
-        "-o",
-        "delete",
-    ];
-    trace!("iscsiadm {:?}", args_discoverydb_del);
-    let output = Command::new(&iscsiadm)
-        .args(&args_discoverydb_del)
-        .output()
-        .expect("Failed iscsiadm login");
-    if !output.status.success() {
-        return Err(String::from_utf8(output.stderr).unwrap());
-    }
     Ok(())
 }
 

--- a/mayastor-test/test_nexus.js
+++ b/mayastor-test/test_nexus.js
@@ -16,6 +16,7 @@ const { createClient } = require('grpc-kit');
 const grpc = require('grpc');
 const common = require('./test_common');
 const enums = require('./grpc_enums');
+const url = require('url');
 // just some UUID used for nexus ID
 const UUID = 'dbe4d7eb-118a-4d15-b789-a18d9af6ff21';
 const UUID2 = 'dbe4d7eb-118a-4d15-b789-a18d9af6ff22';
@@ -154,7 +155,7 @@ var doUring = (function () {
 
 describe('nexus', function () {
   var client;
-  var nbdDevice;
+  var nbdDeviceUri;
   var iscsiUri;
 
   const unpublish = (args) => {
@@ -421,7 +422,7 @@ describe('nexus', function () {
           done(err);
         } else {
           assert(res.device_path);
-          nbdDevice = res.device_path;
+          nbdDeviceUri = res.device_path;
           done();
         }
       }
@@ -447,7 +448,7 @@ describe('nexus', function () {
           done(err);
         } else {
           assert(res.device_path);
-          nbdDevice = res.device_path;
+          nbdDeviceUri = res.device_path;
           done();
         }
       }
@@ -456,7 +457,8 @@ describe('nexus', function () {
 
   it('should be able to write to the NBD device', async () => {
     const fs = require('fs').promises;
-    const fd = await fs.open(nbdDevice, 'w', 666);
+    const deviceURL = new url.URL(nbdDeviceUri);
+    const fd = await fs.open(deviceURL.pathname, 'w', 666);
     const buffer = Buffer.alloc(512, 'z', 'utf8');
     await fd.write(buffer, 0, 512);
     await fd.sync();
@@ -465,7 +467,8 @@ describe('nexus', function () {
 
   it('should be able to read the written data back', async () => {
     const fs = require('fs').promises;
-    const fd = await fs.open(nbdDevice, 'r', 666);
+    const deviceURL = new url.URL(nbdDeviceUri);
+    const fd = await fs.open(deviceURL.pathname, 'r', 666);
     const buffer = Buffer.alloc(512, 'a', 'utf8');
     await fd.read(buffer, 0, 512);
     await fd.close();

--- a/mayastor/src/bdev/nexus/nexus_nbd.rs
+++ b/mayastor/src/bdev/nexus/nexus_nbd.rs
@@ -253,6 +253,11 @@ impl NbdDisk {
                 .to_string()
         }
     }
+
+    /// Get nbd device path uri (file:///dev/nbd...) for the nbd disk.
+    pub fn as_uri(&self) -> String {
+        format!("file://{}", self.get_path())
+    }
 }
 
 impl fmt::Debug for NbdDisk {

--- a/mayastor/src/bdev/nexus/nexus_share.rs
+++ b/mayastor/src/bdev/nexus/nexus_share.rs
@@ -49,7 +49,7 @@ impl Nexus {
                     });
                 } else {
                     warn!("{} is already shared", self.name);
-                    return Ok(nbd_disk.get_path());
+                    return Ok(nbd_disk.as_uri());
                 }
             }
             Some(NexusTarget::NexusIscsiTarget(ref iscsi_target)) => {
@@ -106,7 +106,7 @@ impl Nexus {
                     NbdDisk::create(&name).await.context(ShareNbdNexus {
                         name: self.name.clone(),
                     })?;
-                let device_path = nbd_disk.get_path();
+                let device_path = nbd_disk.as_uri();
                 self.nexus_target = Some(NexusTarget::NbdDisk(nbd_disk));
                 device_path
             }
@@ -181,9 +181,7 @@ impl Nexus {
     /// shared as nbd.
     pub fn get_share_path(&self) -> Option<String> {
         match self.nexus_target {
-            Some(NexusTarget::NbdDisk(ref disk)) => {
-                Some(format!("file://{}", disk.get_path()))
-            }
+            Some(NexusTarget::NbdDisk(ref disk)) => Some(disk.as_uri()),
             Some(NexusTarget::NexusIscsiTarget(ref iscsi_target)) => {
                 Some(iscsi_target.as_uri())
             }

--- a/mayastor/tests/common/mod.rs
+++ b/mayastor/tests/common/mod.rs
@@ -9,6 +9,7 @@ use mayastor::{
 };
 use spdk_sys::spdk_get_thread;
 use std::time::Duration;
+use url::{ParseError, Url};
 
 pub mod ms_exec;
 /// call F cnt times, and sleep for a duration between each invocation
@@ -314,4 +315,13 @@ pub fn compare_devices(
     .unwrap();
     assert_eq!(exit, 0, "stdout: {}\nstderr: {}", stdout, stderr);
     stdout
+}
+
+pub fn device_path_from_uri(device_uri: String) -> String {
+    assert_ne!(
+        Url::parse(device_uri.as_str()),
+        Err(ParseError::RelativeUrlWithoutBase)
+    );
+    let url = Url::parse(device_uri.as_str()).unwrap();
+    String::from(url.path())
 }

--- a/mayastor/tests/mount_fs.rs
+++ b/mayastor/tests/mount_fs.rs
@@ -23,12 +23,14 @@ fn mount_fs() {
         let nexus = nexus_lookup("nexus").unwrap();
 
         //TODO: repeat this test for NVMF and ISCSI
-        let device = nexus
-            .share(ShareProtocolNexus::NexusNbd, None)
-            .await
-            .unwrap();
-        let (s, r) = unbounded();
+        let device = common::device_path_from_uri(
+            nexus
+                .share(ShareProtocolNexus::NexusNbd, None)
+                .await
+                .unwrap(),
+        );
 
+        let (s, r) = unbounded();
         // create an XFS filesystem on the nexus device, mount it, create a file
         // and return the md5 of that file
 
@@ -53,14 +55,18 @@ fn mount_fs() {
 
         // share both nexuses
         //TODO: repeat this test for NVMF and ISCSI, and permutations?
-        let left_device = left
-            .share(ShareProtocolNexus::NexusNbd, None)
-            .await
-            .unwrap();
-        let right_device = right
-            .share(ShareProtocolNexus::NexusNbd, None)
-            .await
-            .unwrap();
+        let left_device = common::device_path_from_uri(
+            left.share(ShareProtocolNexus::NexusNbd, None)
+                .await
+                .unwrap(),
+        );
+
+        let right_device = common::device_path_from_uri(
+            right
+                .share(ShareProtocolNexus::NexusNbd, None)
+                .await
+                .unwrap(),
+        );
 
         let s1 = s.clone();
         std::thread::spawn(move || {
@@ -106,10 +112,12 @@ fn mount_fs_1() {
         let nexus = nexus_lookup("nexus").unwrap();
 
         //TODO: repeat this test for NVMF and ISCSI
-        let device = nexus
-            .share(ShareProtocolNexus::NexusNbd, None)
-            .await
-            .unwrap();
+        let device = common::device_path_from_uri(
+            nexus
+                .share(ShareProtocolNexus::NexusNbd, None)
+                .await
+                .unwrap(),
+        );
 
         std::thread::spawn(move || {
             for _i in 0 .. 10 {
@@ -131,10 +139,12 @@ fn mount_fs_2() {
         let nexus = nexus_lookup("nexus").unwrap();
 
         //TODO: repeat this test for NVMF and ISCSI
-        let device = nexus
-            .share(ShareProtocolNexus::NexusNbd, None)
-            .await
-            .unwrap();
+        let device = common::device_path_from_uri(
+            nexus
+                .share(ShareProtocolNexus::NexusNbd, None)
+                .await
+                .unwrap(),
+        );
         let (s, r) = unbounded::<String>();
 
         std::thread::spawn(move || s.send(common::fio_run_verify(&device)));

--- a/mayastor/tests/nexus_rebuild.rs
+++ b/mayastor/tests/nexus_rebuild.rs
@@ -37,10 +37,12 @@ async fn rebuild_test_start() {
     create_nexus().await;
 
     let nexus = nexus_lookup(NEXUS_NAME).unwrap();
-    let device = nexus
-        .share(ShareProtocolNexus::NexusNbd, None)
-        .await
-        .unwrap();
+    let device = common::device_path_from_uri(
+        nexus
+            .share(ShareProtocolNexus::NexusNbd, None)
+            .await
+            .unwrap(),
+    );
 
     let nexus_device = device.clone();
     let (s, r) = unbounded::<String>();


### PR DESCRIPTION
Return device path as a URI always!
Handle device path as a URI instead of a path to the device
Fix a typo and copy and paste error in iscsiutil