### PR TITLE
fix nvmeadm and rebuild tests

### DIFF
--- a/mayastor/README.md
+++ b/mayastor/README.md
@@ -21,5 +21,37 @@ List SPDK bdevs:
 jsonrpc raw get_bdevs '{}' | jq
 ```
 ```json
-[]
+[
+  {
+    "aliases": [],
+    "assigned_rate_limits": {
+      "r_mbytes_per_sec": 0,
+      "rw_ios_per_sec": 0,
+      "rw_mbytes_per_sec": 0,
+      "w_mbytes_per_sec": 0
+    },
+    "block_size": 512,
+    "claimed": true,
+    "driver_specific": {
+      "aio": {
+        "filename": "/dev/ram1"
+      }
+    },
+    "name": "/dev/ram1",
+    "num_blocks": 2048000,
+    "product_name": "AIO disk",
+    "supported_io_types": {
+      "flush": true,
+      "nvme_admin": false,
+      "nvme_io": false,
+      "read": true,
+      "reset": true,
+      "unmap": false,
+      "write": true,
+      "write_zeroes": true
+    },
+    "uuid": "4f6b7449-886a-4045-96a5-a5626a598302",
+    "zoned": false
+  }
+]
 ```

--- a/mayastor/tests/add_child.rs
+++ b/mayastor/tests/add_child.rs
@@ -17,6 +17,7 @@ pub mod common;
 
 fn test_start() {
     common::mayastor_test_init();
+    common::delete_file(&[DISKNAME1.into(), DISKNAME2.into()]);
     common::truncate_file(DISKNAME1, FILE_SIZE);
     common::truncate_file(DISKNAME2, FILE_SIZE);
 }

--- a/mayastor/tests/nexus_rebuild.rs
+++ b/mayastor/tests/nexus_rebuild.rs
@@ -573,11 +573,13 @@ fn rebuild_multiple() {
 
         for child in 1 ..= active_rebuilds {
             nexus_add_child(child, false).await;
+            nexus.pause_rebuild(&get_dev(child)).await.unwrap();
         }
 
         assert_eq!(RebuildJob::count(), active_rebuilds as usize);
 
         for child in 1 ..= active_rebuilds {
+            nexus.resume_rebuild(&get_dev(child)).await.unwrap();
             common::wait_for_rebuild(
                 get_dev(child),
                 RebuildState::Completed,

--- a/nvmeadm/tests/discovery_test.rs
+++ b/nvmeadm/tests/discovery_test.rs
@@ -21,7 +21,7 @@ static CONFIG_TEXT: &str = "[Malloc]
 [Transport]
   Type TCP
   # reduce memory requirements
-  NumSharedBuffers 32
+  NumSharedBuffers 64
 [Subsystem1]
   NQN nqn.2019-05.io.openebs:disk2
   Listen TCP 127.0.0.1:NVMF_PORT


### PR DESCRIPTION
pause rebuild between checks
bump up the number of shared buffers
update README with an actual example
delete tmp disk files before truncation