### PR TITLE
rebuild: frontend IO whilst rebuilding (CAS-273)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 **/*.terraform
 **/*.tfstate*
 mayastor/local-randrw-0-verify.state
+mayastor/local-write_verify-0-verify.state

--- a/mayastor/src/bdev/nexus/nexus_child.rs
+++ b/mayastor/src/bdev/nexus/nexus_child.rs
@@ -54,7 +54,7 @@ pub enum ChildIoError {
 pub(crate) enum ChildStatus {
     /// available for RW
     Online,
-    /// temporarily unavailable for RW, out of sync with nexus (needs rebuild)
+    /// temporarily unavailable for R, out of sync with nexus (needs rebuild)
     Degraded,
     /// permanently unavailable for RW
     Faulted,
@@ -289,6 +289,16 @@ impl NexusChild {
                     ChildStatus::Online
                 }
             }
+        }
+    }
+
+    pub(crate) fn rebuilding(&self) -> bool {
+        match RebuildJob::lookup(&self.name) {
+            Ok(_) => {
+                self.state == ChildState::Open
+                    && self.status_reasons.out_of_sync
+            }
+            Err(_) => false,
         }
     }
 

--- a/mayastor/src/bdev/nexus/nexus_rpc.rs
+++ b/mayastor/src/bdev/nexus/nexus_rpc.rs
@@ -183,7 +183,7 @@ pub(crate) fn register_rpc_methods() {
     jsonrpc_register("start_rebuild", |args: StartRebuildRequest| {
         let fut = async move {
             let nexus = nexus_lookup(&args.uuid)?;
-            nexus.start_rebuild(&args.uri).map(|_| {})
+            nexus.start_rebuild(&args.uri).await.map(|_| {})
         };
         fut.boxed_local()
     });

--- a/mayastor/src/core/channel.rs
+++ b/mayastor/src/core/channel.rs
@@ -40,7 +40,9 @@ impl IoChannel {
 
 impl Drop for IoChannel {
     fn drop(&mut self) {
-        trace!("[D] {:?}", self);
+        // temporarily comment out the trace message as it floods the test logs
+        // (1 per rebuild IO)
+        // trace!("[D] {:?}", self);
         unsafe { spdk_put_io_channel(self.0) }
     }
 }

--- a/mayastor/src/grpc.rs
+++ b/mayastor/src/grpc.rs
@@ -407,7 +407,7 @@ impl Mayastor for MayastorGrpc {
         let args = request.into_inner();
         trace!("{:?}", args);
         locally! { async move {
-            nexus_lookup(&args.uuid)?.start_rebuild(&args.uri).map(|_|{})
+            nexus_lookup(&args.uuid)?.start_rebuild(&args.uri).await.map(|_|{})
         }};
 
         Ok(Response::new(Null {}))


### PR DESCRIPTION
This allows us to run frontend IO whilst rebuilding a nexus child.
Whenever a child is being rebuilt we now make it part of the nexus
frontend IO channels in WOnly mode.
So, the rebuild child is receiving the latest frontend write but it
does not participate in the read path. This is necessary because we do
not yet have a log of missed frontend writes - we can receive new write
IO to blocks which have already been rebuilt.

When the rebuild completes the child can then participate in the read
path because we know it's been fully rebuilt.

Added simple FIO verify test which runs at the same time as a rebuild.