### PR TITLE
Merge release 0.2.0 staging changes back into master

### DIFF
--- a/csi/src/node.rs
+++ b/csi/src/node.rs
@@ -11,7 +11,6 @@ use crate::{
     format::probed_format,
     mount::{match_mount, mount_fs, mount_opts_compare, unmount_fs},
 };
-use git_version::git_version;
 
 mod iscsiutil;
 use iscsiutil::{iscsi_attach_disk, iscsi_detach_disk, iscsi_find};
@@ -103,10 +102,8 @@ impl node_server::Node for Node {
             glob("/dev/nbd*").expect("Invalid glob pattern").count() as i64;
 
         debug!(
-            "NodeGetInfo request: version={}, ID={}, max volumes={}",
-            git_version!(),
-            node_id,
-            max_volumes_per_node,
+            "NodeGetInfo request: ID={}, max volumes={}",
+            node_id, max_volumes_per_node,
         );
 
         Ok(Response::new(NodeGetInfoResponse {

--- a/csi/src/server.rs
+++ b/csi/src/server.rs
@@ -29,8 +29,6 @@ use std::{
 use tokio::{net::UnixListener, prelude::*};
 use tonic::transport::{server::Connected, Server};
 
-use git_version::git_version;
-
 use crate::{identity::Identity, mount::probe_filesystems, node::Node};
 
 #[allow(dead_code)]
@@ -89,7 +87,6 @@ impl AsyncWrite for UnixStream {
 #[tokio::main]
 async fn main() -> Result<(), String> {
     let matches = App::new("Mayastor agent")
-        .version(git_version!())
         .about("k8s sidecar for Mayastor implementing CSI among others")
         .arg(
             Arg::with_name("address")

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -4,13 +4,6 @@ This quickstart guide has been tested against the following platforms and config
 
 - kubeadm (vanilla k8s cluster)
     - k8s version 1.14 or newer
-- Microsoft Azure Kubernetes Service (AKS)
-    - k8s version 1.16.7
-    - Ubuntu 16.04.6 LTS (GNU/Linux 4.15.0-1077-azure x86_64)
-    - Not tested with scale-sets
-
-    > AKS is not currently recommended for use with Mayastor in production owing to the need, at this time, to make configuration changes to worker nodes which are not readily compatible with upgrades or autoscaling behavior
-
 
 ### Requirements
 

--- a/deploy/mayastor-daemonset.yaml
+++ b/deploy/mayastor-daemonset.yaml
@@ -29,7 +29,7 @@ spec:
       # the same.
       containers:
       - name: mayastor
-        image: mayadata/mayastor:latest
+        image: mayadata/mayastor:v0.2.0
         imagePullPolicy: Always
         env:
         - name: MY_POD_IP
@@ -56,7 +56,7 @@ spec:
             memory: "500Mi"
             hugepages-2Mi: "1Gi"
       - name: mayastor-grpc
-        image: mayadata/mayastor-grpc:latest
+        image: mayadata/mayastor-grpc:v0.2.0
         imagePullPolicy: Always
         # we need privileged because we mount filesystems and use mknod
         securityContext:

--- a/deploy/moac-deployment.yaml
+++ b/deploy/moac-deployment.yaml
@@ -137,7 +137,7 @@ spec:
               mountPath: /var/lib/csi/sockets/pluginproxy/
 
         - name: moac
-          image: mayadata/moac:latest
+          image: mayadata/moac:v0.2.0
           imagePullPolicy: Always
           args:
             - "--csi-address=$(CSI_ENDPOINT)"

--- a/mayastor/src/bdev/nexus/nexus_bdev_children.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev_children.rs
@@ -113,6 +113,14 @@ impl Nexus {
                     "Child added but rebuild failed to start: {}",
                     e.verbose()
                 );
+                match self.get_child_by_name(uri) {
+                    Ok(child) => child.fault(),
+                    Err(e) => error!(
+                        "Failed to find newly added child {}, error: {}",
+                        uri,
+                        e.verbose()
+                    ),
+                };
             }
         }
         Ok(status)

--- a/mayastor/src/bin/main.rs
+++ b/mayastor/src/bin/main.rs
@@ -3,14 +3,12 @@ extern crate log;
 
 use std::path::Path;
 
-use structopt::StructOpt;
-
-use git_version::git_version;
 use mayastor::{
     bdev::uring_util,
     core::{MayastorCliArgs, MayastorEnvironment},
     logger,
 };
+use structopt::StructOpt;
 
 mayastor::CPS_INIT!();
 
@@ -38,7 +36,7 @@ fn main() -> Result<(), std::io::Error> {
     let nr_pages: u32 = sysfs::parse_value(&hugepage_path, "nr_hugepages")?;
     let uring_supported = uring_util::kernel_support();
 
-    info!("Starting Mayastor version {}", git_version!());
+    info!("Starting Mayastor ..");
     info!(
         "kernel io_uring support: {}",
         if uring_supported { "yes" } else { "no" }
@@ -47,7 +45,7 @@ fn main() -> Result<(), std::io::Error> {
     let mut env = MayastorEnvironment::new(args);
     env.enable_grpc = true;
     env.start(|| {
-        info!("Mayastor started {} ({})...", '\u{1F680}', git_version!());
+        info!("Mayastor started {} ...", '\u{1F680}');
     })
     .unwrap();
     Ok(())

--- a/mayastor/src/nexus_uri.rs
+++ b/mayastor/src/nexus_uri.rs
@@ -181,7 +181,11 @@ pub fn bdev_get_name(uri: &str) -> Result<String, BdevCreateDestroy> {
     Ok(match nexus_parse_uri(uri)? {
         BdevType::Aio(args) => args.name,
         BdevType::Iscsi(args) => args.name,
-        BdevType::Nvmf(args) => args.name,
+        BdevType::Nvmf(args) => {
+            // the namespace instance is appended to the nvme bdev, we currently
+            // only support one namespace per bdev.
+            format!("{}{}", args.name, "n1")
+        }
         BdevType::Uring(args) => args.name,
         BdevType::Bdev(name) => name,
     })

--- a/nix/lib/nixPackages.nix
+++ b/nix/lib/nixPackages.nix
@@ -1,7 +1,8 @@
 {}:
 let
-  rev = "10d60f7fae0afae261e5d556379f33777732fd27";
-  sha256 = "0glk8ahm47r26w9pyh5vrhbgv091d2fah55yj4a8jliavbmfsv2s";
+  rev = "db31e48c5c8d99dcaf4e5883a96181f6ac4ad6f6";
+  sha256 = "1j5j7vbnq2i5zyl8498xrf490jca488iw6hylna3lfwji6rlcaqr";
+
 in
 builtins.fetchTarball {
   url = "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz";

--- a/nix/lib/rust.nix
+++ b/nix/lib/rust.nix
@@ -3,15 +3,14 @@ let
   mozilla = fetchFromGitHub {
     owner = "mozilla";
     repo = "nixpkgs-mozilla";
-    rev = "ac8e9d7bbda8fb5e45cae20c5b7e44c52da3ac0c";
-    sha256 = "1irlkqc0jdkxdfznq7r52ycnf0kcvvrz416qc7346xhmilrx2gy6";
+    rev = "e912ed483e980dfb4666ae0ed17845c4220e5e7c";
+    sha256 = "08fvzb8w80bkkabc1iyhzd15f4sm7ra10jn32kfch5klgl0gj3j3";
   };
 
   overlay = import (builtins.toPath "${mozilla}/package-set.nix") { inherit pkgs; };
 in
 rec {
   nightly = overlay.rustChannelOf {
-    date = "2019-12-19";
     channel = "nightly";
   };
 

--- a/nix/mayastor-overlay.nix
+++ b/nix/mayastor-overlay.nix
@@ -6,7 +6,7 @@ self: super: {
   nvme-cli = super.callPackage ./pkgs/nvme-cli { };
   nvmet-cli = super.callPackage ./pkgs/nvmet-cli { };
   libspdk = super.callPackage ./pkgs/libspdk { };
-  mayastor = (super.callPackage ./pkgs/mayastor { }).mayastor;
+  mayastor = (super.callPackage ./pkgs/mayastor { release = true; }).mayastor;
   mayastorImage = (super.callPackage ./pkgs/mayastor { }).mayastorImage;
   mayastorCSIImage = (super.callPackage ./pkgs/mayastor { }).mayastorCSIImage;
   ms-buildenv = super.callPackage ./pkgs/ms-buildenv { };
@@ -14,4 +14,5 @@ self: super: {
   node-moac = (import ./../csi/moac { pkgs = super; }).package;
   node-moacImage = (import ./../csi/moac { pkgs = super; }).buildImage;
   nodePackages = (import ./pkgs/nodePackages { pkgs = super; });
+
 }

--- a/nix/pkgs/libspdk/default.nix
+++ b/nix/pkgs/libspdk/default.nix
@@ -1,7 +1,7 @@
 { binutils
 , callPackage
 , cunit
-, enableDebug ? true
+, enableDebug ? false
 , fetchFromGitHub
 , git
 , lcov
@@ -47,19 +47,19 @@ stdenv.mkDerivation rec {
   #${enableFeature enableDebug "unit-tests"}
 
   configureFlags = [
-    "${enableFeature enableDebug "debug"}"
     "${enableFeature enableDebug "tests"}"
+    "--target-arch=nehalem"
     "--without-isal"
     "--with-iscsi-initiator"
     "--with-internal-vhost-lib"
     "--with-crypto"
     "--with-uring"
-  ];
+  ] ++ stdenv.lib.optionals (enableDebug) [ "--enable-debug" ];
+
 
   enableParallelBuilding = true;
 
   preConfigure = ''
-    patchShebangs ./.
     substituteInPlace dpdk/config/defconfig_x86_64-native-linux-gcc --replace native default
     # A workaround for https://bugs.dpdk.org/show_bug.cgi?id=356
     substituteInPlace dpdk/lib/Makefile --replace 'DEPDIRS-librte_vhost :=' 'DEPDIRS-librte_vhost := librte_hash'
@@ -78,7 +78,13 @@ stdenv.mkDerivation rec {
 
   '';
 
-  NIX_CFLAGS_COMPILE = "-mno-movbe -mno-lzcnt -mno-bmi -mno-bmi2 -march=nehalem";
+  configurePhase = ''
+    patchShebangs ./.
+    ./configure $configureFlags
+  '';
+
+  # experiment if still need this..
+  # NIX_CFLAGS_COMPILE = "-mno-movbe -mno-lzcnt -mno-bmi -mno-bmi2 -march=nehalem";
   hardeningDisable = [ "all" ];
 
   postBuild = ''
@@ -95,7 +101,9 @@ stdenv.mkDerivation rec {
 
   '';
 
-  postInstall = ''
+  installPhase = ''
+    mkdir -p $out/lib
+    mkdir $out/bin
 
     pushd include
     find . -type f -name "*.h" -exec install -D "{}" $out/include/spdk/{} \;

--- a/nix/pkgs/liburing/default.nix
+++ b/nix/pkgs/liburing/default.nix
@@ -5,12 +5,12 @@
 
 stdenv.mkDerivation rec {
   pname = "liburing";
-  version = "0.5";
+  version = "0.6";
 
   src = fetchgit {
     url = "http://git.kernel.dk/${pname}";
-    rev = "3be13f40c02f245ac03a8b3500736e657f04920a";
-    sha256 = "09q33iw0y5xb2237k0px5s54kbk0ch20nr4j2c050nzss3fmsg2f";
+    rev = "f0c5c54945ae92a00cdbb43bdf3abaeab6bd3a23";
+    sha256 = "06lrqx0ch8yszy6ck5y0kj8wn7i1bnjlrdgxbmr3g32ymic1hyln";
   };
 
   separateDebugInfo = true;
@@ -25,14 +25,6 @@ stdenv.mkDerivation rec {
       --libdir=$lib/lib \
       --libdevdir=$lib/lib \
       --mandir=$man/share/man \
-  '';
-
-  # Copy the examples into $out.
-  postInstall = ''
-    mkdir -p $out/bin
-    cp ./examples/io_uring-cp examples/io_uring-test $out/bin
-    cp ./examples/link-cp $out/bin/io_uring-link-cp
-    cp ./examples/ucontext-cp $out/bin/io_uring-ucontext-cp
   '';
 
   meta = with stdenv.lib; {

--- a/nix/pkgs/mayastor/default.nix
+++ b/nix/pkgs/mayastor/default.nix
@@ -1,23 +1,27 @@
 { stdenv
+, busybox
+, clang
+, dockerTools
 , e2fsprogs
+, fetchFromGitHub
+, lib
 , libaio
 , libiscsi
 , libspdk
+, libudev
 , liburing
 , llvmPackages
+, makeRustPlatform
 , numactl
 , openssl
+, pkgs
 , pkg-config
 , protobuf
 , rdma-core
-, clang
+, release ? true
 , utillinux
-, xfsprogs
-, makeRustPlatform
-, fetchFromGitHub
-, dockerTools
 , writeScriptBin
-, pkgs ? import <nixpkgs>
+, xfsprogs
 }:
 let
   channel = import ../../lib/rust.nix {
@@ -29,21 +33,29 @@ let
     cargo = channel.stable.cargo;
   };
 in
-with pkgs; rec {
+rec {
 
   whitelistSource = src: allowedPrefixes:
     builtins.filterSource
       (path: type:
-        pkgs.lib.any
+        lib.any
           (allowedPrefix:
-            pkgs.lib.hasPrefix (toString (src + "/${allowedPrefix}")) path)
-          allowedPrefixes) src;
+            lib.hasPrefix (toString (src + "/${allowedPrefix}")) path)
+          allowedPrefixes)
+      src;
+
+  release-src = fetchFromGitHub {
+    owner = "openebs";
+    repo = "mayastor";
+    rev = "0165058897ae3d8cdd3bcd3c56ef55eb3b1eb13f";
+    sha256 = "09sgj7rbaqalf4ywnjaw6cimpn6p4ibzlbyjdsx5sjf1rlb5jv9a";
+  };
 
   mayastor = rustPlatform.buildRustPackage rec {
     name = "mayastor";
     cargoSha256 = "12h4qy4afl82pwswmvv1jpixvw5b5g6s95x32fnsvbbyhzykiarn";
-    version = "unstable";
-    src = whitelistSource ../../../. [
+    version = "0.1.1";
+    src = if release then release-src else whitelistSource ../../../. [
       "Cargo.lock"
       "Cargo.toml"
       "cli"
@@ -55,17 +67,13 @@ with pkgs; rec {
       "rpc"
       "spdk-sys"
       "sysfs"
-      # We need to copy git as we use git_version!() in rust, we can also
-      # use use nix to pass the hash if we want to by we should, mosty
-      # likely, go with a proper release version.
-      ".git"
     ];
 
-    LIBCLANG_PATH = "${pkgs.llvmPackages.libclang}/lib";
+    LIBCLANG_PATH = "${llvmPackages.libclang}/lib";
 
     # these are required for building the proto files that tonic can't find otherwise.
-    PROTOC = "${pkgs.protobuf}/bin/protoc";
-    PROTOC_INCLUDE = "${pkgs.protobuf}/include";
+    PROTOC = "${protobuf}/bin/protoc";
+    PROTOC_INCLUDE = "${protobuf}/include";
     C_INCLUDE_PATH = "${libspdk}/include/spdk";
 
     buildInputs = [
@@ -86,25 +94,25 @@ with pkgs; rec {
       utillinux.dev
     ];
 
-    buildType = "debug";
+    buildType = if release then "release" else "debug";
     verifyCargoDeps = false;
 
     doCheck = false;
     meta = { platforms = stdenv.lib.platforms.linux; };
   };
 
-  env = pkgs.stdenv.lib.makeBinPath [ pkgs.busybox pkgs.utillinux pkgs.xfsprogs pkgs.e2fsprogs ];
+  env = stdenv.lib.makeBinPath [ busybox utillinux xfsprogs e2fsprogs ];
 
   mayastorIscsiadm = writeScriptBin "mayastor-iscsiadm" ''
-    #!${pkgs.stdenv.shell}
+    #!${stdenv.shell}
     chroot /host /usr/bin/env -i PATH="/sbin:/bin:/usr/bin" iscsiadm "$@"
   '';
 
-  mayastorImage = pkgs.dockerTools.buildLayeredImage {
+  mayastorImage = dockerTools.buildLayeredImage {
     name = "mayadata/mayastor";
-    tag = "latest";
+    tag = release-src.rev;
     created = "now";
-    contents = [ pkgs.busybox mayastor ];
+    contents = [ busybox mayastor ];
     config = {
       Env = [ "PATH=${env}" ];
       ExposedPorts = { "10124/tcp" = { }; };
@@ -112,11 +120,11 @@ with pkgs; rec {
     };
   };
 
-  mayastorCSIImage = pkgs.dockerTools.buildLayeredImage {
+  mayastorCSIImage = dockerTools.buildLayeredImage {
     name = "mayadata/mayastor-grpc";
-    tag = "latest";
+    tag = release-src.rev;
     created = "now";
-    contents = [ pkgs.busybox mayastor mayastorIscsiadm ];
+    contents = [ busybox mayastor mayastorIscsiadm ];
     config = {
       Entrypoint = [ "/bin/mayastor-agent" ];
       Env = [ "PATH=${env}" ];

--- a/nix/pkgs/mayastor/default.nix
+++ b/nix/pkgs/mayastor/default.nix
@@ -47,8 +47,8 @@ rec {
   release-src = fetchFromGitHub {
     owner = "openebs";
     repo = "mayastor";
-    rev = "0165058897ae3d8cdd3bcd3c56ef55eb3b1eb13f";
-    sha256 = "09sgj7rbaqalf4ywnjaw6cimpn6p4ibzlbyjdsx5sjf1rlb5jv9a";
+    rev = "1e5dca302cff3e66220c3cf892a08c89733d535e";
+    sha256 = "0w7apa3rnjbkz2ma1nca42w729zj33k2xvfy34c84x6q0f4s9zjz";
   };
 
   mayastor = rustPlatform.buildRustPackage rec {


### PR DESCRIPTION
Return changes from the release 0.2.0 activities to the develop branch:

1) Fix-up for issues identified with rebuild; Add missing nvmf namespace identifier to the bdev name (cas-317) and additionally, fault a child if a rebuild action on it fails

2) nix: Changes to simplify making release builds:
-  point mayastor/default.nix to an actual commit we release
- bumped packages of nixpkgs itself and liburing
- bumped rust overlay such that are are on rust stable 1.44 (from 1.41)\
- bumped liburing 0.5 -> 0.6
- all images pkgs, by default now, are built in release mode
- fixed the libspdk/default.nix (not all variable are set by configure)

3) Update content of the deploy folder
- Remove tested on Azure AKS notice
- Update moac and mayator deployment yamls to target the v0.2.0 tagged images, and not :latest, which currently has no meaning for the develop branch (we don't push images on each build)


 