### PR TITLE
fix bdev replica names

### DIFF
--- a/mayastor/src/bdev/dev/iscsi.rs
+++ b/mayastor/src/bdev/dev/iscsi.rs
@@ -75,7 +75,8 @@ impl TryFrom<&Url> for Iscsi {
         }
 
         Ok(Iscsi {
-            name: url.path()[1 ..].into(),
+            name: url[url::Position::BeforeHost .. url::Position::AfterPath]
+                .into(),
             alias: url.to_string(),
             iqn: format!("{}:{}", ISCSI_IQN_PREFIX, Uuid::new_v4()),
             url: if segments.len() == 2 {

--- a/mayastor/src/bdev/dev/nvmf.rs
+++ b/mayastor/src/bdev/dev/nvmf.rs
@@ -112,7 +112,8 @@ impl TryFrom<&Url> for Nvmf {
         }
 
         Ok(Nvmf {
-            name: url.path()[1 ..].into(),
+            name: url[url::Position::BeforeHost .. url::Position::AfterPath]
+                .into(),
             alias: url.to_string(),
             host: host.to_string(),
             port: url.port().unwrap_or(DEFAULT_NVMF_PORT),


### PR DESCRIPTION
replicas for the same volume have the same UUID which caused collisions
when trying to open them in the nexus
Include 'host:port/' in the bdev name for nvmf/iscsi

todo: add test case