### PR TITLE
address some CI issues

### DIFF
--- a/.github/workflows/nix-tests.yaml
+++ b/.github/workflows/nix-tests.yaml
@@ -1,10 +1,10 @@
 name: "Nix Workflow Tests"
 on:
-  pull_request:
-    paths-ignore:
-  push:
-    branches:
-      - develop
+  #pull_request:
+  #  paths-ignore:
+  #push:
+  #  branches:
+  #    - develop
 jobs:
   main:
     name: Run Nix Tests

--- a/mayastor/tests/common/mod.rs
+++ b/mayastor/tests/common/mod.rs
@@ -155,7 +155,7 @@ pub fn fscheck(device: &str) {
     assert_eq!(output.status.success(), true);
 }
 
-pub fn mkfs(path: &str, fstype: &str) {
+pub fn mkfs(path: &str, fstype: &str) -> bool {
     let (fs, args) = match fstype {
         "xfs" => ("mkfs.xfs", ["-f", path]),
         "ext4" => ("mkfs.ext4", ["-F", path]),
@@ -171,7 +171,7 @@ pub fn mkfs(path: &str, fstype: &str) {
 
     io::stdout().write_all(&output.stderr).unwrap();
     io::stdout().write_all(&output.stdout).unwrap();
-    assert_eq!(output.status.success(), true);
+    output.status.success()
 }
 
 pub fn delete_file(disks: &[String]) {


### PR DESCRIPTION
Temporarily disable the "Nix Workflow Tests" which occasionally just
stays queued and doesn't seem to run:
"Nix Workflow Tests / Run Nix Tests (pull_request)...
 Queued — Waiting to run this check... "

Also, while we're here unaffinitize the threads used in the mount_fs
tests to reduce contention and also and bring assert to the reactor
thread so we can fail a bit more gracefully.