### PR TITLE
CAS-351: Error handling in Kubernetes cluster.

### DIFF
--- a/mayastor/src/bdev/nexus/nexus_child_error_store.rs
+++ b/mayastor/src/bdev/nexus/nexus_child_error_store.rs
@@ -246,7 +246,9 @@ impl Nexus {
     ) {
         let now = Instant::now();
         let cfg = Config::get();
-        if cfg.err_store_opts.enable_err_store {
+        if cfg.err_store_opts.enable_err_store
+            && (io_op_type == io_type::READ || io_op_type == io_type::WRITE)
+        {
             let nexus_name = self.name.clone();
             // dispatch message to management core to do this
             let mgmt_reactor = Reactors::get_by_core(Cores::first()).unwrap();

--- a/mayastor/src/subsys/config/opts.rs
+++ b/mayastor/src/subsys/config/opts.rs
@@ -503,8 +503,8 @@ impl Default for ErrStoreOpts {
     fn default() -> Self {
         Self {
             err_store_size: 256,
-            enable_err_store: false,
-            action: ActionType::Ignore,
+            enable_err_store: true,
+            action: ActionType::Fault,
             max_errors: 5,
             retention_ns: 10_000_000_000,
         }

--- a/mayastor/tests/error_count.rs
+++ b/mayastor/tests/error_count.rs
@@ -12,7 +12,7 @@ pub use common::error_bdev::{
     VBDEV_IO_FAILURE,
 };
 use mayastor::{
-    bdev::{nexus_create, nexus_lookup, NexusErrStore, QueryType},
+    bdev::{nexus_create, nexus_lookup, ActionType, NexusErrStore, QueryType},
     core::{
         mayastor_env_stop,
         Bdev,
@@ -45,6 +45,7 @@ fn nexus_error_count_test() {
 
     let mut config = Config::default();
     config.err_store_opts.enable_err_store = true;
+    config.err_store_opts.action = ActionType::Ignore;
     config.err_store_opts.err_store_size = 256;
     config.write(YAML_CONFIG_FILE).unwrap();
     test_init!(YAML_CONFIG_FILE);


### PR DESCRIPTION
CAS-351: This enables the option of removing a child if the error count exceeds a limit, currently set at 5 errors in 10 seconds for each child.
This also limits the stored errors to reads and writes to prevent flush errors (seen when using nvmf on the front end) from filling the error store.