### PR TITLE
reactor: enable full speed mode

### DIFF
--- a/mayastor/src/core/reactor.rs
+++ b/mayastor/src/core/reactor.rs
@@ -408,7 +408,12 @@ impl Future for &'static Reactor {
             }
             INIT => {
                 self.poll_once();
-                self.flags.set(DEVELOPER_DELAY);
+
+                if cfg!(debug_assertions) {
+                    self.developer_delayed();
+                } else {
+                    self.running();
+                }
                 cx.waker().wake_by_ref();
                 Poll::Pending
             }

--- a/nix/pkgs/mayastor/default.nix
+++ b/nix/pkgs/mayastor/default.nix
@@ -1,4 +1,5 @@
 { stdenv
+, release ? false
 , e2fsprogs
 , libaio
 , libiscsi
@@ -29,95 +30,96 @@ let
     cargo = channel.stable.cargo;
   };
 in
-  with pkgs; rec {
+with pkgs; rec {
 
-    whitelistSource = src: allowedPrefixes:
-      builtins.filterSource
-        (path: type:
-          pkgs.lib.any
-            (allowedPrefix:
-              pkgs.lib.hasPrefix (toString (src + "/${allowedPrefix}")) path)
-            allowedPrefixes) src;
+  whitelistSource = src: allowedPrefixes:
+    builtins.filterSource
+      (path: type:
+        pkgs.lib.any
+          (allowedPrefix:
+            pkgs.lib.hasPrefix (toString (src + "/${allowedPrefix}")) path)
+          allowedPrefixes) src;
 
-    mayastor = rustPlatform.buildRustPackage rec {
-      name = "mayastor";
-      cargoSha256 = "0pb5j8wg741zhlv25ccbxyad8n4y87q1b36hq7817l41xjpsh2rh";
-      version = "unstable";
-      src = whitelistSource ../../../. [
-        "Cargo.lock"
-        "Cargo.toml"
-        "csi"
-        "cli"
-        "jsonrpc"
-        "mayastor"
-        "rpc"
-        "spdk-sys"
-        "sysfs"
-        "nvmeadm"
-        # We need to copy git as we use git_version!() in rust, we can also
-        # use use nix to pass the hash if we want to by we should, mosty
-        # likely, go with a proper release version.
-        ".git"
-      ];
 
-      LIBCLANG_PATH = "${pkgs.llvmPackages.libclang}/lib";
+  mayastor = rustPlatform.buildRustPackage rec {
+    name = "mayastor";
+    cargoSha256 = "0pb5j8wg741zhlv25ccbxyad8n4y87q1b36hq7817l41xjpsh2rh";
+    version = "unstable";
+    src = whitelistSource ../../../. [
+      "Cargo.lock"
+      "Cargo.toml"
+      "csi"
+      "cli"
+      "jsonrpc"
+      "mayastor"
+      "rpc"
+      "spdk-sys"
+      "sysfs"
+      "nvmeadm"
+      # We need to copy git as we use git_version!() in rust, we can also
+      # use use nix to pass the hash if we want to by we should, mosty
+      # likely, go with a proper release version.
+      ".git"
+    ];
 
-      # these are required for building the proto files that tonic can't find otherwise.
-      PROTOC = "${pkgs.protobuf}/bin/protoc";
-      PROTOC_INCLUDE = "${pkgs.protobuf}/include";
-      C_INCLUDE_PATH = "${libspdk}/include/spdk";
+    LIBCLANG_PATH = "${pkgs.llvmPackages.libclang}/lib";
 
-      buildInputs = [
-        clang
-        e2fsprogs
-        libaio
-        libiscsi.lib
-        libspdk
-        liburing
-        llvmPackages.libclang
-        numactl
-        openssl
-        pkg-config
-        protobuf
-        utillinux
-        xfsprogs
-        utillinux.dev
-      ];
+    # these are required for building the proto files that tonic can't find otherwise.
+    PROTOC = "${pkgs.protobuf}/bin/protoc";
+    PROTOC_INCLUDE = "${pkgs.protobuf}/include";
+    C_INCLUDE_PATH = "${libspdk}/include/spdk";
 
-      buildType = "debug";
-      verifyCargoDeps = false;
+    buildInputs = [
+      clang
+      e2fsprogs
+      libaio
+      libiscsi.lib
+      libspdk
+      liburing
+      llvmPackages.libclang
+      numactl
+      openssl
+      pkg-config
+      protobuf
+      utillinux
+      xfsprogs
+      utillinux.dev
+    ];
 
-      doCheck = false;
-      meta = { platforms = stdenv.lib.platforms.linux; };
+    buildType = if release then "debug" else "release";
+    verifyCargoDeps = false;
+
+    doCheck = false;
+    meta = { platforms = stdenv.lib.platforms.linux; };
+  };
+
+  env = pkgs.stdenv.lib.makeBinPath [ pkgs.busybox pkgs.utillinux pkgs.xfsprogs pkgs.e2fsprogs ];
+
+  mayastorIscsiadm = writeScriptBin "mayastor-iscsiadm" ''
+    #!${pkgs.stdenv.shell}
+    chroot /host /usr/bin/env -i PATH="/sbin:/bin:/usr/bin" iscsiadm "$@"
+  '';
+
+  mayastorImage = pkgs.dockerTools.buildLayeredImage {
+    name = "mayadata/mayastor";
+    tag = "latest";
+    created = "now";
+    contents = [ pkgs.busybox mayastor ];
+    config = {
+      Env = [ "PATH=${env}" ];
+      ExposedPorts = { "10124/tcp" = { }; };
+      Entrypoint = [ "/bin/mayastor" ];
     };
+  };
 
-    env = pkgs.stdenv.lib.makeBinPath [ pkgs.busybox pkgs.utillinux pkgs.xfsprogs pkgs.e2fsprogs ];
-
-    mayastorIscsiadm = writeScriptBin "mayastor-iscsiadm" ''
-      #!${pkgs.stdenv.shell}
-      chroot /host /usr/bin/env -i PATH="/sbin:/bin:/usr/bin" iscsiadm "$@"
-    '';
-
-    mayastorImage = pkgs.dockerTools.buildLayeredImage {
-      name = "mayadata/mayastor";
-      tag = "latest";
-      created = "now";
-      contents = [ pkgs.busybox mayastor ];
-      config = {
-        Env = [ "PATH=${env}" ];
-        ExposedPorts = { "10124/tcp" = { }; };
-        Entrypoint = [ "/bin/mayastor" ];
-      };
+  mayastorCSIImage = pkgs.dockerTools.buildLayeredImage {
+    name = "mayadata/mayastor-grpc";
+    tag = "latest";
+    created = "now";
+    contents = [ pkgs.busybox mayastor mayastorIscsiadm ];
+    config = {
+      Entrypoint = [ "/bin/mayastor-agent" ];
+      Env = [ "PATH=${env}" ];
     };
-
-    mayastorCSIImage = pkgs.dockerTools.buildLayeredImage {
-      name = "mayadata/mayastor-grpc";
-      tag = "latest";
-      created = "now";
-      contents = [ pkgs.busybox mayastor mayastorIscsiadm ];
-      config = {
-        Entrypoint = [ "/bin/mayastor-agent" ];
-        Env = [ "PATH=${env}" ];
-      };
-    };
-  }
+  };
+}


### PR DESCRIPTION
When we moved to the future polling of the reactor, the ability to run
without a developer delay was omitted. When we do release builds we want
to run at full speed.

Also this change adds a release option to mayastor/default.nix