### PR TITLE
moac: pool creation fails when storage node is imported (CAS-336)

### DIFF
--- a/csi/moac/node.js
+++ b/csi/moac/node.js
@@ -180,6 +180,12 @@ class Node extends EventEmitter {
     });
     replicas = reply.replicas;
 
+    // Move the the node to online state before we attempt to merge objects
+    // because they might need to invoke rpc methods on the node.
+    var wasOffline = this.syncFailed > 0;
+    if (wasOffline) {
+      this.syncFailed = 0;
+    }
     // merge pools and replicas
     this._mergePoolsAndReplicas(pools, replicas);
     // merge nexus
@@ -187,8 +193,7 @@ class Node extends EventEmitter {
 
     log.debug(`The node "${this.name}" was successfully synced`);
 
-    if (this.syncFailed > 0) {
-      this.syncFailed = 0;
+    if (wasOffline) {
       this.emit('node', {
         eventType: 'mod',
         object: this


### PR DESCRIPTION
The problem was that the node was marked as online only after calling
various merge object functions, so if those functions wanted to call
RPC method on the node, it failed.