### PR TITLE
pool: Fix failure to destroy pool

### DIFF
--- a/mayastor/src/pool.rs
+++ b/mayastor/src/pool.rs
@@ -498,7 +498,7 @@ impl Pool {
                 return Ok(());
             }
         };
-        let base_bdev_type = self.get_base_bdev().driver();
+        let base_bdev_type = base_bdev.driver();
         debug!("Destroying bdev type {}", base_bdev_type);
 
         let (sender, receiver) = oneshot::channel::<i32>();


### PR DESCRIPTION
The code that determines the base bdev type inadvertently used
lvs_bdev_ptr after it had already been destroyed. Switch to base_bdev
instead so that that the base bdev type can be determined.

Fixes: bcb1cc2 ("pool: Return base bdev type in list pools")