### PR TITLE
Remove nbd storage class and tag moac image as develop in dev

### DIFF
--- a/csi/moac/default.nix
+++ b/csi/moac/default.nix
@@ -43,7 +43,7 @@ result // rec {
   #    of layering.
   buildImage = pkgs.dockerTools.buildLayeredImage {
     name = "mayadata/moac";
-    tag = "latest";
+    tag = "develop";
     created = "now";
     contents = [ pkgs.busybox package ];
     config = {

--- a/deploy/storage-class.yaml
+++ b/deploy/storage-class.yaml
@@ -1,15 +1,6 @@
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
-  name: mayastor
-parameters:
-  repl: '1'
-  protocol: 'nbd'
-provisioner: io.openebs.csi-mayastor
----
-kind: StorageClass
-apiVersion: storage.k8s.io/v1
-metadata:
   name: mayastor-iscsi
 parameters:
   repl: '1'


### PR DESCRIPTION
Remove nbd storage class from example storage class yaml
Make image tags in the develop branch consistent i.e. develop