### PR TITLE
Provision NVMe-oF volumes. CAS-81

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,11 +424,13 @@ dependencies = [
  "glob",
  "http 0.1.21",
  "http-body 0.2.0",
+ "itertools 0.9.0",
  "jsonrpc",
  "libc",
  "log",
  "loopdev",
  "nix 0.17.0",
+ "nvmeadm",
  "once_cell",
  "proc-mounts",
  "prost",
@@ -446,6 +448,7 @@ dependencies = [
  "tonic",
  "tonic-build",
  "tower",
+ "udev",
  "url",
  "which",
 ]
@@ -1066,6 +1069,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1430,6 +1442,7 @@ dependencies = [
 name = "nvmeadm"
 version = "0.1.0"
 dependencies = [
+ "clap",
  "derive_builder 0.7.2",
  "enum-primitive-derive",
  "failure",
@@ -1438,6 +1451,8 @@ dependencies = [
  "libc",
  "nix 0.14.1",
  "num-traits 0.1.43",
+ "once_cell",
+ "uuid",
 ]
 
 [[package]]
@@ -1642,7 +1657,7 @@ checksum = "02b10678c913ecbd69350e8535c3aef91a8676c0773fc1d7b95cdd196d7f2f26"
 dependencies = [
  "bytes 0.5.5",
  "heck",
- "itertools",
+ "itertools 0.8.2",
  "log",
  "multimap",
  "petgraph",
@@ -1659,7 +1674,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "537aa19b95acde10a12fec4301466386f757403de4cd4e5b4fa78fb5ecb18f72"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.8.2",
  "proc-macro2 1.0.18",
  "quote 1.0.7",
  "syn 1.0.33",

--- a/csi/Cargo.toml
+++ b/csi/Cargo.toml
@@ -30,6 +30,7 @@ git-version = "0.3.1"
 glob = "*"
 http = "0.1"
 http-body = "0.2"
+itertools = "0.9"
 jsonrpc = { path = "../jsonrpc" }
 libc = "0.2"
 log = "0.4"
@@ -52,6 +53,8 @@ tonic = "0.1"
 tower = "0.3"
 url = "2.1.1"
 which = "3.1.1"
+nvmeadm = { path = "../nvmeadm", version = "0.1.0" }
+udev = "0.4"
 
 [dependencies.blkid]
 branch = "blkid-sys"

--- a/csi/src/node.rs
+++ b/csi/src/node.rs
@@ -550,12 +550,12 @@ impl node_server::Node for Node {
         debug!("Unstaging volume {} at {}", volume_id, stage_path);
         let (device_path, share_type) = match iscsi_find(volume_id.as_str()) {
             Some(devpath) => {
-                debug!("unstage: is iSCSI device path is {}", devpath);
+                debug!("unstage: iSCSI device path is {}", devpath);
                 (devpath, ShareProtocolNexus::NexusIscsi)
             }
             _ => match nvmf_find(volume_id.as_str()) {
                 Some(devpath) => {
-                    debug!("unstage: is NVMF device path is {}", devpath);
+                    debug!("unstage: NVMF device path is {}", devpath);
                     (devpath, ShareProtocolNexus::NexusNvmf)
                 }
                 // Must be nbd

--- a/csi/src/node/iscsiutil.rs
+++ b/csi/src/node/iscsiutil.rs
@@ -232,7 +232,7 @@ fn get_iscsi_device_path(uuid: &str) -> Option<String> {
     });
 
     for cap in RE_TARGET.captures_iter(op.as_str()) {
-        trace!("unstage: searching for {} got {}", uuid, &cap["uuid"]);
+        trace!("iscsiutil: searching for {} got {}", uuid, &cap["uuid"]);
         if uuid == &cap["uuid"] {
             return Some(format!(
                 "/dev/disk/by-path/ip-{}:{}-iscsi-{}-{}-lun-{}",

--- a/csi/src/node/nvmfutil.rs
+++ b/csi/src/node/nvmfutil.rs
@@ -8,7 +8,6 @@ fn find_nvmf_device_by_uuid(str_uuid: &str) -> Result<String, String> {
     trace!("find_nvmf_device_by_uuid uuid={}", str_uuid);
     let mut enumerator = Enumerator::new().unwrap();
     enumerator.match_subsystem("block").unwrap();
-    //    enumerator.match_property("DEVTYPE", "disk").unwrap();
     enumerator
         .match_property("ID_MODEL", "MayaStor NVMF controller")
         .unwrap();
@@ -59,7 +58,7 @@ fn uuid_from_str(s: &str) -> String {
 }
 
 fn wait_for_path_to_exist(uuid: String, max_retries: i32) -> Option<String> {
-    let second = time::Duration::from_millis(1000);
+    let second = time::Duration::from_secs(1);
     let mut retries: i32 = 0;
     let now = time::Instant::now();
     while retries < max_retries {

--- a/csi/src/node/nvmfutil.rs
+++ b/csi/src/node/nvmfutil.rs
@@ -1,0 +1,179 @@
+use std::{io, thread, time};
+use udev::Enumerator;
+
+fn find_nvmf_device_by_uuid(str_uuid: &str) -> Result<String, String> {
+    let prop = "ID_WWN";
+    let value = format!("uuid.{}", str_uuid);
+
+    trace!("find_nvmf_device_by_uuid uuid={}", str_uuid);
+    let mut enumerator = Enumerator::new().unwrap();
+    enumerator.match_subsystem("block").unwrap();
+    //    enumerator.match_property("DEVTYPE", "disk").unwrap();
+    enumerator
+        .match_property("ID_MODEL", "MayaStor NVMF controller")
+        .unwrap();
+    for dev in enumerator.scan_devices().unwrap() {
+        if let Some(udev_value) = dev.property_value(prop) {
+            if udev_value.to_str().unwrap().contains(&value) {
+                trace!(
+                    "find_nvmf_device_by_uuid {} got {:?}",
+                    str_uuid,
+                    dev.property_value("DEVNAME")
+                );
+
+                return Ok(dev
+                    .property_value("DEVNAME")
+                    .unwrap()
+                    .to_str()
+                    .unwrap()
+                    .to_string());
+            }
+        }
+    }
+
+    // fall through
+    Err(format!("device not found for {}", str_uuid))
+}
+
+fn uuid_from_str(s: &str) -> String {
+    //TODO something more sane.
+    //hack { convert something like
+    //0)    nvmf://192.168.122.98:8420/nqn.2019-
+    //1)        05.io.openebs:nexus-
+    //2)        04089481-
+    //3)        cc69-
+    //4)        45c1-
+    //5)        8009-
+    //6)        8aa7167a633a
+    // to uuid string value.
+    // will return a garbage string if passed in garbage,
+    // but that is okay for now since this is only used
+    // to find devices with a matching uuid and nothing
+    // will match the garbage.
+    let mut frags = s.split('-').collect::<Vec<_>>();
+    while frags.len() > 5 {
+        frags.remove(0);
+    }
+    itertools::join(&frags, "-")
+    // } hack
+}
+
+fn wait_for_path_to_exist(uuid: String, max_retries: i32) -> Option<String> {
+    let second = time::Duration::from_millis(1000);
+    let mut retries: i32 = 0;
+    let now = time::Instant::now();
+    while retries < max_retries {
+        thread::sleep(second);
+
+        if let Ok(path) = find_nvmf_device_by_uuid(&uuid) {
+            trace!(
+                "wait_for_path_to_exist {} {} success for elapsed time is {:?}",
+                uuid,
+                path,
+                now.elapsed()
+            );
+            return Some(path);
+        }
+        retries += 1;
+    }
+    debug!("wait_for_path_to_exist timed out after {:?}", now.elapsed());
+    None
+}
+
+fn nvmeadm_attach_disk(
+    ip_addr: &str,
+    port: u32,
+    nqn: &str,
+    uri: &str,
+) -> Result<String, String> {
+    trace!(
+        "nvmeadm_attach_disk ip_addr={} port={} nqn={}",
+        ip_addr,
+        port,
+        nqn
+    );
+
+    let result = nvmeadm::nvmf_discovery::connect(ip_addr, port, nqn);
+    if let Err(e) = result {
+        let mut in_progress = false;
+        if let Some(ioerr) = e.downcast_ref::<io::Error>() {
+            if let Some(errcode) = ioerr.raw_os_error() {
+                if errcode == 114 {
+                    in_progress = true;
+                    debug!("nvmeadm operation already in progress for {}", uri);
+                }
+            }
+        }
+        if !in_progress {
+            debug!("nvmeadm connect failed error {} {:?}", uri, e);
+            return Err(format!("{}", e));
+        }
+    }
+
+    match wait_for_path_to_exist(uuid_from_str(uri), 10) {
+        Some(path) => Ok(path),
+        _ => {
+            debug!("nvmeadm nvmf device path not found.");
+            Err("No path for nvme device".to_string())
+        }
+    }
+}
+
+pub fn nvmeadm_detach_disk(nqn: &str) -> Result<(), String> {
+    match nvmeadm::nvmf_discovery::disconnect(&nqn) {
+        Ok(_) => {
+            trace!("nvmf disconnected {}", nqn);
+            Ok(())
+        }
+        Err(e) => {
+            debug!("nvmf disconnect {} FAILED.", nqn);
+            Err(format!("{}", e))
+        }
+    }
+}
+
+pub fn nvmf_attach_disk(nvmf_uri: &str) -> Result<String, String> {
+    trace!("nvmf_attach_disk {}", nvmf_uri);
+
+    if let Some(path) = wait_for_path_to_exist(uuid_from_str(nvmf_uri), 1) {
+        return Ok(path);
+    }
+
+    if let Ok(url) = url::Url::parse(nvmf_uri) {
+        if url.scheme() == "nvmf" {
+            let tokens =
+                url.path_segments().map(|c| c.collect::<Vec<_>>()).unwrap();
+            return nvmeadm_attach_disk(
+                url.host_str().unwrap(),
+                u32::from(url.port().unwrap()),
+                tokens[0],
+                nvmf_uri,
+            );
+        }
+    }
+
+    Err(format!("Invalid nvmf URI {}", nvmf_uri))
+}
+
+/// Search for and return path to the device on which a nexus iscsi
+/// target matching the volume id has been mounted or None.
+pub fn nvmf_find(uuid: &str) -> Option<String> {
+    trace!("nvmf_find {}", uuid);
+    match find_nvmf_device_by_uuid(uuid) {
+        Ok(path) => {
+            trace!("nvmf_find for {} got {}", uuid, path);
+            Some(path)
+        }
+        _ => {
+            debug!("nvmf_find for {} FAILED", uuid);
+            None
+        }
+    }
+}
+
+pub fn nvmf_detach_disk(uuid: &str) -> Result<(), String> {
+    // Ugh! hardcoded nqn, bad, bad, bad
+    let nqn = format!("nqn.2019-05.io.openebs:{}", uuid);
+    trace!("nvmf_detach_disk for {} nqn is {}", uuid, nqn);
+    nvmeadm_detach_disk(&nqn)
+}

--- a/csi/src/node/nvmfutil.rs
+++ b/csi/src/node/nvmfutil.rs
@@ -140,8 +140,7 @@ pub fn nvmf_attach_disk(nvmf_uri: &str) -> Result<String, String> {
 
     if let Ok(url) = url::Url::parse(nvmf_uri) {
         if url.scheme() == "nvmf" {
-            let tokens =
-                url.path_segments().map(|c| c.collect::<Vec<_>>()).unwrap();
+            let tokens: Vec<&str> = url.path_segments().unwrap().collect();
             return nvmeadm_attach_disk(
                 url.host_str().unwrap(),
                 u32::from(url.port().unwrap()),
@@ -154,7 +153,7 @@ pub fn nvmf_attach_disk(nvmf_uri: &str) -> Result<String, String> {
     Err(format!("Invalid nvmf URI {}", nvmf_uri))
 }
 
-/// Search for and return path to the device on which a nexus iscsi
+/// Search for and return path to the device on which a nexus nvmf
 /// target matching the volume id has been mounted or None.
 pub fn nvmf_find(uuid: &str) -> Option<String> {
     trace!("nvmf_find {}", uuid);

--- a/deploy/mayastor-daemonset.yaml
+++ b/deploy/mayastor-daemonset.yaml
@@ -91,6 +91,10 @@ spec:
         volumeMounts:
         - name: device
           mountPath: /dev
+        - name: sys
+          mountPath: /sys
+        - name: run-udev
+          mountPath: /run/udev
         - name: host-root
           mountPath: /host
         - name: mayastor-dir
@@ -137,6 +141,14 @@ spec:
       - name: device
         hostPath:
           path: /dev
+          type: Directory
+      - name: sys
+        hostPath:
+          path: /sys
+          type: Directory
+      - name: run-udev
+        hostPath:
+          path: /run/udev
           type: Directory
       - name: host-root
         hostPath:

--- a/deploy/storage-class.yaml
+++ b/deploy/storage-class.yaml
@@ -15,3 +15,12 @@ parameters:
   repl: '1'
   protocol: 'iscsi'
 provisioner: io.openebs.csi-mayastor
+---
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: mayastor-nvmf
+parameters:
+  repl: '1'
+  protocol: 'nvmf'
+provisioner: io.openebs.csi-mayastor

--- a/mayastor-test/test_csi.js
+++ b/mayastor-test/test_csi.js
@@ -323,10 +323,13 @@ describe('csi', function () {
     });
   });
 
+  csiProtocolTest('NBD', enums.NEXUS_NBD, 10000, { uri: 'file:///dev/nbd' + '9' });
   csiProtocolTest('iSCSI', enums.NEXUS_ISCSI, 120000, {
     uri: 'iscsi://192.168.0.197:3260/iqn.2019-05.io.openebs:nexus-11111111-0000-0000-0000-000000000009/0'
   });
-  csiProtocolTest('NBD', enums.NEXUS_NBD, 10000, { uri: 'file:///dev/nbd' + '9' });
+  csiProtocolTest('NVMF', enums.NEXUS_NVMF, 120000, {
+    uri: 'nvmf://192.168.0.197:8420/nqn.2019-05.io.openebs:nexus-11111111-0000-0000-0000-000000000009'
+  });
 });
 
 function csiProtocolTest (protoname, shareType, timeoutMillis, unknownPublishContext) {

--- a/nix/pkgs/images/default.nix
+++ b/nix/pkgs/images/default.nix
@@ -123,7 +123,7 @@ rec {
     name = "mayadata/mayastor-grpc";
     tag = "develop";
     created = "now";
-    contents = [ busybox mayastor-develop ];
+    contents = [ busybox mayastor-develop mayastorIscsiadm ];
     config = {
       Env = [ "PATH=${env}" ];
       ExposedPorts = { "10124/tcp" = { }; };

--- a/nix/pkgs/mayastor/default.nix
+++ b/nix/pkgs/mayastor/default.nix
@@ -35,7 +35,7 @@ let
 in
 rustPlatform.buildRustPackage rec {
   name = "mayastor";
-  cargoSha256 = "0yyic3cgrrlq99nwwzs8r5mbh6ww90b1na8w7pp8qf43vpqs73d3";
+  cargoSha256 = "152yhai7jw6gwap6q76vx5ahc2i318in6mzfrxdiksgprlk4kny8";
   #cargoSha256 = "0000000000000000000000000000000000000000000000000000";
   version = sources.mayastor.branch;
   src = if release then sources.mayastor else

--- a/nix/pkgs/mayastor/default.nix
+++ b/nix/pkgs/mayastor/default.nix
@@ -35,7 +35,7 @@ let
 in
 rustPlatform.buildRustPackage rec {
   name = "mayastor";
-  cargoSha256 = "1m1033apypfycigpppi8rcbw3gmmr1sp0jz15hkffmswgk6hyawc";
+  cargoSha256 = "0yyic3cgrrlq99nwwzs8r5mbh6ww90b1na8w7pp8qf43vpqs73d3";
   #cargoSha256 = "0000000000000000000000000000000000000000000000000000";
   version = sources.mayastor.branch;
   src = if release then sources.mayastor else

--- a/nix/pkgs/mayastor/default.nix
+++ b/nix/pkgs/mayastor/default.nix
@@ -35,7 +35,7 @@ let
 in
 rustPlatform.buildRustPackage rec {
   name = "mayastor";
-  cargoSha256 = "152yhai7jw6gwap6q76vx5ahc2i318in6mzfrxdiksgprlk4kny8";
+  cargoSha256 = "0c70cxiyyncvf8qicsr0k0wd99hf8i77vbj599ly8qyabzdnkbgk";
   #cargoSha256 = "0000000000000000000000000000000000000000000000000000";
   version = sources.mayastor.branch;
   src = if release then sources.mayastor else

--- a/nvmeadm/Cargo.toml
+++ b/nvmeadm/Cargo.toml
@@ -4,12 +4,19 @@ version = "0.1.0"
 authors = ["Jeffry Molanus <jeffry.molanus@gmail.com>"]
 edition = "2018"
 
+[[bin]]
+name = "nvmeadm"
+path = "src/nvmeadm.rs"
+
 [dependencies]
+clap = "2.33.0"
+derive_builder = "0.7"
+enum-primitive-derive = "^0.1"
 failure = "0.1"
 glob = "*"
-derive_builder = "0.7"
-nix = "0.14"
 ioctl-gen = "0.1"
 libc = "0.2"
-enum-primitive-derive = "^0.1"
+nix = "0.14"
 num-traits = "^0.1"
+once_cell = "1.3"
+uuid = { version = "0.7", features = ["v4"] }

--- a/nvmeadm/src/nvmeadm.rs
+++ b/nvmeadm/src/nvmeadm.rs
@@ -1,0 +1,182 @@
+extern crate clap;
+use clap::{App, Arg, ArgMatches};
+
+use std::{io, str::FromStr};
+
+fn main() {
+    let matches = App::new("nvmeadm")
+        .version("0.0.1")
+        .author("Mayadata")
+        .about("nvmeadm a la iscsiadm app")
+        .arg(
+            Arg::with_name("ACTION")
+                .help("Select the action [connect|disconnect|discover|discoverandconnect]")
+                .required(true)
+                .index(1),
+        )
+        .arg(
+            Arg::with_name("traddr")
+                .short("a")
+                .long("traddr")
+                .value_name("traddr")
+                .help(
+                    "This field specifies the network address of the Controller. This should be an IP-based address (ex. IPv4). The default is 127.0.0.1."
+                )
+                .takes_value(true),
+        )
+        .arg(
+            Arg::with_name("trsvcid")
+                .short("s")
+                .long("trsvcid")
+                .value_name("trsvcid")
+                .help(
+                    "This field specifies the transport service id. For transports using IP addressing (e.g. rdma) this field is the port number. By default, the IP port number is 8420."
+                )
+                .takes_value(true),
+        )
+        .arg(
+            Arg::with_name("nqn")
+                .short("n")
+                .long("nqn")
+                .value_name("nqn")
+                .help("This field specifies the name for the NVMe subsystem to connect to.")
+                .takes_value(true),
+        )
+        .arg(
+            Arg::with_name("trtype")
+                .short("t")
+                .long("trtype")
+                .value_name("trtype")
+                .help("This field specifies the network fabric being used for a NVMe-over-Fabrics network. Defaults to tcp, and only tcp is supported.")
+                .takes_value(true),
+        )
+        .get_matches();
+    println!("{:?}", perform_action(matches));
+}
+
+#[allow(dead_code)]
+fn print_type_of<T>(_: &T) {
+    println!("typeof {}", std::any::type_name::<T>())
+}
+
+fn perform_action(matches: ArgMatches) -> Result<String, String> {
+    let ip_addr = matches.value_of("traddr").unwrap_or("127.0.0.1");
+    let port =
+        u32::from_str(matches.value_of("port").unwrap_or("8420")).unwrap();
+
+    println!("Using traddr {} and trsvcid {}", ip_addr, port);
+    match matches.value_of("ACTION").unwrap() {
+        "connect" => {
+            println!("CONNECT");
+            let nqn = match matches.value_of("nqn") {
+                Some(v) => v,
+                None => return Err("nqn is required for connect".to_string()),
+            };
+            let result = nvmeadm::nvmf_discovery::connect(ip_addr, port, nqn);
+            match result {
+                Ok(res) => {
+                    println!("{}", res);
+                    println!("Connected to {}:{} {}", ip_addr, port, nqn);
+                }
+                Err(e) => {
+                    if let Some(ioerr) = e.downcast_ref::<io::Error>() {
+                        if let Some(errcode) = ioerr.raw_os_error() {
+                            if errcode == 114 {
+                                return Ok("In progress".to_string());
+                            }
+                        }
+                    }
+                    return Err(format!(
+                        "Connect to {}:{} {} FAILED {:?}",
+                        ip_addr, port, nqn, e
+                    ));
+                }
+            }
+        }
+        "discoverandconnect" => {
+            println!("DISCOVERANDCONNECT");
+            let nqn = match matches.value_of("nqn") {
+                Some(v) => v,
+                None => return Err("nqn is required for connect".to_string()),
+            };
+            //println!("DiscoveryBuilder ip_addr={} port={}", ip_addr, port);
+            let mut discovered_targets =
+                nvmeadm::nvmf_discovery::DiscoveryBuilder::default()
+                    .transport("tcp".to_string())
+                    .traddr(ip_addr.to_string())
+                    .trsvcid(port)
+                    .build()
+                    .unwrap();
+            //println!("discovered_targets = {:?}", discovered_targets);
+            match discovered_targets.discover() {
+                Ok(_discovrd) => {
+                    //println!("discovered {:?}", discovrd);
+                }
+                Err(e) => {
+                    return Err(format!("discover failed {:?}", e));
+                }
+            }
+            let result = discovered_targets.connect(nqn);
+            match result {
+                Ok(res) => {
+                    println!("{}", res);
+                    println!("Connected to {}:{} {}", ip_addr, port, nqn);
+                }
+                Err(e) => {
+                    if let Some(ioerr) = e.downcast_ref::<io::Error>() {
+                        if let Some(errcode) = ioerr.raw_os_error() {
+                            if errcode == 114 {
+                                return Ok("In progress".to_string());
+                            }
+                        }
+                    }
+                    return Err(format!(
+                        "Connect to {}:{} {} FAILED {:?}",
+                        ip_addr, port, nqn, e
+                    ));
+                }
+            }
+        }
+        "disconnect" => {
+            println!("DISCONNECT");
+            let nqn = match matches.value_of("nqn") {
+                Some(v) => v,
+                None => {
+                    return Err("nqn is required for disconnect".to_string())
+                }
+            };
+            match nvmeadm::nvmf_discovery::disconnect(&nqn) {
+                Ok(_) => {
+                    println!("{} has been disconnected", nqn);
+                }
+                Err(e) => return Err(format!("{}", e)),
+            }
+        }
+        "discover" => {
+            println!("DISCOVER");
+            //println!("DiscoveryBuilder ip_addr={} port={}", ip_addr, port);
+            let mut discovered_targets =
+                nvmeadm::nvmf_discovery::DiscoveryBuilder::default()
+                    .transport("tcp".to_string())
+                    .traddr(ip_addr.to_string())
+                    .trsvcid(port)
+                    .build()
+                    .unwrap();
+
+            let discovered = match discovered_targets.discover() {
+                Ok(discovrd) => discovrd,
+                Err(e) => {
+                    return Err(format!("discover failed {:?}", e));
+                }
+            };
+            for entry in discovered {
+                println!("{:?}", entry);
+            }
+        }
+        _ => {
+            return Err("Unknown action".to_string());
+        }
+    }
+
+    Ok("Done".to_string())
+}

--- a/nvmeadm/src/nvmf_discovery.rs
+++ b/nvmeadm/src/nvmf_discovery.rs
@@ -334,7 +334,7 @@ impl Discovery {
     /// or 4421.
     ///
     /// When we are already connected to the same host we will get back
-    /// connection in progress. These errors are propagated back to use as
+    /// connection in progress. These errors are propagated back to us as
     /// we use the ? marker
     ///
     ///  # Example
@@ -411,7 +411,7 @@ impl DiscoveryLogEntry {
 /// identified by its ip address, port and nqn.
 ///
 /// When we are already connected to the same host we will get back
-/// connection in progress. These errors are propagated back to use as
+/// connection in progress. These errors are propagated back to us as
 /// we use the ? marker
 ///
 ///  # Example

--- a/nvmeadm/src/nvmf_discovery.rs
+++ b/nvmeadm/src/nvmf_discovery.rs
@@ -418,7 +418,7 @@ impl DiscoveryLogEntry {
 ///  ```rust
 ///  use nvmeadm::nvmf_discovery::connect;
 ///
-///  let result = discovered_targets.connect("192.168.122.99", 8420, "mynqn");
+///  let result = connect("192.168.122.99", 8420, "mynqn");
 /// ```
 ///
 

--- a/nvmeadm/src/nvmf_discovery.rs
+++ b/nvmeadm/src/nvmf_discovery.rs
@@ -25,6 +25,21 @@ use std::{
 use num_traits::FromPrimitive;
 use std::{net::IpAddr, os::unix::io::AsRawFd};
 
+static HOST_ID: once_cell::sync::Lazy<String> =
+    once_cell::sync::Lazy::new(|| {
+        let mut host_id = uuid::Uuid::new_v4().to_string();
+        if let Ok(mut fd) = std::fs::File::open(MACHINE_UUID_PATH) {
+            let mut content = String::new();
+            if fd.read_to_string(&mut content).is_ok() {
+                content = content.trim().to_string();
+                if content.len() != 0 {
+                    host_id = content;
+                }
+            }
+        }
+        host_id
+    });
+
 /// The TrType struct for all known transports types note: we are missing loop
 #[derive(Debug, Primitive)]
 #[allow(non_camel_case_types)]
@@ -372,31 +387,16 @@ impl DiscoveryBuilder {
 }
 
 impl DiscoveryLogEntry {
-    fn read_file(&self, file_path: &str) -> Result<String, Error> {
-        let mut fd = std::fs::File::open(file_path)?;
-        let mut content = String::new();
-        fd.read_to_string(&mut content)?;
-        Ok(content.trim().to_string())
-    }
-
-    fn get_host_id(&self) -> Result<String, Error> {
-        let id = self.read_file(MACHINE_UUID_PATH)?;
-        Ok(id)
-    }
-
-    //TODO: we need to pass in the HOSTNAME suggestion is to use env::
-
-    fn my_nqn_name(&self) -> Result<String, Error> {
-        let hostid = self.get_host_id()?;
-        Ok(format!("nqn.2019-05.io.openebs.mayastor:{}", hostid))
-    }
-
     pub fn build_connect_args(&mut self) -> Result<String, Error> {
         let mut connect_args = String::new();
+        let host_id = HOST_ID.as_str();
 
         connect_args.push_str(&format!("nqn={},", self.subnqn));
-        connect_args.push_str(&format!("hostnqn={},", self.my_nqn_name()?));
-        connect_args.push_str(&format!("hostid={},", self.get_host_id()?));
+        connect_args.push_str(&format!(
+            "hostnqn={},",
+            format!("nqn.2019-05.io.openebs.mayastor:{}", host_id)
+        ));
+        connect_args.push_str(&format!("hostid={},", host_id));
 
         connect_args.push_str(&format!("transport={},", self.tr_type));
         connect_args.push_str(&format!("traddr={},", self.traddr));
@@ -405,6 +405,46 @@ impl DiscoveryLogEntry {
         Ok(connect_args)
     }
 }
+
+///
+/// This method connects to a specific NVMf device available over tcp,
+/// identified by its ip address, port and nqn.
+///
+/// When we are already connected to the same host we will get back
+/// connection in progress. These errors are propagated back to use as
+/// we use the ? marker
+///
+///  # Example
+///  ```rust
+///  use nvmeadm::nvmf_discovery::connect;
+///
+///  let result = discovered_targets.connect("192.168.122.99", 8420, "mynqn");
+/// ```
+///
+
+pub fn connect(ip_addr: &str, port: u32, nqn: &str) -> Result<String, Error> {
+    let mut connect_args = String::new();
+    let host_id = HOST_ID.as_str();
+
+    connect_args.push_str(&format!("nqn={},", nqn));
+    connect_args.push_str(&format!(
+        "hostnqn={},",
+        format!("nqn.2019-05.io.openebs.mayastor:{}", host_id)
+    ));
+    connect_args.push_str(&format!("hostid={},", host_id));
+
+    connect_args.push_str(&format!("transport={},", "tcp"));
+    connect_args.push_str(&format!("traddr={},", ip_addr));
+    connect_args.push_str(&format!("trsvcid={}", port));
+    let p = Path::new(NVME_FABRICS_PATH);
+
+    let mut file = OpenOptions::new().write(true).read(true).open(&p)?;
+    file.write_all(connect_args.as_bytes())?;
+    let mut buf = String::new();
+    file.read_to_string(&mut buf)?;
+    Ok(buf)
+}
+
 /// This method disconnects a specific NVMf device, identified by its nqn.
 ///
 ///  # Example


### PR DESCRIPTION
Add nvme-of support to the CSI plugin, to make
 nexuses shared over NVMe-oF available on kubernetes.
Add nvmeadm utility execuatble, primarily as a development
 aid for the nvme library code.
Update k8s yaml files to facilitate functioning of NVMe-oF
 from within the pod container.