### PR TITLE
CAS-381: reject UNMAP and FLUSH when not supported

### DIFF
--- a/mayastor/src/bdev/nexus/nexus_fn_table.rs
+++ b/mayastor/src/bdev/nexus/nexus_fn_table.rs
@@ -118,9 +118,20 @@ impl NexusFnTable {
                         nio.fail();
                     }
                 }
-                io_type::FLUSH => nexus.flush(io, &ch),
-                io_type::WRITE_ZEROES => nexus.write_zeroes(io, &ch),
-
+                io_type::FLUSH => {
+                    if nexus.io_is_supported(io_type) {
+                        nexus.flush(io, &ch)
+                    } else {
+                        nio.fail()
+                    }
+                }
+                io_type::WRITE_ZEROES => {
+                    if nexus.io_is_supported(io_type) {
+                        nexus.write_zeroes(io, &ch)
+                    } else {
+                        nio.fail()
+                    }
+                }
                 _ => panic!(
                     "{} Received unsupported IO! type {}",
                     nexus.name, io_type


### PR DESCRIPTION
Avoid submitting IO to the children when one of the children
does not support the command(s).

```
ila@tixos ~/mayastor                                              [13:04:39]
> $ ./target/debug/mayastor-client bdev create 'malloc:///malloc2?size_mb=100'
{
  "name": "malloc2"
}

gila@tixos ~/mayastor                                              [13:04:44]
> $ ./target/debug/mayastor-client bdev share malloc2              [±unmap ●]
{
  "uri": "nvmf://127.0.0.1:8420/nqn.2019-05.io.openebs:malloc2"
}

gila@tixos ~/mayastor                                              [13:04:48]
> $ sudo nvme connect-all -t tcp -s 8420 -a 127.0.0.1              [±unmap ●]

gila@tixos ~/mayastor                                              [13:05:01]
> $ sudo mkfs.xfs /dev/nvme1n1                                     [±unmap ●]
meta-data=/dev/nvme1n1           isize=512    agcount=4, agsize=6400 blks
         =                       sectsz=512   attr=2, projid32bit=1
         =                       crc=1        finobt=1, sparse=1, rmapbt=0
         =                       reflink=0
data     =                       bsize=4096   blocks=25600, imaxpct=25
         =                       sunit=0      swidth=0 blks
naming   =version 2              bsize=4096   ascii-ci=0, ftype=1
log      =internal log           bsize=4096   blocks=855, version=2
         =                       sectsz=512   sunit=0 blks, lazy-count=1
realtime =none                   extsz=4096   blocks=0, rtextents=0

gila@tixos ~/mayastor                                              [13:05:22]

> $ sudo mkdir /mnt_test                                           [±unmap ●]

gila@tixos ~/mayastor                                              [13:06:48]
> $ sudo mount /dev/nvme0n1p1 /mnt_test                            [±unmap ●]

gila@tixos ~/mayastor                                              [13:08:10]
> $ sudo fio --name=test  --size=50m --filename=/mnt_test/test --direct=1 --ioengine=libaio --runtime=60 --rw=randrw
test: (g=0): rw=randrw, bs=(R) 4096B-4096B, (W) 4096B-4096B, (T) 4096B-4096B, ioengine=libaio, iodepth=1
fio-3.20
Starting 1 process
```

No mesages (dmesg or mayastor) where observed while running fio. 