### PR TITLE
CAS-382 CSI plugin should not assume "ID_SCSI_SERIAL" attribute is present in udev records for iSCSI devices

### DIFF
--- a/csi/src/dev/util.rs
+++ b/csi/src/dev/util.rs
@@ -3,12 +3,18 @@ use uuid::{parser::ParseError, Uuid};
 
 pub(super) fn extract_uuid(value: &str) -> Result<Uuid, ParseError> {
     lazy_static! {
-        static ref PATTERN: Regex = Regex::new(r"^[[:xdigit:]]$").unwrap();
+        static ref PATTERN: Regex = Regex::new(r"^[[:xdigit:]]+-").unwrap();
+    }
+
+    if PATTERN.is_match(value) {
+        if let Ok(uuid) = Uuid::parse_str(value) {
+            return Ok(uuid);
+        }
     }
 
     let mut components: Vec<&str> = value.split('-').collect();
 
-    if !components.is_empty() && !PATTERN.is_match(components[0]) {
+    if !components.is_empty() {
         components.remove(0);
     }
 

--- a/csi/src/match_dev.rs
+++ b/csi/src/match_dev.rs
@@ -52,17 +52,9 @@ macro_rules! require {
     };
 }
 
-pub(super) fn match_iscsi_device<'a>(
-    device: &'a Device,
-    key: &str,
-) -> Option<(&'a str, &'a str)> {
+pub(super) fn match_iscsi_device(device: &Device) -> Option<(&str, &str)> {
     require!("Nexus_CAS_Driver" == device.property_value("ID_MODEL"));
     require!("scsi" == device.property_value("ID_BUS"));
-
-    require!(let serial = device.property_value("ID_SCSI_SERIAL"));
-    if !key.starts_with(serial) {
-        return None;
-    }
 
     require!(let devname = device.property_value("DEVNAME"));
     require!(let path = device.property_value("ID_PATH"));
@@ -76,6 +68,7 @@ pub(super) fn match_nvmf_device<'a>(
 ) -> Option<&'a str> {
     require!("Mayastor NVMe controller" == device.property_value("ID_MODEL"));
     require!(key == device.property_value("ID_WWN"));
+
     require!(let devname = device.property_value("DEVNAME"));
 
     Some(devname)


### PR DESCRIPTION
Modified match_iscsi_device() so that it no longer refers to the "ID_SCSI_SERIAL" attribute when searching for iSCSI devices, as there is no guarantee that it will be present in the udev device record.

Fixed bug in extract_uuid().