### PR TITLE
Integrate develop back into release/0.2.0 ahead of the reciprocal action on develop

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -58,6 +58,7 @@ jobs:
           path: ./target/debug
       - run: ( sudo modprobe nbd )
       - run: ( sudo modprobe xfs )
+      - run: ( sudo modprobe nvme_tcp )
       # In line below change 2048 to 8192 if running on self-hosted instead of ubuntu-latest.
       - run: ( echo 2048 | sudo tee /sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages )
       - run: ( /usr/bin/docker create --name mochaTest --workdir /__w/Mayastor/Mayastor --network host --privileged -v /dev:/dev -v /:/host  --cpus 2 -v "/var/run/docker.sock":"/var/run/docker.sock" -v "/home/runner/work":"/__w" --entrypoint "tail" docker.io/mayadata/ms-buildenv:latest "-f" "/dev/null" )

--- a/mayastor-test/test_nexus.js
+++ b/mayastor-test/test_nexus.js
@@ -662,6 +662,18 @@ describe('nexus', function () {
       );
     });
 
+    it('should discover the nvmf nexus device', (done) => {
+      common.execAsRoot('nvme', ['discover', '-a', externIp, '-s', '8420', '-t', 'tcp', '-q', 'nqn.2014-08.org.nvmexpress.discovery'], (err, stdout) => {
+        if (err) {
+          done(err);
+        } else {
+          // The discovery reply text should contain our nexus
+          assert.include(stdout.toString(), 'nqn.2019-05.io.openebs:nexus-' + UUID);
+          done();
+        }
+      });
+    });
+
     it('should write to nvmf replica', (done) => {
       common.execAsRoot(
         common.getCmdPath('initiator'),

--- a/mayastor/src/subsys/opts.rs
+++ b/mayastor/src/subsys/opts.rs
@@ -29,6 +29,8 @@ use spdk_sys::{
 pub struct NexusOpts {
     /// enable nvmf target
     pub nvmf_enable: bool,
+    /// enable the nvmf discovery subsystem
+    pub nvmf_discovery_enable: bool,
     /// nvmf port over which we export
     pub nvmf_nexus_port: u16,
     /// NOTE: we do not (yet) differentiate between
@@ -56,6 +58,7 @@ impl Default for NexusOpts {
     fn default() -> Self {
         Self {
             nvmf_enable: true,
+            nvmf_discovery_enable: true,
             nvmf_nexus_port: NVMF_PORT_NEXUS,
             nvmf_replica_port: NVMF_PORT_REPLICA,
             iscsi_enable: true,


### PR DESCRIPTION
Changes to GitHub workflow:

Add the NVMEoF discovery susbsytem when we bring up a target
by default (but allow for it to be disabled through config).

Resolves: CAS-192