### PR TITLE
rebuild: fault child on failure (CAS-287)

### DIFF
--- a/mayastor/src/bdev/aio_dev.rs
+++ b/mayastor/src/bdev/aio_dev.rs
@@ -12,7 +12,7 @@ use crate::{
     nexus_uri::{self, BdevCreateDestroy},
 };
 
-#[derive(Debug, Snafu)]
+#[derive(Debug, Snafu, Clone)]
 pub enum AioParseError {
     #[snafu(display("Missing path to aio device"))]
     PathMissing {},

--- a/mayastor/src/bdev/iscsi_dev.rs
+++ b/mayastor/src/bdev/iscsi_dev.rs
@@ -12,7 +12,7 @@ use crate::{
     nexus_uri::{self, BdevCreateDestroy},
 };
 
-#[derive(Debug, Snafu)]
+#[derive(Debug, Snafu, Clone)]
 pub enum IscsiParseError {
     // no parse errors for iscsi urls - we should have some probably
 }

--- a/mayastor/src/bdev/mod.rs
+++ b/mayastor/src/bdev/mod.rs
@@ -10,6 +10,7 @@ pub use nexus::{
         NexusStatus,
         VerboseError,
     },
+    nexus_child::ChildStatus,
     nexus_child_error_store::NexusErrStore,
     nexus_label::{GPTHeader, GptEntry},
     nexus_metadata_content::{

--- a/mayastor/src/bdev/nexus/nexus_bdev.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev.rs
@@ -60,13 +60,15 @@ pub trait VerboseError {
     fn verbose(&self) -> String;
 }
 
-impl VerboseError for Error {
+impl<T> VerboseError for T
+where
+    T: std::error::Error,
+{
     /// loops through the error chain and formats into a single string
     /// containing all the lower level errors
     fn verbose(&self) -> String {
-        let err = self as &dyn std::error::Error;
-        let mut msg = format!("{}", err);
-        let mut opt_source = err.source();
+        let mut msg = format!("{}", self);
+        let mut opt_source = self.source();
         while let Some(source) = opt_source {
             msg = format!("{}: {}", msg, source);
             opt_source = source.source();

--- a/mayastor/src/bdev/nexus/nexus_bdev_children.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev_children.rs
@@ -27,24 +27,27 @@ use futures::future::join_all;
 use snafu::ResultExt;
 
 use crate::{
-    bdev::nexus::{
-        nexus_bdev::{
-            CreateChild,
-            DestroyChild,
-            Error,
-            Nexus,
-            NexusState,
-            NexusStatus,
-            OpenChild,
+    bdev::{
+        nexus::{
+            nexus_bdev::{
+                CreateChild,
+                DestroyChild,
+                Error,
+                Nexus,
+                NexusState,
+                NexusStatus,
+                OpenChild,
+            },
+            nexus_channel::DREvent,
+            nexus_child::{ChildState, NexusChild},
+            nexus_label::{
+                LabelError,
+                NexusChildLabel,
+                NexusLabel,
+                NexusLabelStatus,
+            },
         },
-        nexus_channel::DREvent,
-        nexus_child::{ChildState, NexusChild},
-        nexus_label::{
-            LabelError,
-            NexusChildLabel,
-            NexusLabel,
-            NexusLabelStatus,
-        },
+        VerboseError,
     },
     core::Bdev,
     nexus_uri::{bdev_create, bdev_destroy, BdevCreateDestroy},
@@ -106,7 +109,10 @@ impl Nexus {
         if rebuild {
             if let Err(e) = self.start_rebuild(&uri).await {
                 // todo: CAS-253 retry starting the rebuild again when ready
-                error!("Child added but rebuild failed to start: {}", e);
+                error!(
+                    "Child added but rebuild failed to start: {}",
+                    e.verbose()
+                );
             }
         }
         Ok(status)

--- a/mayastor/src/bdev/nvmf_dev.rs
+++ b/mayastor/src/bdev/nvmf_dev.rs
@@ -19,7 +19,7 @@ use crate::{
     nexus_uri::{self, BdevCreateDestroy},
 };
 
-#[derive(Debug, Snafu)]
+#[derive(Debug, Snafu, Clone)]
 pub enum NvmfParseError {
     #[snafu(display("Missing path component"))]
     PathMissing {},

--- a/mayastor/src/bdev/uring_dev.rs
+++ b/mayastor/src/bdev/uring_dev.rs
@@ -12,7 +12,7 @@ use crate::{
     nexus_uri::{self, BdevCreateDestroy},
 };
 
-#[derive(Debug, Snafu)]
+#[derive(Debug, Snafu, Clone)]
 pub enum UringParseError {
     #[snafu(display("Missing path to io_uring device"))]
     PathMissing {},

--- a/mayastor/src/core/descriptor.rs
+++ b/mayastor/src/core/descriptor.rs
@@ -99,7 +99,7 @@ impl Descriptor {
         &self,
         ctx: &mut RangeContext,
         ch: &IoChannel,
-    ) -> Result<(), std::io::Error> {
+    ) -> Result<(), nix::errno::Errno> {
         let (s, r) = oneshot::channel::<i32>();
         ctx.sender = Box::into_raw(Box::new(s));
 
@@ -113,14 +113,14 @@ impl Descriptor {
                 ctx as *const _ as *mut c_void,
             );
             if rc != 0 {
-                return Err(std::io::Error::from_raw_os_error(rc));
+                return Err(nix::errno::from_i32(rc));
             }
         }
 
         // Wait for the lock to complete
         let rc = r.await.unwrap();
         if rc != 0 {
-            return Err(std::io::Error::from_raw_os_error(rc));
+            return Err(nix::errno::from_i32(rc));
         }
 
         Ok(())
@@ -132,7 +132,7 @@ impl Descriptor {
         &self,
         ctx: &mut RangeContext,
         ch: &IoChannel,
-    ) -> Result<(), std::io::Error> {
+    ) -> Result<(), nix::errno::Errno> {
         let (s, r) = oneshot::channel::<i32>();
         ctx.sender = Box::into_raw(Box::new(s));
 
@@ -146,14 +146,14 @@ impl Descriptor {
                 ctx as *const _ as *mut c_void,
             );
             if rc != 0 {
-                return Err(std::io::Error::from_raw_os_error(rc));
+                return Err(nix::errno::from_i32(rc));
             }
         }
 
         // Wait for the unlock to complete
         let rc = r.await.unwrap();
         if rc != 0 {
-            return Err(std::io::Error::from_raw_os_error(rc));
+            return Err(nix::errno::from_i32(rc));
         }
 
         Ok(())

--- a/mayastor/src/core/dma.rs
+++ b/mayastor/src/core/dma.rs
@@ -12,7 +12,7 @@ use snafu::Snafu;
 
 use spdk_sys::{spdk_dma_free, spdk_dma_zmalloc};
 
-#[derive(Debug, Snafu)]
+#[derive(Debug, Snafu, Clone)]
 pub enum DmaError {
     #[snafu(display("Failed to allocate DMA buffer"))]
     Alloc {},

--- a/mayastor/src/core/mod.rs
+++ b/mayastor/src/core/mod.rs
@@ -25,7 +25,7 @@ mod reactor;
 mod thread;
 mod uuid;
 
-#[derive(Debug, Snafu)]
+#[derive(Debug, Snafu, Clone)]
 #[snafu(visibility = "pub")]
 pub enum CoreError {
     #[snafu(display("bdev {} not found", name))]

--- a/mayastor/src/nexus_uri.rs
+++ b/mayastor/src/nexus_uri.rs
@@ -19,7 +19,7 @@ use crate::{
 };
 
 // parse URI and bdev create/destroy errors common for all types of bdevs
-#[derive(Debug, Snafu)]
+#[derive(Debug, Snafu, Clone)]
 #[snafu(visibility = "pub(crate)")]
 pub enum BdevCreateDestroy {
     // URI parse errors
@@ -175,4 +175,14 @@ pub async fn bdev_create(uri: &str) -> Result<String, BdevCreateDestroy> {
         BdevType::Uring(args) => args.create().await,
         BdevType::Bdev(name) => Ok(name),
     }
+}
+
+pub fn bdev_get_name(uri: &str) -> Result<String, BdevCreateDestroy> {
+    Ok(match nexus_parse_uri(uri)? {
+        BdevType::Aio(args) => args.name,
+        BdevType::Iscsi(args) => args.name,
+        BdevType::Nvmf(args) => args.name,
+        BdevType::Uring(args) => args.name,
+        BdevType::Bdev(name) => name,
+    })
 }

--- a/mayastor/tests/common/error_bdev.rs
+++ b/mayastor/tests/common/error_bdev.rs
@@ -1,0 +1,41 @@
+use spdk_sys::{
+    create_aio_bdev,
+    spdk_vbdev_error_create,
+    spdk_vbdev_error_inject_error,
+};
+
+pub use spdk_sys::{SPDK_BDEV_IO_TYPE_READ, SPDK_BDEV_IO_TYPE_WRITE};
+
+// constant used by the vbdev_error module but not exported
+pub const VBDEV_IO_FAILURE: u32 = 1;
+
+pub fn create_error_bdev(error_device: &str, backing_device: &str) {
+    let mut retval: i32;
+    let cname = std::ffi::CString::new(error_device).unwrap();
+    let filename = std::ffi::CString::new(backing_device).unwrap();
+
+    unsafe {
+        // this allows us to create a bdev without its name being a uri
+        retval = create_aio_bdev(cname.as_ptr(), filename.as_ptr(), 512)
+    };
+    assert_eq!(retval, 0);
+
+    let err_bdev_name_str = std::ffi::CString::new(error_device.to_string())
+        .expect("Failed to create name string");
+    unsafe {
+        retval = spdk_vbdev_error_create(err_bdev_name_str.as_ptr()); // create the error bdev around it
+    }
+    assert_eq!(retval, 0);
+}
+
+pub fn inject_error(error_device: &str, op: u32, mode: u32, count: u32) {
+    let retval: i32;
+    let err_bdev_name_str = std::ffi::CString::new(error_device)
+        .expect("Failed to create name string");
+    let raw = err_bdev_name_str.into_raw();
+
+    unsafe {
+        retval = spdk_vbdev_error_inject_error(raw, op, mode, count);
+    }
+    assert_eq!(retval, 0);
+}

--- a/mayastor/tests/lock_lba_range.rs
+++ b/mayastor/tests/lock_lba_range.rs
@@ -106,7 +106,7 @@ async fn create_nexus() {
 async fn lock_range(
     ctx: &mut RangeContext,
     ch: &IoChannel,
-) -> Result<(), std::io::Error> {
+) -> Result<(), nix::errno::Errno> {
     let nexus = Bdev::open_by_name(NEXUS_NAME, true).unwrap();
     nexus.lock_lba_range(ctx, ch).await
 }
@@ -114,7 +114,7 @@ async fn lock_range(
 async fn unlock_range(
     ctx: &mut RangeContext,
     ch: &IoChannel,
-) -> Result<(), std::io::Error> {
+) -> Result<(), nix::errno::Errno> {
     let nexus = Bdev::open_by_name(NEXUS_NAME, true).unwrap();
     nexus.unlock_lba_range(ctx, ch).await
 }


### PR DESCRIPTION
Fault destination child when the rebuild fails allowing MOAC to replace
it with another when it detects the Faulted state.

Added tests using existing bdev error functionality to inject failures
on both src and dst children during a rebuild to verify that the dst
child is faulted.

todo: if the failure was caused by the src child we should be able to
replace that child with another and proceed with the rebuild