### PR TITLE
Add support for block volumes. CAS-14

### DIFF
--- a/csi/src/block_vol.rs
+++ b/csi/src/block_vol.rs
@@ -1,0 +1,120 @@
+//! Functions for CSI publish and unpublish block mode volumes.
+
+use tonic::{Code, Status};
+
+macro_rules! failure {
+    (Code::$code:ident, $msg:literal) => {{ error!($msg); Status::new(Code::$code, $msg) }};
+    (Code::$code:ident, $fmt:literal $(,$args:expr)+) => {{ let message = format!($fmt $(,$args)+); error!("{}", message); Status::new(Code::$code, message) }};
+}
+
+use crate::{
+    csi::*,
+    dev::Device,
+    mount::{self},
+};
+
+pub async fn publish_block_volume(
+    msg: &NodePublishVolumeRequest,
+) -> Result<(), Status> {
+    let target_path = &msg.target_path;
+    let volume_id = &msg.volume_id;
+
+    let uri = msg.publish_context.get("uri").ok_or_else(|| {
+            failure!(
+                Code::InvalidArgument,
+                "Failed to stage volume {}: URI attribute missing from publish context",
+                volume_id
+            )
+        })?;
+
+    // Block volumes are not staged, instead
+    // bind mount to the device path,
+    // this can be done for mutliple target paths.
+    let device = Device::parse(&uri).map_err(|error| {
+        failure!(
+            Code::Internal,
+            "Failed to publish volume {}: error parsing URI {}: {}",
+            volume_id,
+            uri,
+            error
+        )
+    })?;
+
+    if let Some(device_path) = device.find().await.map_err(|error| {
+        failure!(
+            Code::Internal,
+            "Failed to publish volume {}: error locating device for URI {}: {}",
+            volume_id,
+            uri,
+            error
+        )
+    })? {
+        let devt = unsafe { libc::makedev(259, 254) };
+
+        let cstr_dst = std::ffi::CString::new(target_path.as_str()).unwrap();
+        let res =
+            unsafe { libc::mknod(cstr_dst.as_ptr(), libc::S_IFBLK, devt) };
+
+        if res != 0 {
+            return Err(failure!(
+                Code::Internal,
+                "Failed to publish volume {}: mknod at {} failed",
+                volume_id,
+                target_path
+            ));
+        }
+
+        if let Err(error) = mount::blockdevice_mount(
+            &device_path,
+            target_path.as_str(),
+            msg.readonly,
+        ) {
+            return Err(failure!(
+                Code::Internal,
+                "Failed to publish volume {}: {}",
+                volume_id,
+                error
+            ));
+        }
+        Ok(())
+    } else {
+        Err(failure!(
+            Code::Internal,
+            "Failed to publish volume {}: unable to retrieve device path",
+            volume_id
+        ))
+    }
+}
+
+pub fn unpublish_block_volume(
+    msg: &NodeUnpublishVolumeRequest,
+) -> Result<(), Status> {
+    let target_path = &msg.target_path;
+    let volume_id = &msg.volume_id;
+
+    // block volumes are mounted on block special file, which is not
+    // a regular file.
+    if mount::find_mount(None, Some(target_path)).is_some() {
+        match mount::blockdevice_unmount(&target_path) {
+            Ok(_) => {}
+            Err(err) => {
+                return Err(Status::new(
+                    Code::Internal,
+                    format!(
+                        "Failed to unpublish volume {}: {}",
+                        volume_id, err
+                    ),
+                ));
+            }
+        }
+    }
+
+    debug!("Removing block special file {}", target_path);
+
+    if let Err(error) = std::fs::remove_file(target_path) {
+        warn!("Failed to remove block file {}: {}", target_path, error);
+    }
+
+    info!("Volume {} unpublished from {}", volume_id, target_path);
+    Ok(())
+}

