### PR TITLE
CAS-312 moac logs a warning about unexpected disk change

### DIFF
--- a/csi/moac/node.js
+++ b/csi/moac/node.js
@@ -352,7 +352,6 @@ class Node extends EventEmitter {
     if (!poolInfo) {
       throw new GrpcError(GrpcCode.INTERNAL, `New pool "${name}" not found`);
     }
-    poolInfo.disks.sort();
 
     const newPool = new Pool(poolInfo);
     this._registerPool(newPool);

--- a/csi/moac/test/mayastor_mock.js
+++ b/csi/moac/test/mayastor_mock.js
@@ -80,9 +80,7 @@ class MayastorServer {
         } else {
           self.pools.push({
             name: args.name,
-            disks: args.disks.map((d) => {
-              return 'aio://' + d;
-            }),
+            disks: args.disks,
             state: enums.POOL_ONLINE,
             capacity: 100,
             used: 4
@@ -103,8 +101,14 @@ class MayastorServer {
           cb(err);
         }
       },
-      listPools: (_, cb) => {
-        cb(null, { pools: self.pools });
+      listPools: (_unused, cb) => {
+        cb(null, {
+          pools: self.pools.map(p => {
+            p = _.cloneDeep(p);
+            p.disks = p.disks.map((d) => `aio://${d}`);
+            return p;
+          })
+        });
       },
       createReplica: (call, cb) => {
         const args = call.request;
@@ -159,10 +163,10 @@ class MayastorServer {
           cb(err);
         }
       },
-      listReplicas: (_, cb) => {
+      listReplicas: (_unused, cb) => {
         cb(null, { replicas: self.replicas });
       },
-      statReplicas: (_, cb) => {
+      statReplicas: (_unused, cb) => {
         self.statCounter += STAT_DELTA;
         cb(null, {
           replicas: self.replicas.map((r) => {
@@ -237,7 +241,7 @@ class MayastorServer {
           cb(err);
         }
       },
-      listNexus: (_, cb) => {
+      listNexus: (_unused, cb) => {
         cb(null, { nexusList: self.nexus });
       },
       publishNexus: (call, cb) => {
@@ -299,7 +303,7 @@ class MayastorServer {
         cb();
       },
       // dummy impl to silence the warning about unimplemented method
-      childOperation: (_, cb) => {
+      childOperation: (_unused, cb) => {
         cb();
       }
     });

--- a/csi/moac/test/node_test.js
+++ b/csi/moac/test/node_test.js
@@ -119,8 +119,8 @@ module.exports = function () {
           expect(poolObjects).to.have.lengthOf(1);
           expect(poolObjects[0].name).to.equal('pool');
           expect(poolObjects[0].disks).to.have.lengthOf(2);
-          expect(poolObjects[0].disks[0]).to.equal('/dev/sdb');
-          expect(poolObjects[0].disks[1]).to.equal('/dev/sdc');
+          expect(poolObjects[0].disks[0]).to.equal('aio:///dev/sdb');
+          expect(poolObjects[0].disks[1]).to.equal('aio:///dev/sdc');
           expect(poolObjects[0].state).to.equal('POOL_ONLINE');
           expect(poolObjects[0].capacity).to.equal(100);
           expect(poolObjects[0].used).to.equal(14);
@@ -545,7 +545,7 @@ module.exports = function () {
         expect(ev.eventType).to.equal('new');
         expect(ev.object.name).to.equal('pool');
         expect(ev.object.disks).to.have.lengthOf(1);
-        expect(ev.object.disks[0]).to.equal('/dev/sda');
+        expect(ev.object.disks[0]).to.equal('aio:///dev/sda');
         expect(node.pools).to.have.lengthOf(1);
         emitted = true;
       });

--- a/rpc/proto/mayastor.proto
+++ b/rpc/proto/mayastor.proto
@@ -24,7 +24,7 @@ enum PoolIoIf {
 // Currently we support only concatenation of disks (RAID-0).
 message CreatePoolRequest {
   string name = 1;           // name of the pool
-  repeated string disks = 2; // absolute disk device paths to be claimed by the pool
+  repeated string disks = 2; // disk device paths or URIs to be claimed by the pool
   uint32 block_size = 3; // when using files, we need to specify the block_size
   PoolIoIf io_if = 4;        // I/O interface
 }


### PR DESCRIPTION
... even if there is no change

I reworked the logic a little bit. Previously we have ignored changes to the disk because it was considered as an awkward situation that we didn't know how to respond to. However ignoring such change is not a solution because then msv resources don't reflect the right state on the storage node (the resource did not exist when this code was written). So I think that now the code works better and it fixes the bug that was the primary motivation for changing it.