### PR TITLE
bdev: struct Bdev should not be sync

### DIFF
--- a/mayastor/src/bdev/dev/aio.rs
+++ b/mayastor/src/bdev/dev/aio.rs
@@ -66,7 +66,7 @@ impl GetName for Aio {
     }
 }
 
-#[async_trait]
+#[async_trait(?Send)]
 impl CreateDestroy for Aio {
     type Error = NexusBdevError;
 

--- a/mayastor/src/bdev/dev/iscsi.rs
+++ b/mayastor/src/bdev/dev/iscsi.rs
@@ -80,7 +80,7 @@ impl GetName for Iscsi {
     }
 }
 
-#[async_trait]
+#[async_trait(?Send)]
 impl CreateDestroy for Iscsi {
     type Error = NexusBdevError;
 
@@ -98,11 +98,13 @@ impl CreateDestroy for Iscsi {
             errno: c_int,
         ) {
             let sender = unsafe {
-                Box::from_raw(arg as *mut oneshot::Sender<ErrnoResult<Bdev>>)
+                Box::from_raw(
+                    arg as *mut oneshot::Sender<ErrnoResult<*mut spdk_bdev>>,
+                )
             };
 
             sender
-                .send(errno_result_from_i32(bdev.into(), errno))
+                .send(errno_result_from_i32(bdev, errno))
                 .expect("done callback receiver side disappeared");
         }
 

--- a/mayastor/src/bdev/dev/loopback.rs
+++ b/mayastor/src/bdev/dev/loopback.rs
@@ -45,7 +45,7 @@ impl GetName for Loopback {
     }
 }
 
-#[async_trait]
+#[async_trait(?Send)]
 impl CreateDestroy for Loopback {
     type Error = NexusBdevError;
 

--- a/mayastor/src/bdev/dev/nvmf.rs
+++ b/mayastor/src/bdev/dev/nvmf.rs
@@ -118,7 +118,7 @@ impl GetName for Nvmf {
     }
 }
 
-#[async_trait]
+#[async_trait(?Send)]
 impl CreateDestroy for Nvmf {
     type Error = NexusBdevError;
 

--- a/mayastor/src/bdev/dev/uring.rs
+++ b/mayastor/src/bdev/dev/uring.rs
@@ -66,7 +66,7 @@ impl GetName for Uring {
     }
 }
 
-#[async_trait]
+#[async_trait(?Send)]
 impl CreateDestroy for Uring {
     type Error = NexusBdevError;
 

--- a/mayastor/src/bdev/mod.rs
+++ b/mayastor/src/bdev/mod.rs
@@ -23,7 +23,7 @@ pub trait BdevCreateDestroy: CreateDestroy + GetName {}
 
 impl<T: CreateDestroy + GetName> BdevCreateDestroy for T {}
 
-#[async_trait]
+#[async_trait(?Send)]
 /// Main trait that must be implemented for every supported device type.
 /// Note also that the required methods are declared as async.
 pub trait CreateDestroy {

--- a/mayastor/src/core/bdev.rs
+++ b/mayastor/src/core/bdev.rs
@@ -330,7 +330,7 @@ impl From<*mut spdk_bdev> for Bdev {
         if let Some(b) = NonNull::new(b) {
             Bdev(b)
         } else {
-            panic!("nullptr deference");
+            panic!("nullptr dereferenced while accessing a bdev");
         }
     }
 }


### PR DESCRIPTION
During the URI work, the struct Bdev was marked as
Send. This should not be the case.

Send means that the Struct Bdev would be safe to send to other
threads. There is nothing that guarantees that however.