### PR TITLE
CSI attach idempotency. CAS-340

### DIFF
--- a/csi/src/node/iscsiutil.rs
+++ b/csi/src/node/iscsiutil.rs
@@ -39,13 +39,18 @@ fn get_iscsiadm() -> Result<&'static str, Error> {
     }
 }
 
-fn wait_for_path_to_exist(devpath: &str, max_retries: i32) -> bool {
-    let second = time::Duration::from_millis(1000);
+fn wait_for_path_to_exist(
+    devpath: &str,
+    sleepmillis: u64,
+    millis: u64,
+) -> bool {
+    let millisecond = time::Duration::from_millis(sleepmillis);
+    let max_retries = (millis + sleepmillis - 1) / sleepmillis;
     let device_path = Path::new(devpath);
-    let mut retries: i32 = 0;
+    let mut retries: u64 = 0;
     let now = time::Instant::now();
     while !device_path.exists() && retries < max_retries {
-        thread::sleep(second);
+        thread::sleep(millisecond);
         retries += 1;
     }
     trace!(
@@ -79,67 +84,95 @@ fn attach_disk(
         format!("/dev/disk/by-path/ip-{}-iscsi-{}-lun-{}", tp, iqn, lun);
     let iscsiadm = get_iscsiadm()?;
 
-    let target = format!("{},{} {}", tp, lun, iqn);
+    static RE_SESSION: Lazy<regex::Regex> = Lazy::new(|| {
+        regex::Regex::new(
+            r"\s*(?P<tp>\d+.\d+.\d+.\d+:\d+),0\s*(?P<iqn>iqn.2019-05.io.openebs:nexus-.*)\s"
+    )
+    .unwrap()
+    });
 
-    // If the device path exists then a previous invocation of this
-    // method has succeeded.
-    if wait_for_path_to_exist(device_path.as_str(), 1) {
-        trace!("path already exists!");
-        return Ok(iscsi_realpath(device_path));
-    }
-
-    let args_discovery =
-        ["-m", "discovery", "-t", "st", "-p", &tp, "-I", "default"];
-    trace!("iscsiadm {:?}", &args_discovery);
+    let args_sessions = ["-m", "session"];
     let output = Command::new(&iscsiadm)
-        .args(&args_discovery)
+        .args(&args_sessions)
         .output()
-        .expect("Failed iscsiadm discovery");
-    if !output.status.success() {
-        return Err(Error::from(CSIError::Iscsiadm {
-            error: String::from_utf8(output.stderr).unwrap(),
-        }));
+        .expect("Failed iscsiadm session");
+
+    let mut have_session = false;
+    if output.status.success() {
+        let op = String::from_utf8(output.stdout).unwrap();
+        let haystack: Vec<&str> = op.split('\n').collect();
+        for session in haystack {
+            if let Some(details) = RE_SESSION.captures(session) {
+                if tp == &details["tp"] && iqn == &details["iqn"] {
+                    debug!("Found session for {} {}", tp, iqn);
+                    have_session = true;
+                }
+            }
+        }
     }
 
-    // Check that the output from the iscsiadm discover command lists
-    // the iscsi target we need to login.
-    // If not fail.
-    let op = String::from_utf8(output.stdout).unwrap();
-    let haystack: Vec<&str> = op.split('\n').collect();
-    if !haystack.iter().any(|&s| s == target.as_str()) {
-        trace!("After discovery no record for {}", target);
-        return Err(Error::from(CSIError::Iscsiadm {
-            error: format!("No record for {}", target),
-        }));
-    }
+    // Do not attempt to create a session if one exists.
+    if !have_session {
+        let target = format!("{},{} {}", tp, lun, iqn);
 
-    let args_login = [
-        "-m", "node", "-p", &tp, "-T", &iqn, "-I", "default", "--login",
-    ];
-    trace!("iscsiadm {:?}", args_login);
-    // login to iscsi target
-    let output = Command::new(&iscsiadm)
-        .args(&args_login)
-        .output()
-        .expect("Failed iscsiadm login");
-    if !output.status.success() {
-        let args_login_del = [
-            "-m", "node", "-p", &tp, "-T", &iqn, "-I", "default", "-o",
-            "delete",
+        let args_discovery =
+            ["-m", "discovery", "-t", "st", "-p", &tp, "-I", "default"];
+        trace!("iscsiadm {:?}", &args_discovery);
+        let output = Command::new(&iscsiadm)
+            .args(&args_discovery)
+            .output()
+            .expect("Failed iscsiadm discovery");
+        if !output.status.success() {
+            return Err(Error::from(CSIError::Iscsiadm {
+                error: String::from_utf8(output.stderr).unwrap(),
+            }));
+        }
+
+        // Check that the output from the iscsiadm discover command lists
+        // the iscsi target we need to login.
+        // If not fail.
+        let op = String::from_utf8(output.stdout).unwrap();
+        let haystack: Vec<&str> = op.split('\n').collect();
+        if !haystack.iter().any(|&s| s == target.as_str()) {
+            trace!("After discovery no record for {}", target);
+            return Err(Error::from(CSIError::Iscsiadm {
+                error: format!("No record for {}", target),
+            }));
+        }
+
+        let args_login = [
+            "-m", "node", "-p", &tp, "-T", &iqn, "-I", "default", "--login",
         ];
-        // delete the node record from the database.
-        Command::new(&iscsiadm).args(&args_login_del);
-        return Err(Error::from(CSIError::Iscsiadm {
-            error: String::from_utf8(output.stderr).unwrap(),
-        }));
+        trace!("iscsiadm {:?}", args_login);
+        // login to iscsi target
+        let output = Command::new(&iscsiadm)
+            .args(&args_login)
+            .output()
+            .expect("Failed iscsiadm login");
+        if !output.status.success() {
+            let args_login_del = [
+                "-m", "node", "-p", &tp, "-T", &iqn, "-I", "default", "-o",
+                "delete",
+            ];
+            // delete the node record from the database.
+            Command::new(&iscsiadm).args(&args_login_del);
+            return Err(Error::from(CSIError::Iscsiadm {
+                error: String::from_utf8(output.stderr).unwrap(),
+            }));
+        }
     }
 
-    if wait_for_path_to_exist(device_path.as_str(), 10) {
+    let millis: u64 = 1000;
+    if wait_for_path_to_exist(device_path.as_str(), 10, millis) {
         trace!("{} path exists!", device_path)
     } else {
-        trace!("{} path does not exist after 10s!", device_path);
+        trace!(
+            "{} path does not exist after {} milliseconds!",
+            device_path,
+            millis
+        );
         return Err(Error::from(CSIError::AttachTimeout {
-            value: 1000,
+            value: millis,
         }));
     }
     Ok(iscsi_realpath(device_path))
@@ -274,7 +307,7 @@ fn get_iscsi_device_path(uuid: &str) -> Result<String, Error> {
 /// target matching the volume id has been mounted or None.
 pub fn iscsi_find(uuid: &str) -> Option<String> {
     if let Ok(path) = get_iscsi_device_path(uuid) {
-        if wait_for_path_to_exist(path.as_str(), 0) {
+        if Path::new(path.as_str()).exists() {
             return Some(iscsi_realpath(path));
         }
     }

--- a/csi/src/server.rs
+++ b/csi/src/server.rs
@@ -49,8 +49,8 @@ pub enum CSIError {
     Iscsiadm { error: String },
     #[fail(display = "Cannot find {}", execname)]
     ExecutableNotFound { execname: String },
-    #[fail(display = "Could not attach disk after {} milliseconds", value)]
-    AttachTimeout { value: u64 },
+    #[fail(display = "Could not attach disk after {:?}", value)]
+    AttachTimeout { value: std::time::Duration },
     #[fail(display = "Invalid URI {}", uristr)]
     InvalidURI { uristr: String },
     #[fail(display = "Invalid device path {}", devpath)]

--- a/csi/src/server.rs
+++ b/csi/src/server.rs
@@ -50,7 +50,7 @@ pub enum CSIError {
     #[fail(display = "Cannot find {}", execname)]
     ExecutableNotFound { execname: String },
     #[fail(display = "Could not attach disk after {} milliseconds", value)]
-    AttachTimeout { value: i32 },
+    AttachTimeout { value: u64 },
     #[fail(display = "Invalid URI {}", uristr)]
     InvalidURI { uristr: String },
     #[fail(display = "Invalid device path {}", devpath)]


### PR DESCRIPTION
Make isci attach idempotent:
If a session for the target portal and iqn exists,
skip to just waiting for the device path to exist.

Refine the waiting for device path code,
1) specify granularity of sleeps,
2) reduce the timeout from 10 seconds to 1 second,
on the grounds that large timeouts can mask issues.