### PR TITLE
CAS-241. Functionality to store and query a record of recent errored IOs

### DIFF
--- a/mayastor/src/bdev/mod.rs
+++ b/mayastor/src/bdev/mod.rs
@@ -4,6 +4,7 @@ pub use aio_dev::{AioBdev, AioParseError};
 pub use iscsi_dev::{IscsiBdev, IscsiParseError};
 pub use nexus::{
     nexus_bdev::{nexus_create, nexus_lookup, Nexus, NexusState},
+    nexus_child_error_store::NexusErrStore,
     nexus_label::{GPTHeader, GptEntry},
     nexus_metadata_content::{
         NexusConfig,
@@ -12,6 +13,7 @@ pub use nexus::{
         NexusConfigVersion3,
     },
 };
+
 pub use nvmf_dev::{NvmeCtlAttachReq, NvmfParseError};
 use spdk_sys::{spdk_conf_section, spdk_conf_section_get_nmval};
 pub use uring_dev::{UringBdev, UringParseError};

--- a/mayastor/src/bdev/nexus/mod.rs
+++ b/mayastor/src/bdev/nexus/mod.rs
@@ -12,6 +12,7 @@ pub mod nexus_bdev;
 pub mod nexus_bdev_children;
 mod nexus_channel;
 pub(crate) mod nexus_child;
+pub(crate) mod nexus_child_error_store;
 mod nexus_config;
 pub mod nexus_fn_table;
 pub mod nexus_io;

--- a/mayastor/src/bdev/nexus/nexus_bdev.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev.rs
@@ -5,6 +5,7 @@
 //! application needs synchronous mirroring may be required.
 
 use crate::nexus_uri::bdev_destroy;
+
 use std::{
     fmt,
     fmt::{Display, Formatter},
@@ -113,6 +114,8 @@ pub enum Error {
     ChildGeometry { child: String, name: String },
     #[snafu(display("Child {} of nexus {} cannot be found", child, name))]
     ChildMissing { child: String, name: String },
+    #[snafu(display("Child {} of nexus {} has no error store", child, name))]
+    ChildMissingErrStore { child: String, name: String },
     #[snafu(display("Failed to open child {} of nexus {}", child, name))]
     OpenChild {
         source: ChildError,
@@ -615,7 +618,7 @@ impl Nexus {
 
             pio.ctx_as_mut_ref().status = io_status::FAILED;
         }
-        pio.assess();
+        pio.assess(child_io, success);
         // always free the child IO
         Bio::io_free(child_io);
     }

--- a/mayastor/src/bdev/nexus/nexus_child_error_store.rs
+++ b/mayastor/src/bdev/nexus/nexus_child_error_store.rs
@@ -1,0 +1,306 @@
+use spdk_sys::{spdk_bdev, spdk_bdev_io_type};
+use std::{
+    fmt::{Debug, Display},
+    time::{Duration, Instant},
+};
+
+use crate::subsys::Config;
+
+use crate::bdev::nexus::nexus_io::{io_status, io_type};
+
+use crate::core::{Cores, Reactors};
+
+use crate::bdev::nexus::{
+    nexus_bdev,
+    nexus_bdev::{
+        nexus_lookup,
+        Error::{ChildMissing, ChildMissingErrStore},
+        Nexus,
+    },
+};
+
+use serde::export::{fmt::Error, Formatter};
+
+#[derive(Copy, Clone)]
+pub struct NexusChildErrorRecord {
+    io_offset: u64,
+    io_num_blocks: u64,
+    timestamp: Instant,
+    io_error: i32,
+    io_op: spdk_bdev_io_type,
+}
+
+impl Default for NexusChildErrorRecord {
+    fn default() -> Self {
+        Self {
+            io_op: 0,
+            io_error: 0,
+            io_offset: 0,
+            io_num_blocks: 0,
+            timestamp: Instant::now(), // for lack of another suitable default
+        }
+    }
+}
+
+pub struct NexusErrStore {
+    no_of_records: usize,
+    next_record_index: usize,
+    records: Vec<NexusChildErrorRecord>,
+}
+
+impl NexusErrStore {
+    pub const READ_FLAG: u32 = 1 << (io_type::READ - 1);
+    pub const WRITE_FLAG: u32 = 1 << (io_type::WRITE - 1);
+    pub const UNMAP_FLAG: u32 = 1 << (io_type::UNMAP - 1);
+    pub const FLUSH_FLAG: u32 = 1 << (io_type::FLUSH - 1);
+    pub const RESET_FLAG: u32 = 1 << (io_type::RESET - 1);
+
+    pub const IO_FAILED_FLAG: u32 = 1;
+
+    // the following definitions are for the error_store unit test
+    pub const IO_TYPE_READ: u32 = io_type::READ;
+    pub const IO_TYPE_WRITE: u32 = io_type::WRITE;
+    pub const IO_TYPE_UNMAP: u32 = io_type::UNMAP;
+    pub const IO_TYPE_FLUSH: u32 = io_type::FLUSH;
+    pub const IO_TYPE_RESET: u32 = io_type::RESET;
+
+    pub const IO_FAILED: i32 = io_status::FAILED;
+
+    pub fn new(max_records: usize) -> Self {
+        let mut es = NexusErrStore {
+            no_of_records: 0,
+            next_record_index: 0,
+            records: Vec::with_capacity(max_records),
+        };
+
+        let er: NexusChildErrorRecord = Default::default();
+
+        for _ in 0 .. max_records {
+            es.records.push(er);
+        }
+        es
+    }
+
+    pub fn add_record(
+        &mut self,
+        io_op: spdk_bdev_io_type,
+        io_error: i32,
+        io_offset: u64,
+        io_num_blocks: u64,
+        timestamp: Instant,
+    ) {
+        let new_record = NexusChildErrorRecord {
+            io_op,
+            io_error,
+            io_offset,
+            io_num_blocks,
+            timestamp,
+        };
+
+        self.records[self.next_record_index] = new_record;
+
+        if self.no_of_records < self.records.len() {
+            self.no_of_records += 1;
+        };
+        self.next_record_index =
+             // consider using a mask if we restrict the size to a power-of-2
+            (self.next_record_index + 1) % self.records.len();
+        // debug!("added record - buffer is {}", &self);
+    }
+
+    pub fn query(
+        &self,
+        io_op_flags: u32,
+        io_error_flags: u32,
+        target_timestamp: Option<Instant>,
+    ) -> u32 {
+        let mut idx = self.next_record_index;
+        let mut error_count: u32 = 0;
+
+        for _ in 0 .. self.no_of_records {
+            if idx > 0 {
+                idx -= 1;
+            } else {
+                idx = self.records.len() - 1;
+            }
+            if target_timestamp.is_some()
+                && self.records[idx]
+                    .timestamp
+                    .checked_duration_since(target_timestamp.unwrap())
+                    .is_none()
+            {
+                break; // reached a record older than the wanted timespan
+            }
+            let found_op = match self.records[idx].io_op {
+                io_type::READ => (io_op_flags & NexusErrStore::READ_FLAG) != 0,
+                io_type::WRITE => {
+                    (io_op_flags & NexusErrStore::WRITE_FLAG) != 0
+                }
+                io_type::UNMAP => {
+                    (io_op_flags & NexusErrStore::UNMAP_FLAG) != 0
+                }
+                io_type::FLUSH => {
+                    (io_op_flags & NexusErrStore::FLUSH_FLAG) != 0
+                }
+                io_type::RESET => {
+                    (io_op_flags & NexusErrStore::RESET_FLAG) != 0
+                }
+                _ => false,
+            };
+
+            let found_err = match self.records[idx].io_error {
+                io_status::FAILED => {
+                    (io_error_flags & NexusErrStore::IO_FAILED_FLAG) != 0
+                }
+                _ => false,
+            };
+
+            if found_op && found_err {
+                error_count += 1;
+            }
+        }
+        error_count
+    }
+
+    fn error_fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
+        let mut idx = self.next_record_index;
+        write!(f, "\nErrors ({}):", self.no_of_records)
+            .expect("invalid format");
+        for n in 0 .. self.no_of_records {
+            if idx > 0 {
+                idx -= 1;
+            } else {
+                idx = self.records.len() - 1;
+            }
+            write!(
+                f,
+                "\n    {}: timestamp:{:?} op:{} error:{} offset:{} blocks:{}",
+                n,
+                self.records[idx].timestamp,
+                self.records[idx].io_op,
+                self.records[idx].io_error,
+                self.records[idx].io_offset,
+                self.records[idx].io_num_blocks,
+            )
+            .expect("invalid format");
+        }
+        Ok(())
+    }
+}
+
+impl Debug for NexusErrStore {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
+        self.error_fmt(f)
+    }
+}
+
+impl Display for NexusErrStore {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
+        self.error_fmt(f)
+    }
+}
+
+impl Nexus {
+    pub fn error_record_add(
+        &self,
+        bdev: *const spdk_bdev,
+        io_op_type: spdk_bdev_io_type,
+        io_error_type: i32,
+        io_offset: u64,
+        io_num_blocks: u64,
+    ) {
+        let now = Instant::now();
+        let cfg = Config::by_ref();
+        if cfg.err_store_opts.enable_err_store {
+            let nexus_name = self.name.clone();
+            // dispatch message to management core to do this
+            let mgmt_reactor = Reactors::get_by_core(Cores::first()).unwrap();
+            mgmt_reactor.send_future(async move {
+                Nexus::future_error_record_add(
+                    nexus_name,
+                    bdev,
+                    io_op_type,
+                    io_error_type,
+                    io_offset,
+                    io_num_blocks,
+                    now,
+                );
+            });
+        }
+    }
+
+    fn future_error_record_add(
+        name: String,
+        bdev: *const spdk_bdev,
+        io_op_type: spdk_bdev_io_type,
+        io_error_type: i32,
+        io_offset: u64,
+        io_num_blocks: u64,
+        now: Instant,
+    ) {
+        let nexus = match nexus_lookup(&name) {
+            Some(nexus) => nexus,
+            None => {
+                error!("Failed to find the nexus {}", name);
+                return;
+            }
+        };
+        for child in nexus.children.iter_mut() {
+            if child.bdev.as_ref().unwrap().as_ptr() as *const _ == bdev {
+                if child.err_store.is_some() {
+                    child.err_store.as_mut().unwrap().add_record(
+                        io_op_type,
+                        io_error_type,
+                        io_offset,
+                        io_num_blocks,
+                        now,
+                    );
+                } else {
+                    error!("Failed to record error - child has no error store");
+                }
+                return;
+            }
+        }
+        error!("Failed to record error - could not find child");
+    }
+
+    pub fn error_record_query(
+        &self,
+        child_name: &str,
+        io_op_flags: u32,
+        io_error_flags: u32,
+        age_nano: Option<u64>, // None for any age
+    ) -> Result<Option<u32>, nexus_bdev::Error> {
+        let earliest_time = match age_nano {
+            // can also be None if earlier than the node has been up
+            Some(a) => Instant::now().checked_sub(Duration::from_nanos(a)),
+            None => None,
+        };
+        let cfg = Config::by_ref();
+        if cfg.err_store_opts.enable_err_store {
+            if let Some(child) =
+                self.children.iter().find(|c| c.name == child_name)
+            {
+                if child.err_store.as_ref().is_some() {
+                    Ok(Some(child.err_store.as_ref().unwrap().query(
+                        io_op_flags,
+                        io_error_flags,
+                        earliest_time,
+                    )))
+                } else {
+                    Err(ChildMissingErrStore {
+                        child: child_name.to_string(),
+                        name: self.name.clone(),
+                    })
+                }
+            } else {
+                Err(ChildMissing {
+                    child: child_name.to_string(),
+                    name: self.name.clone(),
+                })
+            }
+        } else {
+            Ok(None)
+        }
+    }
+}

