### PR TITLE
CAS-241. Functionality to store and query a record of the most recent…

### DIFF
--- a/mayastor/src/bdev/mod.rs
+++ b/mayastor/src/bdev/mod.rs
@@ -4,6 +4,7 @@ pub use aio_dev::{AioBdev, AioParseError};
 pub use iscsi_dev::{IscsiBdev, IscsiParseError};
 pub use nexus::{
     nexus_bdev::{nexus_create, nexus_lookup, Nexus, NexusState},
+    nexus_child_error_store::NexusErrStore,
     nexus_label::{GPTHeader, GptEntry},
     nexus_metadata_content::{
         NexusConfig,
@@ -12,6 +13,7 @@ pub use nexus::{
         NexusConfigVersion3,
     },
 };
+
 pub use nvmf_dev::{NvmeCtlAttachReq, NvmfParseError};
 use spdk_sys::{spdk_conf_section, spdk_conf_section_get_nmval};
 pub use uring_dev::{UringBdev, UringParseError};

--- a/mayastor/src/bdev/nexus/mod.rs
+++ b/mayastor/src/bdev/nexus/mod.rs
@@ -12,6 +12,7 @@ pub mod nexus_bdev;
 pub mod nexus_bdev_children;
 mod nexus_channel;
 pub(crate) mod nexus_child;
+pub(crate) mod nexus_child_error_store;
 mod nexus_config;
 pub mod nexus_fn_table;
 pub mod nexus_io;

--- a/mayastor/src/bdev/nexus/nexus_child_error_store.rs
+++ b/mayastor/src/bdev/nexus/nexus_child_error_store.rs
@@ -1,0 +1,151 @@
+use spdk_sys::spdk_bdev_io_type;
+use std::fmt::{Debug, Display};
+
+use crate::bdev::nexus::nexus_io::{io_status, io_type};
+use serde::export::{fmt::Error, Formatter};
+
+#[derive(Default)]
+pub struct NexusChildErrorRecord {
+    timestamp_nano: u64,
+    io_op_flag: u32,
+    io_offset: u64,
+    io_num_blocks: u64,
+    io_error_flag: u32,
+}
+
+pub struct NexusErrStore {
+    no_of_records: usize,
+    next_record_index: usize,
+    records: Vec<NexusChildErrorRecord>,
+}
+
+impl NexusErrStore {
+    pub const READ_FLAG: u32 = 1;
+    pub const WRITE_FLAG: u32 = 2;
+    pub const UNMAP_FLAG: u32 = 4;
+    pub const FLUSH_FLAG: u32 = 8;
+    pub const RESET_FLAG: u32 = 16;
+
+    pub const IO_FAILED_FLAG: u32 = 1;
+
+    // the following definitions are for the error_store unit test
+    pub const IO_TYPE_READ: u32 = io_type::READ;
+    pub const IO_TYPE_WRITE: u32 = io_type::WRITE;
+    pub const IO_TYPE_UNMAP: u32 = io_type::UNMAP;
+    pub const IO_TYPE_FLUSH: u32 = io_type::FLUSH;
+    pub const IO_TYPE_RESET: u32 = io_type::RESET;
+
+    pub const IO_FAILED: i32 = io_status::FAILED;
+
+    pub fn new(max_records: usize) -> Self {
+        let mut es = NexusErrStore {
+            no_of_records: 0,
+            next_record_index: 0,
+
+            records: Vec::with_capacity(max_records),
+        };
+        for _ in 0 .. max_records {
+            let er: NexusChildErrorRecord = Default::default();
+            es.records.push(er);
+        }
+        es
+    }
+
+    pub fn add_record(
+        &mut self,
+        io_op_type: spdk_bdev_io_type,
+        io_error_type: i32,
+        io_offset: u64,
+        io_num_blocks: u64,
+        timestamp_nano: u64,
+    ) -> &mut Self {
+        self.records[self.next_record_index].io_op_flag = match io_op_type {
+            io_type::READ => NexusErrStore::READ_FLAG,
+            io_type::WRITE => NexusErrStore::WRITE_FLAG,
+            io_type::UNMAP => NexusErrStore::UNMAP_FLAG,
+            io_type::FLUSH => NexusErrStore::FLUSH_FLAG,
+            io_type::RESET => NexusErrStore::RESET_FLAG,
+            _ => 0,
+        };
+        self.records[self.next_record_index].io_error_flag = match io_error_type
+        {
+            io_status::FAILED => NexusErrStore::IO_FAILED_FLAG,
+            _ => 0,
+        };
+
+        self.records[self.next_record_index].io_offset = io_offset;
+        self.records[self.next_record_index].io_num_blocks = io_num_blocks;
+        self.records[self.next_record_index].timestamp_nano = timestamp_nano;
+
+        if self.no_of_records < self.records.len() {
+            self.no_of_records += 1;
+        };
+        self.next_record_index =
+            (self.next_record_index + 1) % self.records.len();
+        self
+    }
+
+    pub fn query(
+        &self,
+        io_op_flags: u32,
+        io_error_flags: u32,
+        target_timestamp_nano: u64,
+    ) -> u32 {
+        let mut idx = self.next_record_index;
+        let mut error_count: u32 = 0;
+
+        for _ in 0 .. self.no_of_records {
+            if idx > 0 {
+                idx -= 1;
+            } else {
+                idx = self.records.len() - 1;
+            }
+            if self.records[idx].timestamp_nano < target_timestamp_nano {
+                break;
+            }
+
+            if (self.records[idx].io_op_flag & io_op_flags != 0)
+                && (self.records[idx].io_error_flag & io_error_flags != 0)
+            {
+                error_count += 1;
+            }
+        }
+        error_count
+    }
+    fn error_fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
+        let mut idx = self.next_record_index;
+        write!(f, "\nErrors ({}):", self.no_of_records)
+            .expect("invalid format");
+        for n in 0 .. self.no_of_records {
+            if idx > 0 {
+                idx -= 1;
+            } else {
+                idx = self.records.len() - 1;
+            }
+            write!(
+                f,
+                "\n    {}: timestamp:{} op:{} offset:{} blocks{}: error:{}",
+                n,
+                self.records[idx].timestamp_nano,
+                self.records[idx].io_op_flag,
+                self.records[idx].io_offset,
+                self.records[idx].io_num_blocks,
+                self.records[idx].io_error_flag
+            )
+            .expect("invalid format");
+        }
+        Ok(())
+    }
+}
+
+impl Debug for NexusErrStore {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
+        self.error_fmt(f)
+    }
+}
+
+impl Display for NexusErrStore {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
+        self.error_fmt(f)
+    }
+}

