### PR TITLE
snapshots: Minor refactoring

### DIFF
--- a/mayastor/src/core/handle.rs
+++ b/mayastor/src/core/handle.rs
@@ -197,6 +197,7 @@ impl BdevHandle {
         }
     }
 
+    /// create a snapshot on all children
     pub async fn create_snapshot(&self) -> Result<usize, CoreError> {
         let mut cmd = spdk_sys::spdk_nvme_cmd::default();
         cmd.set_opc(nvme_admin_opc::CREATE_SNAPSHOT.into());
@@ -211,6 +212,7 @@ impl BdevHandle {
         self.nvme_admin(&cmd).await
     }
 
+    /// sends an NVMe Admin command with a custom opcode to all children
     pub async fn nvme_admin_custom(
         &self,
         opcode: u8,
@@ -220,6 +222,7 @@ impl BdevHandle {
         self.nvme_admin(&cmd).await
     }
 
+    /// sends the specified NVMe Admin command to all children
     pub async fn nvme_admin(
         &self,
         nvme_cmd: &spdk_sys::spdk_nvme_cmd,

--- a/mayastor/src/subsys/nvmf/admin_cmd.rs
+++ b/mayastor/src/subsys/nvmf/admin_cmd.rs
@@ -1,0 +1,67 @@
+//! Handlers for custom NVMe Admin commands
+
+use spdk_sys::{spdk_bdev, spdk_bdev_desc, spdk_io_channel, spdk_nvmf_request};
+
+use crate::{
+    bdev::nexus::nexus_io::nvme_admin_opc,
+    core::Bdev,
+    replica::Replica,
+};
+
+/// NVMf custom command handler for opcode c0h
+/// Called from nvmf_ctrlr_process_admin_cmd
+/// Return: <0 for any error, caller handles it as unsupported opcode
+extern "C" fn nvmf_create_snapshot_hdlr(req: *mut spdk_nvmf_request) -> i32 {
+    debug!("nvmf_create_snapshot_hdlr {:?}", req);
+
+    let subsys = unsafe { spdk_sys::spdk_nvmf_request_get_subsystem(req) };
+    if subsys.is_null() {
+        debug!("subsystem is null");
+        return -1;
+    }
+
+    /* Only process this request if it has exactly one namespace */
+    if unsafe { spdk_sys::spdk_nvmf_subsystem_get_max_nsid(subsys) } != 1 {
+        debug!("multiple namespaces");
+        return -1;
+    }
+
+    /* Forward to first namespace if it supports NVME admin commands */
+    let mut bdev: *mut spdk_bdev = std::ptr::null_mut();
+    let mut desc: *mut spdk_bdev_desc = std::ptr::null_mut();
+    let mut ch: *mut spdk_io_channel = std::ptr::null_mut();
+    let rc = unsafe {
+        spdk_sys::spdk_nvmf_request_get_bdev(
+            1, req, &mut bdev, &mut desc, &mut ch,
+        )
+    };
+    if rc != 0 {
+        /* No bdev found for this namespace. Continue. */
+        debug!("no bdev found");
+        return -1;
+    }
+
+    let bd = Bdev::from(bdev);
+    if let Some(replica) = Replica::from_bdev(&bd) {
+        let cmd = unsafe { &*spdk_sys::spdk_nvmf_request_get_cmd(req) };
+        let snapshot_time = unsafe {
+            cmd.__bindgen_anon_1.cdw10 as u64
+                | (cmd.__bindgen_anon_2.cdw11 as u64) << 32
+        };
+        let snapshot_name = format!("{}-snap-{}", bd.name(), snapshot_time);
+        replica.create_snapshot(req, &snapshot_name);
+        1 // SPDK_NVMF_REQUEST_EXEC_STATUS_ASYNCHRONOUS
+    } else {
+        -1
+    }
+}
+
+/// Register custom NVMe admin command handler
+pub fn setup_create_snapshot_hdlr() {
+    unsafe {
+        spdk_sys::spdk_nvmf_set_custom_admin_cmd_hdlr(
+            nvme_admin_opc::CREATE_SNAPSHOT,
+            Some(nvmf_create_snapshot_hdlr),
+        );
+    }
+}

--- a/mayastor/src/subsys/nvmf/mod.rs
+++ b/mayastor/src/subsys/nvmf/mod.rs
@@ -23,11 +23,11 @@ pub use subsystem::{NvmfSubsystem, SubType};
 pub use target::Target;
 
 use crate::{
-    bdev::nexus::nexus_bdev,
     jsonrpc::{Code, RpcErrorCode},
     subsys::{nvmf::target::NVMF_TGT, Config},
 };
 
+mod admin_cmd;
 mod poll_groups;
 mod subsystem;
 mod target;
@@ -87,7 +87,7 @@ impl Nvmf {
         // this code only ever gets run on the first core
 
         // set up custom NVMe Admin command handler
-        nexus_bdev::setup_create_snapshot_hdlr();
+        admin_cmd::setup_create_snapshot_hdlr();
 
         if Config::get().nexus_opts.nvmf_enable {
             NVMF_TGT.with(|tgt| {

--- a/mayastor/tests/common/bdev_io.rs
+++ b/mayastor/tests/common/bdev_io.rs
@@ -1,0 +1,34 @@
+use mayastor::core::{BdevHandle, CoreError};
+
+pub async fn write_some(nexus_name: &str) -> Result<(), CoreError> {
+    let h = BdevHandle::open(nexus_name, true, false).unwrap();
+    let mut buf = h.dma_malloc(512).expect("failed to allocate buffer");
+    buf.fill(0xff);
+
+    let s = buf.as_slice();
+    assert_eq!(s[0], 0xff);
+
+    h.write_at(0, &buf).await?;
+    Ok(())
+}
+
+pub async fn read_some(nexus_name: &str) -> Result<(), CoreError> {
+    let h = BdevHandle::open(nexus_name, true, false).unwrap();
+    let mut buf = h.dma_malloc(1024).expect("failed to allocate buffer");
+    let slice = buf.as_mut_slice();
+
+    assert_eq!(slice[0], 0);
+    slice[512] = 0xff;
+    assert_eq!(slice[512], 0xff);
+
+    let len = h.read_at(0, &mut buf).await?;
+    assert_eq!(len, 1024);
+
+    let slice = buf.as_slice();
+
+    for &it in slice.iter().take(512) {
+        assert_eq!(it, 0xff);
+    }
+    assert_eq!(slice[512], 0);
+    Ok(())
+}

--- a/mayastor/tests/common/mod.rs
+++ b/mayastor/tests/common/mod.rs
@@ -12,8 +12,10 @@ use mayastor::{
 };
 use spdk_sys::spdk_get_thread;
 
+pub mod bdev_io;
 pub mod error_bdev;
 pub mod ms_exec;
+
 /// call F cnt times, and sleep for a duration between each invocation
 pub fn retry<F, T, E>(mut cnt: u32, timeout: Duration, mut f: F) -> T
 where

--- a/mayastor/tests/io.rs
+++ b/mayastor/tests/io.rs
@@ -1,13 +1,8 @@
 use std::process::Command;
 
+use common::bdev_io;
 use mayastor::{
-    core::{
-        mayastor_env_stop,
-        Bdev,
-        MayastorCliArgs,
-        MayastorEnvironment,
-        Reactor,
-    },
+    core::{mayastor_env_stop, MayastorCliArgs, MayastorEnvironment, Reactor},
     nexus_uri::bdev_create,
 };
 
@@ -46,41 +41,7 @@ fn io_test() {
 // only execute one future per reactor loop.
 async fn start() {
     bdev_create(BDEVNAME).await.expect("failed to create bdev");
-    write_some().await;
-    read_some().await;
+    bdev_io::write_some(BDEVNAME).await.unwrap();
+    bdev_io::read_some(BDEVNAME).await.unwrap();
     mayastor_env_stop(0);
-}
-
-async fn write_some() {
-    let bdev = Bdev::lookup_by_name(BDEVNAME).expect("failed to lookup bdev");
-    let d = bdev
-        .open(true)
-        .expect("failed open bdev")
-        .into_handle()
-        .unwrap();
-    let mut buf = d.dma_malloc(512).expect("failed to allocate buffer");
-    buf.fill(0xff);
-
-    let s = buf.as_slice();
-    assert_eq!(s[0], 0xff);
-
-    d.write_at(0, &buf).await.unwrap();
-}
-
-async fn read_some() {
-    let bdev = Bdev::lookup_by_name(BDEVNAME).expect("failed to lookup bdev");
-    let d = bdev.open(false).unwrap().into_handle().unwrap();
-    let mut buf = d.dma_malloc(1024).expect("failed to allocate buffer");
-    let slice = buf.as_mut_slice();
-
-    assert_eq!(slice[0], 0);
-    slice[512] = 0xff;
-    assert_eq!(slice[512], 0xff);
-
-    d.read_at(0, &mut buf).await.unwrap();
-
-    let slice = buf.as_slice();
-
-    assert_eq!(slice[0], 0xff);
-    assert_eq!(slice[512], 0);
 }


### PR DESCRIPTION
Move NVMe admin command handler to the nvmf subsystem.

In Replica, move the snapshot done callback to the function that uses
it, refactor use of nvme_status, and use ffihelper for conversion to a
C string.

Add function comments where appropriate.

In the integration tests, factor out read_some and write_some to
common and swtich current users to that.

Fixes: d909c1e ("replica: Implement create_snapshot")