### PR TITLE
nexus: Close child when destroying all Nexus children

### DIFF
--- a/mayastor/src/bdev/nexus/nexus_bdev_children.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev_children.rs
@@ -434,7 +434,10 @@ impl Nexus {
     /// destroy all children that are part of this nexus closes any child
     /// that might be open first
     pub(crate) async fn destroy_children(&mut self) {
-        let futures = self.children.iter_mut().map(|c| c.destroy());
+        let futures = self.children.iter_mut().map(|c| {
+            c.close();
+            c.destroy()
+        });
         let results = join_all(futures).await;
         if results.iter().any(|c| c.is_err()) {
             error!("{}: Failed to destroy child", self.name);


### PR DESCRIPTION
Make Nexus::destroy_children close a child first before destroying it,
making its behaviour match the code comment.

Addresses this panic when creating a Nexus with multiple children
where the 2nd or later child is inaccessible:

thread 'main' panicked at 'assertion failed: `(left == right)`
  left: `Init`,
 right: `Closed`', mayastor/src/bdev/nexus/nexus_child.rs:218:9

Fixes: 63bd078 ("nexus: add more test cases for adding children")

Resolves: CAS-297