--- a/mayastor/src/subsys/config.rs
+++ b/mayastor/src/subsys/config.rs
@@ -16,6 +16,7 @@ use crate::{
     pool::{create_pool, PoolsIter},
     subsys::opts::{
         BdevOpts,
+        ErrStoreOpts,
         IscsiTgtOpts,
         NexusOpts,
         NvmeBdevOpts,
@@ -47,6 +48,8 @@ pub struct Config {
     pub bdev_opts: BdevOpts,
     /// nexus specific options
     pub nexus_opts: NexusOpts,
+    /// error store opts
+    pub err_store_opts: ErrStoreOpts,
     ///
     /// The next options are intended for usage during testing
     ///
@@ -123,6 +126,7 @@ impl Config {
             nexus_bdevs: None,
             pools: None,
             implicit_share_base: true,
+            err_store_opts: self.err_store_opts.get(),
         };
 
         // collect nexus bdevs and insert them into the config

--- a/mayastor/src/subsys/opts.rs
+++ b/mayastor/src/subsys/opts.rs
@@ -456,3 +456,27 @@ impl GetOpts for IscsiTgtOpts {
         true
     }
 }
+
+#[serde(default, deny_unknown_fields)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ErrStoreOpts {
+    /// ring buffer size
+    pub err_store_size: usize,
+    /// NexusErrStore enabled
+    pub enable_err_store: bool,
+}
+
+impl Default for ErrStoreOpts {
+    fn default() -> Self {
+        Self {
+            err_store_size: 256,
+            enable_err_store: true,
+        }
+    }
+}
+
+impl GetOpts for ErrStoreOpts {
+    fn get(&self) -> Self {
+        self.clone()
+    }
+}

--- a/mayastor/tests/error_count.rs
+++ b/mayastor/tests/error_count.rs
@@ -1,0 +1,193 @@
+extern crate log;
+
+use std::ffi::CString;
+pub mod common;
+use mayastor::{
+    bdev::{nexus_create, nexus_lookup, NexusErrStore},
+    core::{
+        mayastor_env_stop,
+        Bdev,
+        MayastorCliArgs,
+        MayastorEnvironment,
+        Reactor,
+    },
+};
+
+use spdk_sys::{
+    create_aio_bdev,
+    spdk_vbdev_error_create,
+    spdk_vbdev_error_inject_error,
+    SPDK_BDEV_IO_TYPE_READ,
+    SPDK_BDEV_IO_TYPE_WRITE,
+};
+
+static ERROR_COUNT_TEST_NEXUS: &str = "error_count_test_nexus";
+
+static DISKNAME1: &str = "/tmp/disk1.img";
+static BDEVNAME1: &str = "aio:///tmp/disk1.img?blk_size=512";
+
+static DISKNAME2: &str = "/tmp/disk2.img";
+
+static ERROR_DEVICE: &str = "error_device";
+static EE_ERROR_DEVICE: &str = "EE_error_device"; // The prefix is added by the vbdev_error module
+static BDEV_EE_ERROR_DEVICE: &str = "bdev:///EE_error_device";
+
+// constant used by the vbdev_error module but not exported
+const VBDEV_IO_FAILURE: u32 = 1;
+
+#[test]
+fn error_test() {
+    common::truncate_file(DISKNAME1, 64 * 1024);
+    common::truncate_file(DISKNAME2, 64 * 1024);
+
+    test_init!();
+
+    Reactor::block_on(async {
+        create_error_bdev().await;
+        create_nexus().await;
+
+        err_write_nexus().await;
+        err_read_nexus().await;
+
+        nexus_err_query_and_test(
+            BDEV_EE_ERROR_DEVICE,
+            NexusErrStore::READ_FLAG,
+            0,
+        );
+        nexus_err_query_and_test(
+            BDEV_EE_ERROR_DEVICE,
+            NexusErrStore::WRITE_FLAG,
+            0,
+        );
+        nexus_err_query_and_test(
+            BDEVNAME1,
+            NexusErrStore::READ_FLAG | NexusErrStore::WRITE_FLAG,
+            0,
+        );
+
+        inject_error(SPDK_BDEV_IO_TYPE_WRITE, VBDEV_IO_FAILURE, 1).await;
+        err_write_nexus().await;
+        err_read_nexus().await;
+
+        nexus_err_query_and_test(
+            BDEV_EE_ERROR_DEVICE,
+            NexusErrStore::READ_FLAG,
+            0,
+        );
+        nexus_err_query_and_test(
+            BDEV_EE_ERROR_DEVICE,
+            NexusErrStore::WRITE_FLAG,
+            1,
+        );
+        nexus_err_query_and_test(
+            BDEVNAME1,
+            NexusErrStore::READ_FLAG | NexusErrStore::WRITE_FLAG,
+            0,
+        );
+
+        inject_error(SPDK_BDEV_IO_TYPE_READ, VBDEV_IO_FAILURE, 1).await;
+        err_read_nexus().await; // multiple reads because there are two replicas and we may get the
+        err_read_nexus().await; // wrong one
+        err_write_nexus().await;
+
+        nexus_err_query_and_test(
+            BDEV_EE_ERROR_DEVICE,
+            NexusErrStore::READ_FLAG,
+            1,
+        );
+        nexus_err_query_and_test(
+            BDEV_EE_ERROR_DEVICE,
+            NexusErrStore::WRITE_FLAG,
+            1,
+        );
+        nexus_err_query_and_test(
+            BDEVNAME1,
+            NexusErrStore::READ_FLAG | NexusErrStore::WRITE_FLAG,
+            0,
+        );
+    });
+    mayastor_env_stop(0);
+}
+
+async fn inject_error(op: u32, mode: u32, count: u32) {
+    let retval: i32;
+    let err_bdev_name_str =
+        CString::new(EE_ERROR_DEVICE).expect("Failed to create name string");
+    let raw = err_bdev_name_str.into_raw();
+
+    unsafe {
+        retval = spdk_vbdev_error_inject_error(raw, op, mode, count);
+    }
+    assert_eq!(retval, 0);
+}
+
+async fn create_error_bdev() {
+    let mut retval: i32;
+    let cname = CString::new(ERROR_DEVICE).unwrap();
+    let filename = CString::new(DISKNAME2).unwrap();
+
+    unsafe {
+        // this allows us to create a bdev without its name being a uri
+        retval = create_aio_bdev(cname.as_ptr(), filename.as_ptr(), 512)
+    };
+    assert_eq!(retval, 0);
+
+    let err_bdev_name_str = CString::new(ERROR_DEVICE.to_string())
+        .expect("Failed to create name string");
+    unsafe {
+        retval = spdk_vbdev_error_create(err_bdev_name_str.as_ptr()); // create the error bdev around it
+    }
+    assert_eq!(retval, 0);
+}
+
+async fn create_nexus() {
+    let ch = vec![BDEVNAME1.to_string(), BDEV_EE_ERROR_DEVICE.to_string()];
+
+    nexus_create(ERROR_COUNT_TEST_NEXUS, 64 * 1024 * 1024, None, &ch)
+        .await
+        .unwrap();
+}
+
+fn nexus_err_query_and_test(
+    child_bdev: &str,
+    io_type_flags: u32,
+    expected_count: u32,
+) {
+    let nexus = nexus_lookup(ERROR_COUNT_TEST_NEXUS).unwrap();
+    let count = nexus
+        .error_record_query(
+            child_bdev,
+            io_type_flags,
+            NexusErrStore::IO_FAILED_FLAG,
+            1_000_000_000,
+        )
+        .expect("failed to query child");
+    assert!(count.is_some()); // true if the error_store exists in the child
+    assert_eq!(count.unwrap(), expected_count);
+}
+
+async fn err_write_nexus() {
+    let bdev = Bdev::lookup_by_name(ERROR_COUNT_TEST_NEXUS)
+        .expect("failed to lookup nexus");
+    let d = bdev
+        .open(true)
+        .expect("failed open bdev")
+        .into_handle()
+        .unwrap();
+    let buf = d.dma_malloc(512).expect("failed to allocate buffer");
+
+    let _ = d.write_at(0, &buf).await;
+}
+
+async fn err_read_nexus() {
+    let bdev = Bdev::lookup_by_name(ERROR_COUNT_TEST_NEXUS)
+        .expect("failed to lookup nexus");
+    let d = bdev
+        .open(true)
+        .expect("failed open bdev")
+        .into_handle()
+        .unwrap();
+    let mut buf = d.dma_malloc(512).expect("failed to allocate buffer");
+
+    let _ = d.read_at(0, &mut buf).await;
+}

--- a/mayastor/tests/error_store.rs
+++ b/mayastor/tests/error_store.rs
@@ -1,0 +1,107 @@
+pub mod common;
+
+use mayastor::bdev::NexusErrStore;
+
+const ALL_FLAGS: u32 = 0xffff_ffff;
+
+#[test]
+fn nexus_error_loading() {
+    let mut es = NexusErrStore::new(15);
+
+    let mut errors = es.query(ALL_FLAGS, ALL_FLAGS, 0);
+    assert_eq!(errors, 0);
+
+    add_records(&mut es, 1, NexusErrStore::IO_TYPE_READ, 5);
+    add_records(&mut es, 1, NexusErrStore::IO_TYPE_READ, 10);
+
+    errors = es.query(ALL_FLAGS, ALL_FLAGS, 0);
+    assert_eq!(errors, 2);
+
+    add_records(&mut es, 2, NexusErrStore::IO_TYPE_WRITE, 11);
+
+    errors = es.query(ALL_FLAGS, ALL_FLAGS, 0);
+    assert_eq!(errors, 4);
+
+    add_records(&mut es, 3, NexusErrStore::IO_TYPE_UNMAP, 12);
+    errors = es.query(ALL_FLAGS, ALL_FLAGS, 0);
+    assert_eq!(errors, 7);
+
+    add_records(&mut es, 4, NexusErrStore::IO_TYPE_FLUSH, 13);
+    errors = es.query(ALL_FLAGS, ALL_FLAGS, 0);
+    assert_eq!(errors, 11);
+
+    // last RECORD over-writes the first, hence 15 not 16
+    add_records(&mut es, 5, NexusErrStore::IO_TYPE_RESET, 14);
+    errors = es.query(ALL_FLAGS, ALL_FLAGS, 0);
+    assert_eq!(errors, 15);
+
+    /////////////////// filter by time ////////////////////////////
+
+    errors = es.query(ALL_FLAGS, ALL_FLAGS, 0);
+    assert_eq!(errors, 15);
+
+    errors = es.query(ALL_FLAGS, ALL_FLAGS, 10);
+    assert_eq!(errors, 15);
+
+    errors = es.query(ALL_FLAGS, ALL_FLAGS, 11);
+    assert_eq!(errors, 14);
+
+    errors = es.query(ALL_FLAGS, ALL_FLAGS, 12);
+    assert_eq!(errors, 12);
+
+    errors = es.query(ALL_FLAGS, ALL_FLAGS, 13);
+    assert_eq!(errors, 9);
+
+    errors = es.query(ALL_FLAGS, ALL_FLAGS, 14);
+    assert_eq!(errors, 5);
+
+    errors = es.query(ALL_FLAGS, ALL_FLAGS, 15);
+    assert_eq!(errors, 0);
+
+    /////////////////////// filter by op ////////////////////////
+
+    errors = es.query(NexusErrStore::READ_FLAG, ALL_FLAGS, 10);
+    assert_eq!(errors, 1);
+
+    errors = es.query(NexusErrStore::WRITE_FLAG, ALL_FLAGS, 10);
+    assert_eq!(errors, 2);
+
+    errors = es.query(NexusErrStore::UNMAP_FLAG, ALL_FLAGS, 10);
+    assert_eq!(errors, 3);
+
+    errors = es.query(NexusErrStore::FLUSH_FLAG, ALL_FLAGS, 10);
+    assert_eq!(errors, 4);
+
+    errors = es.query(NexusErrStore::RESET_FLAG, ALL_FLAGS, 10);
+    assert_eq!(errors, 5);
+
+    errors = es.query(0, ALL_FLAGS, 10);
+    assert_eq!(errors, 0);
+
+    ////////////////////// filter by failure //////////////////////////
+
+    errors = es.query(ALL_FLAGS, NexusErrStore::IO_FAILED_FLAG, 10);
+    assert_eq!(errors, 15);
+
+    errors = es.query(ALL_FLAGS, 0, 10);
+    assert_eq!(errors, 0);
+}
+
+fn add_records(
+    es: &mut NexusErrStore,
+    how_many: usize,
+    op_flag: u32,
+    when: u64,
+) {
+    let offset: u64 = 0;
+    let num_of_blocks: u64 = 1;
+    for _ in 0 .. how_many {
+        es.add_record(
+            op_flag,
+            NexusErrStore::IO_FAILED,
+            offset,
+            num_of_blocks,
+            when,
+        );
+    }
+}

--- a/mayastor/tests/nexus_metadata.rs
+++ b/mayastor/tests/nexus_metadata.rs
@@ -65,7 +65,7 @@ async fn read_write_metadata() {
             .map(String::from)
             .collect(),
         revision: 38,
-        checksum: 0x3c2d38ab,
+        checksum: 0x3c2d_38ab,
         data: String::from("Hello from v1"),
     }));
 
