### PR TITLE
CAS-377: Increase the rebuild data size

### DIFF
--- a/mayastor-test/test_rebuild.js
+++ b/mayastor-test/test_rebuild.js
@@ -15,8 +15,8 @@ const protoLoader = require('@grpc/proto-loader');
 // backend file for aio bdev
 const child1 = '/tmp/child1';
 const child2 = '/tmp/child2';
-// 64MB is the size of nexus and replicas
-const diskSize = 64 * 1024 * 1024;
+// 100MB is the size of nexus and replicas
+const diskSize = 100 * 1024 * 1024;
 // nexus UUID
 const UUID = 'dbe4d7eb-118a-4d15-b789-a18d9af6ff21';
 // external IP address detected by common lib
@@ -65,7 +65,7 @@ const configNexus = `
 
 const nexusArgs = {
   uuid: UUID,
-  size: 131072,
+  size: 104857600, // Size in bytes
   children: [`aio://${child1}?blk_size=4096`]
 };
 

--- a/mayastor/src/rebuild/rebuild_impl.rs
+++ b/mayastor/src/rebuild/rebuild_impl.rs
@@ -10,7 +10,7 @@ use futures::{
 use once_cell::sync::OnceCell;
 use snafu::ResultExt;
 
-use spdk_sys::spdk_get_thread;
+use spdk_sys::{spdk_get_thread, SPDK_BDEV_LARGE_BUF_MAX_SIZE};
 
 use crate::{
     bdev::VerboseError,
@@ -44,8 +44,7 @@ struct TaskResult {
 /// Number of concurrent copy tasks per rebuild job
 const SEGMENT_TASKS: usize = 16;
 /// Size of each segment used by the copy task
-/// Set to 64KiB to match SPDK's max buffer size (SPDK_BDEV_LARGE_BUF_MAX_SIZE)
-pub const SEGMENT_SIZE: u64 = 64 * 1024; // 64KiB
+pub const SEGMENT_SIZE: u64 = SPDK_BDEV_LARGE_BUF_MAX_SIZE as u64;
 
 /// Each rebuild task needs a unique buffer to read/write from source to target
 /// A mpsc channel is used to communicate with the management task

--- a/mayastor/src/rebuild/rebuild_impl.rs
+++ b/mayastor/src/rebuild/rebuild_impl.rs
@@ -42,9 +42,10 @@ struct TaskResult {
 }
 
 /// Number of concurrent copy tasks per rebuild job
-const SEGMENT_TASKS: usize = 4;
+const SEGMENT_TASKS: usize = 16;
 /// Size of each segment used by the copy task
-pub const SEGMENT_SIZE: u64 = 10 * 1024; // 10KiB
+/// Set to 64KiB to match SPDK's max buffer size (SPDK_BDEV_LARGE_BUF_MAX_SIZE)
+pub const SEGMENT_SIZE: u64 = 64 * 1024; // 64KiB
 
 /// Each rebuild task needs a unique buffer to read/write from source to target
 /// A mpsc channel is used to communicate with the management task


### PR DESCRIPTION
The amount of data that can be rebuilt at any given time has been
increased from 40KiB to 1MiB.

The number of concurrent copy tasks is increased to 16, with each task
copying 64KiB of data.