### PR TITLE
CAS-330: Expose lvol snapshot functionality

### DIFF
--- a/mayastor/src/bdev/nexus/nexus_child.rs
+++ b/mayastor/src/bdev/nexus/nexus_child.rs
@@ -209,7 +209,7 @@ impl NexusChild {
         let child_size = bdev.size_in_bytes();
         if parent_size > child_size {
             error!(
-                "{}: child to small parent size: {} child size: {}",
+                "{}: child too small, parent size: {} child size: {}",
                 self.name, parent_size, child_size
             );
             self.state = ChildState::ConfigInvalid;

--- a/mayastor/src/bdev/nexus/nexus_io.rs
+++ b/mayastor/src/bdev/nexus/nexus_io.rs
@@ -54,7 +54,7 @@ pub mod io_type {
     //    pub const INVALID: u32 = 0;
     pub const FLUSH: u32 = 4;
     pub const RESET: u32 = 5;
-    //    pub const NVME_ADMIN: u32 = 6;
+    pub const NVME_ADMIN: u32 = 6;
     //    pub const NVME_IO: u32 = 7;
     //    pub const NVME_IO_MD: u32 = 8;
     pub const WRITE_ZEROES: u32 = 9;
@@ -73,6 +73,12 @@ pub mod io_status {
     pub const FAILED: i32 = -1;
     //pub const PENDING: i32 = 0;
     pub const SUCCESS: i32 = 1;
+}
+
+/// NVMe Admin opcode, from nvme_spec.h
+pub mod nvme_admin_opc {
+    // Vendor-specific
+    pub const CREATE_SNAPSHOT: u8 = 0xc0;
 }
 
 impl Bio {
@@ -183,6 +189,24 @@ impl Bio {
     #[inline]
     pub(crate) fn num_blocks(&self) -> u64 {
         unsafe { (*self.0).u.bdev.num_blocks }
+    }
+
+    /// NVMe passthru command
+    #[inline]
+    pub(crate) fn nvme_cmd(&self) -> spdk_sys::spdk_nvme_cmd {
+        unsafe { (*self.0).u.nvme_passthru.cmd }
+    }
+
+    /// raw pointer to NVMe passthru data buffer
+    #[inline]
+    pub(crate) fn nvme_buf(&self) -> *mut c_void {
+        unsafe { (*self.0).u.nvme_passthru.buf }
+    }
+
+    /// NVMe passthru number of bytes to transfer
+    #[inline]
+    pub(crate) fn nvme_nbytes(&self) -> u64 {
+        unsafe { (*self.0).u.nvme_passthru.nbytes }
     }
 
     /// free the io directly without completion note that the IO is not freed

--- a/mayastor/src/core/handle.rs
+++ b/mayastor/src/core/handle.rs
@@ -4,6 +4,7 @@ use std::{
     mem::ManuallyDrop,
     os::raw::c_void,
     sync::Arc,
+    time::{SystemTime, UNIX_EPOCH},
 };
 
 use futures::channel::oneshot;
@@ -14,6 +15,7 @@ use spdk_sys::{
     spdk_bdev_desc,
     spdk_bdev_free_io,
     spdk_bdev_io,
+    spdk_bdev_nvme_admin_passthru,
     spdk_bdev_read,
     spdk_bdev_reset,
     spdk_bdev_write,
@@ -21,6 +23,7 @@ use spdk_sys::{
 };
 
 use crate::{
+    bdev::nexus::nexus_io::nvme_admin_opc,
     core::{Bdev, CoreError, Descriptor, DmaBuf, DmaError, IoChannel},
     ffihelper::cb_arg,
 };
@@ -191,6 +194,63 @@ impl BdevHandle {
             Ok(0)
         } else {
             Err(CoreError::ResetFailed {})
+        }
+    }
+
+    pub async fn create_snapshot(&self) -> Result<usize, CoreError> {
+        let mut cmd = spdk_sys::spdk_nvme_cmd::default();
+        cmd.set_opc(nvme_admin_opc::CREATE_SNAPSHOT.into());
+        // Snapshot time as u64 seconds since Unix epoch encoded in cdw10/11
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        cmd.__bindgen_anon_1.cdw10 = now as u32;
+        cmd.__bindgen_anon_2.cdw11 = (now >> 32) as u32;
+        debug!("Creating snapshot at {}", now);
+        self.nvme_admin(&cmd).await
+    }
+
+    pub async fn nvme_admin_custom(
+        &self,
+        opcode: u8,
+    ) -> Result<usize, CoreError> {
+        let mut cmd = spdk_sys::spdk_nvme_cmd::default();
+        cmd.set_opc(opcode.into());
+        self.nvme_admin(&cmd).await
+    }
+
+    pub async fn nvme_admin(
+        &self,
+        nvme_cmd: &spdk_sys::spdk_nvme_cmd,
+    ) -> Result<usize, CoreError> {
+        trace!("Sending nvme_admin {}", nvme_cmd.opc());
+        let (s, r) = oneshot::channel::<bool>();
+        let errno = unsafe {
+            spdk_bdev_nvme_admin_passthru(
+                self.desc.as_ptr(),
+                self.channel.as_ptr(),
+                &*nvme_cmd,
+                std::ptr::null_mut(),
+                0,
+                Some(Self::io_completion_cb),
+                cb_arg(s),
+            )
+        };
+
+        if errno != 0 {
+            return Err(CoreError::NvmeAdminDispatch {
+                source: Errno::from_i32(errno),
+                opcode: (*nvme_cmd).opc(),
+            });
+        }
+
+        if r.await.expect("Failed awaiting NVME Admin IO") {
+            Ok(0)
+        } else {
+            Err(CoreError::NvmeAdminFailed {
+                opcode: (*nvme_cmd).opc(),
+            })
         }
     }
 }

--- a/mayastor/src/core/mod.rs
+++ b/mayastor/src/core/mod.rs
@@ -79,6 +79,11 @@ pub enum CoreError {
     ResetDispatch {
         source: Errno,
     },
+    #[snafu(display("Failed to dispatch NVMe Admin",))]
+    NvmeAdminDispatch {
+        source: Errno,
+        opcode: u16,
+    },
     #[snafu(display("Write failed at offset {} length {}", offset, len))]
     WriteFailed {
         offset: u64,
@@ -91,6 +96,10 @@ pub enum CoreError {
     },
     #[snafu(display("Reset failed"))]
     ResetFailed {},
+    #[snafu(display("NVMe Admin failed"))]
+    NvmeAdminFailed {
+        opcode: u16,
+    },
     #[snafu(display("failed to share {}", source))]
     ShareNvmf {
         source: NvmfError,

--- a/mayastor/src/subsys/config/opts.rs
+++ b/mayastor/src/subsys/config/opts.rs
@@ -197,7 +197,7 @@ impl From<TcpTransportOpts> for spdk_nvmf_transport_opts {
     }
 }
 
-/// generic settings for the NVMe bdev (all our replica's)
+/// generic settings for the NVMe bdev (all our replicas)
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct NvmeBdevOpts {

--- a/mayastor/src/subsys/nvmf/mod.rs
+++ b/mayastor/src/subsys/nvmf/mod.rs
@@ -23,6 +23,7 @@ pub use subsystem::{NvmfSubsystem, SubType};
 pub use target::Target;
 
 use crate::{
+    bdev::nexus::nexus_bdev,
     jsonrpc::{Code, RpcErrorCode},
     subsys::{nvmf::target::NVMF_TGT, Config},
 };
@@ -83,7 +84,10 @@ impl Nvmf {
     extern "C" fn init() {
         debug!("mayastor nvmf subsystem init");
 
-        // this code only ever gets run on the fist core
+        // this code only ever gets run on the first core
+
+        // set up custom NVMe Admin command handler
+        nexus_bdev::setup_create_snapshot_hdlr();
 
         if Config::get().nexus_opts.nvmf_enable {
             NVMF_TGT.with(|tgt| {

--- a/mayastor/tests/replica_snapshot.rs
+++ b/mayastor/tests/replica_snapshot.rs
@@ -1,0 +1,176 @@
+use std::{io, io::Write, process::Command, thread, time};
+
+use common::ms_exec::MayastorProcess;
+use mayastor::{
+    bdev::nexus_create,
+    core::{
+        mayastor_env_stop,
+        BdevHandle,
+        CoreError,
+        MayastorCliArgs,
+        MayastorEnvironment,
+        Reactor,
+    },
+    subsys,
+    subsys::Config,
+};
+
+pub mod common;
+
+static DISKNAME1: &str = "/tmp/disk1.img";
+
+static DISKSIZE_KB: u64 = 128 * 1024;
+
+static CFGNAME1: &str = "/tmp/child1.yaml";
+static UUID1: &str = "00000000-76b6-4fcf-864d-1027d4038756";
+
+static NXNAME: &str = "replica_snapshot_test";
+
+fn generate_config() {
+    let mut config = Config::default();
+
+    config.implicit_share_base = true;
+    config.nexus_opts.iscsi_enable = false;
+    config.nexus_opts.nvmf_replica_port = 8430;
+    config.nexus_opts.nvmf_nexus_port = 8440;
+    let pool = subsys::Pool {
+        name: "pool0".to_string(),
+        disks: vec![DISKNAME1.to_string()],
+        blk_size: 512,
+        io_if: 1, // AIO
+        replicas: Default::default(),
+    };
+    config.pools = Some(vec![pool]);
+    config.write(CFGNAME1).unwrap();
+}
+
+fn start_mayastor(cfg: &str) -> MayastorProcess {
+    let args = vec![
+        "-s".to_string(),
+        "128".to_string(),
+        "-g".to_string(),
+        "127.0.0.1:10125".to_string(),
+        "-y".to_string(),
+        cfg.to_string(),
+    ];
+
+    MayastorProcess::new(Box::from(args)).unwrap()
+}
+
+fn conf_mayastor() {
+    // configuration yaml does not yet support creating replicas
+    let msc = "../target/debug/mayastor-client";
+    let output = Command::new(msc)
+        .args(&[
+            "-p",
+            "10125",
+            "replica",
+            "create",
+            "--protocol",
+            "nvmf",
+            "pool0",
+            UUID1,
+            "--size",
+            "64M",
+        ])
+        .output()
+        .expect("could not exec mayastor-client");
+
+    if !output.status.success() {
+        io::stderr().write_all(&output.stderr).unwrap();
+        panic!("failed to configure mayastor");
+    }
+}
+
+#[test]
+fn replica_snapshot() {
+    generate_config();
+
+    // Start with a fresh pool
+    common::delete_file(&[DISKNAME1.to_string()]);
+    common::truncate_file(DISKNAME1, DISKSIZE_KB);
+
+    let _ms1 = start_mayastor(CFGNAME1);
+    // Allow Mayastor process to start listening on NVMf port
+    thread::sleep(time::Duration::from_millis(250));
+
+    conf_mayastor();
+
+    test_init!();
+
+    Reactor::block_on(async {
+        create_nexus().await;
+        write_some().await.unwrap();
+        custom_nvme_admin(0xc1)
+            .await
+            .expect_err("unexpectedly succeeded invalid nvme admin command");
+        read_some().await.unwrap();
+        create_snapshot().await.unwrap();
+        // Check that IO to the replica still works after creating a snapshot
+        // Checking the snapshot itself is tbd
+        read_some().await.unwrap();
+        write_some().await.unwrap();
+        read_some().await.unwrap();
+    });
+    mayastor_env_stop(0);
+
+    common::delete_file(&[DISKNAME1.to_string()]);
+}
+
+async fn create_nexus() {
+    let ch = vec![
+        "nvmf://127.0.0.1:8430/nqn.2019-05.io.openebs:".to_string()
+            + &UUID1.to_string(),
+    ];
+
+    nexus_create(NXNAME, 64 * 1024 * 1024, None, &ch)
+        .await
+        .unwrap();
+}
+
+async fn write_some() -> Result<(), CoreError> {
+    let h = BdevHandle::open(NXNAME, true, false).unwrap();
+    let mut buf = h.dma_malloc(512).expect("failed to allocate buffer");
+    buf.fill(0xff);
+
+    let s = buf.as_slice();
+    assert_eq!(s[0], 0xff);
+
+    h.write_at(0, &buf).await?;
+    Ok(())
+}
+
+async fn read_some() -> Result<(), CoreError> {
+    let h = BdevHandle::open(NXNAME, true, false).unwrap();
+    let mut buf = h.dma_malloc(1024).expect("failed to allocate buffer");
+    let slice = buf.as_mut_slice();
+
+    assert_eq!(slice[0], 0);
+    slice[512] = 0xff;
+    assert_eq!(slice[512], 0xff);
+
+    let len = h.read_at(0, &mut buf).await?;
+    assert_eq!(len, 1024);
+
+    let slice = buf.as_slice();
+
+    for &it in slice.iter().take(512) {
+        assert_eq!(it, 0xff);
+    }
+    assert_eq!(slice[512], 0);
+    Ok(())
+}
+
+async fn create_snapshot() -> Result<(), CoreError> {
+    let h = BdevHandle::open(NXNAME, true, false).unwrap();
+    h.create_snapshot()
+        .await
+        .expect("failed to create snapshot");
+    Ok(())
+}
+
+async fn custom_nvme_admin(opc: u8) -> Result<(), CoreError> {
+    let h = BdevHandle::open(NXNAME, true, false).unwrap();
+    h.nvme_admin_custom(opc).await?;
+    Ok(())
+}


### PR DESCRIPTION
This implements basic functionality to allow a Nexus to create
a snapshot on a replica using an NVMe Admin command.

Add NVME_ADMIN as a permitted IO type and implement NVMe Admin
Passthru starting from BdevHandle as a standalone function until it
reaches nexus_bdev. Creating a snapshot sends an admin command with
opcode c0h and the current Unix time in cdw10/11.

Register a custom command handler for NVMe Admin opcode c0h with SPDK
to handle snapshot creation when initialising the NVMf subsystem.
The handler creates a snapshot against the replica (lvol) by calling
vbdev_lvol_create_snapshot with a snapshot name derived from the
timestamp. Complete the NVMf request in the snapshot done callback.
The snapshot is then available in the list of replicas.

Add a test of NVMe Admin commands first with an unsupported opcode,
followed by creating a snapshot, given a BdevHandle, on a Nexus.