### PR TITLE
rebuild: more testing bug fixes (CAS-246)

### DIFF
--- a/mayastor/src/bdev/mod.rs
+++ b/mayastor/src/bdev/mod.rs
@@ -3,7 +3,13 @@ use std::ffi::CStr;
 pub use aio_dev::{AioBdev, AioParseError};
 pub use iscsi_dev::{IscsiBdev, IscsiParseError};
 pub use nexus::{
-    nexus_bdev::{nexus_create, nexus_lookup, Nexus, NexusStatus},
+    nexus_bdev::{
+        nexus_create,
+        nexus_lookup,
+        Nexus,
+        NexusStatus,
+        VerboseError,
+    },
     nexus_label::{GPTHeader, GptEntry},
     nexus_metadata_content::{
         NexusConfig,

--- a/mayastor/src/bdev/nexus/nexus_bdev.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev.rs
@@ -53,6 +53,26 @@ use crate::{
     rebuild::RebuildError,
 };
 
+/// Obtain the full error chain
+pub trait VerboseError {
+    fn verbose(&self) -> String;
+}
+
+impl VerboseError for Error {
+    /// loops through the error chain and formats into a single string
+    /// containing all the lower level errors
+    fn verbose(&self) -> String {
+        let err = self as &dyn std::error::Error;
+        let mut msg = format!("{}", err);
+        let mut opt_source = err.source();
+        while let Some(source) = opt_source {
+            msg = format!("{}: {}", msg, source);
+            opt_source = source.source();
+        }
+        msg
+    }
+}
+
 /// Common errors for nexus basic operations and child operations
 /// which are part of nexus object.
 #[derive(Debug, Snafu)]
@@ -136,7 +156,7 @@ pub enum Error {
     #[snafu(display(
         "Failed to create rebuild job for child {} of nexus {}",
         child,
-        name
+        name,
     ))]
     CreateRebuildError {
         source: RebuildError,

--- a/mayastor/src/bdev/nexus/nexus_bdev_children.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev_children.rs
@@ -133,6 +133,7 @@ impl Nexus {
                             err
                         );
                     }
