### PR TITLE
moac: msv is out of date (CAS-323)

### DIFF
--- a/csi/moac/nexus.ts
+++ b/csi/moac/nexus.ts
@@ -204,11 +204,11 @@ export class Nexus {
         `Failed to add uri "${uri}" to nexus "${this}": ${err}`
       );
     }
-    // We assume that child needs to be rebuilt when added, hence the state
-    // is implicitly set to degraded.
+    // The child will need to be rebuilt when added, but until we get
+    // confirmation back from the nexus, set it as pending
     this.children.push({
       uri: uri,
-      state: 'CHILD_DEGRADED'
+      state: 'CHILD_PENDING'
     });
     this.children.sort(compareChildren);
     log.info(`Replica uri "${uri}" added to the nexus "${this}"`);

--- a/csi/moac/test/volumes_test.js
+++ b/csi/moac/test/volumes_test.js
@@ -789,7 +789,7 @@ module.exports = function () {
       expect(volume.state).to.equal('degraded');
 
       const newChild = volume.nexus.children.find(
-        (ch) => ch.state === 'CHILD_DEGRADED'
+        (ch) => ch.state === 'CHILD_PENDING'
       );
       expect(newChild.uri).to.equal('nvmf://replica3');
       newChild.state = 'CHILD_ONLINE';

--- a/csi/moac/volume.js
+++ b/csi/moac/volume.js
@@ -191,9 +191,9 @@ class Volume {
     }
 
     // If we don't have sufficient number of sound replicas (sound means online
-    // or under rebuild) then add a new one.
+    // , under rebuild or pending) then add a new one.
     var soundCount = children.filter((ch) => {
-      return ['CHILD_ONLINE', 'CHILD_DEGRADED'].indexOf(ch.state) >= 0;
+      return ['CHILD_ONLINE', 'CHILD_DEGRADED', 'CHILD_PENDING'].indexOf(ch.state) >= 0;
     }).length;
     if (this.replicaCount > soundCount) {
       this._setState('degraded');
@@ -208,10 +208,11 @@ class Volume {
       return;
     }
 
-    // The condition for later actions is that volume must not be rebuilt.
-    // So check that and return if that's the case.
-    var rebuildCount = children.filter((ch) => ch.state === 'CHILD_DEGRADED')
-      .length;
+    // The condition for later actions is that volume must not be rebuilding or
+    // waiting for a child add. So check that and return if that's the case.
+    var rebuildCount = children.filter((ch) => {
+      return ['CHILD_DEGRADED', 'CHILD_PENDING'].indexOf(ch.state) >= 0;
+    }).length;
     if (rebuildCount > 0) {
       this._setState('degraded');
       return;


### PR DESCRIPTION
When a new child is added, the msv is temporarily showing incorrect
information until we get back a grpc list response. Instead, set the
child as pending until we retrieve the correct information via the list
nexus.

The update volume is also failing as there are concurrent updates, so
serialise these using the workq and also bypass the cache.