### PR TITLE
nexus: address child sizing mismatches

### DIFF
--- a/mayastor-test/test_csi.js
+++ b/mayastor-test/test_csi.js
@@ -430,7 +430,7 @@ describe('csi', function () {
           assert.lengthOf(res.usage, 1);
           assert.equal(res.usage[0].unit, 'BYTES');
           // 25MB size of the bdev - something for the metadata
-          assert.equal(res.usage[0].total, 24092672);
+          assert.equal(res.usage[0].total, 24096768);
           // TODO: These are not available yet:
           // assert.equal(res.usage[0].available, 1);
           // assert.equal(res.usage[0].used, 0);

--- a/mayastor/src/bdev/nexus/nexus_bdev.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev.rs
@@ -450,9 +450,11 @@ impl Nexus {
         // to ensure we adhere to the partitions.
         self.data_ent_offset = label.offset();
         let size_blocks = self.size / self.bdev.block_len() as u64;
-        // label might be smaller than the nexus size due to the partitioning
+
         self.bdev.set_block_count(std::cmp::min(
+            // nexus is allowed to be smaller than the children
             size_blocks,
+            // label might be smaller than expected due to the on disk metadata
             label.get_block_count(),
         ));
 

--- a/mayastor/src/bdev/nexus/nexus_bdev.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev.rs
@@ -449,7 +449,12 @@ impl Nexus {
         // Now register the bdev but update its size first
         // to ensure we adhere to the partitions.
         self.data_ent_offset = label.offset();
-        self.bdev.set_block_count(label.get_block_count());
+        let size_blocks = self.size / self.bdev.block_len() as u64;
+        // label might be smaller than the nexus size due to the partitioning
+        self.bdev.set_block_count(std::cmp::min(
+            size_blocks,
+            label.get_block_count(),
+        ));
 
         Ok(())
     }

--- a/mayastor/src/bdev/nexus/nexus_bdev_children.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev_children.rs
@@ -106,7 +106,7 @@ impl Nexus {
         let child_bdev = match Bdev::lookup_by_name(&name) {
             Some(child) => {
                 if child.block_len() != self.bdev.block_len()
-                    || self.min_num_blocks() < child.num_blocks()
+                    || self.min_num_blocks() > child.num_blocks()
                 {
                     if let Err(err) = bdev_destroy(uri).await {
                         error!(
@@ -115,7 +115,7 @@ impl Nexus {
                         );
                     }
                     return Err(Error::ChildGeometry {
-                        child: child.name(),
+                        child: name,
                         name: self.name.clone(),
                     });
                 } else {

--- a/mayastor/src/bdev/nexus/nexus_label.rs
+++ b/mayastor/src/bdev/nexus/nexus_label.rs
@@ -613,7 +613,7 @@ impl NexusLabel {
 
     /// returns the number of total blocks in this segment
     pub(crate) fn get_block_count(&self) -> u64 {
-        self.partitions[1].ent_end - self.partitions[1].ent_start
+        self.partitions[1].ent_end - self.partitions[1].ent_start + 1
     }
 }
 

--- a/mayastor/tests/common/mod.rs
+++ b/mayastor/tests/common/mod.rs
@@ -325,3 +325,17 @@ pub fn device_path_from_uri(device_uri: String) -> String {
     let url = Url::parse(device_uri.as_str()).unwrap();
     String::from(url.path())
 }
+
+pub fn get_device_size(nexus_device: &str) -> u64 {
+    let output = Command::new("blockdev")
+        .args(&["--getsize64", nexus_device])
+        .output()
+        .expect("failed to get block device size");
+
+    assert_eq!(output.status.success(), true);
+    String::from_utf8(output.stdout)
+        .unwrap()
+        .trim_end()
+        .parse::<u64>()
+        .unwrap()
+}

--- a/mayastor/tests/core.rs
+++ b/mayastor/tests/core.rs
@@ -124,7 +124,7 @@ fn core_3() {
 }
 
 #[test]
-// Test nexus with different combinations of sizes for src and dst children
+// Test nexus with children with different sizes
 fn core_4() {
     test_init!();
 


### PR DESCRIPTION
When a child fails to be added due to a different block size or invalid
size the returned error does not use the name form the bdev which is
now destroyed.

When adding a new child the size of the child has to be larger than the
minimum required.

The nexus bdev now takes into account the requested size when it was
created rather than just looking at its children sizes.
At the moment new children need to be as large as the smallest child,
this is due to the partition being done in relation to the smallest
child. We might want to consider doing it in relation to the nexus size
+ metadata.

Resolves CAS-247