+
                     return Err(Error::ChildGeometry {
                         child: name,
                         name: self.name.clone(),
@@ -243,7 +244,7 @@ impl Nexus {
     }
 
     /// online a child and reconfigure the IO channels. The child is already
-    /// registered, but simpy not opened. This can be required in case where
+    /// registered, but simply not opened. This can be required in case where
     /// a child is misbehaving.
     pub async fn online_child(
         &mut self,

--- a/mayastor/src/bdev/nexus/nexus_bdev_rebuild.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev_rebuild.rs
@@ -58,8 +58,10 @@ impl Nexus {
             &self.name,
             &src_child_name,
             &dst_child.name,
-            self.data_ent_offset,
-            self.bdev.num_blocks() + self.data_ent_offset,
+            std::ops::Range::<u64> {
+                start: self.data_ent_offset,
+                end: self.bdev.num_blocks() + self.data_ent_offset,
+            },
             |nexus, job| {
                 Reactors::current().send_future(async move {
                     Nexus::notify_rebuild(nexus, job).await;

--- a/mayastor/src/replicas/mod.rs
+++ b/mayastor/src/replicas/mod.rs
@@ -7,4 +7,6 @@ pub mod rebuild {
     pub mod rebuild_impl;
 
     pub use rebuild_api::*;
+    // for the tests only
+    pub use rebuild_impl::SEGMENT_SIZE;
 }

--- a/mayastor/tests/common/mod.rs
+++ b/mayastor/tests/common/mod.rs
@@ -277,7 +277,7 @@ pub fn thread() -> Option<Mthread> {
 }
 
 pub fn dd_urandom_blkdev(device: &str) -> String {
-    let (exit, stdout, _stderr) = run_script::run(
+    let (exit, stdout, stderr) = run_script::run(
         r#"
         dd if=/dev/urandom of=$1 conv=fsync,nocreat,notrunc iflag=count_bytes count=`blockdev --getsize64 $1`
     "#,
@@ -285,7 +285,7 @@ pub fn dd_urandom_blkdev(device: &str) -> String {
     &run_script::ScriptOptions::new(),
     )
     .unwrap();
-    assert_eq!(exit, 0);
+    assert_eq!(exit, 0, "stdout: {}\nstderr: {}", stdout, stderr);
     stdout
 }
 

--- a/mayastor/tests/common/mod.rs
+++ b/mayastor/tests/common/mod.rs
@@ -1,5 +1,4 @@
 use crossbeam::channel::{after, select, unbounded};
-use log::info;
 use std::{env, io, io::Write, process::Command, time::Duration};
 
 use once_cell::sync::OnceCell;
@@ -315,16 +314,18 @@ pub fn compare_nexus_device(
 pub fn compare_devices(
     first_device: &str,
     second_device: &str,
+    size: u64,
     expected_pass: bool,
 ) -> String {
     let (exit, stdout, stderr) = run_script::run(
         r#"
-        cmp -b $1 $2 5M 5M
-        test $? -eq $3
+        cmp -b $1 $2 5M 5M -n $3
+        test $? -eq $4
     "#,
         &vec![
             first_device.into(),
             second_device.into(),
+            size.to_string(),
             (!expected_pass as i32).to_string(),
         ],
         &run_script::ScriptOptions::new(),
@@ -358,28 +359,42 @@ pub fn get_device_size(nexus_device: &str) -> u64 {
 }
 
 /// Waits for the rebuild to reach `state`, up to `timeout`
-pub fn wait_for_rebuild(name: String, state: RebuildState, timeout: Duration) {
+pub fn wait_for_rebuild(
+    name: String,
+    state: RebuildState,
+    timeout: Duration,
+) -> Result<(), ()> {
     let (s, r) = unbounded::<()>();
     let job = match RebuildJob::lookup(&name) {
         Ok(job) => job,
-        Err(_) => return,
+        Err(_) => return Ok(()),
     };
 
+    let mut curr_state = job.state();
     let ch = job.notify_chan.1.clone();
-    std::thread::spawn(move || {
+    let t = std::thread::spawn(move || {
         let now = std::time::Instant::now();
-        while {
-            let current_state = select! {
+        let mut error = Ok(());
+        while curr_state != state && error.is_ok() {
+            select! {
                 recv(ch) -> state => {
-                    info!("rebuild of child {} signalled with state {:?}", name, state);
-                    state.unwrap()
+                    log::trace!("rebuild of child {} signalled with state {:?}", name, state);
+                    curr_state = state.unwrap_or_else(|e| {
+                        log::error!("failed to wait for the rebuild with error: {}", e);
+                        error = Err(());
+                        curr_state
+                    })
                 },
-                recv(after(timeout - now.elapsed())) -> _ => panic!("timed out waiting for the rebuild to complete after {:?}", timeout),
-            };
+                recv(after(timeout - now.elapsed())) -> _ => {
+                    log::error!("timed out waiting for the rebuild after {:?}", timeout);
+                    error = Err(())
+                }
+            }
+        }
 
-            current_state != state
-        } {}
-        s.send(())
+        s.send(()).ok();
+        error
     });
     reactor_poll!(r);
+    t.join().unwrap()
 }

--- a/mayastor/tests/nexus_rebuild.rs
+++ b/mayastor/tests/nexus_rebuild.rs
@@ -211,6 +211,9 @@ async fn nexus_create_with_size(size: u64, children: u64) {
             .unwrap(),
     );
 
+    // wait for the device to be ready
+    reactor_poll!(100);
+
     let nexus_device = device.clone();
     let (s, r) = unbounded::<String>();
     std::thread::spawn(move || {

--- a/mayastor/tests/nexus_rebuild.rs
+++ b/mayastor/tests/nexus_rebuild.rs
@@ -3,22 +3,36 @@ use crossbeam::channel::unbounded;
 pub mod common;
 
 use mayastor::{
-    bdev::nexus_lookup,
+    bdev::{nexus_lookup, VerboseError},
     core::{MayastorCliArgs, MayastorEnvironment, Reactor},
-    replicas::rebuild::RebuildState,
+    replicas::rebuild::{RebuildJob, RebuildState, SEGMENT_SIZE},
 };
 
+use once_cell::sync::Lazy;
 use rpc::mayastor::ShareProtocolNexus;
+use std::sync::Mutex;
 
-const NEXUS_NAME: &str = "rebuild_test_nexus";
-const NEXUS_SIZE: u64 = 10 * 1024 * 1024; // 10MiB
+// each test `should` use a different nexus name to prevent clashing with
+// one another. This allows the failed tests to `panic gracefully` improving
+// the output log and allowing the CI to fail gracefully as well
+static NEXUS_NAME: Lazy<Mutex<&str>> = Lazy::new(|| Mutex::new("Default"));
+pub fn nexus_name() -> &'static str {
+    &NEXUS_NAME.lock().unwrap()
+}
+
+static NEXUS_SIZE: u64 = 5 * 1024 * 1024; // 10MiB
+
+// approximate on-disk metadata that will be written to the child by the nexus
+const META_SIZE: u64 = 5 * 1024 * 1024; // 5MiB
 const MAX_CHILDREN: u64 = 16;
 
-fn test_ini() {
+fn test_ini(name: &'static str) {
+    *NEXUS_NAME.lock().unwrap() = name;
+
     test_init!();
     for i in 0 .. MAX_CHILDREN {
         common::delete_file(&[get_disk(i)]);
-        common::truncate_file_bytes(&get_disk(i), NEXUS_SIZE);
+        common::truncate_file_bytes(&get_disk(i), NEXUS_SIZE + META_SIZE);
     }
 }
 fn test_fini() {
@@ -32,17 +46,17 @@ fn get_disk(number: u64) -> String {
     format!("/tmp/disk{}.img", number)
 }
 fn get_dev(number: u64) -> String {
-    format!("aio://{}?blk_size=512", get_disk(number))
+    format!("aio://{}-{}?blk_size=512", nexus_name(), get_disk(number))
 }
 
 #[test]
-fn rebuild_test() {
-    test_ini();
+fn rebuild_test_basic() {
+    test_ini("rebuild_test_basic");
 
     Reactor::block_on(async {
         nexus_create(1).await;
         nexus_add_child(1, true).await;
-        nexus_lookup(NEXUS_NAME).unwrap().destroy().await.unwrap();
+        nexus_lookup(nexus_name()).unwrap().destroy().await.unwrap();
     });
 
     test_fini();
@@ -51,11 +65,11 @@ fn rebuild_test() {
 #[test]
 // test the rebuild flag of the add_child operation
 fn rebuild_test_add() {
-    test_ini();
+    test_ini("rebuild_test_add");
 
     Reactor::block_on(async {
         nexus_create(1).await;
-        let nexus = nexus_lookup(NEXUS_NAME).unwrap();
+        let nexus = nexus_lookup(nexus_name()).unwrap();
 
         nexus.add_child(&get_dev(1), true).await.unwrap();
         nexus
@@ -68,7 +82,7 @@ fn rebuild_test_add() {
             .start_rebuild(&get_dev(2))
             .expect("rebuild not expected to be present");
 
-        nexus_lookup(NEXUS_NAME).unwrap().destroy().await.unwrap();
+        nexus_lookup(nexus_name()).unwrap().destroy().await.unwrap();
     });
 
     test_fini();
@@ -76,10 +90,10 @@ fn rebuild_test_add() {
 
 #[test]
 fn rebuild_progress() {
-    test_ini();
+    test_ini("rebuild_progress");
 
     async fn test_progress(polls: u64, progress: u64) -> u64 {
-        let nexus = nexus_lookup(NEXUS_NAME).unwrap();
+        let nexus = nexus_lookup(nexus_name()).unwrap();
         nexus.resume_rebuild(&get_dev(1)).await.unwrap();
         // { polls } to poll with an expr rather than an ident
         reactor_poll!({ polls });
@@ -88,7 +102,8 @@ fn rebuild_progress() {
             get_dev(1),
             RebuildState::Paused,
             std::time::Duration::from_millis(100),
-        );
+        )
+        .unwrap();
         let p = nexus.get_rebuild_progress(&get_dev(1)).unwrap();
         assert!(p.progress >= progress);
         p.progress
@@ -102,7 +117,7 @@ fn rebuild_progress() {
         for _ in 0 .. 10 {
             progress = test_progress(50, progress).await;
         }
-        nexus_lookup(NEXUS_NAME).unwrap().destroy().await.unwrap();
+        nexus_lookup(nexus_name()).unwrap().destroy().await.unwrap();
     });
 
     test_fini();
@@ -110,12 +125,12 @@ fn rebuild_progress() {
 
 #[test]
 fn rebuild_child_faulted() {
-    test_ini();
+    test_ini("rebuild_child_faulted");
 
     Reactor::block_on(async move {
         nexus_create(2).await;
 
-        let nexus = nexus_lookup(NEXUS_NAME).unwrap();
+        let nexus = nexus_lookup(nexus_name()).unwrap();
         nexus
             .start_rebuild(&get_dev(1))
             .expect_err("Rebuild only degraded children!");
@@ -134,14 +149,14 @@ fn rebuild_child_faulted() {
 
 #[test]
 fn rebuild_dst_removal() {
-    test_ini();
+    test_ini("rebuild_dst_removal");
 
     Reactor::block_on(async move {
         let new_child = 2;
         nexus_create(new_child).await;
         nexus_add_child(new_child, false).await;
 
-        let nexus = nexus_lookup(NEXUS_NAME).unwrap();
+        let nexus = nexus_lookup(nexus_name()).unwrap();
         nexus.pause_rebuild(&get_dev(new_child)).await.unwrap();
         nexus.remove_child(&get_dev(new_child)).await.unwrap();
 
@@ -153,7 +168,7 @@ fn rebuild_dst_removal() {
 
 #[test]
 fn rebuild_src_removal() {
-    test_ini();
+    test_ini("rebuild_src_removal");
 
     Reactor::block_on(async move {
         let new_child = 2;
@@ -161,7 +176,7 @@ fn rebuild_src_removal() {
         nexus_create(new_child).await;
         nexus_add_child(new_child, false).await;
 
-        let nexus = nexus_lookup(NEXUS_NAME).unwrap();
+        let nexus = nexus_lookup(nexus_name()).unwrap();
         nexus.pause_rebuild(&get_dev(new_child)).await.unwrap();
         nexus.remove_child(&get_dev(0)).await.unwrap();
 
@@ -176,16 +191,19 @@ fn rebuild_src_removal() {
 }
 
 async fn nexus_create(children: u64) {
+    nexus_create_with_size(NEXUS_SIZE, children).await
+}
+async fn nexus_create_with_size(size: u64, children: u64) {
     let mut ch = Vec::new();
     for i in 0 .. children {
         ch.push(get_dev(i));
     }
 
-    mayastor::bdev::nexus_create(NEXUS_NAME, NEXUS_SIZE, None, &ch)
+    mayastor::bdev::nexus_create(nexus_name(), size, None, &ch)
         .await
         .unwrap();
 
-    let nexus = nexus_lookup(NEXUS_NAME).unwrap();
+    let nexus = nexus_lookup(nexus_name()).unwrap();
     let device = common::device_path_from_uri(
         nexus
             .share(ShareProtocolNexus::NexusNbd, None)
@@ -208,7 +226,7 @@ async fn nexus_create(children: u64) {
 }
 
 async fn nexus_add_child(new_child: u64, wait: bool) {
-    let nexus = nexus_lookup(NEXUS_NAME).unwrap();
+    let nexus = nexus_lookup(nexus_name()).unwrap();
 
     nexus.add_child(&get_dev(new_child), true).await.unwrap();
 
@@ -217,7 +235,8 @@ async fn nexus_add_child(new_child: u64, wait: bool) {
             get_dev(new_child),
             RebuildState::Completed,
             std::time::Duration::from_secs(10),
-        );
+        )
+        .unwrap();
 
         nexus_test_child(new_child).await;
     } else {
@@ -231,15 +250,273 @@ async fn nexus_test_child(child: u64) {
         get_dev(child),
         RebuildState::Completed,
         std::time::Duration::from_secs(10),
-    );
+    )
+    .unwrap();
+
+    let nexus = nexus_lookup(nexus_name()).unwrap();
 
     let (s, r) = unbounded::<String>();
     std::thread::spawn(move || {
         s.send(common::compare_devices(
             &get_disk(0),
             &get_disk(child),
+            nexus.size(),
             true,
         ))
     });
     reactor_poll!(r);
+}
+
+#[test]
+// test rebuild with different combinations of sizes for src and dst children
+fn rebuild_sizes() {
+    test_ini("rebuild_sizes");
+
+    let nexus_size = 10 * 1024 * 1024; // 10MiB
+    let child_size = nexus_size + META_SIZE;
+    let mut test_cases = vec![
+        // size of (first child, second, third)
+        // first child size is same as the nexus size to set it as the minimum
+        // otherwise a child bigger than the nexus but smaller than the
+        // smallest child would not be allowed
+        (nexus_size, child_size, child_size),
+        (nexus_size, child_size * 2, child_size),
+        (nexus_size, child_size, child_size * 2),
+        (nexus_size, child_size * 2, child_size * 2),
+    ];
+    // now for completeness sake we also test the cases where the actual
+    // nexus_size will be lower due to the on-disk metadata
+    let child_size = nexus_size;
+    test_cases.extend(vec![
+        (nexus_size, child_size, child_size),
+        (nexus_size, child_size * 2, child_size),
+        (nexus_size, child_size, child_size * 2),
+        (nexus_size, child_size * 2, child_size * 2),
+    ]);
+
+    for (test_case_index, test_case) in test_cases.iter().enumerate() {
+        common::delete_file(&[get_disk(0), get_disk(1), get_disk(1)]);
+        // first healthy child in the list is used as the rebuild source
+        common::truncate_file_bytes(&get_disk(0), test_case.1);
+        common::truncate_file_bytes(&get_disk(1), test_case.0);
+        common::truncate_file_bytes(&get_disk(2), test_case.2);
+
+        let nexus_size = test_case.0;
+        Reactor::block_on(async move {
+            // add an extra child so that the minimum size is set to
+            // match the nexus size
+            nexus_create_with_size(nexus_size, 2).await;
+            let nexus = nexus_lookup(nexus_name()).unwrap();
+            nexus.add_child(&get_dev(2), false).await.unwrap();
+            // within start_rebuild the size should be validated
+            let _ = nexus.start_rebuild(&get_dev(2)).unwrap_or_else(|e| {
+                log::error!( "Case {} - Child should have started to rebuild but got error:\n {:}",
+                    test_case_index, e.verbose());
+                panic!(
+                    "Case {} - Child should have started to rebuild but got error:\n {}",
+                    test_case_index, e.verbose()
+                )
+            });
+            // sanity check that the rebuild does succeed
+            nexus_test_child(2).await;
+
+            nexus.destroy().await.unwrap();
+        });
+    }
+
+    test_fini();
+}
+
+#[test]
+// tests the rebuild with multiple size and a non-multiple size of the segment
+fn rebuild_segment_sizes() {
+    test_ini("rebuild_segment_sizes");
+
+    assert!(SEGMENT_SIZE > 512 && SEGMENT_SIZE < NEXUS_SIZE);
+
+    let test_cases = vec![
+        // multiple of SEGMENT_SIZE
+        SEGMENT_SIZE * 10,
+        // not multiple of SEGMENT_SIZE
+        (SEGMENT_SIZE * 10) + 512,
+    ];
+
+    for test_case in test_cases.iter() {
+        let nexus_size = *test_case;
+        Reactor::block_on(async move {
+            nexus_create_with_size(nexus_size, 1).await;
+            nexus_add_child(1, true).await;
+            nexus_lookup(nexus_name()).unwrap().destroy().await.unwrap();
+        });
+    }
+
+    test_fini();
+}
+
+#[test]
+fn rebuild_lookup() {
+    test_ini("rebuild_lookup");
+
+    Reactor::block_on(async move {
+        let children = 6;
+        nexus_create(children).await;
+        let nexus = nexus_lookup(nexus_name()).unwrap();
+        nexus.add_child(&get_dev(children), false).await.unwrap();
+
+        for child in 0 .. children {
+            RebuildJob::lookup(&get_dev(child)).expect_err("Should not exist");
+
+            RebuildJob::lookup_src(&get_dev(child))
+                .iter()
+                .inspect(|&job| {
+                    log::error!(
+                        "Job {:?} should be associated with src child {}",
+                        job,
+                        child
+                    );
+                })
+                .any(|_| panic!("Should not have found any jobs!"));
+        }
+
+        let _ = nexus.start_rebuild(&get_dev(children)).unwrap();
+        for child in 0 .. children - 1 {
+            RebuildJob::lookup(&get_dev(child))
+                .expect_err("rebuild job not created yet");
+        }
+        let src = RebuildJob::lookup(&get_dev(children))
+            .expect("now the job should exist")
+            .source
+            .clone();
+
+        for child in 0 .. children {
+            if get_dev(child) != src {
+                RebuildJob::lookup_src(&get_dev(child))
+                    .iter()
+                    .filter(|s| s.destination != get_dev(child))
+                    .inspect(|&job| {
+                        log::error!(
+                            "Job {:?} should be associated with src child {}",
+                            job,
+                            child
+                        );
+                    })
+                    .any(|_| panic!("Should not have found any jobs!"));
+            }
+        }
+
+        assert_eq!(
+            RebuildJob::lookup_src(&src)
+                .iter()
+                .inspect(|&job| {
+                    assert_eq!(job.destination, get_dev(children));
+                })
+                .count(),
+            1
+        );
+        nexus
+            .add_child(&get_dev(children + 1), false)
+            .await
+            .unwrap();
+        let _ = nexus.start_rebuild(&get_dev(children + 1)).unwrap();
+        assert_eq!(RebuildJob::lookup_src(&src).len(), 2);
+
+        nexus.remove_child(&get_dev(children)).await.unwrap();
+        nexus.remove_child(&get_dev(children + 1)).await.unwrap();
+        nexus_lookup(nexus_name()).unwrap().destroy().await.unwrap();
+    });
+
+    test_fini();
+}
+
+#[test]
+// todo: decide whether to keep the idempotence on the operations or to
+// create a RPC version which achieves the idempotence
+fn rebuild_operations() {
+    test_ini("rebuild_operations");
+
+    Reactor::block_on(async {
+        nexus_create(1).await;
+        let nexus = nexus_lookup(nexus_name()).unwrap();
+
+        nexus
+            .resume_rebuild(&get_dev(1))
+            .await
+            .expect_err("no rebuild to resume");
+
+        nexus_add_child(1, false).await;
+
+        nexus
+            .resume_rebuild(&get_dev(1))
+            .await
+            .expect("already running");
+
+        nexus.pause_rebuild(&get_dev(1)).await.unwrap();
+        reactor_poll!(10);
+        // already pausing so no problem
+        nexus.pause_rebuild(&get_dev(1)).await.unwrap();
+
+        let _ = nexus
+            .start_rebuild(&get_dev(1))
+            .expect_err("a rebuild already exists");
+
+        nexus.stop_rebuild(&get_dev(1)).await.unwrap();
+        common::wait_for_rebuild(
+            get_dev(1),
+            RebuildState::Stopped,
+            // already stopping, should be enough
+            std::time::Duration::from_millis(250),
+        )
+        .unwrap();
+        // already stopped
+        nexus.stop_rebuild(&get_dev(1)).await.unwrap();
+
+        nexus_lookup(nexus_name()).unwrap().destroy().await.unwrap();
+    });
+
+    test_fini();
+}
+
+#[test]
+fn rebuild_concurrently() {
+    test_ini("rebuild_concurrently");
+
+    let concurrent_rebuilds = 4;
+    Reactor::block_on(async move {
+        nexus_create(1).await;
+        let nexus = nexus_lookup(nexus_name()).unwrap();
+
+        for child in 1 ..= concurrent_rebuilds {
+            nexus_add_child(child, false).await;
+        }
+
+        assert_eq!(RebuildJob::count(), concurrent_rebuilds as usize);
+
+        for child in 1 ..= concurrent_rebuilds {
+            common::wait_for_rebuild(
+                get_dev(child),
+                RebuildState::Completed,
+                std::time::Duration::from_secs(10),
+            )
+            .unwrap();
+            nexus.remove_child(&get_dev(child)).await.unwrap();
+        }
+
+        for child in 1 ..= concurrent_rebuilds {
+            nexus_add_child(child, false).await;
+        }
+
+        for child in 1 ..= concurrent_rebuilds {
+            common::wait_for_rebuild(
+                get_dev(child),
+                RebuildState::Running,
+                std::time::Duration::from_millis(100),
+            )
+            .unwrap();
+            nexus.remove_child(&get_dev(child)).await.unwrap();
+        }
+
+        nexus.destroy().await.unwrap();
+    });
+
+    test_fini();
 }

--- a/mayastor/tests/reconfigure.rs
+++ b/mayastor/tests/reconfigure.rs
@@ -177,7 +177,8 @@ async fn works() {
         child2.to_string(),
         RebuildState::Completed,
         std::time::Duration::from_secs(20),
-    );
+    )
+    .unwrap();
 
     assert_eq!(nexus.status(), NexusStatus::Online);
 


### PR DESCRIPTION
added a few more testcases and that led to fixing a few bugs

rebuild with childs of different sizes (prior that would fail) including
using children with sizes < metadata
using non multiple of the segment size for completeness
the lookup of rebuild jobs and concurrent rebuild jobs which revealed a
bug
rebuild operations idempotence (currently on the client api) though we
may want to restrict it to RPC specifically

bonus: when the rebuild tests fail (local or CI) the cargo test itself
gets stuck which is caused by panics on a different thread (?) so moved
the failures to the reactor thread and also use different nexus and bdev
names on each test - this produces a cleaner failure log

rebuild code coverage reported by grcov is now ~84% (if you trust it)

todo: cas-287 will test the IO failures

Resolves: CAS-246