### PR TITLE
CAS-317: Fixup rebuild of nvmf replica

### DIFF
--- a/mayastor/src/bdev/nexus/nexus_bdev_children.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev_children.rs
@@ -113,6 +113,14 @@ impl Nexus {
                     "Child added but rebuild failed to start: {}",
                     e.verbose()
                 );
+                match self.get_child_by_name(uri) {
+                    Ok(child) => child.fault(),
+                    Err(e) => error!(
+                        "Failed to find newly added child {}, error: {}",
+                        uri,
+                        e.verbose()
+                    ),
+                };
             }
         }
         Ok(status)

--- a/mayastor/src/nexus_uri.rs
+++ b/mayastor/src/nexus_uri.rs
@@ -181,7 +181,11 @@ pub fn bdev_get_name(uri: &str) -> Result<String, BdevCreateDestroy> {
     Ok(match nexus_parse_uri(uri)? {
         BdevType::Aio(args) => args.name,
         BdevType::Iscsi(args) => args.name,
-        BdevType::Nvmf(args) => args.name,
+        BdevType::Nvmf(args) => {
+            // the namespace instance is appended to the nvme bdev, we currently
+            // only support one namespace per bdev.
+            format!("{}{}", args.name, "n1")
+        }
         BdevType::Uring(args) => args.name,
         BdevType::Bdev(name) => name,
     })


### PR DESCRIPTION
Add missing nvmf namespace identifier to the bdev name
Additionally fault the child if a rebuild fails to start
