### PR TITLE
moac: msn is out of date (CAS-327)

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@master
       - uses: actions-rs/toolchain@master
         with:
-          toolchain: nightly
+          toolchain: nightly-2020-06-21
           components: clippy
       - uses: actions-rs/clippy-check@v1.0.5
         with:

--- a/csi/moac/test/watcher_stub.js
+++ b/csi/moac/test/watcher_stub.js
@@ -57,6 +57,10 @@ class Watcher extends EventEmitter {
 
   async stop () {}
 
+  async getRawBypass (name) {
+    return this.getRaw(name);
+  }
+
   getRaw (name) {
     const obj = this.objects[name];
     if (!obj) {

--- a/csi/moac/watcher.js
+++ b/csi/moac/watcher.js
@@ -201,6 +201,46 @@ class Watcher extends EventEmitter {
     }
   }
 
+  // Fetches the latest object(s) from k8s and updates the cache; then it
+  // returns the k8s object(s) from the cache or null if it does not exist.
+  async getRawBypass (name) {
+    var getObj = null;
+
+    try {
+      getObj = await this.getEp(name).get();
+    } catch (err) {
+      if (err.code !== 404) {
+        log.error(`Failed to fetch latest "${name}" from k8s, error: "${err}". Will only use the cached values instead.`);
+      }
+    }
+
+    if (getObj) {
+      if (getObj.statusCode === 200) {
+        const k8sObj = getObj.body;
+        const cachedObj = this.objects[name];
+
+        if (!cachedObj) {
+          // we still haven't processed the "ADDED" event so add it now
+          this._processEvent({
+            type: 'ADDED',
+            object: k8sObj
+          });
+        } else if (!k8sObj.metadata.generation || cachedObj.metadata.generation < k8sObj.metadata.generation) {
+          // the object already exists so modify it
+          this._processEvent({
+            type: 'MODIFIED',
+            object: k8sObj
+          });
+        }
+      } else {
+        const code = getObj.statusCode;
+        log.error(`Failed to fetch latest "${name}" from k8s, code: "${code}". Will only use the cached values instead.`);
+      }
+    }
+
+    return this.getRaw(name);
+  }
+
   // Return the collection of objects
   list () {
     return Object.values(this.objects).map((ent) => this.filterCb(ent));


### PR DESCRIPTION
Makes use of the existing work queue to serialise node updates

Sometimes the watcher is out of date with k8s. A temporary fix is to
always bypass the cache and get the information we need directly from
k8s and update. We also update the watcher cache with the new value.
(I've raised cas-328 to track this issue)

Also added the corresponding watcher tests