### PR TITLE
doc: Clarify CPU architecture requirements in quick.md

### DIFF
--- a/nix/pkgs/libspdk/default.nix
+++ b/nix/pkgs/libspdk/default.nix
@@ -78,7 +78,7 @@ stdenv.mkDerivation rec {
 
   '';
 
-  NIX_CFLAGS_COMPILE = "-mno-movbe -mno-lzcnt -mno-bmi -mno-bmi2 -march=corei7";
+  NIX_CFLAGS_COMPILE = "-mno-movbe -mno-lzcnt -mno-bmi -mno-bmi2 -march=nehalem";
   hardeningDisable = [ "all" ];
 
   postBuild = ''


### PR DESCRIPTION
State the SSE4.2 instruction set requirement and list the processors
that satisfy that requirement. Also change the libspdk build flag to
-march=nehalem as -march=corei7 was renamed in gcc-4.9.

Update the requirements section and minor fixes for the rest of the
document.