### PR TITLE
moac should accept URIs for pool devices (CAS-311)

### DIFF
--- a/csi/moac/crds/mayastorpool.yaml
+++ b/csi/moac/crds/mayastorpool.yaml
@@ -47,7 +47,7 @@ spec:
               description: Name of the k8s node where the storage pool is located.
               type: string
             disks:
-              description: Disk device names from /dev which comprise the storage pool.
+              description: Disk devices (paths or URIs) that should be used for the pool.
               type: array
               items:
                 type: string
@@ -61,6 +61,11 @@ spec:
             reason:
               description: Reason for the pool state value if applicable.
               type: string
+            disks:
+              description: Disk device URIs that are actually used for the pool.
+              type: array
+              items:
+                type: string
             capacity:
               description: Capacity of the pool in bytes.
               type: integer


### PR DESCRIPTION
Add a new field "disks" to status part of mayastor pool CRD. The
difference between disks in spec and status part is that spec part
describes what is desired (i.e. /dev/sdb) and the status part tells what
is actually used (i.e. aio://dev/sdb). They should be the same except
the protocol part in some cases.