--- a/mayastor/src/bdev/nexus/nexus_io.rs
+++ b/mayastor/src/bdev/nexus/nexus_io.rs
@@ -65,7 +65,7 @@ pub mod io_type {
     //    pub const IO_NUM_TYPES: u32 = 14;
 }
 
-/// the status of an IO
+/// the status of an IO - note: values copied from spdk bdev_module.h
 pub mod io_status {
     //pub const NOMEM: i32 = -4;
     //pub const SCSI_ERROR: i32 = -3;
@@ -108,11 +108,31 @@ impl Bio {
 
     /// assess the IO if we need to mark it failed or ok.
     #[inline]
-    pub(crate) fn assess(&mut self) {
+    pub(crate) fn assess(
+        &mut self,
+        child_io: *const spdk_bdev_io,
+        success: bool,
+    ) {
         self.ctx_as_mut_ref().in_flight -= 1;
 
         if cfg!(debug_assertions) {
             assert_ne!(self.ctx_as_mut_ref().in_flight, -1);
+        }
+
+        if !success && !child_io.is_null() {
+            let io_type = Bio::io_type(self.0).unwrap();
+            let io_offset = self.offset();
+            let io_num_blocks = self.num_blocks();
+
+            unsafe {
+                self.nexus_as_ref().error_record_add(
+                    (*child_io).bdev,
+                    io_type,
+                    io_status::FAILED,
+                    io_offset,
+                    io_num_blocks,
+                );
+            }
         }
 
         if self.ctx_as_mut_ref().in_flight == 0 {

--- a/mayastor/src/subsys/config.rs
+++ b/mayastor/src/subsys/config.rs
@@ -16,6 +16,7 @@ use crate::{
     pool::{create_pool, PoolsIter},
     subsys::opts::{
         BdevOpts,
+        ErrStoreOpts,
         IscsiTgtOpts,
         NexusOpts,
         NvmeBdevOpts,
@@ -47,6 +48,8 @@ pub struct Config {
     pub bdev_opts: BdevOpts,
     /// nexus specific options
     pub nexus_opts: NexusOpts,
+    /// error store opts
+    pub err_store_opts: ErrStoreOpts,
     ///
     /// The next options are intended for usage during testing
     ///
@@ -123,6 +126,7 @@ impl Config {
             nexus_bdevs: None,
             pools: None,
             implicit_share_base: true,
+            err_store_opts: self.err_store_opts.get(),
         };
 
         // collect nexus bdevs and insert them into the config

--- a/mayastor/src/subsys/opts.rs
+++ b/mayastor/src/subsys/opts.rs
@@ -471,3 +471,27 @@ impl GetOpts for IscsiTgtOpts {
         true
     }
 }
+
+#[serde(default, deny_unknown_fields)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ErrStoreOpts {
+    /// ring buffer size
+    pub err_store_size: usize,
+    /// NexusErrStore enabled
+    pub enable_err_store: bool,
+}
+
+impl Default for ErrStoreOpts {
+    fn default() -> Self {
+        Self {
+            err_store_size: 256,
+            enable_err_store: true,
+        }
+    }
+}
+
+impl GetOpts for ErrStoreOpts {
+    fn get(&self) -> Self {
+        self.clone()
+    }
+}

--- a/mayastor/tests/error_count.rs
+++ b/mayastor/tests/error_count.rs
@@ -1,0 +1,293 @@
+extern crate log;
+
+use crossbeam::channel::unbounded;
+
+use std::{ffi::CString, time::Duration};
+pub mod common;
+use mayastor::{
+    bdev::{nexus_create, nexus_lookup, NexusErrStore},
+    core::{
+        mayastor_env_stop,
+        Bdev,
+        MayastorCliArgs,
+        MayastorEnvironment,
+        Reactor,
+    },
+};
+
+use spdk_sys::{
+    create_aio_bdev,
+    spdk_vbdev_error_create,
+    spdk_vbdev_error_inject_error,
+    SPDK_BDEV_IO_TYPE_READ,
+    SPDK_BDEV_IO_TYPE_WRITE,
+};
+
+static ERROR_COUNT_TEST_NEXUS: &str = "error_count_test_nexus";
+
+static DISKNAME1: &str = "/tmp/disk1.img";
+static BDEVNAME1: &str = "aio:///tmp/disk1.img?blk_size=512";
+
+static DISKNAME2: &str = "/tmp/disk2.img";
+
+static ERROR_DEVICE: &str = "error_device";
+static EE_ERROR_DEVICE: &str = "EE_error_device"; // The prefix is added by the vbdev_error module
+static BDEV_EE_ERROR_DEVICE: &str = "bdev:///EE_error_device";
+
+// constant used by the vbdev_error module but not exported
+const VBDEV_IO_FAILURE: u32 = 1;
+
+#[test]
+fn nexus_error_count_test() {
+    common::truncate_file(DISKNAME1, 64 * 1024);
+    common::truncate_file(DISKNAME2, 64 * 1024);
+
+    test_init!();
+
+    Reactor::block_on(async {
+        create_error_bdev().await;
+        create_nexus().await;
+        err_write_nexus(true).await;
+        err_read_nexus_both(true).await;
+    });
+
+    reactor_run_millis(1); // give time for any errors to be added to the error store
+
+    nexus_err_query_and_test(
+        BDEV_EE_ERROR_DEVICE,
+        NexusErrStore::READ_FLAG,
+        0,
+        Some(1_000_000_000),
+    );
+
+    nexus_err_query_and_test(
+        BDEV_EE_ERROR_DEVICE,
+        NexusErrStore::WRITE_FLAG,
+        0,
+        Some(1_000_000_000),
+    );
+    nexus_err_query_and_test(
+        BDEVNAME1,
+        NexusErrStore::READ_FLAG | NexusErrStore::WRITE_FLAG,
+        0,
+        Some(1_000_000_000),
+    );
+
+    Reactor::block_on(async {
+        inject_error(SPDK_BDEV_IO_TYPE_WRITE, VBDEV_IO_FAILURE, 1).await;
+        err_write_nexus(false).await;
+        err_read_nexus_both(true).await;
+    });
+
+    reactor_run_millis(1); // give time for any errors to be added to the error store
+
+    nexus_err_query_and_test(
+        BDEV_EE_ERROR_DEVICE,
+        NexusErrStore::READ_FLAG,
+        0,
+        Some(1_000_000_000),
+    );
+
+    nexus_err_query_and_test(
+        BDEV_EE_ERROR_DEVICE,
+        NexusErrStore::WRITE_FLAG,
+        1,
+        Some(1_000_000_000),
+    );
+    nexus_err_query_and_test(
+        BDEVNAME1,
+        NexusErrStore::READ_FLAG | NexusErrStore::WRITE_FLAG,
+        0,
+        Some(1_000_000_000),
+    );
+
+    Reactor::block_on(async {
+        inject_error(SPDK_BDEV_IO_TYPE_READ, VBDEV_IO_FAILURE, 1).await;
+        err_read_nexus_both(false).await;
+        err_write_nexus(true).await;
+    });
+
+    reactor_run_millis(1); // give time for any errors to be added to the error store
+
+    nexus_err_query_and_test(
+        BDEV_EE_ERROR_DEVICE,
+        NexusErrStore::READ_FLAG,
+        1,
+        Some(1_000_000_000),
+    );
+
+    nexus_err_query_and_test(
+        BDEV_EE_ERROR_DEVICE,
+        NexusErrStore::WRITE_FLAG,
+        1,
+        Some(1_000_000_000),
+    );
+    nexus_err_query_and_test(
+        BDEVNAME1,
+        NexusErrStore::READ_FLAG | NexusErrStore::WRITE_FLAG,
+        0,
+        Some(1_000_000_000),
+    );
+
+    // overflow the error store with errored reads and writes, assumes default
+    // buffer size of 256 records
+    Reactor::block_on(async {
+        inject_error(SPDK_BDEV_IO_TYPE_READ, VBDEV_IO_FAILURE, 257).await;
+        inject_error(SPDK_BDEV_IO_TYPE_WRITE, VBDEV_IO_FAILURE, 100).await;
+        for _ in 0 .. 257 {
+            err_read_nexus_both(false).await;
+        }
+        for _ in 0 .. 100 {
+            err_write_nexus(false).await;
+        }
+    });
+
+    reactor_run_millis(1); // give time for any errors to be added to the error store
+
+    nexus_err_query_and_test(
+        BDEV_EE_ERROR_DEVICE,
+        NexusErrStore::READ_FLAG,
+        156,
+        Some(1_000_000_000),
+    );
+    nexus_err_query_and_test(
+        BDEV_EE_ERROR_DEVICE,
+        NexusErrStore::WRITE_FLAG,
+        100,
+        Some(1_000_000_000),
+    );
+
+    nexus_err_query_and_test(
+        BDEV_EE_ERROR_DEVICE,
+        NexusErrStore::WRITE_FLAG,
+        0,
+        Some(0), // too recent, so nothing there
+    );
+
+    nexus_err_query_and_test(
+        BDEV_EE_ERROR_DEVICE,
+        NexusErrStore::WRITE_FLAG,
+        100,
+        Some(1_000_000_000_000_000_000), // underflow, so assumes any age
+    );
+
+    nexus_err_query_and_test(
+        BDEV_EE_ERROR_DEVICE,
+        NexusErrStore::WRITE_FLAG,
+        100,
+        None, // no time specified
+    );
+
+    mayastor_env_stop(0);
+}
+
+async fn inject_error(op: u32, mode: u32, count: u32) {
+    let retval: i32;
+    let err_bdev_name_str =
+        CString::new(EE_ERROR_DEVICE).expect("Failed to create name string");
+    let raw = err_bdev_name_str.into_raw();
+
+    unsafe {
+        retval = spdk_vbdev_error_inject_error(raw, op, mode, count);
+    }
+    assert_eq!(retval, 0);
+}
+
+async fn create_error_bdev() {
+    let mut retval: i32;
+    let cname = CString::new(ERROR_DEVICE).unwrap();
+    let filename = CString::new(DISKNAME2).unwrap();
+
+    unsafe {
+        // this allows us to create a bdev without its name being a uri
+        retval = create_aio_bdev(cname.as_ptr(), filename.as_ptr(), 512)
+    };
+    assert_eq!(retval, 0);
+
+    let err_bdev_name_str = CString::new(ERROR_DEVICE.to_string())
+        .expect("Failed to create name string");
+    unsafe {
+        retval = spdk_vbdev_error_create(err_bdev_name_str.as_ptr()); // create the error bdev around it
+    }
+    assert_eq!(retval, 0);
+}
+
+async fn create_nexus() {
+    let ch = vec![BDEVNAME1.to_string(), BDEV_EE_ERROR_DEVICE.to_string()];
+
+    nexus_create(ERROR_COUNT_TEST_NEXUS, 64 * 1024 * 1024, None, &ch)
+        .await
+        .unwrap();
+}
+
+fn nexus_err_query_and_test(
+    child_bdev: &str,
+    io_type_flags: u32,
+    expected_count: u32,
+    age_nano: Option<u64>,
+) {
+    let nexus = nexus_lookup(ERROR_COUNT_TEST_NEXUS).unwrap();
+    let count = nexus
+        .error_record_query(
+            child_bdev,
+            io_type_flags,
+            NexusErrStore::IO_FAILED_FLAG,
+            age_nano,
+        )
+        .expect("failed to query child");
+    assert!(count.is_some()); // true if the error_store is enabled
+    assert_eq!(count.unwrap(), expected_count);
+}
+
+async fn err_write_nexus(succeed: bool) {
+    let bdev = Bdev::lookup_by_name(ERROR_COUNT_TEST_NEXUS)
+        .expect("failed to lookup nexus");
+    let d = bdev
+        .open(true)
+        .expect("failed open bdev")
+        .into_handle()
+        .unwrap();
+    let buf = d.dma_malloc(512).expect("failed to allocate buffer");
+
+    match d.write_at(0, &buf).await {
+        Ok(_) => {
+            assert_eq!(succeed, true);
+        }
+        Err(_) => {
+            assert_eq!(succeed, false);
+        }
+    };
+}
+
+async fn err_read_nexus_both(succeed: bool) {
+    let res1 = err_read_nexus().await;
+    let res2 = err_read_nexus().await;
+
+    if succeed {
+        assert!(res1 && res2); // both succeeded
+    } else {
+        assert_ne!(res1, res2); // one succeeded, one failed
+    }
+}
+
+async fn err_read_nexus() -> bool {
+    let bdev = Bdev::lookup_by_name(ERROR_COUNT_TEST_NEXUS)
+        .expect("failed to lookup nexus");
+    let d = bdev
+        .open(true)
+        .expect("failed open bdev")
+        .into_handle()
+        .unwrap();
+    let mut buf = d.dma_malloc(512).expect("failed to allocate buffer");
+
+    d.read_at(0, &mut buf).await.is_ok()
+}
+
+fn reactor_run_millis(milliseconds: u64) {
+    let (s, r) = unbounded::<()>();
+    std::thread::spawn(move || {
+        std::thread::sleep(Duration::from_millis(milliseconds));
+        s.send(())
+    });
+    reactor_poll!(r);
+}

--- a/mayastor/tests/error_store.rs
+++ b/mayastor/tests/error_store.rs
@@ -1,0 +1,137 @@
+pub mod common;
+
+use mayastor::bdev::NexusErrStore;
+use std::time::{Duration, Instant};
+
+const ALL_FLAGS: u32 = 0xffff_ffff;
+
+#[test]
+fn nexus_child_error_store_test() {
+    let mut es = NexusErrStore::new(15);
+    let start_inst = Instant::now();
+
+    let mut errors = do_query(&es, ALL_FLAGS, ALL_FLAGS, start_inst, 0);
+    assert_eq!(errors, 0);
+
+    add_records(&mut es, 1, NexusErrStore::IO_TYPE_READ, start_inst, 5);
+    add_records(&mut es, 1, NexusErrStore::IO_TYPE_READ, start_inst, 10);
+
+    errors = do_query(&es, ALL_FLAGS, ALL_FLAGS, start_inst, 0);
+    assert_eq!(errors, 2);
+
+    add_records(&mut es, 2, NexusErrStore::IO_TYPE_WRITE, start_inst, 11);
+
+    errors = do_query(&es, ALL_FLAGS, ALL_FLAGS, start_inst, 0);
+    assert_eq!(errors, 4);
+
+    add_records(&mut es, 3, NexusErrStore::IO_TYPE_UNMAP, start_inst, 12);
+    errors = do_query(&es, ALL_FLAGS, ALL_FLAGS, start_inst, 0);
+    assert_eq!(errors, 7);
+
+    add_records(&mut es, 4, NexusErrStore::IO_TYPE_FLUSH, start_inst, 13);
+    errors = do_query(&es, ALL_FLAGS, ALL_FLAGS, start_inst, 0);
+    assert_eq!(errors, 11);
+
+    add_records(&mut es, 5, NexusErrStore::IO_TYPE_RESET, start_inst, 14);
+    errors = do_query(&es, ALL_FLAGS, ALL_FLAGS, start_inst, 0);
+    // last record over-writes the first, hence 15 not 16
+    assert_eq!(errors, 15);
+
+    /////////////////// filter by time ////////////////////////////
+
+    errors = do_query(&es, ALL_FLAGS, ALL_FLAGS, start_inst, 0);
+    assert_eq!(errors, 15);
+
+    errors = do_query(&es, ALL_FLAGS, ALL_FLAGS, start_inst, 10);
+    assert_eq!(errors, 15);
+
+    errors = do_query(&es, ALL_FLAGS, ALL_FLAGS, start_inst, 11);
+    assert_eq!(errors, 14);
+
+    errors = do_query(&es, ALL_FLAGS, ALL_FLAGS, start_inst, 12);
+    assert_eq!(errors, 12);
+
+    errors = do_query(&es, ALL_FLAGS, ALL_FLAGS, start_inst, 13);
+    assert_eq!(errors, 9);
+
+    errors = do_query(&es, ALL_FLAGS, ALL_FLAGS, start_inst, 14);
+    assert_eq!(errors, 5);
+
+    errors = do_query(&es, ALL_FLAGS, ALL_FLAGS, start_inst, 15);
+    assert_eq!(errors, 0);
+
+    errors = es.query(ALL_FLAGS, ALL_FLAGS, None); // no time specified
+    assert_eq!(errors, 15);
+
+    /////////////////////// filter by op ////////////////////////
+
+    errors = do_query(&es, NexusErrStore::READ_FLAG, ALL_FLAGS, start_inst, 10);
+    assert_eq!(errors, 1);
+
+    errors =
+        do_query(&es, NexusErrStore::WRITE_FLAG, ALL_FLAGS, start_inst, 10);
+    assert_eq!(errors, 2);
+
+    errors =
+        do_query(&es, NexusErrStore::UNMAP_FLAG, ALL_FLAGS, start_inst, 10);
+    assert_eq!(errors, 3);
+
+    errors =
+        do_query(&es, NexusErrStore::FLUSH_FLAG, ALL_FLAGS, start_inst, 10);
+    assert_eq!(errors, 4);
+
+    errors =
+        do_query(&es, NexusErrStore::RESET_FLAG, ALL_FLAGS, start_inst, 10);
+    assert_eq!(errors, 5);
+
+    errors = do_query(&es, 0, ALL_FLAGS, start_inst, 10);
+    assert_eq!(errors, 0);
+
+    ////////////////////// filter by failure //////////////////////////
+
+    errors = do_query(
+        &es,
+        ALL_FLAGS,
+        NexusErrStore::IO_FAILED_FLAG,
+        start_inst,
+        10,
+    );
+    assert_eq!(errors, 15);
+
+    errors = do_query(&es, ALL_FLAGS, 0, start_inst, 10);
+    assert_eq!(errors, 0);
+}
+
+fn add_records(
+    es: &mut NexusErrStore,
+    how_many: usize,
+    op: u32,
+    start_inst: Instant,
+    when: u64,
+) {
+    let offset: u64 = 0;
+    let num_of_blocks: u64 = 1;
+    for _ in 0 .. how_many {
+        es.add_record(
+            op,
+            NexusErrStore::IO_FAILED,
+            offset,
+            num_of_blocks,
+            start_inst + Duration::from_nanos(when),
+        );
+    }
+}
+
+fn do_query(
+    es: &NexusErrStore,
+    op_flags: u32,
+    err_flags: u32,
+    start_inst: Instant,
+    when: u64,
+) -> u32 {
+    es.query(
+        op_flags,
+        err_flags,
+        Some(start_inst + Duration::from_nanos(when)),
+    )
+}

--- a/spdk-sys/wrapper.h
+++ b/spdk-sys/wrapper.h
@@ -1,5 +1,6 @@
 #include <bdev/aio/bdev_aio.h>
 #include <bdev/crypto/vbdev_crypto.h>
+#include <bdev/error/vbdev_error.h>
 #include <bdev/iscsi/bdev_iscsi.h>
 #include <bdev/lvol/vbdev_lvol.h>
 #include <bdev/malloc/bdev_malloc.h>


### PR DESCRIPTION
CAS-241. Functionality to store and query a record of recent errored IOs in each nexus child and a means of enabling the feature and setting the buffer size.
Test added which adds an error bdev layer between the nexus and one of its
replicas and allows unit testing of the feature. Also included unit testing
of the error store independenly of the bdev.

Addressed some code-review comments, ops and errors are stored
instead of flags, also made the ordering of parameters more consistent.
Use monolithic time instead of absolute time in error store.
Using message-passing to the management core.

Addressed some code-review comments, ops and errors are stored
instead of flags, also made the ordering of parameters more consistent.
Use monolithic time instead of absolute time in error store.
Using message-passing to the management core.
The age parameter in the query is now an Option, if absent all ages allowed.