### PR TITLE
Split mayastor daemonset yaml into csi-agent and mayastor yamls (CAS-294)

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -85,20 +85,27 @@ The YAML files named below are to be found in the `deploy` folder of the Mayasto
 5.  Deploy the Mayastor and CSI components
     ```bash
     kubectl create -f nats-deployment.yaml
+    kubectl create -f csi-daemonset.yaml
     kubectl create -f mayastorpoolcrd.yaml
     kubectl create -f moac-rbac.yaml
     kubectl create -f moac-deployment.yaml
     kubectl create -f mayastor-daemonset.yaml
     ```
 
-6.  Confirm that the MOAC and NATS pods are running:
+6.  Confirm that the pods are running:
     ```bash
     kubectl -n mayastor get pod
     ```
     ```
     NAME                   READY   STATUS    RESTARTS   AGE
     nats-5fc4d79d66-lvdcg  1/1     Running   0          31s
-    moac-5f7cb764d-sshvz   3/3     Running   0          34s
+    moac-5f7cb764d-sshvz   3/3     Running   0          30s
+    mayastor-csi-xs6qk     2/2     Running   0          29s
+    mayastor-csi-r59pp     2/2     Running   0          29s
+    mayastor-csi-kg442     2/2     Running   0          29s
+    mayastor-m6w2l         1/1     Running   0          28s
+    mayastor-x575m         1/1     Running   0          28s
+    mayastor-8lfmv         1/1     Running   0          28s
     ```
 
 7. Confirm that the Mayastor daemonset is fully deployed:

--- a/deploy/csi-daemonset.yaml
+++ b/deploy/csi-daemonset.yaml
@@ -1,0 +1,118 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  namespace: mayastor
+  name: mayastor-csi
+  labels:
+    openebs/engine: mayastor
+spec:
+  selector:
+    matchLabels:
+      app: mayastor-csi
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  minReadySeconds: 10
+  template:
+    metadata:
+      labels:
+        app: mayastor-csi
+    spec:
+      hostNetwork: true
+      nodeSelector:
+        kubernetes.io/arch: amd64
+      # NOTE: Each container must have mem/cpu limits defined in order to
+      # belong to Guaranteed QoS class, hence can never get evicted in case of
+      # pressure unless they exceed those limits. limits and requests must be
+      # the same.
+      containers:
+      - name: mayastor-csi
+        image: mayadata/mayastor-csi:v0.2.0
+        imagePullPolicy: Always
+        # we need privileged because we mount filesystems and use mknod
+        securityContext:
+          privileged: true
+        env:
+        - name: MY_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: RUST_BACKTRACE
+          value: "1"
+        args:
+        - "--csi-socket=/csi/csi.sock"
+        - "--node-name=$(MY_NODE_NAME)"
+        - "-v"
+        volumeMounts:
+        - name: device
+          mountPath: /dev
+        - name: sys
+          mountPath: /sys
+        - name: run-udev
+          mountPath: /run/udev
+        - name: host-root
+          mountPath: /host
+        - name: plugin-dir
+          mountPath: /csi
+        - name: kubelet-dir
+          mountPath: /var/lib/kubelet
+          mountPropagation: "Bidirectional"
+        resources:
+          limits:
+            cpu: "100m"
+            memory: "50Mi"
+          requests:
+            cpu: "100m"
+            memory: "50Mi"
+      - name: csi-driver-registrar
+        image: quay.io/k8scsi/csi-node-driver-registrar:v1.3.0
+        args:
+        - "--csi-address=/csi/csi.sock"
+        - "--kubelet-registration-path=/var/lib/kubelet/plugins/mayastor.openebs.io/csi.sock"
+        lifecycle:
+          preStop:
+            exec:
+              # this is needed in order for CSI to detect that the plugin is gone
+              command: ["/bin/sh", "-c", "rm -f /registration/io.openebs.csi-mayastor-reg.sock /csi/csi.sock"]
+        volumeMounts:
+        - name: plugin-dir
+          mountPath: /csi
+        - name: registration-dir
+          mountPath: /registration
+        resources:
+          limits:
+            cpu: "100m"
+            memory: "50Mi"
+          requests:
+            cpu: "100m"
+            memory: "50Mi"
+      volumes:
+      - name: device
+        hostPath:
+          path: /dev
+          type: Directory
+      - name: sys
+        hostPath:
+          path: /sys
+          type: Directory
+      - name: run-udev
+        hostPath:
+          path: /run/udev
+          type: Directory
+      - name: host-root
+        hostPath:
+          path: /
+          type: Directory
+      - name: registration-dir
+        hostPath:
+          path: /var/lib/kubelet/plugins_registry/
+          type: Directory
+      - name: plugin-dir
+        hostPath:
+          path: /var/lib/kubelet/plugins/mayastor.openebs.io/
+          type: DirectoryOrCreate
+      - name: kubelet-dir
+        hostPath:
+          path: /var/lib/kubelet
+          type: Directory

