### PR TITLE
CAS-348: export config on grpc / CAS-349: persist the config in k8s

### DIFF
--- a/deploy/mayastor-daemonset.yaml
+++ b/deploy/mayastor-daemonset.yaml
@@ -42,10 +42,13 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: IMPORT_NEXUSES
+          value: "false"
         args:
         - "-N$(MY_NODE_NAME)"
         - "-g$(MY_POD_IP)"
         - "-nnats"
+        - "-y/var/local/mayastor/config.yaml"
         securityContext:
           privileged: true
         volumeMounts:
@@ -53,6 +56,10 @@ spec:
           mountPath: /dev
         - name: dshm
           mountPath: /dev/shm
+        - name: configlocation
+          mountPath: /var/local/mayastor/
+        - name: config
+          mountPath: /var/local/mayastor/config.yaml
         resources:
           limits:
             cpu: "1"
@@ -78,3 +85,11 @@ spec:
       - name: hugepage
         emptyDir:
           medium: HugePages
+      - name: configlocation
+        hostPath:
+          path: /var/local/mayastor/
+          type: DirectoryOrCreate
+      - name: config
+        hostPath:
+          path: /var/local/mayastor/config.yaml
+          type: FileOrCreate

--- a/mayastor/src/replica.rs
+++ b/mayastor/src/replica.rs
@@ -139,6 +139,7 @@ pub struct Replica {
     lvol_ptr: *mut spdk_lvol,
 }
 
+#[derive(Debug, PartialEq, Serialize, Deserialize, Clone, Copy)]
 /// Types of remote access storage protocols and IDs for sharing replicas.
 pub enum ShareType {
     Nvmf,

--- a/mayastor/tests/yaml_config.rs
+++ b/mayastor/tests/yaml_config.rs
@@ -124,6 +124,7 @@ fn yaml_pool_tests() {
         disks: vec!["/tmp/disk1.img".into()],
         blk_size: 512,
         io_if: 1,
+        replicas: Default::default(),
     };
 
     // we use this UUID to ensure that the created pool is indeed  -- the pool


### PR DESCRIPTION
CAS-348: Export the config file on "state-changing" grpc calls
If we fail to export (unexpected) then we fail the grpc and rely on the
control plane to retry - methods should be idempotent

Change the config device creation order:
1. pools
2. share pool replicas (if shared)
3. nexus (may be using the pool)
only if IMPORT_NEXUSES is true as when a node comes back up it may have
outdated view of the volumes and it would be dangerous to blindly
recreate the nexuses
4. base bdevs (last, otherwise the nexus fails to create)

CAS-349: persist the config ...
for k8s in the following host path: /var/local/mayastor/config.yaml
This is achieve using the host path volume:
directoryOrCreate type mount to create the path
fileOrCreate type mount to create the file

set IMPORT_NEXUSES env variable to false as we don't want to
automatically import/recreate nexuses after a crash as this information
might be outdated