### PR TITLE
Remove k8s scheduler constraint for iscsi/nvmf volumes (CAS-295)

### DIFF
--- a/csi/moac/test/index.js
+++ b/csi/moac/test/index.js
@@ -45,8 +45,8 @@ describe('moac', function () {
   describe('volume object', volumeObject);
   describe('volumes', volumesTest);
   describe('volume operator', volumeOperator);
-  describe('REST API', restApi);
-  describe('CSI controller', csiTest);
+  describe('rest api', restApi);
+  describe('csi', csiTest);
 
   // Start moac without k8s and NATS server just to test basic errors
   it('start moac process', function (done) {


### PR DESCRIPTION
The constraint to schedule app locally on storage node is preserved for NBD. For iSCSI and nvmf the k8s scheduler is free to use any node with running mayastor csi plugin.

The fix to split mayastor daemon yaml file and decouple csi plugin from mayastor is ready and will follow this PR.