### PR TITLE
Prepare deploy folder content for v0.2.0 staging

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -4,13 +4,6 @@ This quickstart guide has been tested against the following platforms and config
 
 - kubeadm (vanilla k8s cluster)
     - k8s version 1.14 or newer
-- Microsoft Azure Kubernetes Service (AKS)
-    - k8s version 1.16.7
-    - Ubuntu 16.04.6 LTS (GNU/Linux 4.15.0-1077-azure x86_64)
-    - Not tested with scale-sets
-
-    > AKS is not currently recommended for use with Mayastor in production owing to the need, at this time, to make configuration changes to worker nodes which are not readily compatible with upgrades or autoscaling behavior
-
 
 ### Requirements
 

--- a/deploy/mayastor-daemonset.yaml
+++ b/deploy/mayastor-daemonset.yaml
@@ -29,7 +29,7 @@ spec:
       # the same.
       containers:
       - name: mayastor
-        image: mayadata/mayastor:latest
+        image: mayadata/mayastor:v0.2.0
         imagePullPolicy: Always
         env:
         - name: MY_POD_IP
@@ -56,7 +56,7 @@ spec:
             memory: "500Mi"
             hugepages-2Mi: "1Gi"
       - name: mayastor-grpc
-        image: mayadata/mayastor-grpc:latest
+        image: mayadata/mayastor-grpc:v0.2.0
         imagePullPolicy: Always
         # we need privileged because we mount filesystems and use mknod
         securityContext:

--- a/deploy/moac-deployment.yaml
+++ b/deploy/moac-deployment.yaml
@@ -137,7 +137,7 @@ spec:
               mountPath: /var/lib/csi/sockets/pluginproxy/
 
         - name: moac
-          image: mayadata/moac:latest
+          image: mayadata/moac:v0.2.0
           imagePullPolicy: Always
           args:
             - "--csi-address=$(CSI_ENDPOINT)"


### PR DESCRIPTION
Update the moac deployment and mayastor daemonset yaml files to reflect the correct image tags for this release (i.e. imagename:v.0.2.0)

Update the README.md (Quickstart guide) to remove references to this release having been tested on Azure AKS, since we know that there are possibly some issues with this at this time and further investigation is required.  The notes on AKS section is left in situ, since this is very likely to still apply to Azure deployments.