### PR TITLE
CAS-341: replica not replaced when node leaves

### DIFF
--- a/csi/moac/node.js
+++ b/csi/moac/node.js
@@ -88,6 +88,12 @@ class Node extends EventEmitter {
     this._offline();
   }
 
+  unbind () {
+    // todo: on user explicit removal should we destroy the pools as well?
+    this.pools.forEach((pool) => pool.unbind());
+    this.nexus.forEach((nexus) => nexus.unbind());
+  }
+
   // The node is considered broken, emit offline events on all objects
   // that are present on the node.
   _offline () {

--- a/csi/moac/registry.js
+++ b/csi/moac/registry.js
@@ -95,6 +95,7 @@ class Registry extends EventEmitter {
     if (!node) return;
     delete this.nodes[name];
     node.disconnect();
+    node.unbind();
 
     log.info(`mayastor on node "${name}" left`);
     this.emit('node', {

--- a/csi/moac/volume.js
+++ b/csi/moac/volume.js
@@ -228,12 +228,12 @@ class Volume {
     );
     if (!rmChild) {
       rmChild = children.find((ch) => ch.state === 'CHILD_FAULTED');
-      // If all replicas are online, then continue searching for a candidate
-      // only if there are more online replicas than it needs to be.
-      if (!rmChild && onlineCount > this.replicaCount) {
+      if (!rmChild) {
         // A child that is unknown to us (without replica object)
         rmChild = children.find((ch) => !ch.replica);
-        if (!rmChild) {
+        // If all replicas are online, then continue searching for a candidate
+        // only if there are more online replicas than it needs to be.
+        if (!rmChild && onlineCount > this.replicaCount) {
           // The replica with the lowest score must go away
           const rmReplica = this._prioritizeReplicas(
             children.map((ch) => ch.replica)


### PR DESCRIPTION
When a node leaves it should at least unbind its existing resources.
todo: when a node is removed gracefully should we also destroy the
pools?

Also we now replace children which have no underlying replica with new
ones during the volume fsa irregardless of the online count which seems
reasonable.