### PR TITLE
CAS-373: Add rebuild support to mayastor-client

### DIFF
--- a/mayastor/src/bin/cli/cli.rs
+++ b/mayastor/src/bin/cli/cli.rs
@@ -16,6 +16,7 @@ mod bdev_cli;
 mod context;
 mod nexus_cli;
 mod pool_cli;
+mod rebuild_cli;
 mod replica_cli;
 
 type MayaClient = MayastorClient<Channel>;
@@ -74,6 +75,7 @@ async fn main() -> Result<(), Status> {
         .subcommand(nexus_cli::subcommands())
         .subcommand(replica_cli::subcommands())
         .subcommand(bdev_cli::subcommands())
+        .subcommand(rebuild_cli::subcommands())
         .get_matches();
 
     let ctx = Context::new(&matches).await;
@@ -83,6 +85,7 @@ async fn main() -> Result<(), Status> {
         ("nexus", Some(args)) => nexus_cli::handler(ctx, args).await?,
         ("pool", Some(args)) => pool_cli::handler(ctx, args).await?,
         ("replica", Some(args)) => replica_cli::handler(ctx, args).await?,
+        ("rebuild", Some(args)) => rebuild_cli::handler(ctx, args).await?,
 
         _ => eprintln!("Internal Error: Not implemented"),
     };

--- a/mayastor/src/bin/cli/nexus_cli.rs
+++ b/mayastor/src/bin/cli/nexus_cli.rs
@@ -67,6 +67,12 @@ pub fn subcommands<'a, 'b>() -> App<'a, 'b> {
                 .required(true)
                 .index(2)
                 .help("uri of child to add"),
+        )
+        .arg(
+            Arg::with_name("norebuild")
+                .default_value("false")
+                .index(3)
+                .help("determines if a rebuild job runs automatically"),
         );
 
     let remove = SubCommand::with_name("remove")

--- a/mayastor/src/bin/cli/nexus_cli.rs
+++ b/mayastor/src/bin/cli/nexus_cli.rs
@@ -72,7 +72,7 @@ pub fn subcommands<'a, 'b>() -> App<'a, 'b> {
             Arg::with_name("norebuild")
                 .default_value("false")
                 .index(3)
-                .help("determines if a rebuild job runs automatically"),
+                .help("specify if a rebuild job runs automatically"),
         );
 
     let remove = SubCommand::with_name("remove")

--- a/mayastor/src/bin/cli/rebuild_cli.rs
+++ b/mayastor/src/bin/cli/rebuild_cli.rs
@@ -1,0 +1,272 @@
+//!
+//! methods to interact with the rebuild process
+
+use crate::context::Context;
+use ::rpc::mayastor as rpc;
+use clap::{App, AppSettings, Arg, ArgMatches, SubCommand};
+use tonic::Status;
+
+pub async fn handler(
+    ctx: Context,
+    matches: &ArgMatches<'_>,
+) -> Result<(), Status> {
+    match matches.subcommand() {
+        ("start", Some(args)) => start(ctx, &args).await,
+        ("stop", Some(args)) => stop(ctx, &args).await,
+        ("pause", Some(args)) => pause(ctx, &args).await,
+        ("resume", Some(args)) => resume(ctx, &args).await,
+        ("state", Some(args)) => state(ctx, &args).await,
+        ("progress", Some(args)) => progress(ctx, &args).await,
+        (cmd, _) => {
+            Err(Status::not_found(format!("command {} does not exist", cmd)))
+        }
+    }
+}
+
+pub fn subcommands<'a, 'b>() -> App<'a, 'b> {
+    let start = SubCommand::with_name("start")
+        .about("starts a rebuild")
+        .arg(
+            Arg::with_name("uuid")
+                .required(true)
+                .index(1)
+                .help("uuid of the nexus"),
+        )
+        .arg(
+            Arg::with_name("uri")
+                .required(true)
+                .index(2)
+                .help("uri of child to start rebuilding"),
+        );
+
+    let stop = SubCommand::with_name("stop")
+        .about("stops a rebuild")
+        .arg(
+            Arg::with_name("uuid")
+                .required(true)
+                .index(1)
+                .help("uuid of the nexus"),
+        )
+        .arg(
+            Arg::with_name("uri")
+                .required(true)
+                .index(2)
+                .help("uri of child to stop rebuilding"),
+        );
+
+    let pause = SubCommand::with_name("pause")
+        .about("pauses a rebuild")
+        .arg(
+            Arg::with_name("uuid")
+                .required(true)
+                .index(1)
+                .help("uuid of the nexus"),
+        )
+        .arg(
+            Arg::with_name("uri")
+                .required(true)
+                .index(2)
+                .help("uri of child to pause rebuilding"),
+        );
+
+    let resume = SubCommand::with_name("resume")
+        .about("resumes a rebuild")
+        .arg(
+            Arg::with_name("uuid")
+                .required(true)
+                .index(1)
+                .help("uuid of the nexus"),
+        )
+        .arg(
+            Arg::with_name("uri")
+                .required(true)
+                .index(2)
+                .help("uri of child to resume rebuilding"),
+        );
+
+    let state = SubCommand::with_name("state")
+        .about("gets the rebuild state of the child")
+        .arg(
+            Arg::with_name("uuid")
+                .required(true)
+                .index(1)
+                .help("uuid of the nexus"),
+        )
+        .arg(
+            Arg::with_name("uri")
+                .required(true)
+                .index(2)
+                .help("uri of child to get the rebuild state from"),
+        );
+
+    let progress = SubCommand::with_name("progress")
+        .about("shows the progress of a rebuild")
+        .arg(
+            Arg::with_name("uuid")
+                .required(true)
+                .index(1)
+                .help("uuid of the nexus"),
+        )
+        .arg(
+            Arg::with_name("uri")
+                .required(true)
+                .index(2)
+                .help("uri of child to get the rebuild progress from"),
+        );
+
+    SubCommand::with_name("rebuild")
+        .settings(&[
+            AppSettings::SubcommandRequiredElseHelp,
+            AppSettings::ColoredHelp,
+            AppSettings::ColorAlways,
+        ])
+        .about("Rebuild management")
+        .subcommand(start)
+        .subcommand(stop)
+        .subcommand(pause)
+        .subcommand(resume)
+        .subcommand(state)
+        .subcommand(progress)
+}
+
+async fn start(
+    mut ctx: Context,
+    matches: &ArgMatches<'_>,
+) -> Result<(), Status> {
+    let uuid = matches.value_of("uuid").unwrap().to_string();
+    let uri = matches.value_of("uri").unwrap().to_string();
+
+    ctx.v2(&format!(
+        "Starting rebuild of child {} on nexus {}",
+        uri, uuid
+    ));
+    ctx.client
+        .start_rebuild(rpc::StartRebuildRequest {
+            uuid: uuid.clone(),
+            uri: uri.clone(),
+        })
+        .await?;
+    ctx.v1(&format!(
+        "Started rebuild of child {} on nexus {}",
+        uri, uuid
+    ));
+    Ok(())
+}
+
+async fn stop(
+    mut ctx: Context,
+    matches: &ArgMatches<'_>,
+) -> Result<(), Status> {
+    let uuid = matches.value_of("uuid").unwrap().to_string();
+    let uri = matches.value_of("uri").unwrap().to_string();
+
+    ctx.v2(&format!(
+        "Stopping rebuild of child {} on nexus {}",
+        uri, uuid
+    ));
+    ctx.client
+        .stop_rebuild(rpc::StopRebuildRequest {
+            uuid: uuid.clone(),
+            uri: uri.clone(),
+        })
+        .await?;
+    ctx.v1(&format!(
+        "Stopped rebuild of child {} on nexus {}",
+        uri, uuid
+    ));
+    Ok(())
+}
+
+async fn pause(
+    mut ctx: Context,
+    matches: &ArgMatches<'_>,
+) -> Result<(), Status> {
+    let uuid = matches.value_of("uuid").unwrap().to_string();
+    let uri = matches.value_of("uri").unwrap().to_string();
+
+    ctx.v2(&format!(
+        "Pausing rebuild of child {} on nexus {}",
+        uri, uuid
+    ));
+    ctx.client
+        .pause_rebuild(rpc::PauseRebuildRequest {
+            uuid: uuid.clone(),
+            uri: uri.clone(),
+        })
+        .await?;
+    ctx.v1(&format!(
+        "Paused rebuild of child {} on nexus {}",
+        uri, uuid
+    ));
+    Ok(())
+}
+
+async fn resume(
+    mut ctx: Context,
+    matches: &ArgMatches<'_>,
+) -> Result<(), Status> {
+    let uuid = matches.value_of("uuid").unwrap().to_string();
+    let uri = matches.value_of("uri").unwrap().to_string();
+
+    ctx.v2(&format!(
+        "Resuming rebuild of child {} on nexus {}",
+        uri, uuid
+    ));
+    ctx.client
+        .resume_rebuild(rpc::ResumeRebuildRequest {
+            uuid: uuid.clone(),
+            uri: uri.clone(),
+        })
+        .await?;
+    ctx.v1(&format!(
+        "Resumed rebuild of child {} on nexus {}",
+        uri, uuid
+    ));
+    Ok(())
+}
+
+async fn state(
+    mut ctx: Context,
+    matches: &ArgMatches<'_>,
+) -> Result<(), Status> {
+    let uuid = matches.value_of("uuid").unwrap().to_string();
+    let uri = matches.value_of("uri").unwrap().to_string();
+
+    ctx.v2(&format!(
+        "Getting the rebuild state of child {} on nexus {}",
+        uri, uuid
+    ));
+    let response = ctx
+        .client
+        .get_rebuild_state(rpc::RebuildStateRequest {
+            uuid: uuid.clone(),
+            uri: uri.clone(),
+        })
+        .await?
+        .into_inner();
+    println!("{}", response.state);
+    Ok(())
+}
+
+async fn progress(
+    mut ctx: Context,
+    matches: &ArgMatches<'_>,
+) -> Result<(), Status> {
+    let uuid = matches.value_of("uuid").unwrap().to_string();
+    let uri = matches.value_of("uri").unwrap().to_string();
+
+    ctx.v2(&format!(
+        "Getting the rebuild progress of child {} on nexus {}",
+        uri, uuid
+    ));
+    let response = ctx
+        .client
+        .get_rebuild_progress(rpc::RebuildProgressRequest {
+            uuid: uuid.clone(),
+            uri: uri.clone(),
+        })
+        .await?
+        .into_inner();
+    println!("{}% complete", response.progress);
+    Ok(())
+}

--- a/mayastor/src/bin/cli/rebuild_cli.rs
+++ b/mayastor/src/bin/cli/rebuild_cli.rs
@@ -23,6 +23,7 @@ pub async fn handler(
     }
 }
 
