### PR TITLE
CAS-345: normalize the dev name

### DIFF
--- a/mayastor-test/test_nexus.js
+++ b/mayastor-test/test_nexus.js
@@ -283,7 +283,7 @@ describe('nexus', function () {
     size: 131072,
     children: [
       'nvmf://127.0.0.1:8420/nqn.2019-05.io.openebs:disk2',
-      `aio:///${aioFile}?blk_size=4096`
+      `aio://${aioFile}?blk_size=4096`
     ]
   };
   this.timeout(50000); // for network tests we need long timeouts
@@ -327,7 +327,7 @@ describe('nexus', function () {
           fs.truncate(uringFile, diskSize, next);
         },
         (next) => {
-          if (doUring()) { createArgs.children.push(`uring:///${uringFile}?blk_size=4096`); }
+          if (doUring()) { createArgs.children.push(`uring://${uringFile}?blk_size=4096`); }
           next();
         },
         (next) => {
@@ -378,12 +378,12 @@ describe('nexus', function () {
       size: diskSize,
       children: [
         'bdev:///Malloc0',
-        `aio:///${aioFile}?blk_size=4096`,
+        `aio://${aioFile}?blk_size=4096`,
         'nvmf://127.0.0.1:8420/nqn.2019-05.io.openebs:disk2'
       ]
     };
     if (doIscsiReplica) args.children.push(`iscsi://iscsi://${externIp}:${iscsiReplicaPort}/iqn.2019-05.io.openebs:disk1`);
-    if (doUring()) args.children.push(`uring:///${uringFile}?blk_size=4096`);
+    if (doUring()) args.children.push(`uring://${uringFile}?blk_size=4096`);
 
     client.CreateNexus(args, done);
   });
@@ -401,7 +401,7 @@ describe('nexus', function () {
       assert.lengthOf(nexus.children, expectedChildren);
       assert.equal(nexus.children[0].uri, 'bdev:///Malloc0');
       assert.equal(nexus.children[0].state, 'CHILD_ONLINE');
-      assert.equal(nexus.children[1].uri, `aio:///${aioFile}?blk_size=4096`);
+      assert.equal(nexus.children[1].uri, `aio://${aioFile}?blk_size=4096`);
       assert.equal(nexus.children[1].state, 'CHILD_ONLINE');
 
       assert.equal(
@@ -421,7 +421,7 @@ describe('nexus', function () {
         const uringIndex = 3 + doIscsiReplica;
         assert.equal(
           nexus.children[uringIndex].uri,
-          `uring:///${uringFile}?blk_size=4096`
+          `uring://${uringFile}?blk_size=4096`
         );
         assert.equal(nexus.children[uringIndex].state, 'CHILD_ONLINE');
       }
@@ -683,9 +683,10 @@ describe('nexus', function () {
         size: 131072,
         children: [
         `iscsi://${externIp}:${iscsiReplicaPort}/iqn.2019-05.io.openebs:disk1`,
-        `aio:///${aioFile}?blk_size=512`
+        `aio://${aioFile}?blk_size=512`
         ]
       };
+
       client.CreateNexus(args, (err, data) => {
         if (!err) return done(new Error('Expected error'));
         assert.equal(err.code, grpc.status.INVALID_ARGUMENT);
@@ -705,7 +706,10 @@ describe('nexus', function () {
 
       client.CreateNexus(args, (err, data) => {
         if (!err) return done(new Error('Expected error'));
-        assert.equal(err.code, grpc.status.INVALID_ARGUMENT);
+        // todo: fixme
+        // in this case we hit a Error::NexusCreate which atm is converted
+        // into a grpc internal error
+        assert.equal(err.code, grpc.status.INTERNAL);
         done();
       });
     });

--- a/mayastor-test/test_rebuild.js
+++ b/mayastor-test/test_rebuild.js
@@ -66,29 +66,29 @@ const configNexus = `
 const nexusArgs = {
   uuid: UUID,
   size: 131072,
-  children: [`aio:///${child1}?blk_size=4096`]
+  children: [`aio://${child1}?blk_size=4096`]
 };
 
 const rebuildArgs = {
   uuid: UUID,
-  uri: `aio:///${child2}?blk_size=4096`
+  uri: `aio://${child2}?blk_size=4096`
 };
 
 const addChildArgs = {
   uuid: UUID,
-  uri: `aio:///${child2}?blk_size=4096`,
+  uri: `aio://${child2}?blk_size=4096`,
   norebuild: true
 };
 
 const childOnlineArgs = {
   uuid: UUID,
-  uri: `aio:///${child2}?blk_size=4096`,
+  uri: `aio://${child2}?blk_size=4096`,
   action: 1
 };
 
 const childOfflineArgs = {
   uuid: UUID,
-  uri: `aio:///${child2}?blk_size=4096`,
+  uri: `aio://${child2}?blk_size=4096`,
   action: 0
 };
 

--- a/mayastor/src/bdev/dev/aio.rs
+++ b/mayastor/src/bdev/dev/aio.rs
@@ -17,7 +17,7 @@ use crate::{
 #[derive(Debug)]
 pub(super) struct Aio {
     name: String,
-    aliases: Vec<String>,
+    alias: String,
     blk_size: u32,
     uuid: Option<uuid::Uuid>,
 }
@@ -61,7 +61,7 @@ impl TryFrom<&Url> for Aio {
 
         Ok(Aio {
             name: url.path().into(),
-            aliases: vec![url.to_string()],
+            alias: url.to_string(),
             blk_size,
             uuid,
         })
@@ -102,10 +102,11 @@ impl CreateDestroy for Aio {
                         if let Some(uuid) = self.uuid {
                             bdev.set_uuid(Some(uuid.to_string()));
                         }
-                        if !bdev.add_aliases(&self.aliases) {
+                        if !bdev.add_alias(&self.alias) {
                             error!(
-                                "Failed to add all aliases to device {}",
-                                self.name
+                                "Failed to add alias {} to device {}",
+                                self.alias,
+                                self.get_name()
                             );
                         }
                     };

--- a/mayastor/src/bdev/dev/iscsi.rs
+++ b/mayastor/src/bdev/dev/iscsi.rs
@@ -25,6 +25,7 @@ const ISCSI_IQN_PREFIX: &str = "iqn.1980-05.mayastor";
 #[derive(Debug)]
 pub(super) struct Iscsi {
     name: String,
+    aliases: Vec<String>,
     iqn: String,
     url: String,
     uuid: Option<uuid::Uuid>,
@@ -74,7 +75,8 @@ impl TryFrom<&Url> for Iscsi {
         }
 
         Ok(Iscsi {
-            name: url.to_string(),
+            name: url.path()[1 ..].into(),
+            aliases: vec![url.to_string()],
             iqn: format!("{}:{}", ISCSI_IQN_PREFIX, Uuid::new_v4()),
             url: if segments.len() == 2 {
                 url[.. url::Position::AfterPath].to_string()
@@ -150,7 +152,10 @@ impl CreateDestroy for Iscsi {
             })?;
 
         if let Some(u) = self.uuid {
-            bdev.set_uuid(Some(u.to_string()))
+            bdev.set_uuid(Some(u.to_string()));
+        }
+        if !bdev.add_aliases(&self.aliases) {
+            error!("Failed to add all aliases to device {}", self.name);
         }
 
         Ok(bdev.name())

--- a/mayastor/src/bdev/dev/iscsi.rs
+++ b/mayastor/src/bdev/dev/iscsi.rs
@@ -25,7 +25,7 @@ const ISCSI_IQN_PREFIX: &str = "iqn.1980-05.mayastor";
 #[derive(Debug)]
 pub(super) struct Iscsi {
     name: String,
-    aliases: Vec<String>,
+    alias: String,
     iqn: String,
     url: String,
     uuid: Option<uuid::Uuid>,
@@ -76,7 +76,7 @@ impl TryFrom<&Url> for Iscsi {
 
         Ok(Iscsi {
             name: url.path()[1 ..].into(),
-            aliases: vec![url.to_string()],
+            alias: url.to_string(),
             iqn: format!("{}:{}", ISCSI_IQN_PREFIX, Uuid::new_v4()),
             url: if segments.len() == 2 {
                 url[.. url::Position::AfterPath].to_string()
@@ -154,8 +154,12 @@ impl CreateDestroy for Iscsi {
         if let Some(u) = self.uuid {
             bdev.set_uuid(Some(u.to_string()));
         }
-        if !bdev.add_aliases(&self.aliases) {
-            error!("Failed to add all aliases to device {}", self.name);
+        if !bdev.add_alias(&self.alias) {
+            error!(
+                "Failed to add alias {} to device {}",
+                self.alias,
+                self.get_name()
+            );
         }
 
         Ok(bdev.name())

--- a/mayastor/src/bdev/dev/loopback.rs
+++ b/mayastor/src/bdev/dev/loopback.rs
@@ -13,7 +13,7 @@ use crate::{
 #[derive(Debug)]
 pub(super) struct Loopback {
     name: String,
-    aliases: Vec<String>,
+    alias: String,
     uuid: Option<uuid::Uuid>,
 }
 
@@ -45,7 +45,7 @@ impl TryFrom<&Url> for Loopback {
 
         Ok(Loopback {
             name: segments.join("/"),
-            aliases: vec![url.to_string()],
+            alias: url.to_string(),
             uuid,
         })
     }
@@ -66,8 +66,12 @@ impl CreateDestroy for Loopback {
             if let Some(uuid) = self.uuid {
                 bdev.set_uuid(Some(uuid.to_string()));
             }
-            if !bdev.add_aliases(&self.aliases) {
-                error!("Failed to add all aliases to device {}", self.name);
+            if !bdev.add_alias(&self.alias) {
+                error!(
+                    "Failed to add alias {} to device {}",
+                    self.alias,
+                    self.get_name()
+                );
             }
         };
         Ok(self.get_name())

--- a/mayastor/src/bdev/dev/malloc.rs
+++ b/mayastor/src/bdev/dev/malloc.rs
@@ -18,8 +18,8 @@ pub struct Malloc {
     /// the name of the bdev we created, this is equal to the URI path minus
     /// the leading '/'
     name: String,
-    /// list of aliases which can be used to open the bdev
-    aliases: Vec<String>,
+    /// alias which can be used to open the bdev
+    alias: String,
     /// the number of blocks the device should have
     num_blocks: u64,
     /// the size of a single block if no blk_size is given we default to 512
@@ -105,7 +105,7 @@ impl TryFrom<&Url> for Malloc {
 
         Ok(Self {
             name: uri.path()[1 ..].into(),
-            aliases: vec![uri.to_string()],
+            alias: uri.to_string(),
             num_blocks: if num_blocks != 0 {
                 num_blocks
             } else {
@@ -155,10 +155,11 @@ impl CreateDestroy for Malloc {
             self.uuid.map(|u| {
                 Bdev::lookup_by_name(&self.name).map(|mut b| {
                     b.set_uuid(Some(u.to_string()));
-                    if !b.add_aliases(&self.aliases) {
+                    if !b.add_alias(&self.alias) {
                         error!(
-                            "Failed to add all aliases to device {}",
-                            self.name
+                            "Failed to add alias {} to device {}",
+                            self.alias,
+                            self.get_name()
                         );
                     }
                 })

--- a/mayastor/src/bdev/dev/nvmf.rs
+++ b/mayastor/src/bdev/dev/nvmf.rs
@@ -30,8 +30,11 @@ const DEFAULT_NVMF_PORT: u16 = 4420;
 
 #[derive(Debug)]
 pub(super) struct Nvmf {
-    /// name of the bdev that should be created
+    /// name of the nvme controller and base name of the bdev
+    /// that should be created for each namespace found
     name: String,
+    /// list of aliases which can be used to open the bdev
+    aliases: Vec<String>,
     /// the remote target host (address)
     host: String,
     /// the transport service id (ie. port)
@@ -109,7 +112,8 @@ impl TryFrom<&Url> for Nvmf {
         }
 
         Ok(Nvmf {
-            name: url.to_string(),
+            name: url.path()[1 ..].into(),
+            aliases: vec![url.to_string()],
             host: host.to_string(),
             port: url.port().unwrap_or(DEFAULT_NVMF_PORT),
             subnqn: segments[0].to_string(),
@@ -133,9 +137,9 @@ impl CreateDestroy for Nvmf {
 
     /// Create an NVMF bdev
     async fn create(&self) -> Result<String, Self::Error> {
-        if Bdev::lookup_by_name(&self.name).is_some() {
+        if Bdev::lookup_by_name(&self.get_name()).is_some() {
             return Err(NexusBdevError::BdevExists {
-                name: self.name.clone(),
+                name: self.get_name(),
             });
         }
 
@@ -185,13 +189,19 @@ impl CreateDestroy for Nvmf {
                 name: self.name.clone(),
             })?;
 
-        Bdev::lookup_by_name(&self.get_name()).map(|b| {
-            self.uuid.map(|u| {
-                if b.uuid_as_string() != u.to_hyphenated().to_string() {
-                    error!("Connected to device {} but expect to connect to {} instead", b.uuid_as_string(), u.to_hyphenated().to_string());
+        if let Some(bdev) = Bdev::lookup_by_name(&self.get_name()) {
+            if let Some(u) = self.uuid {
+                if bdev.uuid_as_string() != u.to_hyphenated().to_string() {
+                    error!("Connected to device {} but expect to connect to {} instead", bdev.uuid_as_string(), u.to_hyphenated().to_string());
                 }
-            })
-        });
+            };
+            if !bdev.add_aliases(&self.aliases) {
+                error!(
+                    "Failed to add all aliases to device {}",
+                    self.get_name()
+                );
+            }
+        };
 
         Ok(unsafe { CStr::from_ptr(context.names[0]) }
             .to_str()
@@ -217,7 +227,7 @@ impl CreateDestroy for Nvmf {
                 .await
             }
             None => Err(NexusBdevError::BdevNotFound {
-                name: self.name.clone(),
+                name: self.get_name(),
             }),
         }
     }

--- a/mayastor/src/bdev/dev/nvmf.rs
+++ b/mayastor/src/bdev/dev/nvmf.rs
@@ -33,8 +33,8 @@ pub(super) struct Nvmf {
     /// name of the nvme controller and base name of the bdev
     /// that should be created for each namespace found
     name: String,
-    /// list of aliases which can be used to open the bdev
-    aliases: Vec<String>,
+    /// alias which can be used to open the bdev
+    alias: String,
     /// the remote target host (address)
     host: String,
     /// the transport service id (ie. port)
@@ -113,7 +113,7 @@ impl TryFrom<&Url> for Nvmf {
 
         Ok(Nvmf {
             name: url.path()[1 ..].into(),
-            aliases: vec![url.to_string()],
+            alias: url.to_string(),
             host: host.to_string(),
             port: url.port().unwrap_or(DEFAULT_NVMF_PORT),
             subnqn: segments[0].to_string(),
@@ -195,9 +195,10 @@ impl CreateDestroy for Nvmf {
                     error!("Connected to device {} but expect to connect to {} instead", bdev.uuid_as_string(), u.to_hyphenated().to_string());
                 }
             };
-            if !bdev.add_aliases(&self.aliases) {
+            if !bdev.add_alias(&self.alias) {
                 error!(
-                    "Failed to add all aliases to device {}",
+                    "Failed to add alias {} to device {}",
+                    self.alias,
                     self.get_name()
                 );
             }

--- a/mayastor/src/bdev/dev/uring.rs
+++ b/mayastor/src/bdev/dev/uring.rs
@@ -17,7 +17,7 @@ use crate::{
 #[derive(Debug)]
 pub(super) struct Uring {
     name: String,
-    aliases: Vec<String>,
+    alias: String,
     blk_size: u32,
     uuid: Option<uuid::Uuid>,
 }
@@ -61,7 +61,7 @@ impl TryFrom<&Url> for Uring {
 
         Ok(Uring {
             name: url.path().into(),
-            aliases: vec![url.to_string()],
+            alias: url.to_string(),
             blk_size,
             uuid,
         })
@@ -95,9 +95,10 @@ impl CreateDestroy for Uring {
             if let Some(u) = self.uuid {
                 bdev.set_uuid(Some(u.to_string()))
             }
-            if !bdev.add_aliases(&self.aliases) {
+            if !bdev.add_alias(&self.alias) {
                 error!(
-                    "Failed to add all aliases to device {}",
+                    "Failed to add alias {} to device {}",
+                    self.alias,
                     self.get_name()
                 );
             }

--- a/mayastor/src/bdev/nexus/nexus_bdev.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev.rs
@@ -1013,8 +1013,7 @@ pub async fn nexus_create(
         }
 
         Err(e) => {
-            // XXX If we destroy the children here, we panic:
-            //   ni.destroy_children().await;
+            ni.destroy_children().await;
             return Err(e);
         }
 

--- a/mayastor/src/core/bdev.rs
+++ b/mayastor/src/core/bdev.rs
@@ -195,6 +195,16 @@ impl Bdev {
         uuid.to_hyphenated().to_string()
     }
 
+    /// Set a list of aliases on the bdev, used to find the bdev later
+    pub fn add_aliases(&self, alias: &[String]) -> bool {
+        let r = alias
+            .iter()
+            .filter(|a| -> bool { !self.add_alias(a) })
+            .collect::<Vec<&String>>();
+
+        r.is_empty()
+    }
+
     /// Set an alias on the bdev, this alias can be used to find the bdev later
     pub fn add_alias(&self, alias: &str) -> bool {
         let alias = std::ffi::CString::new(alias).unwrap();

--- a/mayastor/src/grpc/bdev_grpc.rs
+++ b/mayastor/src/grpc/bdev_grpc.rs
@@ -40,6 +40,7 @@ impl From<Bdev> for RpcBdev {
             blk_size: b.block_len(),
             claimed: b.is_claimed(),
             claimed_by: b.claimed_by().unwrap_or_else(|| "Orphaned".into()),
+            aliases: b.aliases().join(","),
         }
     }
 }

--- a/mayastor/tests/nexus_rebuild.rs
+++ b/mayastor/tests/nexus_rebuild.rs
@@ -64,14 +64,14 @@ fn get_disk(number: u64) -> String {
     if get_err_bdev().contains(&number) {
         format!("error_device{}", number)
     } else {
-        format!("/tmp/disk{}.img", number)
+        format!("/tmp/{}-disk{}.img", nexus_name(), number)
     }
 }
 fn get_dev(number: u64) -> String {
     if get_err_bdev().contains(&number) {
         format!("bdev:///EE_error_device{}", number)
     } else {
-        format!("aio://{}-{}?blk_size=512", nexus_name(), get_disk(number))
+        format!("aio://{}?blk_size=512", get_disk(number))
     }
 }
 

--- a/rpc/proto/mayastor.proto
+++ b/rpc/proto/mayastor.proto
@@ -335,6 +335,7 @@ message Bdev {
 	uint32 blk_size = 5;
 	bool claimed = 6;
 	string claimed_by = 7;
+	string aliases = 8;
 }
 
 message Bdevs {


### PR DESCRIPTION
All "URI devices" are now created and set to their proper name and not
the full URI. The URI is still set as an alias which the rest of the
code currently relies on.

For example an aio device:
aio:///dev/ram0?blk_size=512 now has the name /dev/ram0

Add aliases to the output of mayastor-client bdev list subcommand.

Also, destroy the nexus children when failing to create a nexus with a
generic error. This fixes a JS test which was "passing" incorrectly.
Also temporarily "patch" that test which was not failing as expected.