### PR TITLE
CAS-144 Allow default nexus and replica iSCSI target and nvmf ports to be overridden.

### DIFF
--- a/mayastor/src/core/env.rs
+++ b/mayastor/src/core/env.rs
@@ -50,7 +50,7 @@ use crate::{
     grpc::grpc_server_init,
     logger,
     subsys::Config,
-    target,
+    target::{iscsi, nvmf},
 };
 
 fn parse_mb(src: &str) -> Result<i32, String> {
@@ -275,13 +275,13 @@ async fn do_shutdown(arg: *mut c_void) {
 
     let cfg = Config::by_ref();
     if cfg.nexus_opts.iscsi_enable {
-        target::iscsi::fini();
+        iscsi::fini();
         debug!("iSCSI target down");
     };
 
     if cfg.nexus_opts.nvmf_enable {
         let f = async move {
-            if let Err(msg) = target::nvmf::fini().await {
+            if let Err(msg) = nvmf::fini().await {
                 error!("Failed to finalize nvmf target: {}", msg);
             }
             debug!("nvmf target down");
@@ -561,7 +561,7 @@ impl MayastorEnvironment {
         let cfg = Config::by_ref();
 
         if cfg.nexus_opts.iscsi_enable {
-            if let Err(msg) = target::iscsi::init(&address) {
+            if let Err(msg) = iscsi::init(&address) {
                 error!("Failed to initialize Mayastor iSCSI target: {}", msg);
                 return Err(EnvError::InitTarget {
                     target: "iscsi".into(),
@@ -571,7 +571,7 @@ impl MayastorEnvironment {
 
         if cfg.nexus_opts.nvmf_enable {
             let f = async move {
-                if let Err(msg) = target::nvmf::init(&address).await {
+                if let Err(msg) = nvmf::init(&address).await {
                     error!(
                         "Failed to initialize Mayastor nvmf target: {}",
                         msg

--- a/mayastor/src/subsys/opts.rs
+++ b/mayastor/src/subsys/opts.rs
@@ -24,8 +24,6 @@ use spdk_sys::{
     spdk_nvmf_transport_opts,
 };
 
-use crate::target::{iscsi, nvmf};
-
 #[serde(default, deny_unknown_fields)]
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct NexusOpts {
@@ -44,15 +42,25 @@ pub struct NexusOpts {
     pub iscsi_replica_port: u16,
 }
 
+/// Default nvmf port used for replicas.
+/// It's different from the standard nvmf port 4420 because we don't want
+/// to conflict with nexus exported over nvmf running on the same node.
+const NVMF_PORT_REPLICA: u16 = 8420;
+const NVMF_PORT_NEXUS: u16 = 4421;
+
+/// Default iSCSI target (portal) port numbers
+const ISCSI_PORT_NEXUS: u16 = 3260;
+const ISCSI_PORT_REPLICA: u16 = 3262;
+
 impl Default for NexusOpts {
     fn default() -> Self {
         Self {
             nvmf_enable: true,
-            nvmf_nexus_port: nvmf::NVMF_PORT_NEXUS,
-            nvmf_replica_port: nvmf::NVMF_PORT_REPLICA,
+            nvmf_nexus_port: NVMF_PORT_NEXUS,
+            nvmf_replica_port: NVMF_PORT_REPLICA,
             iscsi_enable: true,
-            iscsi_nexus_port: iscsi::ISCSI_PORT_NEXUS,
-            iscsi_replica_port: iscsi::ISCSI_PORT_REPLICA,
+            iscsi_nexus_port: ISCSI_PORT_NEXUS,
+            iscsi_replica_port: ISCSI_PORT_REPLICA,
         }
     }
 }

--- a/mayastor/src/subsys/opts.rs
+++ b/mayastor/src/subsys/opts.rs
@@ -24,28 +24,35 @@ use spdk_sys::{
     spdk_nvmf_transport_opts,
 };
 
+use crate::target::{iscsi, nvmf};
+
 #[serde(default, deny_unknown_fields)]
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct NexusOpts {
-    /// always nvmf
-    pub replica_port: u16,
+    /// enable nvmf target
+    pub nvmf_enable: bool,
     /// nvmf port over which we export
     pub nvmf_nexus_port: u16,
-    /// enable nvmf target
-    /// NOTE: we do not differentiate between the replica and nexus nvmf target
-    /// yet
-    pub nvmf_enable: bool,
+    /// NOTE: we do not (yet) differentiate between
+    /// the nexus and replica nvmf target
+    pub nvmf_replica_port: u16,
     /// enable iSCSI support
     pub iscsi_enable: bool,
+    /// Port for nexus target portal
+    pub iscsi_nexus_port: u16,
+    /// Port for replica target portal
+    pub iscsi_replica_port: u16,
 }
 
 impl Default for NexusOpts {
     fn default() -> Self {
         Self {
-            replica_port: 8420,
-            nvmf_nexus_port: 4421,
             nvmf_enable: true,
+            nvmf_nexus_port: nvmf::NVMF_PORT_NEXUS,
+            nvmf_replica_port: nvmf::NVMF_PORT_REPLICA,
             iscsi_enable: true,
+            iscsi_nexus_port: iscsi::ISCSI_PORT_NEXUS,
+            iscsi_replica_port: iscsi::ISCSI_PORT_REPLICA,
         }
     }
 }

--- a/mayastor/src/target/iscsi.rs
+++ b/mayastor/src/target/iscsi.rs
@@ -70,10 +70,7 @@ impl RpcErrorCode for Error {
 
 type Result<T, E = Error> = std::result::Result<T, E>;
 
-/// Default iSCSI target port numbers
-pub const ISCSI_PORT_NEXUS: u16 = 3260;
-pub const ISCSI_PORT_REPLICA: u16 = 3262;
-
+/// Portal Group Tags
 const ISCSI_PORTAL_GROUP_NEXUS: c_int = 0;
 const ISCSI_PORTAL_GROUP_REPLICA: c_int = 2;
 

--- a/mayastor/src/target/nvmf.rs
+++ b/mayastor/src/target/nvmf.rs
@@ -123,11 +123,6 @@ impl RpcErrorCode for Error {
 
 type Result<T, E = Error> = std::result::Result<T, E>;
 
-/// Default nvmf port used for replicas. It is different from standard
-/// nvmf port 4420, because we don't want to conflict with nexus exported
-/// over nvmf running on the same node.
-pub const NVMF_PORT_REPLICA: u16 = 8420;
-pub const NVMF_PORT_NEXUS: u16 = 4421;
 static TRANSPORT_NAME: Lazy<CString> =
     Lazy::new(|| CString::new("TCP").unwrap());
 

--- a/mayastor/tests/replica_timeout.rs
+++ b/mayastor/tests/replica_timeout.rs
@@ -50,11 +50,11 @@ fn generate_config() {
     config.base_bdevs = Some(vec![child1_bdev]);
     config.implicit_share_base = true;
     config.nexus_opts.iscsi_enable = false;
-    config.nexus_opts.replica_port = 8430;
+    config.nexus_opts.nvmf_replica_port = 8430;
     config.write(CFGNAME1).unwrap();
 
     config.base_bdevs = Some(vec![child2_bdev]);
-    config.nexus_opts.replica_port = 8431;
+    config.nexus_opts.nvmf_replica_port = 8431;
     config.write(CFGNAME2).unwrap();
 }
 

--- a/mayastor/tests/reset.rs
+++ b/mayastor/tests/reset.rs
@@ -37,11 +37,11 @@ fn generate_config() {
     config.base_bdevs = Some(vec![child1_bdev]);
     config.implicit_share_base = true;
     config.nexus_opts.iscsi_enable = false;
-    config.nexus_opts.replica_port = 8430;
+    config.nexus_opts.nvmf_replica_port = 8430;
     config.write("/tmp/child1.yaml").unwrap();
 
     config.base_bdevs = Some(vec![child2_bdev]);
-    config.nexus_opts.replica_port = 8431;
+    config.nexus_opts.nvmf_replica_port = 8431;
     config.write("/tmp/child2.yaml").unwrap();
 }
 


### PR DESCRIPTION
The preferred method for having multiple iSCSI target portals is to use different IP addresses, together with the well known port (3260). As this is not straightforward to do for kubernetes pods (which have a single IP address) we need to use other non-standard ports. In this case we need to allow the port values to be configurable.
resolves CAS-144