@@ -76,7 +76,7 @@ async fn read_write_metadata() {
             .map(String::from)
             .collect(),
         revision: 40,
-        checksum: 0x3c2e40ab,
+        checksum: 0x3c2e_40ab,
         data: String::from("Hello from v2"),
         count: 100,
     }));
@@ -84,7 +84,7 @@ async fn read_write_metadata() {
     data.push(NexusConfig::Version3(NexusConfigVersion3 {
         name: "Hello".to_string(),
         revision: 42,
-        checksum: 0x3c2f42ab,
+        checksum: 0x3c2f_42ab,
         data: String::from("Hello from v3")
             .split_whitespace()
             .map(String::from)

--- a/spdk-sys/wrapper.h
+++ b/spdk-sys/wrapper.h
@@ -1,5 +1,6 @@
 #include <bdev/aio/bdev_aio.h>
 #include <bdev/crypto/vbdev_crypto.h>
+#include <bdev/error/vbdev_error.h>
 #include <bdev/iscsi/bdev_iscsi.h>
 #include <bdev/lvol/vbdev_lvol.h>
 #include <bdev/malloc/bdev_malloc.h>


### PR DESCRIPTION
CAS-241. Functionality to store and query a record of the most recent in each nexus child and a means of enabling the feature and setting the buffer size.
The query function returns the number of error IOs more recent than a specified interval and filtered by flags specifying the IO operation and a flag specifying the type of error (currently only one type "FAILED").
Test added which adds an error bdev layer between the nexus and one of its
replicas and allows unit testing of the feature. This currently tests only failures of reads and writes.
Also included unit testing of the error store independently of the bdev.