--- a/csi/src/filesystem_vol.rs
+++ b/csi/src/filesystem_vol.rs
@@ -1,0 +1,348 @@
+//! Functions for CSI stage, unstage, publish and unpublish filesystem volumes.
+
+use std::{fs, io::ErrorKind, path::PathBuf};
+
+use tonic::{Code, Status};
+
+macro_rules! failure {
+    (Code::$code:ident, $msg:literal) => {{ error!($msg); Status::new(Code::$code, $msg) }};
+    (Code::$code:ident, $fmt:literal $(,$args:expr)+) => {{ let message = format!($fmt $(,$args)+); error!("{}", message); Status::new(Code::$code, message) }};
+}
+
+use crate::{
+    csi::{volume_capability::MountVolume, *},
+    format::prepare_device,
+    mount::{self, subset, ReadOnly},
+};
+
+pub async fn stage_fs_volume(
+    msg: &NodeStageVolumeRequest,
+    device_path: String,
+    mnt: &MountVolume,
+    filesystems: &[String],
+) -> Result<(), Status> {
+    let volume_id = &msg.volume_id;
+    let fs_staging_path = &msg.staging_target_path;
+
+    // One final check for fs volumes, ignore for block volumes.
+    if let Err(err) = fs::create_dir_all(PathBuf::from(&fs_staging_path)) {
+        if err.kind() != ErrorKind::AlreadyExists {
+            return Err(Status::new(
+                Code::Internal,
+                format!(
+                    "Failed to create mountpoint {} for volume {}: {}",
+                    &fs_staging_path, volume_id, err
+                ),
+            ));
+        }
+    }
+
+    debug!("Staging volume {} to {}", volume_id, fs_staging_path);
+
+    let fstype = if mnt.fs_type.is_empty() {
+        String::from(&filesystems[0])
+    } else {
+        match filesystems.iter().find(|&entry| entry == &mnt.fs_type) {
+            Some(fstype) => String::from(fstype),
+            None => {
+                return Err(failure!(
+                        Code::InvalidArgument,
+                        "Failed to stage volume {}: unsupported filesystem type: {}",
+                        volume_id,
+                        mnt.fs_type
+                    ));
+            }
+        }
+    };
+
+    if mount::find_mount(Some(&device_path), Some(&fs_staging_path)).is_some() {
+        debug!(
+            "Device {} is already mounted onto {}",
+            device_path, fs_staging_path
+        );
+        info!(
+            "Volume {} is already staged to {}",
+            volume_id, fs_staging_path
+        );
+        return Ok(());
+    }
+
+    // abort if device is mounted somewhere else
+    if mount::find_mount(Some(&device_path), None).is_some() {
+        return Err(failure!(
+            Code::AlreadyExists,
+            "Failed to stage volume {}: device {} is already mounted elsewhere",
+            volume_id,
+            device_path
+        ));
+    }
+
+    // abort if some another device is mounted on staging_path
+    if mount::find_mount(None, Some(&fs_staging_path)).is_some() {
+        return Err(failure!(
+                    Code::AlreadyExists,
+                    "Failed to stage volume {}: another device is already mounted onto {}",
+                    volume_id,
+                    fs_staging_path
+                ));
+    }
+
+    if let Err(error) = prepare_device(&device_path, &fstype).await {
+        return Err(failure!(
+            Code::Internal,
+            "Failed to stage volume {}: error preparing device {}: {}",
+            volume_id,
+            device_path,
+            error
+        ));
+    }
+
+    debug!("Mounting device {} onto {}", device_path, fs_staging_path);
+
+    if let Err(error) = mount::filesystem_mount(
+        &device_path,
+        &fs_staging_path,
+        &fstype,
+        &mnt.mount_flags,
+    ) {
+        return Err(failure!(
+            Code::Internal,
+            "Failed to stage volume {}: failed to mount device {} onto {}: {}",
+            volume_id,
+            device_path,
+            fs_staging_path,
+            error
+        ));
+    }
+
+    info!("Volume {} staged to {}", volume_id, fs_staging_path);
+
+    Ok(())
+}
+
+/// Unstage a filesystem volume
+pub async fn unstage_fs_volume(
+    msg: &NodeUnstageVolumeRequest,
+) -> Result<(), Status> {
+    let volume_id = &msg.volume_id;
+    let fs_staging_path = &msg.staging_target_path;
+
+    if let Some(mount) = mount::find_mount(None, Some(&fs_staging_path)) {
+        debug!(
+            "Unstaging filesystem volume {}, unmounting device {} from {}",
+            volume_id, mount.source, fs_staging_path
+        );
+        if let Err(error) = mount::filesystem_unmount(&fs_staging_path) {
+            return Err(failure!(
+                    Code::Internal,
+                    "Failed to unstage volume {}: failed to unmount device {} from {}: {}",
+                    volume_id,
+                    mount.source,
+                    fs_staging_path,
+                    error
+                ));
+        }
+    }
+
+    Ok(())
+}
+
+/// Publish a filesystem volume
+pub fn publish_fs_volume(
+    msg: &NodePublishVolumeRequest,
+    mnt: &MountVolume,
+    filesystems: &[String],
+) -> Result<(), Status> {
+    let target_path = &msg.target_path;
+    let volume_id = &msg.volume_id;
+    let fs_staging_path = &msg.staging_target_path;
+
+    debug!(
+        "Publishing volume {} from {} to {}",
+        volume_id, fs_staging_path, target_path
+    );
+
+    let staged =
+        mount::find_mount(None, Some(&fs_staging_path)).ok_or_else(|| {
+            failure!(
+                Code::InvalidArgument,
+                "Failed to publish volume {}: no mount for staging path {}",
+                volume_id,
+                fs_staging_path
+            )
+        })?;
+
+    // TODO: Should also check that the staged "device"
+    // corresponds to the the volume uuid
+
+    if mnt.fs_type != "" && mnt.fs_type != staged.fstype {
+        return Err(failure!(
+                Code::InvalidArgument,
+                "Failed to publish volume {}: filesystem type ({}) does not match staged volume ({})",
+                volume_id,
+                mnt.fs_type,
+                staged.fstype
+            ));
+    }
+
+    if filesystems
+        .iter()
+        .find(|&entry| entry == &staged.fstype)
+        .is_none()
+    {
+        return Err(failure!(
+            Code::InvalidArgument,
+            "Failed to publish volume {}: unsupported filesystem type: {}",
+            volume_id,
+            staged.fstype
+        ));
+    }
+
+    let readonly = staged.options.readonly();
+
+    if readonly && !msg.readonly {
+        return Err(failure!(
+                Code::InvalidArgument,
+                "Failed to publish volume {}: volume is staged as \"ro\" but publish requires \"rw\"",
+                volume_id
+            ));
+    }
+
+    if let Some(mount) = mount::find_mount(None, Some(target_path)) {
+        if mount.source != staged.source {
+            return Err(failure!(
+                Code::AlreadyExists,
+                "Failed to publish volume {}: directory {} is already in use",
+                volume_id,
+                target_path
+            ));
+        }
+
+        if !subset(&mnt.mount_flags, &mount.options)
+            || msg.readonly != mount.options.readonly()
+        {
+            return Err(failure!(
+                    Code::AlreadyExists,
+                    "Failed to publish volume {}: directory {} is already mounted but with incompatible flags",
+                    volume_id,
+                    target_path
+                ));
+        }
+
+        info!(
+            "Volume {} is already published to {}",
+            volume_id, target_path
+        );
+
+        return Ok(());
+    }
+
+    debug!("Creating directory {}", target_path);
+
+    if let Err(error) = fs::create_dir_all(PathBuf::from(target_path)) {
+        if error.kind() != ErrorKind::AlreadyExists {
+            return Err(failure!(
+                    Code::Internal,
+                    "Failed to publish volume {}: failed to create directory {}: {}",
+                    volume_id,
+                    target_path,
+                    error
+                ));
+        }
+    }
+
+    debug!("Mounting {} to {}", fs_staging_path, target_path);
+
+    if let Err(error) = mount::bind_mount(&fs_staging_path, &target_path, false)
+    {
+        return Err(failure!(
+            Code::Internal,
+            "Failed to publish volume {}: failed to mount {} to {}: {}",
+            volume_id,
+            fs_staging_path,
+            target_path,
+            error
+        ));
+    }
+
+    if msg.readonly && !readonly {
+        let mut options = mnt.mount_flags.clone();
+        options.push(String::from("ro"));
+
+        debug!("Remounting {} as readonly", target_path);
+
+        if let Err(error) = mount::bind_remount(&target_path, &options) {
+            let message = format!(
+                    "Failed to publish volume {}: failed to mount {} to {} as readonly: {}",
+                    volume_id,
+                    fs_staging_path,
+                    target_path,
+                    error
+                );
+
+            error!("Failed to remount {}: {}", target_path, error);
+
+            debug!("Unmounting {}", target_path);
+
+            if let Err(error) = mount::bind_unmount(&target_path) {
+                error!("Failed to unmount {}: {}", target_path, error);
+            }
+
+            return Err(Status::new(Code::Internal, message));
+        }
+    }
+
+    info!("Volume {} published to {}", volume_id, target_path);
+
+    Ok(())
+}
+
+pub fn unpublish_fs_volume(
+    msg: &NodeUnpublishVolumeRequest,
+) -> Result<(), Status> {
+    // filesystem mount
+    let target_path = &msg.target_path;
+    let volume_id = &msg.volume_id;
+
+    if mount::find_mount(None, Some(target_path)).is_none() {
+        // No mount found for target_path.
+        // The idempotency requirement means this is not an error.
+        // Just clean up as best we can and claim success.
+
+        if let Err(error) = fs::remove_dir(PathBuf::from(target_path)) {
+            if error.kind() != ErrorKind::NotFound {
+                error!("Failed to remove directory {}: {}", target_path, error);
+            }
+        }
+
+        info!(
+            "Volume {} is already unpublished from {}",
+            volume_id, target_path
+        );
+
+        return Ok(());
+    }
+
+    debug!("Unmounting {}", target_path);
+
+    if let Err(error) = mount::bind_unmount(target_path) {
+        return Err(failure!(
+            Code::Internal,
+            "Failed to unpublish volume {}: failed to unmount {}: {}",
+            volume_id,
+            target_path,
+            error
+        ));
+    }
+
+    debug!("Removing directory {}", target_path);
+
+    if let Err(error) = fs::remove_dir(PathBuf::from(target_path)) {
+        if error.kind() != ErrorKind::NotFound {
+            error!("Failed to remove directory {}: {}", target_path, error);
+        }
+    }
+
+    info!("Volume {} unpublished from {}", volume_id, target_path);
+    Ok(())
+}

--- a/csi/src/mount.rs
+++ b/csi/src/mount.rs
@@ -267,3 +267,47 @@ pub fn bind_unmount(target: &str) -> Result<(), Error> {
 
     Ok(())
 }
