### PR TITLE
Reworking the mayastor-client

### DIFF
--- a/csi/src/client.rs
+++ b/csi/src/client.rs
@@ -8,40 +8,19 @@
 extern crate clap;
 
 use byte_unit::Byte;
-use bytesize::ByteSize;
 use clap::{App, AppSettings, Arg, ArgMatches, SubCommand};
-use rpc::mayastor::{
-    CreateNexusRequest,
-    DestroyNexusRequest,
-    Null,
-    PublishNexusRequest,
-};
-use tonic::{transport::Channel, Code, Request, Status};
+use tonic::{transport::Channel, Code, Status};
 
-use rpc::service::mayastor_client::MayastorClient;
+use ::rpc::{mayastor as rpc, service::mayastor_client::MayastorClient};
 
 type MayaClient = MayastorClient<Channel>;
 
-/// parses a human string into bytes accounts for MiB and MB
-pub(crate) fn parse_size(src: &str) -> Result<u64, String> {
-    if let Ok(val) = Byte::from_str(src) {
-        Ok(val.get_bytes() as u64)
-    } else {
-        Err(src.to_string())
-    }
-}
-fn parse_share_protocol(pcol: Option<&str>) -> Result<i32, Status> {
+fn parse_replica_protocol(pcol: Option<&str>) -> Result<i32, Status> {
     match pcol {
-        None => Ok(rpc::mayastor::ShareProtocolReplica::ReplicaNone as i32),
-        Some("nvmf") => {
-            Ok(rpc::mayastor::ShareProtocolReplica::ReplicaNvmf as i32)
-        }
-        Some("iscsi") => {
-            Ok(rpc::mayastor::ShareProtocolReplica::ReplicaIscsi as i32)
-        }
-        Some("none") => {
-            Ok(rpc::mayastor::ShareProtocolReplica::ReplicaNone as i32)
-        }
+        None => Ok(rpc::ShareProtocolReplica::ReplicaNone as i32),
+        Some("nvmf") => Ok(rpc::ShareProtocolReplica::ReplicaNvmf as i32),
+        Some("iscsi") => Ok(rpc::ShareProtocolReplica::ReplicaIscsi as i32),
+        Some("none") => Ok(rpc::ShareProtocolReplica::ReplicaNone as i32),
         Some(_) => Err(Status::new(
             Code::Internal,
             "Invalid value of share protocol".to_owned(),
@@ -49,599 +28,666 @@ fn parse_share_protocol(pcol: Option<&str>) -> Result<i32, Status> {
     }
 }
 
-async fn publish_nexus(
-    mut client: MayaClient,
-    matches: &ArgMatches<'_>,
-) -> Result<(), Status> {
-    let request = PublishNexusRequest {
-        uuid: matches.value_of("uuid").unwrap().to_string(),
-        key: matches.value_of("key").unwrap_or("").to_string(),
-        share: parse_share_protocol(matches.value_of("PROTOCOL"))?,
-    };
-
-    let path = client.publish_nexus(request).await?;
-    println!("nexus published at {:?}", path);
-    Ok(())
-}
-async fn list_nexus(
-    mut client: MayaClient,
-    _matches: &ArgMatches<'_>,
-) -> Result<(), Status> {
-    let request = Null {};
-
-    let list = client.list_nexus(request).await?;
-
-    list.into_inner().nexus_list.into_iter().for_each(|n| {
-        // TODO: debug output is not user-friendly. Look at list_pools on
-        // how it should be done.
-        println!("{:?}", n);
-    });
-
-    Ok(())
+fn replica_protocol_to_str(idx: i32) -> &'static str {
+    match rpc::ShareProtocolReplica::from_i32(idx) {
+        Some(rpc::ShareProtocolReplica::ReplicaNone) => "none",
+        Some(rpc::ShareProtocolReplica::ReplicaNvmf) => "nvmf",
+        Some(rpc::ShareProtocolReplica::ReplicaIscsi) => "iscsi",
+        None => "unknown",
+    }
 }
 
-async fn destroy_nexus(
-    mut client: MayaClient,
-    matches: &ArgMatches<'_>,
-) -> Result<(), Status> {
-    let request = DestroyNexusRequest {
-        uuid: matches.value_of("uuid").unwrap().to_string(),
-    };
-
-    client.destroy_nexus(request).await?;
-
-    Ok(())
+fn pool_state_to_str(idx: i32) -> &'static str {
+    match rpc::PoolState::from_i32(idx).unwrap() {
+        rpc::PoolState::PoolUnknown => "unknown",
+        rpc::PoolState::PoolOnline => "online",
+        rpc::PoolState::PoolDegraded => "degraded",
+        rpc::PoolState::PoolFaulted => "faulted",
+    }
 }
 
-async fn create_nexus(
-    mut client: MayaClient,
-    matches: &ArgMatches<'_>,
-) -> Result<(), Status> {
-    let size = parse_size(matches.value_of("size").unwrap())
-        .map_err(|s| Status::invalid_argument(format!("Bad size '{}'", s)))?;
-
-    let request = CreateNexusRequest {
-        uuid: matches.value_of("uuid").unwrap().to_string(),
-        size,
-        children: matches
-            .value_of("children")
-            .unwrap()
-            .split_whitespace()
-            .map(|c| c.to_string())
-            .collect::<Vec<String>>(),
-    };
-
-    client.create_nexus(request).await?;
-    Ok(())
+pub(crate) fn parse_size(src: &str) -> Result<Byte, String> {
+    Byte::from_str(src).map_err(|_| src.to_string())
 }
 
-async fn create_pool(
-    mut client: MayastorClient<Channel>,
+struct Context {
+    client: MayaClient,
+    verbosity: u64,
+    units: char,
+}
+
+impl Context {
+    fn v1(&self, s: &str) {
+        if self.verbosity > 0 {
+            println!("{}", s)
+        }
+    }
+    fn v2(&self, s: &str) {
+        if self.verbosity > 1 {
+            println!("{}", s)
+        }
+    }
+    fn units(&self, n: Byte) -> String {
+        match self.units {
+            'i' => n.get_appropriate_unit(true).to_string(),
+            'd' => n.get_appropriate_unit(false).to_string(),
+            _ => n.get_bytes().to_string(),
+        }
+    }
+}
+
+//
+// POOL
+//
+
+async fn pool_create(
+    mut ctx: Context,
     matches: &ArgMatches<'_>,
-    verbose: bool,
 ) -> Result<(), Status> {
-    let name = matches.value_of("POOL").unwrap().to_owned();
+    let name = matches.value_of("pool").unwrap().to_owned();
     let disks = matches
-        .values_of("DISK")
+        .values_of("disk")
         .unwrap()
         .map(|dev| dev.to_owned())
         .collect();
     let block_size = value_t!(matches.value_of("block-size"), u32).unwrap_or(0);
     let io_if = match matches.value_of("io-if") {
-        None | Some("auto") => rpc::mayastor::PoolIoIf::PoolIoAuto as i32,
-        Some("aio") => rpc::mayastor::PoolIoIf::PoolIoAio as i32,
-        Some("uring") => rpc::mayastor::PoolIoIf::PoolIoUring as i32,
-        Some(_) => {
-            return Err(Status::new(
-                Code::Internal,
-                "Invalid value of I/O interface".to_owned(),
-            ));
-        }
-    };
+        None | Some("auto") => Ok(rpc::PoolIoIf::PoolIoAuto as i32),
+        Some("aio") => Ok(rpc::PoolIoIf::PoolIoAio as i32),
+        Some("uring") => Ok(rpc::PoolIoIf::PoolIoUring as i32),
+        Some(_) => Err(Status::new(
+            Code::Internal,
+            "Invalid value of I/O interface".to_owned(),
+        )),
+    }?;
 
-    if verbose {
-        println!("Creating the pool {}", name);
-    }
-
-    let _ = client
-        .create_pool(Request::new(rpc::mayastor::CreatePoolRequest {
-            name,
+    ctx.v2(&format!("Creating pool {}", name));
+    ctx.client
+        .create_pool(rpc::CreatePoolRequest {
+            name: name.clone(),
             disks,
             block_size,
             io_if,
-        }))
+        })
         .await?;
-
+    ctx.v1(&format!("Created pool {}", name));
     Ok(())
 }
 
-async fn destroy_pool(
-    mut client: MayastorClient<Channel>,
+async fn pool_destroy(
+    mut ctx: Context,
     matches: &ArgMatches<'_>,
-    verbose: bool,
 ) -> Result<(), Status> {
-    let name = matches.value_of("POOL").unwrap().to_owned();
+    let name = matches.value_of("pool").unwrap().to_owned();
 
-    if verbose {
-        println!("Destroying the pool {}", name);
-    }
-
-    client
-        .destroy_pool(Request::new(rpc::mayastor::DestroyPoolRequest {
-            name,
-        }))
+    ctx.v2(&format!("Destroying pool {}", name));
+    ctx.client
+        .destroy_pool(rpc::DestroyPoolRequest {
+            name: name.clone(),
+        })
         .await?;
-
+    ctx.v1(&format!("Destroyed pool {}", name));
     Ok(())
 }
 
-async fn list_pools(
-    mut client: MayastorClient<Channel>,
-    verbose: bool,
-    quiet: bool,
+async fn pool_list(
+    mut ctx: Context,
+    _matches: &ArgMatches<'_>,
 ) -> Result<(), Status> {
-    if verbose {
-        println!("Requesting a list of pools");
+    ctx.v2("Requesting a list of pools");
+
+    let reply = ctx.client.list_pools(rpc::Null {}).await?;
+    let pools = &reply.get_ref().pools;
+    if pools.is_empty() {
+        ctx.v1("No pools found");
+        return Ok(());
     }
 
-    let f = client
-        .list_pools(Request::new(rpc::mayastor::Null {}))
-        .await?;
+    ctx.v1(&format!(
+        "{: <20} {: <8} {: >12} {: >12}   DISKS",
+        "NAME", "STATE", "CAPACITY", "USED"
+    ));
 
-    let pools = &f.get_ref().pools;
-
-    if pools.is_empty() && !quiet {
-        println!("No pools have been created");
-    } else {
-        if !quiet {
-            println!(
-                "{: <20} {: <8} {: >12} {: >12}   DISKS",
-                "NAME", "STATE", "CAPACITY", "USED"
-            );
+    for p in pools {
+        let cap = Byte::from_bytes(p.capacity.into());
+        let used = Byte::from_bytes(p.used.into());
+        let state = pool_state_to_str(p.state);
+        print!(
+            "{: <20} {: <8} {: >12} {: >12}  ",
+            p.name,
+            state,
+            ctx.units(cap),
+            ctx.units(used)
+        );
+        for disk in &p.disks {
+            print!(" {}", disk);
         }
-        for p in pools {
-            print!(
-                "{: <20} {: <8} {: >12} {: >12}  ",
-                p.name,
-                match rpc::mayastor::PoolState::from_i32(p.state).unwrap() {
-                    rpc::mayastor::PoolState::PoolUnknown => "unknown",
-                    rpc::mayastor::PoolState::PoolOnline => "online",
-                    rpc::mayastor::PoolState::PoolDegraded => "degraded",
-                    rpc::mayastor::PoolState::PoolFaulted => "faulted",
-                },
-                ByteSize::b(p.capacity).to_string_as(true),
-                ByteSize::b(p.used).to_string_as(true),
-            );
-            for disk in &p.disks {
-                print!(" {}", disk);
-            }
-            println!();
-        }
+        println!();
     }
     Ok(())
 }
 
-async fn create_replica(
-    mut client: MayastorClient<Channel>,
+//
+// NEXUS
+//
+
+async fn nexus_create(
+    mut ctx: Context,
     matches: &ArgMatches<'_>,
-    verbose: bool,
 ) -> Result<(), Status> {
-    let pool = matches.value_of("POOL").unwrap().to_owned();
-    let uuid = matches.value_of("UUID").unwrap().to_owned();
-    let size = value_t!(matches.value_of("size"), u64).unwrap();
+    let uuid = matches.value_of("uuid").unwrap().to_string();
+    let size = parse_size(matches.value_of("size").unwrap())
+        .map_err(|s| Status::invalid_argument(format!("Bad size '{}'", s)))?;
+    let children = matches
+        .value_of("children")
+        .unwrap()
+        .split_whitespace()
+        .map(|c| c.to_string())
+        .collect::<Vec<String>>();
+
+    ctx.v2(&format!(
+        "Creating nexus {} of size {} ",
+        uuid,
+        ctx.units(size)
+    ));
+    ctx.v2(&format!(" with children {:?}", children));
+    let size = size.get_bytes() as u64;
+    ctx.client
+        .create_nexus(rpc::CreateNexusRequest {
+            uuid: uuid.clone(),
+            size,
+            children,
+        })
+        .await?;
+    ctx.v1(&format!("Nexus {} created", uuid));
+    Ok(())
+}
+
+async fn nexus_destroy(
+    mut ctx: Context,
+    matches: &ArgMatches<'_>,
+) -> Result<(), Status> {
+    let uuid = matches.value_of("uuid").unwrap().to_string();
+
+    ctx.v2(&format!("Destroying nexus {}", uuid));
+    ctx.client
+        .destroy_nexus(rpc::DestroyNexusRequest {
+            uuid: uuid.clone(),
+        })
+        .await?;
+    ctx.v1(&format!("Nexus {} destroyed", uuid));
+    Ok(())
+}
+
+async fn nexus_list(
+    mut ctx: Context,
+    _matches: &ArgMatches<'_>,
+) -> Result<(), Status> {
+    let list = ctx.client.list_nexus(rpc::Null {}).await?;
+
+    ctx.v2("Found following nexus:");
+    list.into_inner().nexus_list.into_iter().for_each(|n| {
+        println!("{:?}", n);
+    });
+    Ok(())
+}
+
+async fn nexus_publish(
+    mut ctx: Context,
+    matches: &ArgMatches<'_>,
+) -> Result<(), Status> {
+    let uuid = matches.value_of("uuid").unwrap().to_string();
+    let key = matches.value_of("key").unwrap_or("").to_string();
+    let prot = match matches.value_of("protocol") {
+        None => rpc::ShareProtocolNexus::NexusNbd,
+        Some("nvmf") => rpc::ShareProtocolNexus::NexusNvmf,
+        Some("iscsi") => rpc::ShareProtocolNexus::NexusIscsi,
+        Some(_) => {
+            return Err(Status::new(
+                Code::Internal,
+                "Invalid value of share protocol".to_owned(),
+            ))
+        }
+    };
+
+    ctx.v2(&format!("Publishing nexus {} over {:?}", uuid, prot));
+    let path = ctx
+        .client
+        .publish_nexus(rpc::PublishNexusRequest {
+            uuid,
+            key,
+            share: prot.into(),
+        })
+        .await?;
+    ctx.v1(&format!("Nexus published at {:?}", path));
+    Ok(())
+}
+
+async fn nexus_unpublish(
+    mut ctx: Context,
+    matches: &ArgMatches<'_>,
+) -> Result<(), Status> {
+    let uuid = matches.value_of("uuid").unwrap().to_string();
+
+    ctx.v2(&format!("Unpublishing nexus {}", uuid));
+    ctx.client
+        .unpublish_nexus(rpc::UnpublishNexusRequest {
+            uuid: uuid.clone(),
+        })
+        .await?;
+    ctx.v1(&format!("Nexus {} unpublished", uuid));
+    Ok(())
+}
+
+async fn nexus_add(
+    mut ctx: Context,
+    matches: &ArgMatches<'_>,
+) -> Result<(), Status> {
+    let uuid = matches.value_of("uuid").unwrap().to_string();
+    let uri = matches.value_of("uri").unwrap().to_string();
+
+    ctx.v2(&format!("Adding {} to children of {}", uri, uuid));
+    ctx.client
+        .add_child_nexus(rpc::AddChildNexusRequest {
+            uuid: uuid.clone(),
+            uri: uri.clone(),
+        })
+        .await?;
+    ctx.v1(&format!("Added {} to children of {}", uri, uuid));
+    Ok(())
+}
+
+async fn nexus_remove(
+    mut ctx: Context,
+    matches: &ArgMatches<'_>,
+) -> Result<(), Status> {
+    let uuid = matches.value_of("uuid").unwrap().to_string();
+    let uri = matches.value_of("uri").unwrap().to_string();
+
+    ctx.v2(&format!("Removing {} from children of {}", uri, uuid));
+    ctx.client
+        .remove_child_nexus(rpc::RemoveChildNexusRequest {
+            uuid: uuid.clone(),
+            uri: uri.clone(),
+        })
+        .await?;
+    ctx.v2(&format!("Removed {} from children of {}", uri, uuid));
+    Ok(())
+}
+
+//
+// REPLICA
+//
+
+async fn replica_create(
+    mut ctx: Context,
+    matches: &ArgMatches<'_>,
+) -> Result<(), Status> {
+    let pool = matches.value_of("pool").unwrap().to_owned();
+    let uuid = matches.value_of("uuid").unwrap().to_owned();
+    let size = parse_size(matches.value_of("size").unwrap())
+        .map_err(|s| Status::invalid_argument(format!("Bad size '{}'", s)))?;
     let thin = matches.is_present("thin");
-    let share = parse_share_protocol(matches.value_of("protocol"))?;
+    let share = parse_replica_protocol(matches.value_of("protocol"))?;
 
-    if verbose {
-        println!("Creating replica {} on pool {}", uuid, pool);
-    }
-
-    let resp = client
-        .create_replica(Request::new(rpc::mayastor::CreateReplicaRequest {
-            uuid,
-            pool,
-            thin,
-            share,
-            size: size * (1024 * 1024),
-        }))
-        .await?;
-    println!("{}", resp.get_ref().uri);
+    ctx.v2(&format!("Creating replica {} on pool {}", uuid, pool));
+    let rq = rpc::CreateReplicaRequest {
+        uuid,
+        pool,
+        thin,
+        share,
+        size: size.get_bytes() as u64,
+    };
+    let resp = ctx.client.create_replica(rq).await?;
+    ctx.v1(&format!("Created {}", resp.get_ref().uri));
     Ok(())
 }
 
-async fn destroy_replica(
-    mut client: MayastorClient<Channel>,
+async fn replica_destroy(
+    mut ctx: Context,
     matches: &ArgMatches<'_>,
-    verbose: bool,
 ) -> Result<(), Status> {
-    let uuid = matches.value_of("UUID").unwrap().to_owned();
+    let uuid = matches.value_of("uuid").unwrap().to_owned();
 
-    if verbose {
-        println!("Destroying replica {}", uuid);
-    }
-
-    client
-        .destroy_replica(Request::new(rpc::mayastor::DestroyReplicaRequest {
+    ctx.v2(&format!("Destroying replica {}", uuid));
+    ctx.client
+        .destroy_replica(rpc::DestroyReplicaRequest {
             uuid,
-        }))
+        })
         .await?;
     Ok(())
 }
 
-async fn share_replica(
-    mut client: MayastorClient<Channel>,
+async fn replica_share(
+    mut ctx: Context,
     matches: &ArgMatches<'_>,
-    verbose: bool,
 ) -> Result<(), Status> {
-    let uuid = matches.value_of("UUID").unwrap().to_owned();
-    let share = parse_share_protocol(matches.value_of("PROTOCOL"))?;
+    let uuid = matches.value_of("uuid").unwrap().to_owned();
+    let share = parse_replica_protocol(matches.value_of("protocol"))?;
 
-    if verbose {
-        println!("Sharing replica {}", uuid);
-    }
+    ctx.v2(&format!("Sharing replica {} on {}", uuid, share));
 
-    let resp = client
-        .share_replica(Request::new(rpc::mayastor::ShareReplicaRequest {
+    let resp = ctx
+        .client
+        .share_replica(rpc::ShareReplicaRequest {
             uuid,
             share,
-        }))
+        })
         .await?;
-    println!("{}", resp.get_ref().uri);
+    ctx.v1(&format!("Shared {}", resp.get_ref().uri));
     Ok(())
 }
 
-async fn list_replicas(
-    mut client: MayastorClient<Channel>,
-    verbose: bool,
-    quiet: bool,
+async fn replica_list(
+    mut ctx: Context,
+    _matches: &ArgMatches<'_>,
 ) -> Result<(), Status> {
-    if verbose {
-        println!("Requesting a list of replicas");
+    ctx.v2("Requesting a list of replicas");
+
+    let resp = ctx.client.list_replicas(rpc::Null {}).await?;
+    let replicas = &resp.get_ref().replicas;
+    if replicas.is_empty() {
+        ctx.v1("No replicas have been created");
+        return Ok(());
     }
 
-    let resp = client
-        .list_replicas(Request::new(rpc::mayastor::Null {}))
-        .await?;
+    ctx.v1(&format!(
+        "{: <15} {: <36} {: <8} {: <8} {: <10} URI",
+        "POOL", "NAME", "THIN", "SHARE", "SIZE"
+    ));
 
-    let replicas = &resp.get_ref().replicas;
-
-    if replicas.is_empty() && !quiet {
-        println!("No replicas have been created");
-    } else {
-        if !quiet {
-            println!(
-                "{: <15} {: <36} {: <8} {: <8} {: <10} URI",
-                "POOL", "NAME", "THIN", "SHARE", "SIZE",
-            );
-        }
-        for r in replicas {
-            println!(
-                "{: <15} {: <36} {: <8} {: <8} {: <10} {}",
-                r.pool,
-                r.uuid,
-                r.thin,
-                match rpc::mayastor::ShareProtocolReplica::from_i32(r.share) {
-                    Some(rpc::mayastor::ShareProtocolReplica::ReplicaNone) => {
-                        "none"
-                    }
-                    Some(rpc::mayastor::ShareProtocolReplica::ReplicaNvmf) => {
-                        "nvmf"
-                    }
-                    Some(rpc::mayastor::ShareProtocolReplica::ReplicaIscsi) => {
-                        "iscsi"
-                    }
-                    None => "unknown",
-                },
-                ByteSize::b(r.size).to_string_as(true),
-                r.uri,
-            );
-        }
+    for r in replicas {
+        let proto = replica_protocol_to_str(r.share);
+        let size = ctx.units(Byte::from_bytes(r.size.into()));
+        println!(
+            "{: <15} {: <36} {: <8} {: <8} {: <10} {}",
+            r.pool, r.uuid, r.thin, proto, size, r.uri
+        );
     }
     Ok(())
 }
 
-async fn stat_replicas(
-    mut client: MayastorClient<Channel>,
-    verbose: bool,
-    quiet: bool,
+async fn replica_stat(
+    mut ctx: Context,
+    _matches: &ArgMatches<'_>,
 ) -> Result<(), Status> {
-    if verbose {
-        println!("Requesting replicas stats");
+    ctx.v2("Requesting replicas stats");
+
+    let resp = ctx.client.stat_replicas(rpc::Null {}).await?;
+    let replicas = &resp.get_ref().replicas;
+    if replicas.is_empty() {
+        ctx.v1("No replicas have been created");
     }
 
-    let resp = client
-        .stat_replicas(Request::new(rpc::mayastor::Null {}))
-        .await?;
-    let replicas = &resp.get_ref().replicas;
+    ctx.v1(&format!(
+        "{: <20} {: <36} {: >10} {: >10} {: >10} {: >10}",
+        "POOL", "NAME", "RDCNT", "WRCNT", "RDBYTES", "WRBYTES"
+    ));
 
-    if replicas.is_empty() && !quiet {
-        println!("No replicas have been created");
-    } else {
-        if !quiet {
-            println!(
-                "{: <20} {: <36} {: >10} {: >10} {: >10} {: >10}",
-                "POOL", "NAME", "RDCNT", "WRCNT", "RDBYTES", "WRBYTES",
-            );
-        }
-        for r in replicas {
-            let stats = r.stats.as_ref().unwrap();
-            println!(
-                "{: <20} {: <36} {: >10} {: >10} {: >10} {: >10}",
-                r.pool,
-                r.uuid,
-                stats.num_read_ops,
-                stats.num_write_ops,
-                stats.bytes_read,
-                stats.bytes_written,
-            );
-        }
+    for r in replicas {
+        let stats = r.stats.as_ref().unwrap();
+        let read = ctx.units(Byte::from_bytes(stats.bytes_read.into()));
+        let written = ctx.units(Byte::from_bytes(stats.bytes_written.into()));
+        println!(
+            "{: <20} {: <36} {: >10} {: >10} {: >10} {: >10}",
+            r.pool,
+            r.uuid,
+            stats.num_read_ops,
+            stats.num_write_ops,
+            read,
+            written
+        );
     }
     Ok(())
 }
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let matches = App::new("Mayastor grpc client")
+    let pools_subcommand = {
+        let create = SubCommand::with_name("create")
+            .about("Create storage pool")
+            .arg(
+                Arg::with_name("block-size")
+                    .short("b")
+                    .long("block-size")
+                    .value_name("NUMBER")
+                    .help("block size of the underlying devices"),
+            )
+            .arg(
+                Arg::with_name("io-if")
+                    .short("i")
+                    .long("io-if")
+                    .value_name("IF")
+                    .help("I/O interface for the underlying devices"),
+            )
+            .arg(
+                Arg::with_name("pool")
+                    .required(true)
+                    .index(1)
+                    .help("Storage pool name"),
+            )
+            .arg(
+                Arg::with_name("disk")
+                    .required(true)
+                    .multiple(true)
+                    .index(2)
+                    .help("Disk device files"),
+            );
+        let destroy = SubCommand::with_name("destroy")
+            .about("Destroy storage pool")
+            .arg(
+                Arg::with_name("pool")
+                    .required(true)
+                    .index(1)
+                    .help("Storage pool name"),
+            );
+        SubCommand::with_name("pool")
+            .about("Storage pool management")
+            .subcommand(create)
+            .subcommand(destroy)
+            .subcommand(
+                SubCommand::with_name("list").about("List storage pools"),
+            )
+    };
+
+    let nexus_subcommand = {
+        let create = SubCommand::with_name("create")
+            .about("create a new nexus device")
+            .arg(
+                Arg::with_name("uuid")
+                    .required(true)
+                    .index(1)
+                    .help("uuid for the nexus"),
+            )
+            .arg(
+                Arg::with_name("size")
+                    .required(true)
+                    .index(2)
+                    .help("size in mb"),
+            )
+            .arg(
+                Arg::with_name("children")
+                    .required(true)
+                    .multiple(true)
+                    .index(3)
+                    .help("list of children to add"),
+            );
+        let destroy = SubCommand::with_name("destroy")
+            .about("destroy the nexus with given name")
+            .arg(
+                Arg::with_name("uuid")
+                    .required(true)
+                    .index(1)
+                    .help("uuid for the nexus"),
+            );
+        let publish = SubCommand::with_name("publish").about("publish the nexus")
+            .arg(Arg::with_name("protocol").short("p").long("protocol").value_name("PROTOCOL")
+                .help("Name of a protocol (nvmf, iscsi) used for publishing the nexus remotely"))
+            .arg(Arg::with_name("uuid").required(true).index(1)
+                .help("uuid for the nexus"))
+            .arg(Arg::with_name("key").required(false).index(2)
+                .help("crypto key to use"));
+        let add = SubCommand::with_name("add")
+            .about("add a child")
+            .arg(
+                Arg::with_name("uuid")
+                    .required(true)
+                    .index(1)
+                    .help("uuid for the nexus"),
+            )
+            .arg(
+                Arg::with_name("uri")
+                    .required(true)
+                    .index(2)
+                    .help("uri of child to add"),
+            );
+        let remove = SubCommand::with_name("remove")
+            .about("remove a child")
+            .arg(
+                Arg::with_name("uuid")
+                    .required(true)
+                    .index(1)
+                    .help("uuid for the nexus"),
+            )
+            .arg(
+                Arg::with_name("uri")
+                    .required(true)
+                    .index(2)
+                    .help("uri of child to remove"),
+            );
+        SubCommand::with_name("nexus")
+            .about("nexus management")
+            .subcommand(create)
+            .subcommand(destroy)
+            .subcommand(publish)
+            .subcommand(add)
+            .subcommand(remove)
+            .subcommand(
+                SubCommand::with_name("list").about("list all nexus devices"),
+            )
+            .subcommand(
+                SubCommand::with_name("unpublish").about("unpublish a nexus"),
+            )
+    };
+
+    let replica_subcommand = {
+        let create = SubCommand::with_name("create").about("Create replica on pool")
+            .arg(Arg::with_name("pool").required(true).index(1)
+                .help("Storage pool name"))
+            .arg(Arg::with_name("uuid").required(true).index(2)
+                .help("Unique replica uuid"))
+            .arg(Arg::with_name("protocol").short("p").long("protocol")
+                .takes_value(true).value_name("PROTOCOL")
+                .help("Name of a protocol (nvmf, iscsi) used for sharing the replica (default none)"))
+            .arg(Arg::with_name("size").short("s").long("size")
+                .takes_value(true).required(true).value_name("NUMBER")
+                .help("Size of the replica"))
+            .arg(Arg::with_name("thin").short("t").long("thin").takes_value(false)
+                .help("Whether replica is thin provisioned (default false)"));
+        let destroy = SubCommand::with_name("destroy")
+            .about("Destroy replica")
+            .arg(
+                Arg::with_name("uuid")
+                    .required(true)
+                    .index(1)
+                    .help("Replica uuid"),
+            );
+        let share = SubCommand::with_name("share").about("Share or unshare replica")
+            .arg(Arg::with_name("uuid").required(true).index(1)
+                .help("Replica uuid"))
+            .arg(Arg::with_name("protocol").required(true).index(2)
+                .help("Name of a protocol (nvmf, iscsi) used for sharing or \"none\" to unshare the replica"));
+        SubCommand::with_name("replica")
+            .about("Replica management")
+            .subcommand(create)
+            .subcommand(destroy)
+            .subcommand(share)
+            .subcommand(SubCommand::with_name("list").about("List replicas"))
+            .subcommand(
+                SubCommand::with_name("stats").about("IO stats of replicas"),
+            )
+    };
+
+    let matches = App::new("Mayastor gRPC client")
         .version("0.1")
         .settings(&[AppSettings::SubcommandRequiredElseHelp,
                   AppSettings::ColoredHelp, AppSettings::ColorAlways])
         .about("Client for mayastor gRPC server")
-        .arg(
-            Arg::with_name("address")
-                .short("a")
-                .long("address")
-                .value_name("HOST")
-                .help("IP address of mayastor server (default 127.0.0.1)")
-                .takes_value(true),
-        )
-        .arg(
-            Arg::with_name("port")
-                .short("p")
-                .long("port")
-                .value_name("NUMBER")
-                .help("Port number of mayastor server (default 10124)")
-                .takes_value(true),
-        )
-        .arg(
-            Arg::with_name("verbose")
-                .short("v")
-                .long("verbose")
-                .multiple(true)
-                .help("Verbose output"),
-        )
-        .arg(
-            Arg::with_name("quiet")
-                .short("q")
-                .long("quiet")
-                .help("Do not print any output except for list records"),
-        )
-        .subcommand(
-            SubCommand::with_name("pool")
-                .about("Storage pool management")
-                .subcommand(
-                    SubCommand::with_name("create")
-                        .about("Create storage pool")
-                        .arg(
-                            Arg::with_name("block-size")
-                                .short("b")
-                                .long("block-size")
-                                .value_name("NUMBER")
-                                .help("block size of the underlying devices")
-                                .takes_value(true),
-                        )
-                        .arg(
-                            Arg::with_name("io-if")
-                                .short("i")
-                                .long("io-if")
-                                .help("I/O interface for the underlying devices")
-                        )
-                        .arg(
-                            Arg::with_name("POOL")
-                                .help("Storage pool name")
-                                .required(true)
-                                .index(1),
-                        )
-                        .arg(
-                            Arg::with_name("DISK")
-                                .help("Disk device files")
-                                .required(true)
-                                .multiple(true)
-                                .index(2),
-                        ),
-                )
-                .subcommand(
-                    SubCommand::with_name("destroy")
-                        .about("Destroy storage pool")
-                        .arg(
-                            Arg::with_name("POOL")
-                                .help("Storage pool name")
-                                .required(true)
-                                .index(1),
-                        ),
-                )
-                .subcommand(SubCommand::with_name("list").about("List storage pools")),
-        )
-        .subcommand(
-            SubCommand::with_name("nexus")
-                .about("nexus management")
-                .subcommand(
-                    SubCommand::with_name("create")
-                        .about("create a new nexus device")
-                        .arg(
-                            Arg::with_name("uuid")
-                                .help("uuid for the nexus")
-                                .required(true)
-                                .index(1),
-                        )
-                        .arg(
-                            Arg::with_name("size")
-                                .help("size in mb")
-                                .required(true)
-                                .index(2),
-                        )
-                        .arg(
-                            Arg::with_name("children")
-                                .help("list of children to add")
-                                .required(true)
-                                .multiple(true)
-                                .index(3)
-                        )
-                    )
-                .subcommand(
-                        SubCommand::with_name("destroy")
-                            .about("destroy the nexus with given name")
-                            .arg(
-                                Arg::with_name("uuid")
-                                    .help("uuid for the nexus")
-                                    .required(true)
-                                    .index(1),
-                            )
-                        )
-                .subcommand(
-                        SubCommand::with_name("list")
-                            .about("list all nexus devices")
-                        )
-                .subcommand(
-                    SubCommand::with_name("publish")
-                        .about("publish the nexus")
-                        .arg(
-                            Arg::with_name("uuid")
-                                .help("uuid for the nexus")
-                                .required(true)
-                                .index(1),
-                        )
-                        .arg(
-                            Arg::with_name("key")
-                                .help("crypto key to use")
-                                .required(false)
-                                .index(2),
-                        )
-                )
-        )
-        .subcommand(
-            SubCommand::with_name("replica")
-                .about("Replica management")
-                .subcommand(
-                    SubCommand::with_name("create")
-                        .about("Create replica on pool")
-                        .arg(
-                            Arg::with_name("POOL")
-                                .help("Storage pool name")
-                                .required(true)
-                                .index(1),
-                        )
-                        .arg(
-                            Arg::with_name("UUID")
-                                .help("Unique replica uuid")
-                                .required(true)
-                                .index(2),
-                        )
-                        .arg(
-                            Arg::with_name("protocol")
-                                .short("p")
-                                .long("protocol")
-                                .value_name("PROTOCOL")
-                                .help("Name of a protocol (nvmf, iscsi) used for sharing the replica (default none)")
-                                .takes_value(true),
-                        )
-                        .arg(
-                            Arg::with_name("size")
-                                .short("s")
-                                .long("size")
-                                .value_name("NUMBER")
-                                .help("Size of the replica in MiB")
-                                .takes_value(true)
-                                .required(true),
-                        )
-                        .arg(
-                            Arg::with_name("thin")
-                                .short("t")
-                                .long("thin")
-                                .help("Replica is thin provisioned (default false)")
-                                .takes_value(false),
-                        ),
-                )
-                .subcommand(
-                    SubCommand::with_name("destroy")
-                        .about("Destroy replica")
-                        .arg(
-                            Arg::with_name("UUID")
-                                .help("Replica uuid")
-                                .required(true)
-                                .index(1),
-                        ),
-                )
-                .subcommand(
-                    SubCommand::with_name("share")
-                        .about("Share or unshare replica")
-                        .arg(
-                            Arg::with_name("UUID")
-                                .help("Replica uuid")
-                                .required(true)
-                                .index(1),
-                        )
-                        .arg(
-                            Arg::with_name("PROTOCOL")
-                                .help("Replica uuid")
-                                .help("Name of a protocol (nvmf, iscsi) used for sharing or \"none\" to unshare the replica")
-                                .required(true)
-                                .index(2),
-                        ),
-                )
-                .subcommand(SubCommand::with_name("list").about("List replicas"))
-                .subcommand(SubCommand::with_name("stats").about("IO stats of replicas")),
-        )
+        .arg(Arg::with_name("address").short("a").long("address")
+            .default_value("127.0.0.1").value_name("HOST")
+            .help("IP address of mayastor server"))
+        .arg(Arg::with_name("port").short("p").long("port")
+            .default_value("10124").value_name("NUMBER")
+            .help("Port number of mayastor server"))
+        .arg(Arg::with_name("quiet").short("q").long("quiet")
+            .help("Do not print any output except for list records"))
+        .arg(Arg::with_name("verbose").short("v").long("verbose").multiple(true)
+            .help("Verbose output").conflicts_with("quiet"))
+        .arg(Arg::with_name("units").short("u").long("units")
+            .value_name("BASE").possible_values(&["i","d"])
+            .hide_possible_values(true).next_line_help(true)
+            .help("Output with large units: i for kiB, etc. or d for kB, etc."))
+        .subcommand(pools_subcommand)
+        .subcommand(nexus_subcommand)
+        .subcommand(replica_subcommand)
         .get_matches();
 
-    let endpoint = {
-        let addr = matches.value_of("address").unwrap_or("127.0.0.1");
-        let port = value_t!(matches.value_of("port"), u16).unwrap_or(10124);
-        format!("{}:{}", addr, port)
+    let ctx = {
+        let verbosity = if matches.is_present("quiet") {
+            0
+        } else {
+            matches.occurrences_of("verbose") + 1
+        };
+        let units = matches
+            .value_of("units")
+            .and_then(|u| u.chars().next())
+            .unwrap_or('b');
+        let endpoint = {
+            let addr = matches.value_of("address").unwrap_or("127.0.0.1");
+            let port = value_t!(matches.value_of("port"), u16).unwrap_or(10124);
+            format!("{}:{}", addr, port)
+        };
+        let uri = format!("http://{}", endpoint);
+        if verbosity > 1 {
+            println!("Connecting to {}", uri);
+        }
+        let client = MayaClient::connect(uri).await?;
+        Context {
+            client,
+            verbosity,
+            units,
+        }
     };
-
-    let verbose = matches.occurrences_of("verbose") > 0;
-    let quiet = matches.is_present("quiet");
-
-    let uri = format!("http://{}", endpoint);
-
-    let client = MayastorClient::connect(uri).await?;
 
     match matches.subcommand() {
         ("pool", Some(m)) => match m.subcommand() {
-            ("create", Some(m)) => create_pool(client, &m, verbose).await?,
-            ("list", Some(_m)) => list_pools(client, verbose, quiet).await?,
-            ("destroy", Some(m)) => destroy_pool(client, &m, quiet).await?,
+            ("create", Some(m)) => pool_create(ctx, &m).await?,
+            ("list", Some(m)) => pool_list(ctx, &m).await?,
+            ("destroy", Some(m)) => pool_destroy(ctx, &m).await?,
             _ => {}
         },
 
         ("nexus", Some(m)) => match m.subcommand() {
-            ("create", Some(m)) => create_nexus(client, &m).await?,
-            ("destroy", Some(m)) => destroy_nexus(client, &m).await?,
-            ("list", Some(m)) => list_nexus(client, &m).await?,
-            ("publish", Some(m)) => publish_nexus(client, &m).await?,
+            ("create", Some(m)) => nexus_create(ctx, &m).await?,
+            ("destroy", Some(m)) => nexus_destroy(ctx, &m).await?,
+            ("list", Some(m)) => nexus_list(ctx, &m).await?,
+            ("publish", Some(m)) => nexus_publish(ctx, &m).await?,
+            ("unpublish", Some(m)) => nexus_unpublish(ctx, &m).await?,
+            ("add", Some(m)) => nexus_add(ctx, &m).await?,
+            ("remove", Some(m)) => nexus_remove(ctx, &m).await?,
             _ => {}
         },
 
         ("replica", Some(m)) => match m.subcommand() {
-            ("create", Some(matches)) => {
-                create_replica(client, matches, verbose).await?
-            }
-            ("destroy", Some(matches)) => {
-                destroy_replica(client, matches, verbose).await?
-            }
-            ("share", Some(matches)) => {
-                share_replica(client, matches, verbose).await?
-            }
-            ("list", Some(_matches)) => {
-                list_replicas(client, verbose, quiet).await?
-            }
-            ("stats", Some(_matches)) => {
-                stat_replicas(client, verbose, quiet).await?
-            }
+            ("create", Some(m)) => replica_create(ctx, &m).await?,
+            ("destroy", Some(m)) => replica_destroy(ctx, &m).await?,
+            ("share", Some(m)) => replica_share(ctx, &m).await?,
+            ("list", Some(m)) => replica_list(ctx, &m).await?,
+            ("stats", Some(m)) => replica_stat(ctx, &m).await?,
             _ => {}
         },
 
-        _ => {}
+        _ => eprintln!("Internal Error: Not implemented"),
     };
     Ok(())
 }

--- a/mayastor-test/test_cli.js
+++ b/mayastor-test/test_cli.js
@@ -196,7 +196,7 @@ describe('cli', function () {
 
     it('should create a pool', function (done) {
       const cmd = util.format(
-        '%s pool create -b 512 %s %s',
+        '%s -q pool create -b 512 %s %s',
         EGRESS_CMD,
         POOL,
         DISK
@@ -213,7 +213,7 @@ describe('cli', function () {
     });
 
     it('should list pools', function (done) {
-      const cmd = util.format('%s -q pool list', EGRESS_CMD);
+      const cmd = util.format('%s -ui -q pool list', EGRESS_CMD);
 
       exec(cmd, (err, stdout, stderr) => {
         const pools = [];
@@ -248,17 +248,17 @@ describe('cli', function () {
 
         assert.equal(pools[0].name, POOL + '1');
         assert.equal(pools[0].state, 'online');
-        assert.equal(pools[0].capacity, '100.0');
+        assert.equal(pools[0].capacity, '100.00');
         assert.equal(pools[0].capacity_unit, 'MiB');
-        assert.equal(pools[0].used, '50.0');
+        assert.equal(pools[0].used, '50.00');
         assert.equal(pools[0].used_unit, 'MiB');
         assert.deepEqual(pools[0].disks, [DISK + '1']);
 
         assert.equal(pools[1].name, POOL + '2');
         assert.equal(pools[1].state, 'degraded');
-        assert.equal(pools[1].capacity, '1.0');
-        assert.equal(pools[1].capacity_unit, 'GiB');
-        assert.equal(pools[1].used, '99.0');
+        assert.equal(pools[1].capacity, '1000.00');
+        assert.equal(pools[1].capacity_unit, 'MiB');
+        assert.equal(pools[1].used, '99.00');
         assert.equal(pools[1].used_unit, 'MiB');
         assert.deepEqual(pools[1].disks, [DISK + '2a', DISK + '2b']);
 
@@ -267,7 +267,7 @@ describe('cli', function () {
     });
 
     it('should destroy a pool', function (done) {
-      const cmd = util.format('%s pool destroy %s', EGRESS_CMD, POOL);
+      const cmd = util.format('%s -q pool destroy %s', EGRESS_CMD, POOL);
 
       exec(cmd, (err, stdout, stderr) => {
         if (err) {
@@ -281,7 +281,7 @@ describe('cli', function () {
 
     it('should create a replica', function (done) {
       const cmd = util.format(
-        '%s replica create %s %s --size=1000 --thin --protocol=nvmf',
+        '%s replica create %s %s --size=1000Mib --thin --protocol=nvmf',
         EGRESS_CMD,
         POOL,
         UUID
@@ -292,7 +292,7 @@ describe('cli', function () {
           return done(err);
         }
         assert.isEmpty(stderr);
-        assert.match(stdout, /^nvmf:\/\//);
+        assert.match(stdout, /nvmf:\/\//);
         done();
       });
     });
@@ -305,13 +305,13 @@ describe('cli', function () {
           return done(err);
         }
         assert.isEmpty(stderr);
-        assert.match(stdout, /^iscsi:\/\//);
+        assert.match(stdout, /iscsi:\/\//);
         done();
       });
     });
 
     it('should list replicas', function (done) {
-      const cmd = util.format('%s -q replica list', EGRESS_CMD);
+      const cmd = util.format('%s -ui -q replica list', EGRESS_CMD);
 
       exec(cmd, (err, stdout, stderr) => {
         const repls = [];
@@ -348,7 +348,7 @@ describe('cli', function () {
         assert.equal(repls[0].pool, POOL);
         assert.equal(repls[0].thin, 'true');
         assert.equal(repls[0].share, 'none');
-        assert.equal(repls[0].size, '9.8'); // 10000MiB -> 9.8 GiB
+        assert.equal(repls[0].size, '9.77'); // 10000MiB -> 9.77 GiB
         assert.equal(repls[0].size_unit, 'GiB');
         assert.match(repls[0].uri, /^bdev:\/\/\/\d+/);
 
@@ -356,7 +356,7 @@ describe('cli', function () {
         assert.equal(repls[1].pool, POOL);
         assert.equal(repls[1].thin, 'false');
         assert.equal(repls[1].share, 'nvmf');
-        assert.equal(repls[1].size, '10.0');
+        assert.equal(repls[1].size, '10.00');
         assert.equal(repls[1].size_unit, 'MiB');
         assert.match(repls[1].uri, /^nvmf:\/\/\d+/);
 
@@ -364,7 +364,7 @@ describe('cli', function () {
         assert.equal(repls[2].pool, POOL);
         assert.equal(repls[2].thin, 'false');
         assert.equal(repls[2].share, 'iscsi');
-        assert.equal(repls[2].size, '10.0');
+        assert.equal(repls[2].size, '10.00');
         assert.equal(repls[2].size_unit, 'MiB');
         assert.match(repls[2].uri, /^iscsi:\/\/\d+/);
 
@@ -564,7 +564,7 @@ describe('cli', function () {
 
     it('should not create a replica if it already exists', function (done) {
       const cmd = util.format(
-        '%s replica create %s %s --size=1000 --thin',
+        '%s replica create %s %s --size=1000Mib --thin',
         EGRESS_CMD,
         POOL,
         UUID


### PR DESCRIPTION
I have reworked the mayastor-client:
Streamlined the command line argument handling;
Completed the implementations of nexus, pool, and replica functionality;
Ensured input byte sizes are acceptable as bytes, or with binary & SI multipliers;
Output byte sizes shown as bytes, command line options to switch to binary or SI multipliers.
CAS-69 CAS-70 CAS-71 CAS-77