### PR TITLE
moac emits debug messages about stale object events (CAS-316)

### DIFF
--- a/csi/moac/package.json
+++ b/csi/moac/package.json
@@ -15,6 +15,7 @@
   "scripts": {
     "prepare": "./bundle_protos.sh",
     "clean": "rm -f replica.js pool.js",
+    "purge": "rm -rf node_modules proto replica.js pool.js",
     "compile": "tsc --pretty",
     "start": "./index.js",
     "test": "mocha test/index.js",

--- a/csi/moac/watcher.js
+++ b/csi/moac/watcher.js
@@ -254,8 +254,10 @@ class Watcher extends EventEmitter {
         // we assume that if generation # remained the same => no change
         // TODO: add 64-bit integer overflow protection
         this.emit('mod', obj);
+      } else if (oldObj.metadata.generation === generation) {
+        log.trace(`Status of ${this.name} object changed`);
       } else {
-        log.debug(`Ignoring stale ${this.name} object event`);
+        log.warn(`Ignoring stale ${this.name} object event`);
       }
 
       // TODO: subtle race condition when delete event is related to object which


### PR DESCRIPTION
It can happen that generation number remains the same in case when status part of CRD is changed. In that case the event is of no interest to us (because moac makes status changes so it would react to self), but we should print less disturbing message to the log file.

Resolves: CAS-316