--- a/deploy/mayastor-daemonset.yaml
+++ b/deploy/mayastor-daemonset.yaml
@@ -53,8 +53,6 @@ spec:
           mountPath: /dev
         - name: dshm
           mountPath: /dev/shm
-        - name: mayastor-dir
-          mountPath: /mayastor
         resources:
           limits:
             cpu: "1"
@@ -64,88 +62,14 @@ spec:
             cpu: "1"
             memory: "500Mi"
             hugepages-2Mi: "1Gi"
-      - name: mayastor-csi
-        image: mayadata/mayastor-csi:v0.2.0
-        imagePullPolicy: Always
-        # we need privileged because we mount filesystems and use mknod
-        securityContext:
-          privileged: true
-        env:
-        - name: MY_NODE_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
-        - name: RUST_BACKTRACE
-          value: "1"
-        args:
-        - "--csi-socket=/csi/csi.sock"
-        - "--node-name=$(MY_NODE_NAME)"
-        - "-v"
-        volumeMounts:
-        - name: device
-          mountPath: /dev
-        - name: sys
-          mountPath: /sys
-        - name: run-udev
-          mountPath: /run/udev
-        - name: host-root
-          mountPath: /host
-        - name: mayastor-dir
-          mountPath: /mayastor
-        - name: plugin-dir
-          mountPath: /csi
-        - name: kubelet-dir
-          mountPath: /var/lib/kubelet
-          mountPropagation: "Bidirectional"
-        resources:
-          limits:
-            cpu: "100m"
-            memory: "50Mi"
-          requests:
-            cpu: "100m"
-            memory: "50Mi"
         ports:
         - containerPort: 10124
           protocol: TCP
           name: mayastor
-      - name: csi-driver-registrar
-        image: quay.io/k8scsi/csi-node-driver-registrar:v1.3.0
-        args:
-        - "--csi-address=/csi/csi.sock"
-        - "--kubelet-registration-path=/var/lib/kubelet/plugins/mayastor.openebs.io/csi.sock"
-        lifecycle:
-          preStop:
-            exec:
-              # this is needed in order for CSI to detect that the plugin is gone
-              command: ["/bin/sh", "-c", "rm -f /registration/io.openebs.csi-mayastor-reg.sock /csi/csi.sock"]
-        volumeMounts:
-        - name: plugin-dir
-          mountPath: /csi
-        - name: registration-dir
-          mountPath: /registration
-        resources:
-          limits:
-            cpu: "100m"
-            memory: "50Mi"
-          requests:
-            cpu: "100m"
-            memory: "50Mi"
       volumes:
       - name: device
         hostPath:
           path: /dev
-          type: Directory
-      - name: sys
-        hostPath:
-          path: /sys
-          type: Directory
-      - name: run-udev
-        hostPath:
-          path: /run/udev
-          type: Directory
-      - name: host-root
-        hostPath:
-          path: /
           type: Directory
       - name: dshm
         emptyDir:
@@ -154,17 +78,3 @@ spec:
       - name: hugepage
         emptyDir:
           medium: HugePages
-      - name: mayastor-dir
-        emptyDir: {}
-      - name: registration-dir
-        hostPath:
-          path: /var/lib/kubelet/plugins_registry/
-          type: Directory
-      - name: plugin-dir
-        hostPath:
-          path: /var/lib/kubelet/plugins/mayastor.openebs.io/
-          type: DirectoryOrCreate
-      - name: kubelet-dir
-        hostPath:
-          path: /var/lib/kubelet
-          type: Directory


### PR DESCRIPTION
csi-agent runs on all nodes so that iscsi and nvmf exported volumes can be mounted anywhere.