+
+/// Mount a block device
+pub fn blockdevice_mount(
+    source: &str,
+    target: &str,
+    readonly: bool,
+) -> Result<Mount, Error> {
+    debug!("Mounting {} ...", source);
+
+    let mut flags = MountFlags::empty();
+    flags.insert(MountFlags::BIND);
+
+    let mount = Mount::new(
+        source,
+        target,
+        FilesystemType::Manual("none"),
+        flags,
+        None,
+    )?;
+    info!("Block device {} mounted to {}", source, target,);
+
+    if readonly {
+        flags.insert(MountFlags::REMOUNT);
+        flags.insert(MountFlags::RDONLY);
+
+        let mount =
+            Mount::new("", target, FilesystemType::Manual(""), flags, None)?;
+        info!("Remounted block device {} (readonly) to {}", source, target,);
+        return Ok(mount);
+    }
+
+    Ok(mount)
+}
+
+/// Unmount a block device.
+pub fn blockdevice_unmount(target: &str) -> Result<(), Error> {
+    let flags = UnmountFlags::FORCE;
+
+    debug!("Unmounting block device {} (flags={:?}) ...", target, flags);
+
+    unmount(&target, flags)?;
+    info!("block device at {} has been unmounted", target);
+    Ok(())
+}

--- a/csi/src/node.rs
+++ b/csi/src/node.rs
@@ -2,7 +2,7 @@ use std::{
     boxed::Box,
     fs,
     io::ErrorKind,
-    path::PathBuf,
+    path::{Path, PathBuf},
     time::Duration,
     vec::Vec,
 };
