### PR TITLE
ci: Have the linter check all javascript files

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -24,5 +24,5 @@ jobs:
       image: docker.io/mayadata/ms-buildenv:latest
     steps:
       - uses: actions/checkout@master
-      - run: git diff-tree --no-commit-id --name-only -r ${{ github.sha }} | grep '\.js$' || true | xargs -r semistandard --env node --env mocha
+      - run: git ls-files | grep '\.js$' | xargs -r semistandard --env node --env mocha
         shell: bash

--- a/mayastor-test/sudo.js
+++ b/mayastor-test/sudo.js
@@ -9,7 +9,6 @@ var pidof = require('pidof');
 const sudoBin = inpathSync('sudo', process.env.PATH.split(':'));
 
 var cachedPassword;
-var lastAnswer;
 
 function sudo (command, options, nameInPs) {
   var prompt = '#node-sudo-passwd#';
@@ -64,6 +63,7 @@ function sudo (command, options, nameInPs) {
               silent: true
             },
             function (error, answer) {
+              if (error) throw new Error('Failed to get password');
               child.stdin.write(answer + '\n');
               if (options.cachePassword) {
                 cachedPassword = answer;


### PR DESCRIPTION
If we only lint javascript files which have changed in the most recent
commit, files changed in previous commits in a PR won't be checked.
We also wouldn't run the linter for a PR which updates the toolchain.
Either of these scenarios would leave extra work for future developers
working on unrelated changes.
(As part of rolling this out, also updated sudo.js to conform to the
current linting standard.)