### PR TITLE
Increase the default disk size in TF scripts to 6G

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -25,7 +25,7 @@ variable "image_path" {
 variable "disk_size" {
   type        = number
   description = "The size of the root disk in bytes"
-  default     = 5361393664
+  default     = 6442450944
 }
 
 variable "hostname_formatter" {


### PR DESCRIPTION
Pods are getting evicted in response to disk pressure event with
libvirt provider in some cases.