+// TODO: Make subcommands use the name of the child rather than the uri
 pub fn subcommands<'a, 'b>() -> App<'a, 'b> {
     let start = SubCommand::with_name("start")
         .about("starts a rebuild")

--- a/mayastor/src/bin/cli/rebuild_cli.rs
+++ b/mayastor/src/bin/cli/rebuild_cli.rs
@@ -136,10 +136,6 @@ async fn start(
     let uuid = matches.value_of("uuid").unwrap().to_string();
     let uri = matches.value_of("uri").unwrap().to_string();
 
-    ctx.v2(&format!(
-        "Starting rebuild of child {} on nexus {}",
-        uri, uuid
-    ));
     ctx.client
         .start_rebuild(rpc::StartRebuildRequest {
             uuid: uuid.clone(),
@@ -147,7 +143,7 @@ async fn start(
         })
         .await?;
     ctx.v1(&format!(
-        "Started rebuild of child {} on nexus {}",
+        "Starting rebuild of child {} on nexus {}",
         uri, uuid
     ));
     Ok(())
@@ -160,10 +156,6 @@ async fn stop(
     let uuid = matches.value_of("uuid").unwrap().to_string();
     let uri = matches.value_of("uri").unwrap().to_string();
 
-    ctx.v2(&format!(
-        "Stopping rebuild of child {} on nexus {}",
-        uri, uuid
-    ));
     ctx.client
         .stop_rebuild(rpc::StopRebuildRequest {
             uuid: uuid.clone(),
@@ -171,7 +163,7 @@ async fn stop(
         })
         .await?;
     ctx.v1(&format!(
-        "Stopped rebuild of child {} on nexus {}",
+        "Stopping rebuild of child {} on nexus {}",
         uri, uuid
     ));
     Ok(())
@@ -184,10 +176,6 @@ async fn pause(
     let uuid = matches.value_of("uuid").unwrap().to_string();
     let uri = matches.value_of("uri").unwrap().to_string();
 
-    ctx.v2(&format!(
-        "Pausing rebuild of child {} on nexus {}",
-        uri, uuid
-    ));
     ctx.client
         .pause_rebuild(rpc::PauseRebuildRequest {
             uuid: uuid.clone(),
@@ -195,7 +183,7 @@ async fn pause(
         })
         .await?;
     ctx.v1(&format!(
-        "Paused rebuild of child {} on nexus {}",
+        "Pausing rebuild of child {} on nexus {}",
         uri, uuid
     ));
     Ok(())
@@ -208,10 +196,6 @@ async fn resume(
     let uuid = matches.value_of("uuid").unwrap().to_string();
     let uri = matches.value_of("uri").unwrap().to_string();
 
-    ctx.v2(&format!(
-        "Resuming rebuild of child {} on nexus {}",
-        uri, uuid
-    ));
     ctx.client
         .resume_rebuild(rpc::ResumeRebuildRequest {
             uuid: uuid.clone(),
@@ -219,7 +203,7 @@ async fn resume(
         })
         .await?;
     ctx.v1(&format!(
-        "Resumed rebuild of child {} on nexus {}",
+        "Resuming rebuild of child {} on nexus {}",
         uri, uuid
     ));
     Ok(())


### PR DESCRIPTION
Added support for the following rebuild operations:
  - start
  - stop
  - pause
  - resume
  - state
  - progress

Added the optional "norebuild" argument to the "nexus add" command. This
determines whether or not a rebuild is started automatically for the
added child. If false, a rebuild is started. If true a rebuild is not
started. (Note: false is the default value)