### PR TITLE
CAS-344: add UUID to URI format

### DIFF
--- a/mayastor/src/bdev/dev.rs
+++ b/mayastor/src/bdev/dev.rs
@@ -11,8 +11,8 @@
 //!  - Arranging for the try_from() method to be called by the parse() function
 //!    below for a URI with the appropriate scheme.
 //!
-//! See mod.rs for the approriate trait definition(s), and refer
-//! to the files in the dev directoy for sample implementations.
+//! See mod.rs for the appropriate trait definition(s), and refer
+//! to the files in the dev directory for sample implementations.
 //!
 //! Creating a bdev for any supported device type is now as simple as:
 //! ```ignore

--- a/mayastor/src/bdev/util/uri.rs
+++ b/mayastor/src/bdev/util/uri.rs
@@ -54,3 +54,9 @@ pub(crate) fn boolean(
     }
     value.parse::<bool>()
 }
+
+pub(crate) fn uuid(
+    value: Option<String>,
+) -> Result<Option<uuid::Uuid>, uuid::parser::ParseError> {
+    value.map(|uuid| uuid::Uuid::parse_str(&uuid)).transpose()
+}

--- a/mayastor/src/nexus_uri.rs
+++ b/mayastor/src/nexus_uri.rs
@@ -39,6 +39,14 @@ pub enum NexusBdevError {
         uri: String,
         parameter: String,
     },
+    #[snafu(display(
+        "Invalid URI \"{}\": could not parse uuid parameter value",
+        uri,
+    ))]
+    UuidParamParseError {
+        source: uuid::parser::ParseError,
+        uri: String,
+    },
     // Bdev create/destroy errors
     #[snafu(display("bdev {} already exists", name))]
     BdevExists { name: String },

--- a/mayastor/src/subsys/config.rs
+++ b/mayastor/src/subsys/config.rs
@@ -13,7 +13,7 @@ use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    bdev::{nexus::instances, nexus_create},
+    bdev::{nexus::instances, nexus_create, VerboseError},
     core::{Bdev, Cores, Reactor},
     nexus_uri::bdev_create,
     pool::{create_pool, PoolsIter},
@@ -216,16 +216,19 @@ impl Config {
                 info!("creating nexus {}", nexus.name);
                 match Byte::from_str(&nexus.size) {
                     Ok(val) => {
-                        if nexus_create(
+                        if let Err(e) = nexus_create(
                             &nexus.name,
                             val.get_bytes() as u64,
                             Some(&nexus.uuid),
                             &nexus.children,
                         )
                         .await
-                        .is_err()
                         {
-                            error!("Failed to create nexus {}", nexus.name);
+                            error!(
+                                "Failed to create nexus {}, error={}",
+                                nexus.name,
+                                e.verbose()
+                            );
                             failures += 1;
                         }
                     }


### PR DESCRIPTION
Support for optional UUID query parameter for storage URIs, example:

aio:///disk1.img?blk_size=512&uuid=e40efd60-05a9-4f96-99af-1b6a25e109dd

If one is provided then we set the uuid of the bdev to that.