### PR TITLE
pool: support creation by means of URIs

### DIFF
--- a/mayastor/src/core/share.rs
+++ b/mayastor/src/core/share.rs
@@ -14,5 +14,6 @@ pub trait Share: std::fmt::Debug {
     async fn share_nvmf(self) -> Result<Self::Output, Self::Error>;
     async fn unshare(&self) -> Result<Self::Output, Self::Error>;
     fn shared(&self) -> Option<Protocol>;
-    fn get_share_uri(&self) -> Option<String>;
+    fn share_uri(&self) -> Option<String>;
+    fn bdev_uri(&self) -> Option<String>;
 }

--- a/mayastor/src/grpc/bdev_grpc.rs
+++ b/mayastor/src/grpc/bdev_grpc.rs
@@ -130,7 +130,7 @@ impl BdevRpc for BdevSvc {
         .map(|share| {
             let bdev = Bdev::lookup_by_name(&name).unwrap();
             Response::new(BdevShareReply {
-                uri: bdev.get_share_uri().unwrap_or(share),
+                uri: bdev.share_uri().unwrap_or(share),
             })
         })
     }

--- a/mayastor/src/nexus_uri.rs
+++ b/mayastor/src/nexus_uri.rs
@@ -83,6 +83,21 @@ pub fn bdev_get_name(uri: &str) -> Result<String, NexusBdevError> {
     Ok(Uri::parse(uri)?.get_name())
 }
 
+impl std::cmp::PartialEq<url::Url> for &Bdev {
+    fn eq(&self, uri: &url::Url) -> bool {
+        match Uri::parse(&uri.to_string()) {
+            Ok(device) if device.get_name() == self.name() => {
+                self.driver()
+                    == match uri.scheme() {
+                        "nvmf" | "pcie" => "nvme",
+                        scheme => scheme,
+                    }
+            }
+            _ => false,
+        }
+    }
+}
+
 impl std::cmp::PartialEq<url::Url> for Bdev {
     fn eq(&self, uri: &url::Url) -> bool {
         match Uri::parse(&uri.to_string()) {

--- a/mayastor/tests/pool.rs
+++ b/mayastor/tests/pool.rs
@@ -1,0 +1,145 @@
+use std::panic::catch_unwind;
+
+use mayastor::{
+    core::{
+        mayastor_env_stop,
+        MayastorCliArgs,
+        MayastorEnvironment,
+        Reactor,
+        Share,
+    },
+    pool::{create_pool, Pool, PoolsIter},
+};
+use rpc::mayastor::CreatePoolRequest;
+
+pub mod common;
+
+static DISKNAME1: &str = "/tmp/disk1.img";
+
+#[test]
+fn create_pool_legacy() {
+    common::delete_file(&[DISKNAME1.into()]);
+    common::truncate_file(DISKNAME1, 64 * 1024);
+    common::mayastor_test_init();
+    let mut args = MayastorCliArgs::default();
+    args.reactor_mask = "0x3".into();
+
+    let result = catch_unwind(|| {
+        MayastorEnvironment::new(args)
+            .start(|| {
+                // create a pool with legacy device names
+                Reactor::block_on(async {
+                    create_pool(CreatePoolRequest {
+                        name: "legacy".into(),
+                        disks: vec![DISKNAME1.to_string()],
+                        block_size: 0,
+                        io_if: 0,
+                    })
+                    .await
+                    .unwrap();
+                });
+
+                // create a pool using uri's
+                Reactor::block_on(async {
+                    create_pool(CreatePoolRequest {
+                        name: "uri".into(),
+                        disks: vec!["malloc:///malloc0?size_mb=64".to_string()],
+                        block_size: 0,
+                        io_if: 0,
+                    })
+                    .await
+                    .unwrap();
+                });
+
+                // should succeed to create the same pool with the same name and
+                // with the same bdev (idempotent)
+
+                Reactor::block_on(async {
+                    let pool = create_pool(CreatePoolRequest {
+                        name: "uri".into(),
+                        disks: vec!["malloc:///malloc0?size_mb=64".to_string()],
+                        block_size: 0,
+                        io_if: 0,
+                    })
+                    .await;
+
+                    assert_eq!(pool.is_ok(), true);
+                });
+
+                // should fail to create the pool with same name and different
+                // bdev
+                Reactor::block_on(async {
+                    let pool = create_pool(CreatePoolRequest {
+                        name: "uri".into(),
+                        disks: vec!["malloc:///malloc1?size_mb=64".to_string()],
+                        block_size: 0,
+                        io_if: 0,
+                    })
+                    .await;
+                    assert_eq!(pool.is_err(), true)
+                });
+
+                // validate some properties from the pool(s)
+                Reactor::block_on(async {
+                    let pool = Pool::lookup("uri").unwrap();
+                    assert_eq!(pool.get_name(), "uri");
+                    let bdev = pool.get_base_bdev();
+                    assert_eq!(bdev.name(), "malloc0");
+                    assert_eq!(
+                        bdev.bdev_uri().unwrap(),
+                        format!(
+                            "malloc:///malloc0?size_mb=64&uuid={}",
+                            bdev.uuid_as_string()
+                        )
+                    );
+                });
+
+                // destroy the pool
+                Reactor::block_on(async {
+                    let pool = Pool::lookup("uri").unwrap();
+                    pool.destroy().await.unwrap();
+                });
+
+                // destroy the legacy pool
+                Reactor::block_on(async {
+                    let pool = Pool::lookup("legacy").unwrap();
+                    pool.destroy().await.unwrap();
+                });
+
+                // create the pools again
+                Reactor::block_on(async {
+                    create_pool(CreatePoolRequest {
+                        name: "uri".into(),
+                        disks: vec!["malloc:///malloc0?size_mb=64".to_string()],
+                        block_size: 0,
+                        io_if: 0,
+                    })
+                    .await
+                    .unwrap();
+
+                    create_pool(CreatePoolRequest {
+                        name: "legacy".into(),
+                        disks: vec![DISKNAME1.to_string()],
+                        block_size: 0,
+                        io_if: 0,
+                    })
+                    .await
+                    .unwrap();
+                });
+
+                // validate they are there again and then destroy them
+                Reactor::block_on(async {
+                    assert_eq!(PoolsIter::new().count(), 2);
+                    for p in PoolsIter::new() {
+                        p.destroy().await.unwrap();
+                    }
+                });
+
+                mayastor_env_stop(0);
+            })
+            .unwrap();
+    });
+
+    common::delete_file(&[DISKNAME1.into()]);
+    result.unwrap();
+}


### PR DESCRIPTION
This change will create base bdevs using URIs if we are passed
a valid scheme. If we use the legacy model where we specify
a device path like /dev/sdx -- we will use that