@@ -19,7 +19,7 @@ use uuid::Uuid;
 
 use crate::{
     csi::{
-        volume_capability::{access_mode::Mode, AccessType, MountVolume},
+        volume_capability::{access_mode::Mode, AccessType},
         *,
     },
     dev::Device,
@@ -31,6 +31,25 @@ use crate::{
 pub struct Node {
     pub node_name: String,
     pub filesystems: Vec<String>,
+}
+
+const FS_MOUNT: &str = "fs_mnt";
+// For block volumes we do not stage a mount.
+// For filesystem volumes we stage the mount at a subdirectory
+// At unstage we differentiate between a filesystemvolume,
+// a block volume by checking for the presence of the sub directory
+
+/// Construct the filesystem volume staging path.
+fn make_fs_staging_path(staging_path: &str) -> Result<String, String> {
+    let mut fs_path = PathBuf::from(staging_path);
+    fs_path.push(FS_MOUNT);
+    match fs_path.into_os_string().into_string() {
+        Ok(path) => Ok(path),
+        Err(_) => Err(format!(
+            "Failed to construct path {}/{}",
+            staging_path, FS_MOUNT
+        )),
+    }
 }
 
 // Determine if given access mode in conjunction with ro mount flag makes
@@ -82,19 +101,13 @@ fn check_access_mode(
     }
 }
 
-// TODO: Need to support block volumes
-/// Retrieve the MountVolume from VolumeCapability
-fn get_access_mount(
+/// Retrieve the AccessType from VolumeCapability
+fn get_access_type(
     volume_capability: &Option<VolumeCapability>,
-) -> Result<&MountVolume, String> {
+) -> Result<&AccessType, String> {
     match volume_capability {
         Some(capability) => match &capability.access_type {
-            Some(access) => match access {
-                AccessType::Block(_) => Err(String::from(
-                    "volume capability: BLOCK volumes not currently supported",
-                )),
-                AccessType::Mount(mount) => Ok(mount),
-            },
+            Some(access) => Ok(access),
             None => Err(String::from("volume capability: missing access type")),
         },
         None => Err(String::from("missing volume capability")),
@@ -172,9 +185,31 @@ impl node_server::Node for Node {
 
         trace!("node_publish_volume {:?}", msg);
 
-        let staging_path = &msg.staging_target_path;
         let target_path = &msg.target_path;
         let volume_id = &msg.volume_id;
+
+        if let Err(error) =
+            check_access_mode(&msg.volume_capability, msg.readonly)
+        {
+            return Err(failure!(
+                Code::InvalidArgument,
+                "Failed to publish volume {}: {}",
+                volume_id,
+                error
+            ));
+        }
+
+        // The CO must ensure that the parent of target path exists.
+        let target_parent = Path::new(target_path).parent().unwrap();
+        if let Err(err) = fs::create_dir_all(PathBuf::from(target_parent)) {
+            return Err(Status::new(
+                Code::Internal,
+                format!(
+                    "Failed to find parent dir for mountpoint {}, volume {}: {}",
+                    target_path, volume_id, err
+                ),
+            ));
+        }
 
         if volume_id.is_empty() {
             return Err(failure!(
@@ -193,7 +228,7 @@ impl node_server::Node for Node {
 
         // Note that the staging path is NOT optional,
         // as we advertise StageUnstageVolume.
-        if staging_path.is_empty() {
+        if msg.staging_target_path.is_empty() {
             return Err(failure!(
                 Code::InvalidArgument,
                 "Failed to publish volume {}: missing staging path",
@@ -201,167 +236,249 @@ impl node_server::Node for Node {
             ));
         }
 
-        // TODO: Support block volumes
-        let mnt =
-            get_access_mount(&msg.volume_capability).map_err(|error| {
-                failure!(
-                    Code::InvalidArgument,
-                    "Failed to publish volume {}: {}",
-                    volume_id,
-                    error
-                )
-            })?;
+        let uri = msg.publish_context.get("uri").ok_or_else(|| {
+            failure!(
+                Code::InvalidArgument,
+                "Failed to stage volume {}: URI attribute missing from publish context",
+                volume_id
+            )
+        })?;
 
-        debug!(
-            "Publishing volume {} from {} to {}",
-            volume_id, staging_path, target_path
-        );
-
-        let staged =
-            mount::find_mount(None, Some(staging_path)).ok_or_else(|| {
-                failure!(
-                    Code::InvalidArgument,
-                    "Failed to publish volume {}: no mount for staging path {}",
-                    volume_id,
-                    staging_path
-                )
-            })?;
-
-        // TODO: Should also check that the staged "device"
-        // corresponds to the the volume uuid
-
-        if let Err(error) =
-            check_access_mode(&msg.volume_capability, msg.readonly)
-        {
-            return Err(failure!(
+        match get_access_type(&msg.volume_capability).map_err(|error| {
+            failure!(
                 Code::InvalidArgument,
                 "Failed to publish volume {}: {}",
                 volume_id,
                 error
-            ));
-        }
+            )
+        })? {
+            AccessType::Mount(mnt) => {
+                // Filesystem mount
+                let fs_staging_path =
+                    match make_fs_staging_path(&msg.staging_target_path) {
+                        Ok(path) => path,
+                        Err(error) => {
+                            return Err(failure!(
+                                Code::Internal,
+                                "{}: {}",
+                                error,
+                                volume_id
+                            ))
+                        }
+                    };
 
-        if mnt.fs_type != "" && mnt.fs_type != staged.fstype {
-            return Err(failure!(
+                debug!(
+                    "Publishing volume {} from {} to {}",
+                    volume_id, fs_staging_path, target_path
+                );
+
+                let staged = mount::find_mount(None, Some(&fs_staging_path))
+                    .ok_or_else(|| {
+                        failure!(
+                    Code::InvalidArgument,
+                    "Failed to publish volume {}: no mount for staging path {}",
+                    volume_id,
+                    fs_staging_path
+                )
+                    })?;
+
+                // TODO: Should also check that the staged "device"
+                // corresponds to the the volume uuid
+
+                if mnt.fs_type != "" && mnt.fs_type != staged.fstype {
+                    return Err(failure!(
                 Code::InvalidArgument,
                 "Failed to publish volume {}: filesystem type ({}) does not match staged volume ({})",
                 volume_id,
                 mnt.fs_type,
                 staged.fstype
             ));
-        }
+                }
 
-        if self
-            .filesystems
-            .iter()
-            .find(|&entry| entry == &staged.fstype)
-            .is_none()
-        {
-            return Err(failure!(
+                if self
+                    .filesystems
+                    .iter()
+                    .find(|&entry| entry == &staged.fstype)
+                    .is_none()
+                {
+                    return Err(failure!(
                 Code::InvalidArgument,
                 "Failed to publish volume {}: unsupported filesystem type: {}",
                 volume_id,
                 staged.fstype
             ));
-        }
+                }
 
-        let readonly = staged.options.readonly();
+                let readonly = staged.options.readonly();
 
-        if readonly && !msg.readonly {
-            return Err(failure!(
+                if readonly && !msg.readonly {
+                    return Err(failure!(
                 Code::InvalidArgument,
                 "Failed to publish volume {}: volume is staged as \"ro\" but publish requires \"rw\"",
                 volume_id
             ));
-        }
+                }
 
-        if let Some(mount) = mount::find_mount(None, Some(target_path)) {
-            if mount.source != staged.source {
-                return Err(failure!(
+                if let Some(mount) = mount::find_mount(None, Some(target_path))
+                {
+                    if mount.source != staged.source {
+                        return Err(failure!(
                     Code::AlreadyExists,
                     "Failed to publish volume {}: directory {} is already in use",
                     volume_id,
                     target_path
                 ));
-            }
+                    }
 
-            if !subset(&mnt.mount_flags, &mount.options)
-                || msg.readonly != mount.options.readonly()
-            {
-                return Err(failure!(
+                    if !subset(&mnt.mount_flags, &mount.options)
+                        || msg.readonly != mount.options.readonly()
+                    {
+                        return Err(failure!(
                     Code::AlreadyExists,
                     "Failed to publish volume {}: directory {} is already mounted but with incompatible flags",
                     volume_id,
                     target_path
                 ));
-            }
+                    }
 
-            info!(
-                "Volume {} is already published to {}",
-                volume_id, target_path
-            );
+                    info!(
+                        "Volume {} is already published to {}",
+                        volume_id, target_path
+                    );
 
-            return Ok(Response::new(NodePublishVolumeResponse {}));
-        }
+                    return Ok(Response::new(NodePublishVolumeResponse {}));
+                }
 
-        debug!("Creating directory {}", target_path);
+                debug!("Creating directory {}", target_path);
 
-        if let Err(error) = fs::create_dir_all(PathBuf::from(target_path)) {
-            if error.kind() != ErrorKind::AlreadyExists {
-                return Err(failure!(
+                if let Err(error) =
+                    fs::create_dir_all(PathBuf::from(target_path))
+                {
+                    if error.kind() != ErrorKind::AlreadyExists {
+                        return Err(failure!(
                     Code::Internal,
                     "Failed to publish volume {}: failed to create directory {}: {}",
                     volume_id,
                     target_path,
                     error
                 ));
-            }
-        }
+                    }
+                }
 
-        debug!("Mounting {} to {}", staging_path, target_path);
+                debug!("Mounting {} to {}", fs_staging_path, target_path);
 
-        if let Err(error) =
-            mount::bind_mount(&staging_path, &target_path, false)
-        {
-            return Err(failure!(
-                Code::Internal,
-                "Failed to publish volume {}: failed to mount {} to {}: {}",
-                volume_id,
-                staging_path,
-                target_path,
-                error
-            ));
-        }
+                if let Err(error) =
+                    mount::bind_mount(&fs_staging_path, &target_path, false)
+                {
+                    return Err(failure!(
+                    Code::Internal,
+                    "Failed to publish volume {}: failed to mount {} to {}: {}",
+                    volume_id,
+                    fs_staging_path,
+                    target_path,
+                    error
+                ));
+                }
 
-        if msg.readonly && !readonly {
-            let mut options = mnt.mount_flags.clone();
-            options.push(String::from("ro"));
+                if msg.readonly && !readonly {
+                    let mut options = mnt.mount_flags.clone();
+                    options.push(String::from("ro"));
 
-            debug!("Remounting {} as readonly", target_path);
+                    debug!("Remounting {} as readonly", target_path);
 
-            if let Err(error) = mount::bind_remount(&target_path, &options) {
-                let message = format!(
+                    if let Err(error) =
+                        mount::bind_remount(&target_path, &options)
+                    {
+                        let message = format!(
                     "Failed to publish volume {}: failed to mount {} to {} as readonly: {}",
                     volume_id,
-                    staging_path,
+                    fs_staging_path,
                     target_path,
                     error
                 );
 
-                error!("Failed to remount {}: {}", target_path, error);
+                        error!("Failed to remount {}: {}", target_path, error);
 
-                debug!("Unmounting {}", target_path);
+                        debug!("Unmounting {}", target_path);
 
-                if let Err(error) = mount::bind_unmount(&target_path) {
-                    error!("Failed to unmount {}: {}", target_path, error);
+                        if let Err(error) = mount::bind_unmount(&target_path) {
+                            error!(
+                                "Failed to unmount {}: {}",
+                                target_path, error
+                            );
+                        }
+
+                        return Err(Status::new(Code::Internal, message));
+                    }
                 }
 
-                return Err(Status::new(Code::Internal, message));
+                info!("Volume {} published to {}", volume_id, target_path);
+                Ok(Response::new(NodePublishVolumeResponse {}))
+            }
+            AccessType::Block(_) => {
+                // Block volumes are not staged, instead
+                // bind mount to the device path,
+                // this can be done for mutliple target paths.
+                let device = Device::parse(&uri).map_err(|error| {
+                    failure!(
+                        Code::Internal,
+                        "Failed to publish volume {}: error parsing URI {}: {}",
+                        volume_id,
+                        uri,
+                        error
+                    )
+                })?;
+
+                if let Some(device_path) =
+                    device.find().await.map_err(|error| {
+                        failure!(
+            Code::Internal,
+            "Failed to publish volume {}: error locating device for URI {}: {}",
+            volume_id,
+            uri,
+            error
+        )
+                    })?
+                {
+                    let devt = unsafe { libc::makedev(259, 254) };
+
+                    let cstr_dst =
+                        std::ffi::CString::new(target_path.as_str()).unwrap();
+                    let res = unsafe {
+                        libc::mknod(cstr_dst.as_ptr(), libc::S_IFBLK, devt)
+                    };
+
+                    if res != 0 {
+                        return Err(failure!(
+                            Code::Internal,
+                            "Failed to publish volume {}: mknod at {} failed",
+                            volume_id,
+                            target_path
+                        ));
+                    }
+
+                    if let Err(error) = mount::blockdevice_mount(
+                        &device_path,
+                        target_path.as_str(),
+                        msg.readonly,
+                    ) {
+                        return Err(failure!(
+                            Code::Internal,
+                            "Failed to publish volume {}: {}",
+                            volume_id,
+                            error
+                        ));
+                    }
+                    Ok(Response::new(NodePublishVolumeResponse {}))
+                } else {
+                    Err(failure!(
+                        Code::Internal,
+                        "Failed to publish volume {}: unable to retrieve device path",
+                        volume_id
+                    ))
+                }
             }
         }
-
-        info!("Volume {} published to {}", volume_id, target_path);
-        Ok(Response::new(NodePublishVolumeResponse {}))
     }
 
     /// This RPC is called by the CO when a workload using the specified
@@ -380,69 +497,120 @@ impl node_server::Node for Node {
 
         trace!("node_unpublish_volume {:?}", msg);
 
-        let target_path = &msg.target_path;
-        let volume_id = &msg.volume_id;
-
-        if volume_id.is_empty() {
+        if msg.volume_id.is_empty() {
             return Err(failure!(
                 Code::InvalidArgument,
                 "Failed to unpublish volume: missing volume id"
             ));
         }
 
-        if target_path.is_empty() {
+        if msg.target_path.is_empty() {
             return Err(failure!(
                 Code::InvalidArgument,
                 "Failed to unpublish volume {}: missing target path",
-                volume_id
+                msg.volume_id
             ));
         }
 
-        debug!("Unpublishing volume {} from {}", volume_id, target_path);
+        // target path will have been created previously in node_publish_volume
+        // and is one of
+        //  1. a directory for filesystem volumes ,
+        //  2. a block special file for block volumes.
+        //
+        // If it does not exist, then a previously unpublish request has
+        // succeeded.
+        let path_target_path = Path::new(&msg.target_path);
+        if path_target_path.exists() {
+            let target_path = &msg.target_path;
+            let volume_id = &msg.volume_id;
 
-        if mount::find_mount(None, Some(target_path)).is_none() {
-            // No mount found for target_path.
-            // The idempotency requirement means this is not an error.
-            // Just clean up as best we can and claim success.
+            if path_target_path.is_dir() {
+                // filesystem mount
+                if mount::find_mount(None, Some(target_path)).is_none() {
+                    // No mount found for target_path.
+                    // The idempotency requirement means this is not an error.
+                    // Just clean up as best we can and claim success.
 
-            if let Err(error) = fs::remove_dir(PathBuf::from(target_path)) {
-                if error.kind() != ErrorKind::NotFound {
-                    error!(
-                        "Failed to remove directory {}: {}",
+                    if let Err(error) =
+                        fs::remove_dir(PathBuf::from(target_path))
+                    {
+                        if error.kind() != ErrorKind::NotFound {
+                            error!(
+                                "Failed to remove directory {}: {}",
+                                target_path, error
+                            );
+                        }
+                    }
+
+                    info!(
+                        "Volume {} is already unpublished from {}",
+                        volume_id, target_path
+                    );
+
+                    return Ok(Response::new(NodeUnpublishVolumeResponse {}));
+                }
+
+                debug!("Unmounting {}", target_path);
+
+                if let Err(error) = mount::bind_unmount(target_path) {
+                    return Err(failure!(
+                    Code::Internal,
+                    "Failed to unpublish volume {}: failed to unmount {}: {}",
+                    volume_id,
+                    target_path,
+                    error
+                ));
+                }
+
+                debug!("Removing directory {}", target_path);
+
+                if let Err(error) = fs::remove_dir(PathBuf::from(target_path)) {
+                    if error.kind() != ErrorKind::NotFound {
+                        error!(
+                            "Failed to remove directory {}: {}",
+                            target_path, error
+                        );
+                    }
+                }
+            } else {
+                if path_target_path.is_file() {
+                    return Err(Status::new(
+                        Code::Unknown,
+                        format!(
+                            "Failed to unpublish volume {}: {} is a file.",
+                            volume_id, target_path
+                        ),
+                    ));
+                }
+                // block volumes are mounted on block special file, which is not
+                // a regular file.
+                if mount::find_mount(None, Some(target_path)).is_some() {
+                    match mount::blockdevice_unmount(&target_path) {
+                        Ok(_) => {}
+                        Err(err) => {
+                            return Err(Status::new(
+                                Code::Internal,
+                                format!(
+                                    "Failed to unpublish volume {}: {}",
+                                    volume_id, err
+                                ),
+                            ));
+                        }
+                    }
+                }
+
+                debug!("Removing block special file {}", target_path);
+
+                if let Err(error) = std::fs::remove_file(target_path) {
+                    warn!(
+                        "Failed to remove block file {}: {}",
                         target_path, error
                     );
                 }
             }
 
-            info!(
-                "Volume {} is already unpublished from {}",
-                volume_id, target_path
-            );
-
-            return Ok(Response::new(NodeUnpublishVolumeResponse {}));
+            info!("Volume {} unpublished from {}", volume_id, target_path);
         }
-
-        debug!("Unmounting {}", target_path);
-
-        if let Err(error) = mount::bind_unmount(target_path) {
-            return Err(failure!(
-                Code::Internal,
-                "Failed to unpublish volume {}: failed to unmount {}: {}",
-                volume_id,
-                target_path,
-                error
-            ));
-        }
-
-        debug!("Removing directory {}", target_path);
-
-        if let Err(error) = fs::remove_dir(PathBuf::from(target_path)) {
-            if error.kind() != ErrorKind::NotFound {
-                error!("Failed to remove directory {}: {}", target_path, error);
-            }
-        }
-
-        info!("Volume {} unpublished from {}", volume_id, target_path);
         Ok(Response::new(NodeUnpublishVolumeResponse {}))
     }
 
@@ -487,7 +655,6 @@ impl node_server::Node for Node {
     ) -> Result<Response<NodeStageVolumeResponse>, Status> {
         let msg = request.into_inner();
         let volume_id = &msg.volume_id;
-        let staging_path = &msg.staging_target_path;
         let publish_context = &msg.publish_context;
 
         trace!("node_stage_volume {:?}", msg);
@@ -499,24 +666,13 @@ impl node_server::Node for Node {
             ));
         }
 
-        if staging_path.is_empty() {
+        if msg.staging_target_path.is_empty() {
             return Err(failure!(
                 Code::InvalidArgument,
                 "Failed to stage volume {}: missing staging path",
                 volume_id
             ));
         }
-
-        // TODO: Support block volumes
-        let mnt =
-            get_access_mount(&msg.volume_capability).map_err(|error| {
-                failure!(
-                    Code::InvalidArgument,
-                    "Failed to stage volume {}: {}",
-                    volume_id,
-                    error
-                )
-            })?;
 
         if let Err(error) = check_access_mode(
             &msg.volume_capability,
@@ -530,24 +686,6 @@ impl node_server::Node for Node {
                 error
             ));
         };
-
-        let fstype = if mnt.fs_type.is_empty() {
-            &self.filesystems[0]
-        } else {
-            match self.filesystems.iter().find(|&entry| entry == &mnt.fs_type) {
-                Some(fstype) => fstype,
-                None => {
-                    return Err(failure!(
-                        Code::InvalidArgument,
-                        "Failed to stage volume {}: unsupported filesystem type: {}",
-                        volume_id,
-                        mnt.fs_type
-                    ));
-                }
-            }
-        };
-
-        debug!("Staging volume {} to {}", volume_id, staging_path);
 
         let uri = publish_context.get("uri").ok_or_else(|| {
             failure!(
@@ -569,152 +707,277 @@ impl node_server::Node for Node {
             )
         })?;
 
-        if let Some(device_path) = device.find().await.map_err(|error| {
+        // 10 retries at 100ms intervals
+        const TIMEOUT: Duration = Duration::from_millis(100);
+        const RETRIES: u32 = 100;
+
+        match get_access_type(&msg.volume_capability).map_err(|error| {
             failure!(
+                Code::InvalidArgument,
+                "Failed to publish volume {}: {}",
+                volume_id,
+                error
+            )
+        })? {
+            AccessType::Mount(mnt) => {
+                let fs_staging_path =
+                    match make_fs_staging_path(&msg.staging_target_path) {
+                        Ok(path) => path,
+                        Err(error) => {
+                            return Err(failure!(
+                                Code::Internal,
+                                "Failed to stage volume{}: {}",
+                                volume_id,
+                                error
+                            ))
+                        }
+                    };
+
+                if let Err(error) =
+                    fs::create_dir_all(PathBuf::from(&fs_staging_path))
+                {
+                    return Err(failure!(
+                        Code::Internal,
+                        "Failed to stage volumes{}: {}",
+                        volume_id,
+                        error
+                    ));
+                }
+
+                debug!("Staging volume {} to {}", volume_id, fs_staging_path);
+
+                let fstype = if mnt.fs_type.is_empty() {
+                    &self.filesystems[0]
+                } else {
+                    match self
+                        .filesystems
+                        .iter()
+                        .find(|&entry| entry == &mnt.fs_type)
+                    {
+                        Some(fstype) => fstype,
+                        None => {
+                            return Err(failure!(
+                        Code::InvalidArgument,
+                        "Failed to stage volume {}: unsupported filesystem type: {}",
+                        volume_id,
+                        mnt.fs_type
+                    ));
+                        }
+                    }
+                };
+
+                debug!("Volume {} has URI {}", volume_id, uri);
+
+                let device = Device::parse(&uri).map_err(|error| {
+                    failure!(
+                        Code::Internal,
+                        "Failed to stage volume {}: error parsing URI {}: {}",
+                        volume_id,
+                        uri,
+                        error
+                    )
+                })?;
+
+                if let Some(device_path) =
+                    device.find().await.map_err(|error| {
+                        failure!(
             Code::Internal,
             "Failed to stage volume {}: error locating device for URI {}: {}",
             volume_id,
             uri,
             error
         )
-        })? {
-            debug!("Found device {} for URI {}", device_path, uri);
+                    })?
+                {
+                    debug!("Found device {} for URI {}", device_path, uri);
 
-            if mount::find_mount(Some(&device_path), Some(&staging_path))
-                .is_some()
-            {
-                debug!(
-                    "Device {} is already mounted onto {}",
-                    device_path, staging_path
-                );
-                info!(
-                    "Volume {} is already staged to {}",
-                    volume_id, staging_path
-                );
-                return Ok(Response::new(NodeStageVolumeResponse {}));
-            }
+                    if mount::find_mount(
+                        Some(&device_path),
+                        Some(&fs_staging_path),
+                    )
+                    .is_some()
+                    {
+                        debug!(
+                            "Device {} is already mounted onto {}",
+                            device_path, fs_staging_path
+                        );
+                        info!(
+                            "Volume {} is already staged to {}",
+                            volume_id, fs_staging_path
+                        );
+                        return Ok(Response::new(NodeStageVolumeResponse {}));
+                    }
 
-            // abort if device is mounted somewhere else
-            if mount::find_mount(Some(&device_path), None).is_some() {
-                return Err(failure!(
+                    // abort if device is mounted somewhere else
+                    if mount::find_mount(Some(&device_path), None).is_some() {
+                        return Err(failure!(
                     Code::AlreadyExists,
                     "Failed to stage volume {}: device {} is already mounted elsewhere",
                     volume_id,
                     device_path
                 ));
-            }
+                    }
 
-            // abort if some another device is mounted on staging_path
-            if mount::find_mount(None, Some(&staging_path)).is_some() {
-                return Err(failure!(
+                    // abort if some another device is mounted on staging_path
+                    if mount::find_mount(None, Some(&fs_staging_path)).is_some()
+                    {
+                        return Err(failure!(
                     Code::AlreadyExists,
                     "Failed to stage volume {}: another device is already mounted onto {}",
                     volume_id,
-                    staging_path
+                    fs_staging_path
                 ));
-            }
+                    }
 
-            if let Err(error) = prepare_device(&device_path, &fstype).await {
-                return Err(failure!(
+                    if let Err(error) =
+                        prepare_device(&device_path, &fstype).await
+                    {
+                        return Err(failure!(
                     Code::Internal,
                     "Failed to stage volume {}: error preparing device {}: {}",
                     volume_id,
                     device_path,
                     error
                 ));
-            }
+                    }
 
-            debug!("Mounting device {} onto {}", device_path, staging_path);
+                    debug!(
+                        "Mounting device {} onto {}",
+                        device_path, fs_staging_path
+                    );
 
-            if let Err(error) = mount::filesystem_mount(
-                &device_path,
-                &staging_path,
-                &fstype,
-                &mnt.mount_flags,
-            ) {
-                return Err(failure!(
+                    if let Err(error) = mount::filesystem_mount(
+                        &device_path,
+                        &fs_staging_path,
+                        &fstype,
+                        &mnt.mount_flags,
+                    ) {
+                        return Err(failure!(
                     Code::Internal,
                     "Failed to stage volume {}: failed to mount device {} onto {}: {}",
                     volume_id,
                     device_path,
-                    staging_path,
+                    fs_staging_path,
                     error
                 ));
-            }
+                    }
 
-            info!("Volume {} staged to {}", volume_id, staging_path);
-            return Ok(Response::new(NodeStageVolumeResponse {}));
-        }
+                    info!("Volume {} staged to {}", volume_id, fs_staging_path);
+                    return Ok(Response::new(NodeStageVolumeResponse {}));
+                }
 
-        // device is not attached
+                // device is not attached
 
-        // abort if some another device is mounted on staging_path
-        if mount::find_mount(None, Some(&staging_path)).is_some() {
-            return Err(failure!(
+                // abort if some another device is mounted on staging_path
+                if mount::find_mount(None, Some(&fs_staging_path)).is_some() {
+                    return Err(failure!(
                 Code::AlreadyExists,
                 "Failed to stage volume {}: another device is already mounted onto {}",
                 volume_id,
-                staging_path
+                fs_staging_path
             ));
-        }
+                }
 
-        debug!("Attaching volume");
-        if let Err(error) = device.attach().await {
-            return Err(failure!(
-                Code::Internal,
-                "Failed to stage volume {}: attach failed: {}",
-                volume_id,
-                error
-            ));
-        }
+                debug!("Attaching volume");
+                if let Err(error) = device.attach().await {
+                    return Err(failure!(
+                        Code::Internal,
+                        "Failed to stage volume {}: attach failed: {}",
+                        volume_id,
+                        error
+                    ));
+                }
 
-        // 10 retries at 100ms intervals
-        const TIMEOUT: Duration = Duration::from_millis(100);
-        const RETRIES: u32 = 10;
+                let device_path =
+                    Device::wait_for_device(device, TIMEOUT, RETRIES)
+                        .await
+                        .map_err(|error| {
+                            failure!(
+                                Code::Unavailable,
+                                "Failed to stage volume {}: {}",
+                                volume_id,
+                                error
+                            )
+                        })?;
 
-        let device_path = Device::wait_for_device(device, TIMEOUT, RETRIES)
-            .await
-            .map_err(|error| {
-                failure!(
+                debug!("Found new device {} for URI {}", device_path, uri);
+
+                if let Err(error) = prepare_device(&device_path, &fstype).await
+                {
+                    return Err(failure!(
                     Code::Internal,
-                    "Failed to stage volume {}: {}",
+                    "Failed to stage volume {}: error preparing device {}: {}",
                     volume_id,
+                    device_path,
                     error
-                )
-            })?;
+                ));
+                }
 
-        debug!("Found new device {} for URI {}", device_path, uri);
+                debug!(
+                    "Mounting device {} onto {}",
+                    device_path, fs_staging_path
+                );
 
-        if let Err(error) = prepare_device(&device_path, &fstype).await {
-            return Err(failure!(
-                Code::Internal,
-                "Failed to stage volume {}: error preparing device {}: {}",
-                volume_id,
-                device_path,
-                error
-            ));
-        }
-
-        debug!("Mounting device {} onto {}", device_path, staging_path);
-
-        if let Err(error) = mount::filesystem_mount(
-            &device_path,
-            &staging_path,
-            &fstype,
-            &mnt.mount_flags,
-        ) {
-            return Err(failure!(
+                if let Err(error) = mount::filesystem_mount(
+                    &device_path,
+                    &fs_staging_path,
+                    &fstype,
+                    &mnt.mount_flags,
+                ) {
+                    return Err(failure!(
                 Code::Internal,
                 "Failed to stage volume {}: failed to mount device {} onto {}: {}",
                 volume_id,
                 device_path,
-                staging_path,
+                fs_staging_path,
                 error
             ));
-        }
+                }
 
-        info!("Volume {} staged to {}", volume_id, staging_path);
-        Ok(Response::new(NodeStageVolumeResponse {}))
+                info!("Volume {} staged to {}", volume_id, fs_staging_path);
+                Ok(Response::new(NodeStageVolumeResponse {}))
+            }
+            AccessType::Block(_) => {
+                let device_path = device.find().await.map_err(|error| {
+                    failure!(
+            Code::Internal,
+            "Failed to stage volume {}: error locating device for URI {}: {}",
+            volume_id,
+            uri,
+            error
+        )
+                })?;
+
+                if device_path.is_some() {
+                    // Device is already attached
+                    return Ok(Response::new(NodeStageVolumeResponse {}));
+                }
+
+                debug!("Attaching volume");
+                // device.attach is idempotent, so does not restart the attach
+                // process
+                if let Err(error) = device.attach().await {
+                    return Err(failure!(
+                        Code::Internal,
+                        "Failed to stage volume {}: attach failed: {}",
+                        volume_id,
+                        error
+                    ));
+                }
+
+                let _ = Device::wait_for_device(device, TIMEOUT, RETRIES)
+                    .await
+                    .map_err(|error| {
+                        failure!(
+                            Code::Unavailable,
+                            "Failed to stage volume {}: {}",
+                            volume_id,
+                            error
+                        )
+                    })?;
+                Ok(Response::new(NodeStageVolumeResponse {}))
+            }
+        }
     }
 
     async fn node_unstage_volume(
@@ -724,7 +987,6 @@ impl node_server::Node for Node {
         let msg = request.into_inner();
 
         let volume_id = msg.volume_id.clone();
-        let staging_path = msg.staging_target_path;
 
         if volume_id.is_empty() {
             return Err(failure!(
@@ -733,7 +995,7 @@ impl node_server::Node for Node {
             ));
         }
 
-        if staging_path.is_empty() {
+        if msg.staging_target_path.is_empty() {
             return Err(failure!(
                 Code::InvalidArgument,
                 "Failed to unstage volume {}: missing staging path",
@@ -741,7 +1003,23 @@ impl node_server::Node for Node {
             ));
         }
 
-        debug!("Unstaging volume {} from {}", volume_id, staging_path);
+        // Get the filesystem staging mount point
+        // If it does not exist, that means the volume
+        // is a block mounted volume.
+        let fs_staging_path =
+            match make_fs_staging_path(&msg.staging_target_path) {
+                Ok(path) => path,
+                Err(error) => {
+                    return Err(failure!(
+                        Code::Internal,
+                        "{}: {}",
+                        error,
+                        volume_id
+                    ))
+                }
+            };
+
+        debug!("Unstaging volume {} from {}", volume_id, fs_staging_path);
 
         let uuid = Uuid::parse_str(&volume_id).map_err(|error| {
             failure!(
@@ -763,60 +1041,71 @@ impl node_server::Node for Node {
             let device_path = device.devname();
             debug!("Device path is {}", device_path);
 
-            if mount::find_mount(Some(&device_path), Some(&staging_path))
-                .is_some()
-            {
-                debug!(
-                    "Unmounting device {} from {}",
-                    device_path, staging_path
-                );
+            if Path::new(&fs_staging_path).exists() {
+                // Filesystem staging.
+                if mount::find_mount(Some(&device_path), Some(&fs_staging_path))
+                    .is_some()
+                {
+                    debug!(
+                        "Unmounting device {} from {}",
+                        device_path, fs_staging_path
+                    );
 
-                if let Err(error) = mount::filesystem_unmount(&staging_path) {
-                    return Err(failure!(
+                    if let Err(error) =
+                        mount::filesystem_unmount(&fs_staging_path)
+                    {
+                        return Err(failure!(
                         Code::Internal,
                         "Failed to unstage volume {}: failed to unmount device {} from {}: {}",
                         volume_id,
                         device_path,
-                        staging_path,
+                        fs_staging_path,
                         error
                     ));
-                }
+                    }
 
-                debug!("Detaching device {}", device_path);
-                if let Err(error) = device.detach().await {
-                    return Err(failure!(
+                    debug!("Detaching device {}", device_path);
+                    if let Err(error) = device.detach().await {
+                        return Err(failure!(
                         Code::Internal,
                         "Failed to unstage volume {}: failed to detach device {}: {}",
                         volume_id,
                         device_path,
                         error
                     ));
+                    }
+
+                    info!(
+                        "Volume {} unstaged from {}",
+                        volume_id, fs_staging_path
+                    );
+                    return Ok(Response::new(NodeUnstageVolumeResponse {}));
                 }
 
-                info!("Volume {} unstaged from {}", volume_id, staging_path);
-                return Ok(Response::new(NodeUnstageVolumeResponse {}));
-            }
-
-            // abort if device is mounted somewhere else
-            if mount::find_mount(Some(&device_path), None).is_some() {
-                return Err(failure!(
+                // abort if device is mounted somewhere else
+                if mount::find_mount(Some(&device_path), None).is_some() {
+                    return Err(failure!(
                     Code::AlreadyExists,
                     "Failed to unstage volume {}: device {} is mounted elsewhere",
                     volume_id,
                     device_path
                 ));
-            }
+                }
 
-            // abort if some other device is mounted on staging_path
-            if mount::find_mount(None, Some(&staging_path)).is_some() {
-                return Err(failure!(
+                // abort if some other device is mounted on staging_path
+                if mount::find_mount(None, Some(&fs_staging_path)).is_some() {
+                    return Err(failure!(
                     Code::AlreadyExists,
                     "Failed to stage volume {}: another device is mounted onto {}",
                     volume_id,
-                    staging_path
+                    fs_staging_path
                 ));
+                }
+            } else {
+                // Block volumes are not staged.
             }
 
+            // Detach is required for filesystem and block volume mounts.
             debug!("Detaching device {}", device_path);
             if let Err(error) = device.detach().await {
                 return Err(failure!(
@@ -828,7 +1117,10 @@ impl node_server::Node for Node {
                 ));
             }
 
-            info!("Volume {} unstaged from {}", volume_id, staging_path);
+            info!("Volume {} unstaged ", volume_id);
+            if let Err(e) = std::fs::remove_dir(fs_staging_path) {
+                warn!("{}", e);
+            }
             return Ok(Response::new(NodeUnstageVolumeResponse {}));
         }
 
@@ -838,21 +1130,33 @@ impl node_server::Node for Node {
         // just assume that the device in question does not need
         // to be detached once it has been unmounted.
 
-        if let Some(mount) = mount::find_mount(None, Some(&staging_path)) {
-            debug!("Unmounting device {} from {}", mount.source, staging_path);
-            if let Err(error) = mount::filesystem_unmount(&staging_path) {
-                return Err(failure!(
+        if Path::new(&fs_staging_path).exists() {
+            if let Some(mount) = mount::find_mount(None, Some(&fs_staging_path))
+            {
+                debug!(
+                    "Unmounting device {} from {}",
+                    mount.source, fs_staging_path
+                );
+                if let Err(error) = mount::filesystem_unmount(&fs_staging_path)
+                {
+                    return Err(failure!(
                     Code::Internal,
                     "Failed to unstage volume {}: failed to unmount device {} from {}: {}",
                     volume_id,
                     mount.source,
-                    staging_path,
+                    fs_staging_path,
                     error
                 ));
+                }
             }
+            if let Err(e) = std::fs::remove_dir(fs_staging_path) {
+                warn!("{}", e);
+            }
+        } else {
+            // Nothing to do for Block volumes.
         }
 
-        info!("Volume {} unstaged from {}", volume_id, staging_path);
+        info!("Volume {} unstaged", volume_id);
         Ok(Response::new(NodeUnstageVolumeResponse {}))
     }
 }

--- a/csi/src/node.rs
+++ b/csi/src/node.rs
@@ -31,8 +31,7 @@ pub struct Node {
     pub filesystems: Vec<String>,
 }
 
-// Timeout settings for device attach
-// 10 retries at 100ms intervals
+// 10 retries at 100ms intervals = 1 second.
 const ATTACH_TIMEOUT_INTERVAL: Duration = Duration::from_millis(100);
 const ATTACH_RETRIES: u32 = 100;
 
@@ -401,7 +400,7 @@ impl node_server::Node for Node {
         })? {
             Some(devpath) => devpath,
             None => {
-                debug!("Attaching volume");
+                debug!("Attaching volume {}", &msg.volume_id);
                 // device.attach is idempotent, so does not restart the attach
                 // process
                 if let Err(error) = device.attach().await {

--- a/csi/src/server.rs
+++ b/csi/src/server.rs
@@ -41,6 +41,8 @@ pub mod csi {
 mod dev;
 mod error;
 
+mod block_vol;
+mod filesystem_vol;
 mod format;
 mod identity;
 mod match_dev;

--- a/mayastor-test/test_csi.js
+++ b/mayastor-test/test_csi.js
@@ -63,11 +63,16 @@ function createCsiClient (service) {
 }
 
 function cleanPublishDir (mountTarget, done) {
-  const proc = common.runAsRoot('umount', ['-f', mountTarget]);
+  const proc = common.runAsRoot('umount', ['-f', mountTarget + '/fs_mnt']);
   proc.once('close', (code, signal) => {
     try {
+      fs.rmdirSync(mountTarget + '/fs_mnt');
+    } catch (err) {
+    }
+    try {
       fs.rmdirSync(mountTarget);
-    } catch (err) {}
+    } catch (err) {
+    }
 
     done();
   });
@@ -412,7 +417,7 @@ function csiProtocolTest (protoname, shareType, timeoutMillis) {
       it('should be able to stage volume (xfs)', (done) => {
         client.nodeStageVolume(getDefaultArgs(), (err) => {
           if (err) return done(err);
-          assert.equal(getFsType(mountTarget), 'xfs');
+          assert.equal(getFsType(mountTarget + '/fs_mnt'), 'xfs');
           done();
         });
       });
@@ -550,7 +555,7 @@ function csiProtocolTest (protoname, shareType, timeoutMillis) {
           },
           (err) => {
             if (err) return done(err);
-            assert.equal(getFsType(mountTarget), 'ext4');
+            assert.equal(getFsType(mountTarget + '/fs_mnt'), 'ext4');
             done();
           }
         );

--- a/mayastor-test/test_csi.js
+++ b/mayastor-test/test_csi.js
@@ -63,16 +63,11 @@ function createCsiClient (service) {
 }
 
 function cleanPublishDir (mountTarget, done) {
-  const proc = common.runAsRoot('umount', ['-f', mountTarget + '/fs_mnt']);
+  const proc = common.runAsRoot('umount', ['-f', mountTarget]);
   proc.once('close', (code, signal) => {
     try {
-      fs.rmdirSync(mountTarget + '/fs_mnt');
-    } catch (err) {
-    }
-    try {
       fs.rmdirSync(mountTarget);
-    } catch (err) {
-    }
+    } catch (err) {}
 
     done();
   });
@@ -417,7 +412,7 @@ function csiProtocolTest (protoname, shareType, timeoutMillis) {
       it('should be able to stage volume (xfs)', (done) => {
         client.nodeStageVolume(getDefaultArgs(), (err) => {
           if (err) return done(err);
-          assert.equal(getFsType(mountTarget + '/fs_mnt'), 'xfs');
+          assert.equal(getFsType(mountTarget), 'xfs');
           done();
         });
       });
@@ -555,7 +550,7 @@ function csiProtocolTest (protoname, shareType, timeoutMillis) {
           },
           (err) => {
             if (err) return done(err);
-            assert.equal(getFsType(mountTarget + '/fs_mnt'), 'ext4');
+            assert.equal(getFsType(mountTarget), 'ext4');
             done();
           }
         );


### PR DESCRIPTION
To support block volumes.
  at node stage volume
    - attach to the device
  at node publish volume
    - create a block special file
    - bind mount the device path to the block special file
  at node unpublish volume
    - unmount the block special file
    - delete the block special file
  at node unstage volume
    - detach from the device

To facilitate this
At staging ensure the sequence of operations is
 1 Attach the device.
 2 For fs volumes only, mount the device on the staging path.

At unstaging ensure the sequence of operations is
 1 For fs volumes only, unmount staging path from the device.
 2 Detach the device.

Ensure that each of the above operations are idempotent.

For clarity move
 - filesystem volume functions (un/stage, un/publish),
 - block volume (un/publish)
to separarate files.