### PR TITLE
CAS-332: rework the pool layer

### DIFF
--- a/mayastor/src/core/mod.rs
+++ b/mayastor/src/core/mod.rs
@@ -108,4 +108,8 @@ pub enum CoreError {
     ShareIscsi {
         source: iscsi::Error,
     },
+    #[snafu(display("the operation is invalid for this bdev: {}", source))]
+    NotSupported {
+        source: Errno,
+    },
 }

--- a/mayastor/src/ffihelper.rs
+++ b/mayastor/src/ffihelper.rs
@@ -8,8 +8,15 @@ use std::{
     ptr::NonNull,
 };
 
-use futures::channel::oneshot;
+use futures::channel::{
+    oneshot,
+    oneshot::{Receiver, Sender},
+};
 use nix::errno::Errno;
+
+pub fn pair<T>() -> (Sender<T>, Receiver<T>) {
+    oneshot::channel::<T>()
+}
 
 pub(crate) trait AsStr {
     fn as_str(&self) -> &str;

--- a/mayastor/src/lib.rs
+++ b/mayastor/src/lib.rs
@@ -16,6 +16,7 @@ pub mod ffihelper;
 pub mod grpc;
 pub mod jsonrpc;
 pub mod logger;
+pub mod lvs;
 pub mod nats;
 pub mod nexus_uri;
 pub mod pool;

--- a/mayastor/src/lvs/error.rs
+++ b/mayastor/src/lvs/error.rs
@@ -1,0 +1,37 @@
+use crate::{core::CoreError, nexus_uri::NexusBdevError};
+use nix::errno::Errno;
+use snafu::Snafu;
+
+#[derive(Debug, Snafu)]
+#[snafu(visibility = "pub(crate)")]
+pub enum Error {
+    #[snafu(display("failed to import pool {}", msg))]
+    Import { err: Errno, msg: String },
+    #[snafu(display("failed to create pool {}", msg))]
+    Create { err: Errno, msg: String },
+    #[snafu(display("failed to export pool {}", msg))]
+    Export { err: Errno, msg: String },
+    #[snafu(display("failed to destroy pool {}", msg))]
+    Destroy { source: NexusBdevError, msg: String },
+    #[snafu(display("invalid bdev specified {}", msg))]
+    InvalidBdev { source: NexusBdevError, msg: String },
+    #[snafu(display(
+        "Invalid number of disks specified: should be 1, got {}",
+        num
+    ))]
+    BadNumDisks { num: usize },
+    #[snafu(display("lvol exists {}", msg))]
+    RepExists { err: Errno, msg: String },
+    #[snafu(display("failed to create lvol {}", msg))]
+    RepCreate { source: Errno, msg: String },
+    #[snafu(display("failed to create lvol {}", msg))]
+    RepDestroy { source: Errno, msg: String },
+    #[snafu(display("bdev is not a lvol"))]
+    NotALvol { source: Errno, msg: String },
+    #[snafu(display("failed to share lvol {}", msg))]
+    LvolShare { source: CoreError, msg: String },
+    #[snafu(display("failed to share lvol {}", msg))]
+    LvolUnShare { source: CoreError, msg: String },
+    #[snafu(display("{}", msg))]
+    Property { source: Errno, msg: String },
+}

--- a/mayastor/src/lvs/lvol.rs
+++ b/mayastor/src/lvs/lvol.rs
@@ -1,0 +1,315 @@
+use std::{
+    convert::TryFrom,
+    ffi::{c_void, CStr},
+    fmt::Display,
+    os::raw::c_char,
+    ptr::NonNull,
+};
+
+use async_trait::async_trait;
+use futures::channel::oneshot;
+use nix::errno::Errno;
+use pin_utils::core_reexport::fmt::Formatter;
+use tracing::instrument;
+
+use spdk_sys::{
+    spdk_blob_get_xattr_value,
+    spdk_blob_set_xattr,
+    spdk_blob_sync_md,
+    spdk_lvol,
+    vbdev_lvol_destroy,
+    vbdev_lvol_get_from_bdev,
+};
+
+use crate::{
+    core::{Bdev, CoreError, Protocol, Share},
+    ffihelper::{
+        cb_arg,
+        errno_result_from_i32,
+        pair,
+        ErrnoResult,
+        FfiResult,
+        IntoCString,
+    },
+    lvs::{error::Error, pool::Lvs},
+};
+
+/// properties we allow for being set on the lvol, this information is stored on
+/// disk
+#[derive(Debug, PartialEq)]
+#[non_exhaustive]
+pub enum PropValue {
+    Shared(bool),
+}
+
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum PropName {
+    Shared,
+}
+
+#[derive(Debug)]
+/// struct representing an lvol
+pub struct Lvol(pub(crate) NonNull<spdk_lvol>);
+
+impl TryFrom<Bdev> for Lvol {
+    type Error = Error;
+
+    fn try_from(b: Bdev) -> Result<Self, Self::Error> {
+        if b.driver() == "lvol" {
+            unsafe {
+                Ok(Lvol(NonNull::new_unchecked(vbdev_lvol_get_from_bdev(
+                    b.as_ptr(),
+                ))))
+            }
+        } else {
+            Err(Error::NotALvol {
+                source: Errno::EINVAL,
+                msg: format!("bdev {} is not a lvol", b.name()),
+            })
+        }
+    }
+}
+
+impl From<Lvol> for Bdev {
+    fn from(l: Lvol) -> Self {
+        Bdev::from(unsafe { l.0.as_ref().bdev })
+    }
+}
+
+impl Display for Lvol {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}:{}", self.pool(), self.name())
+    }
+}
+
+#[async_trait(? Send)]
+impl Share for Lvol {
+    type Error = Error;
+    type Output = String;
+
+    /// we dont (want to) support replica's over iSCSI
+    async fn share_iscsi(&self) -> Result<Self::Output, Self::Error> {
+        Err(Error::LvolShare {
+            source: CoreError::NotSupported {
+                source: Errno::EINVAL,
+            },
+            msg: "iSCSI shares not allowed for lvols".to_string(),
+        })
+    }
+
+    /// share the lvol as a nvmf target
+    #[instrument(level = "debug", err)]
+    async fn share_nvmf(&self) -> Result<Self::Output, Self::Error> {
+        let share = self.as_bdev().share_nvmf().await.map_err(|e| {
+            Error::LvolShare {
+                source: e,
+                msg: format!("failed to share lvol {}", self.name()),
+            }
+        })?;
+
+        self.set(PropValue::Shared(true)).await?;
+
+        Ok(share)
+    }
+
+    /// unshare the nvmf target
+    #[instrument(level = "debug", err)]
+    async fn unshare(&self) -> Result<Self::Output, Self::Error> {
+        let share =
+            self.as_bdev()
+                .unshare()
+                .await
+                .map_err(|e| Error::LvolUnShare {
+                    source: e,
+                    msg: format!("failed to unshare {}", self.name()),
+                })?;
+
+        self.set(PropValue::Shared(false)).await?;
+        Ok(share)
+    }
+
+    /// return the protocol this bdev is shared under
+    fn shared(&self) -> Option<Protocol> {
+        self.as_bdev().shared()
+    }
+
+    /// returns the share URI this lvol is shared as
+    fn share_uri(&self) -> Option<String> {
+        self.as_bdev().share_uri()
+    }
+
+    /// returns the URI that is used to construct the bdev. This is always None
+    /// as lvols can not be created by URIs directly, but only through the
+    /// ['Lvs'] interface.
+    fn bdev_uri(&self) -> Option<String> {
+        None
+    }
+}
+
+impl Lvol {
+    /// generic callback for lvol operations
+    pub(crate) extern "C" fn lvol_cb(
+        sender_ptr: *mut c_void,
+        lvol_ptr: *mut spdk_lvol,
+        errno: i32,
+    ) {
+        let sender = unsafe {
+            Box::from_raw(
+                sender_ptr as *mut oneshot::Sender<ErrnoResult<*mut spdk_lvol>>,
+            )
+        };
+        sender
+            .send(errno_result_from_i32(lvol_ptr, errno))
+            .expect("Receiver is gone");
+    }
+
+    /// returns the underlying bdev of the lvol
+    pub(crate) fn as_bdev(&self) -> Bdev {
+        Bdev::from(unsafe { self.0.as_ref().bdev })
+    }
+    /// return the size of the lvol in bytes
+    pub fn size(&self) -> u64 {
+        self.as_bdev().size_in_bytes()
+    }
+
+    /// returns the name of the bdev
+    pub fn name(&self) -> String {
+        self.as_bdev().name()
+    }
+
+    /// returns the UUID of the lvol
+    pub fn uuid(&self) -> String {
+        self.as_bdev().uuid_as_string()
+    }
+
+    /// returns the pool of the lvol
+    pub fn pool(&self) -> String {
+        unsafe {
+            Lvs(NonNull::new_unchecked(self.0.as_ref().lvol_store))
+                .name()
+                .to_string()
+        }
+    }
+
+    /// returns a boolean indicating if the lvol is thin provisioned
+    pub fn is_thin(&self) -> bool {
+        unsafe { self.0.as_ref().thin_provision }
+    }
+
+    /// destroy the lvol
+    #[instrument(level = "debug", err)]
+    pub async fn destroy(self) -> Result<String, Error> {
+        extern "C" fn destroy_cb(sender: *mut c_void, errno: i32) {
+            let sender =
+                unsafe { Box::from_raw(sender as *mut oneshot::Sender<i32>) };
+            sender.send(errno).unwrap();
+        }
+
+        let name = self.name();
+
+        let (s, r) = pair::<i32>();
+        unsafe {
+            vbdev_lvol_destroy(self.0.as_ptr(), Some(destroy_cb), cb_arg(s))
+        };
+
+        r.await
+            .expect("lvol destroy callback is gone")
+            .to_result(|e| Error::RepDestroy {
+                source: Errno::from_i32(e),
+                msg: format!("failed to destroy lvol {}", name),
+            })?;
+
+        info!("Destroyed lvol {}", name);
+        Ok(name)
+    }
+
+    /// callback executed after synchronizing the lvols metadata
+    extern "C" fn blob_sync_cb(sender_ptr: *mut c_void, errno: i32) {
+        let sender =
+            unsafe { Box::from_raw(sender_ptr as *mut oneshot::Sender<i32>) };
+        sender.send(errno).expect("blob cb receiver is gone");
+    }
+
+    /// write the property prop on to the lvol which is stored on disk
+    #[allow(clippy::unit_arg)] // here to silence the Ok(()) variant
+    #[instrument(level = "debug", err)]
+    pub async fn set(&self, prop: PropValue) -> Result<(), Error> {
+        let blob = unsafe { self.0.as_ref().blob };
+        assert_ne!(blob.is_null(), true);
+
+        match prop {
+            PropValue::Shared(val) => {
+                let name = "shared".into_cstring();
+                let value = if val { "true" } else { "false" }.into_cstring();
+                unsafe {
+                    spdk_blob_set_xattr(
+                        blob,
+                        name.as_ptr(),
+                        value.as_bytes_with_nul().as_ptr() as *const _,
+                        value.as_bytes_with_nul().len() as u16,
+                    )
+                }
+                .to_result(|e| Error::Property {
+                    source: Errno::from_i32(e),
+                    msg: format!(
+                        "failed to set the property {:?} on {}",
+                        prop,
+                        self.name()
+                    ),
+                })?;
+            }
+        };
+
+        let (s, r) = pair::<i32>();
+        unsafe {
+            spdk_blob_sync_md(blob, Some(Self::blob_sync_cb), cb_arg(s));
+        };
+
+        r.await.expect("sync callback is gone").to_result(|e| {
+            Error::Property {
+                source: Errno::from_i32(e),
+                msg: format!("failed to sync blob md for {}", self.name()),
+            }
+        })?;
+
+        Ok(())
+    }
+
+    /// get/read a property from this lvol from disk
+    #[instrument(level = "debug", err)]
+    pub async fn get(&self, prop: PropName) -> Result<PropValue, Error> {
+        let blob = unsafe { self.0.as_ref().blob };
+        assert_ne!(blob.is_null(), true);
+
+        match prop {
+            PropName::Shared => {
+                let name = "shared".into_cstring();
+                let mut value: *const libc::c_char =
+                    std::ptr::null::<libc::c_char>();
+                let mut value_len: u64 = 0;
+                unsafe {
+                    spdk_blob_get_xattr_value(
+                        blob,
+                        name.as_ptr(),
+                        &mut value as *mut *const c_char as *mut *const c_void,
+                        &mut value_len,
+                    )
+                }
+                .to_result(|e| Error::Property {
+                    source: Errno::from_i32(e),
+                    msg: format!("failed to get the property {:?}", prop),
+                })?;
+                match unsafe { CStr::from_ptr(value).to_str() } {
+                    Ok("true") => Ok(PropValue::Shared(true)),
+                    Ok("false") => Ok(PropValue::Shared(false)),
+                    _ => Err(Error::Property {
+                        source: Errno::EINVAL,
+                        msg: "the property contained an invalid value"
+                            .to_string(),
+                    }),
+                }
+            }
+        }
+    }
+}

--- a/mayastor/src/lvs/mod.rs
+++ b/mayastor/src/lvs/mod.rs
@@ -1,0 +1,7 @@
+pub use error::Error;
+pub use lvol::{Lvol, PropName, PropValue};
+pub use pool::Lvs;
+
+mod error;
+mod lvol;
+mod pool;

--- a/mayastor/src/lvs/pool.rs
+++ b/mayastor/src/lvs/pool.rs
@@ -1,0 +1,511 @@
+use std::{convert::TryFrom, fmt::Debug, os::raw::c_void, ptr::NonNull};
+
+use futures::channel::oneshot;
+use nix::errno::Errno;
+use pin_utils::core_reexport::fmt::Formatter;
+use tracing::instrument;
+
+use rpc::mayastor::CreatePoolRequest;
+use spdk_sys::{
+    lvol_store_bdev,
+    spdk_bs_free_cluster_count,
+    spdk_bs_get_cluster_size,
+    spdk_bs_total_data_cluster_count,
+    spdk_lvol,
+    spdk_lvol_store,
+    vbdev_get_lvol_store_by_name,
+    vbdev_get_lvs_bdev_by_lvs,
+    vbdev_lvol_create,
+    vbdev_lvol_store_first,
+    vbdev_lvol_store_next,
+    vbdev_lvs_create,
+    vbdev_lvs_destruct,
+    vbdev_lvs_examine,
+    vbdev_lvs_unload,
+    LVOL_CLEAR_WITH_UNMAP,
+    LVOL_CLEAR_WITH_WRITE_ZEROES,
+    LVS_CLEAR_WITH_NONE,
+    SPDK_BDEV_IO_TYPE_UNMAP,
+};
+
+use crate::{
+    bdev::Uri,
+    core::{Bdev, Share, Uuid},
+    ffihelper::{cb_arg, pair, AsStr, ErrnoResult, FfiResult, IntoCString},
+    lvs::{Error, Lvol, PropName, PropValue},
+    nexus_uri::{bdev_destroy, NexusBdevError},
+};
+
+impl From<*mut spdk_lvol_store> for Lvs {
+    fn from(p: *mut spdk_lvol_store) -> Self {
+        Lvs(NonNull::new(p).unwrap())
+    }
+}
+
+/// iterator over all lvol stores
+pub struct LvsIterator(*mut lvol_store_bdev);
+
+impl LvsIterator {
+    fn new() -> Self {
+        LvsIterator(unsafe { vbdev_lvol_store_first() })
+    }
+}
+
+impl Default for LvsIterator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Iterator for LvsIterator {
+    type Item = Lvs;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.0.is_null() {
+            None
+        } else {
+            let current = self.0;
+            self.0 = unsafe { vbdev_lvol_store_next(current) };
+            Some(Lvs::from(unsafe { (*current).lvs }))
+        }
+    }
+}
+
+impl IntoIterator for Lvs {
+    type Item = Lvs;
+    type IntoIter = LvsIterator;
+
+    fn into_iter(self) -> Self::IntoIter {
+        LvsIterator(unsafe { vbdev_lvol_store_first() })
+    }
+}
+
+impl Debug for Lvs {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "name: {}, uuid: {}, base_bdev: {}",
+            self.name(),
+            self.uuid(),
+            self.base_bdev().name()
+        )
+    }
+}
+
+/// Logical Volume Store (LVS) stores the lvols
+pub struct Lvs(pub(crate) NonNull<spdk_lvol_store>);
+
+impl Lvs {
+    /// generic lvol store callback
+    extern "C" fn lvs_cb(
+        sender_ptr: *mut c_void,
+        _lvs: *mut spdk_lvol_store,
+        errno: i32,
+    ) {
+        let sender =
+            unsafe { Box::from_raw(sender_ptr as *mut oneshot::Sender<i32>) };
+        sender.send(errno).unwrap();
+    }
+
+    /// callback when operation has been performed on lvol
+    extern "C" fn lvs_op_cb(sender: *mut c_void, errno: i32) {
+        let sender =
+            unsafe { Box::from_raw(sender as *mut oneshot::Sender<i32>) };
+        sender.send(errno).unwrap();
+    }
+
+    /// returns a new iterator over all lvols
+    pub fn iter() -> LvsIterator {
+        LvsIterator::default()
+    }
+
+    /// lookup a lvol store by its name
+    pub fn lookup(name: &str) -> Option<Self> {
+        let name = name.into_cstring();
+
+        let lvs = unsafe { vbdev_get_lvol_store_by_name(name.as_ptr()) };
+        if lvs.is_null() {
+            None
+        } else {
+            Some(Lvs::from(lvs))
+        }
+    }
+
+    /// return the name of the current store
+    pub fn name(&self) -> &str {
+        unsafe { self.0.as_ref().name.as_str() }
+    }
+
+    /// returns the total capacity of the store
+    pub fn capacity(&self) -> u64 {
+        let blobs = unsafe { self.0.as_ref().blobstore };
+        unsafe {
+            spdk_bs_get_cluster_size(blobs)
+                * spdk_bs_total_data_cluster_count(blobs)
+        }
+    }
+
+    /// returns the available capacity
+    pub fn available(&self) -> u64 {
+        let blobs = unsafe { self.0.as_ref().blobstore };
+        unsafe {
+            spdk_bs_get_cluster_size(blobs) * spdk_bs_free_cluster_count(blobs)
+        }
+    }
+
+    /// returns the used capacity
+    pub fn used(&self) -> u64 {
+        self.capacity() - self.available()
+    }
+
+    /// returns the base bdev of this lvs
+    pub fn base_bdev(&self) -> Bdev {
+        Bdev::from(unsafe {
+            (*vbdev_get_lvs_bdev_by_lvs(self.0.as_ptr())).bdev
+        })
+    }
+
+    /// returns the UUID of the lvs
+    pub fn uuid(&self) -> String {
+        let t = unsafe { self.0.as_ref().uuid.u.raw };
+        Uuid::from_bytes(t).to_string()
+    }
+
+    /// imports a pool based on its name and base bdev name
+    #[instrument(level = "debug", err)]
+    pub async fn import(name: &str, bdev: &str) -> Result<Lvs, Error> {
+        let (sender, receiver) = pair::<i32>();
+
+        debug!("Trying to import pool {} on {}", name, bdev);
+
+        let bdev = Bdev::lookup_by_name(bdev).ok_or(Error::InvalidBdev {
+            source: NexusBdevError::BdevNotFound {
+                name: bdev.to_string(),
+            },
+            msg: "trying to import a pool on a bdev that does not exist".into(),
+        })?;
+
+        // examining a bdev that is in-use by an lvs, will hang to avoid this
+        // we will determine the usage of the bdev prior to examining it.
+
+        if bdev.is_claimed() {
+            return Err(Error::Import {
+                err: Errno::EBUSY,
+                msg: format!(
+                    "bdev {} is already in use by {}",
+                    bdev.name(),
+                    bdev.claimed_by().unwrap()
+                ),
+            });
+        }
+
+        unsafe {
+            vbdev_lvs_examine(
+                bdev.as_ptr(),
+                Some(Self::lvs_cb),
+                cb_arg(sender),
+            );
+        }
+
+        receiver
+            .await
+            .expect("Cancellation is not supported")
+            .to_result(|e| Error::Import {
+                err: Errno::from_i32(e),
+                msg: name.into(),
+            })?;
+
+        // could be that a pool with a different name was imported
+        match Self::lookup(&name) {
+            Some(pool) => {
+                pool.share_all().await;
+                info!("The pool '{}' has been imported", name);
+                Ok(pool)
+            }
+            None => Err(Error::Import {
+                err: Errno::ENOENT,
+                msg: format!("No pool '{}' found to import", name),
+            }),
+        }
+    }
+
+    #[instrument(level = "debug", err)]
+    /// Create a pool on base bdev
+    pub async fn create(name: &str, bdev: &str) -> Result<Lvs, Error> {
+        let pool_name = name.into_cstring();
+
+        let (sender, receiver) = pair::<i32>();
+        unsafe {
+            vbdev_lvs_create(
+                Bdev::lookup_by_name(bdev).unwrap().as_ptr(),
+                pool_name.as_ptr(),
+                0,
+                // We used to clear a pool with UNMAP but that takes awfully
+                // long time on large SSDs (~ can take an hour). Clearing the
+                // pool is not necessary. Clearing the lvol must be done, but
+                // lvols tend to be small so there the overhead is acceptable.
+                LVS_CLEAR_WITH_NONE,
+                Some(Self::lvs_cb),
+                cb_arg(sender),
+            )
+        }
+        .to_result(|e| Error::Create {
+            err: Errno::from_i32(e),
+            msg: format!("failed to create pool '{}'", name),
+        })?;
+
+        receiver
+            .await
+            .expect("Cancellation is not supported")
+            .to_result(|e| Error::Create {
+                err: Errno::from_i32(e),
+                msg: "failed to create pool".into(),
+            })?;
+
+        match Self::lookup(&name) {
+            Some(pool) => {
+                info!("The pool '{}' has been created on {}", name, bdev);
+                Ok(pool)
+            }
+            None => Err(Error::Create {
+                err: Errno::ENOENT,
+                msg: format!("The pool {} is gone right after creation!", name),
+            }),
+        }
+    }
+
+    /// imports the pool if it exists, otherwise try to create it
+    #[instrument(level = "debug", err)]
+    pub async fn create_or_import(
+        args: CreatePoolRequest,
+    ) -> Result<Lvs, Error> {
+        if args.disks.len() != 1 {
+            return Err(Error::BadNumDisks {
+                num: args.disks.len(),
+            });
+        }
+
+        let parsed =
+            Uri::parse(&args.disks[0]).map_err(|e| Error::InvalidBdev {
+                source: e,
+                msg: "invalid bdev specified for pool".to_string(),
+            })?;
+
+        if let Some(pool) = Self::lookup(&args.name) {
+            return if pool.base_bdev().name() == parsed.get_name() {
+                Ok(pool)
+            } else {
+                Err(Error::Create {
+                    err: Errno::EEXIST,
+                    msg: format!("pool {} already exists", args.name),
+                })
+            };
+        }
+
+        let bdev = match parsed.create().await {
+            Err(e) => match e {
+                NexusBdevError::BdevExists {
+                    ..
+                } => Ok(parsed.get_name()),
+                _ => Err(Error::InvalidBdev {
+                    source: e,
+                    msg: "base_bdev for the pool does not match".into(),
+                }),
+            },
+            Ok(name) => Ok(name),
+        }?;
+
+        match Self::import(&args.name, &bdev).await {
+            Ok(pool) => Ok(pool),
+            Err(_) => Self::create(&args.name, &bdev).await,
+        }
+    }
+
+    /// export the given lvl
+    #[allow(clippy::unit_arg)] // here to silence the () argument
+    #[instrument(level = "debug", err)]
+    pub async fn export(self) -> Result<(), Error> {
+        let pool = self.name().to_string();
+        let base_bdev = self.base_bdev();
+        let (s, r) = pair::<i32>();
+
+        self.unshare_all().await;
+
+        unsafe {
+            vbdev_lvs_unload(self.0.as_ptr(), Some(Self::lvs_op_cb), cb_arg(s))
+        };
+
+        r.await
+            .expect("callback gone while exporting lvs")
+            .to_result(|e| Error::Export {
+                err: Errno::from_i32(e),
+                msg: format!("failed to export pool {}", pool),
+            })?;
+
+        info!("pool {} exported successfully", pool);
+        bdev_destroy(&base_bdev.bdev_uri().unwrap())
+            .await
+            .map_err(|e| Error::Destroy {
+                source: e,
+                msg: format!(
+                    "pool {} destroyed but failed to delete base_bdev {}",
+                    pool,
+                    base_bdev.name()
+                ),
+            })?;
+        Ok(())
+    }
+
+    /// unshare all lvols prior to export or destroy
+    async fn unshare_all(&self) {
+        for l in self.lvols().unwrap() {
+            // notice we dont use the unshare impl of the bdev
+            // here. we do this to avoid the on disk persistence
+            let bdev = l.as_bdev();
+            if let Err(e) = bdev.unshare().await {
+                error!("failed to unshare lvol {} error {}", l, e.to_string())
+            }
+        }
+    }
+
+    /// share all lvols who have the shared property set, this is implicitly
+    /// shared over nvmf
+    async fn share_all(&self) {
+        if let Some(lvols) = self.lvols() {
+            for l in lvols {
+                if let Ok(prop) = l.get(PropName::Shared).await {
+                    match prop {
+                        PropValue::Shared(true) => {
+                            if let Err(e) = l.share_nvmf().await {
+                                error!(
+                                    "failed to share {} {}",
+                                    l.name(),
+                                    e.to_string()
+                                );
+                            }
+                        }
+                        PropValue::Shared(false) => {
+                            debug!("{} not shared on disk", l.name())
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// destroys the given pool deleting the on disk super blob before doing so,
+    /// un share all targets
+    #[allow(clippy::unit_arg)]
+    #[instrument(level = "debug", err)]
+    pub async fn destroy(self) -> Result<(), Error> {
+        let pool = self.name().to_string();
+        let (s, r) = pair::<i32>();
+
+        // when destroying a pool unshare all volumes
+        self.unshare_all().await;
+
+        let base_bdev = self.base_bdev();
+
+        unsafe {
+            vbdev_lvs_destruct(
+                self.0.as_ptr(),
+                Some(Self::lvs_op_cb),
+                cb_arg(s),
+            )
+        };
+
+        r.await
+            .expect("callback gone while destroying lvs")
+            .to_result(|e| Error::Export {
+                err: Errno::from_i32(e),
+                msg: format!("failed to export pool {}", pool),
+            })?;
+
+        info!("pool {} destroyed successfully", pool);
+
+        bdev_destroy(&base_bdev.bdev_uri().unwrap())
+            .await
+            .map_err(|e| Error::Destroy {
+                source: e,
+                msg: format!(
+                    "pool {} destroyed but failed to delete base_bdev {}",
+                    pool,
+                    base_bdev.name()
+                ),
+            })?;
+
+        Ok(())
+    }
+
+    /// return an iterator that filters out all bdevs that patch the pool
+    /// signature
+    pub fn lvols(&self) -> Option<impl Iterator<Item = Lvol>> {
+        if let Some(bdev) = Bdev::bdev_first() {
+            let pool_name = format!("{}/", self.name().to_string());
+            Some(
+                bdev.into_iter()
+                    .filter(move |b| {
+                        b.driver() == "lvol"
+                            && b.aliases()
+                                .iter()
+                                .any(|a| a.contains(&pool_name))
+                    })
+                    .map(|b| Lvol::try_from(b).unwrap()),
+            )
+        } else {
+            None
+        }
+    }
+
+    #[instrument(level = "debug", err)]
+    /// create a new lvol on this pool
+    pub async fn create_lvol(
+        &self,
+        name: &str,
+        size: u64,
+        thin: bool,
+    ) -> Result<Lvol, Error> {
+        let clear_method =
+            if self.base_bdev().io_type_supported(SPDK_BDEV_IO_TYPE_UNMAP) {
+                LVOL_CLEAR_WITH_UNMAP
+            } else {
+                LVOL_CLEAR_WITH_WRITE_ZEROES
+            };
+
+        if Bdev::lookup_by_name(name).is_some() {
+            return Err(Error::RepExists {
+                err: Errno::EEXIST,
+                msg: format!("lvol {} already exists", name),
+            });
+        };
+
+        let (s, r) = pair::<ErrnoResult<*mut spdk_lvol>>();
+
+        let name = name.into_cstring();
+        unsafe {
+            vbdev_lvol_create(
+                self.0.as_ptr(),
+                name.as_ptr(),
+                size,
+                thin,
+                clear_method,
+                Some(Lvol::lvol_cb),
+                cb_arg(s),
+            )
+        }
+        .to_result(|e| Error::RepCreate {
+            source: Errno::from_i32(e),
+            msg: "failed to dispatch lvol creation event".to_string(),
+        })?;
+
+        let lvol =
+            r.await
+                .expect("lvol creation callback dropped")
+                .map_err(|e| Error::RepCreate {
+                    source: e,
+                    msg: "".to_string(),
+                })?;
+
+        Ok(Lvol(NonNull::new(lvol).unwrap()))
+    }
+}

--- a/mayastor/tests/lvs_pool.rs
+++ b/mayastor/tests/lvs_pool.rs
@@ -1,0 +1,378 @@
+use std::panic::catch_unwind;
+
+use mayastor::{
+    core::{
+        mayastor_env_stop,
+        Bdev,
+        MayastorCliArgs,
+        MayastorEnvironment,
+        Protocol,
+        Reactor,
+        Share,
+    },
+    lvs::{Lvs, PropName, PropValue},
+    nexus_uri::bdev_create,
+    subsys::NvmfSubsystem,
+};
+use rpc::mayastor::CreatePoolRequest;
+
+pub mod common;
+
+static DISKNAME1: &str = "/tmp/disk1.img";
+
+#[test]
+fn lvs_pool_test() {
+    common::delete_file(&[DISKNAME1.into()]);
+    common::truncate_file(DISKNAME1, 64 * 1024);
+    common::mayastor_test_init();
+    let mut args = MayastorCliArgs::default();
+    args.reactor_mask = "0x3".into();
+
+    let result = catch_unwind(|| {
+        MayastorEnvironment::new(args)
+            .start(|| {
+                // should fail to import a pool that does not exist on disk
+                Reactor::block_on(async {
+                    assert_eq!(
+                        Lvs::import("tpool", "aio:///tmp/disk1.img")
+                            .await
+                            .is_err(),
+                        true
+                    )
+                });
+
+                // should succeed to create a pool we can not import
+                Reactor::block_on(async {
+                    Lvs::create_or_import(CreatePoolRequest {
+                        name: "tpool".into(),
+                        disks: vec!["aio:///tmp/disk1.img".into()],
+                        block_size: 0,
+                        io_if: 0,
+                    })
+                    .await
+                    .unwrap();
+                });
+
+                // returns OK when the pool is already there and we create
+                // it again
+                Reactor::block_on(async {
+                    assert_eq!(
+                        Lvs::create_or_import(CreatePoolRequest {
+                            name: "tpool".into(),
+                            disks: vec!["aio:///tmp/disk1.img".into()],
+                            block_size: 0,
+                            io_if: 0,
+                        })
+                        .await
+                        .is_ok(),
+                        true
+                    )
+                });
+
+                // should fail to create the pool again, notice that we use
+                // create directly here to ensure that if we
+                // have an idempotent snafu, we dont crash and
+                // burn
+                Reactor::block_on(async {
+                    assert_eq!(
+                        Lvs::create("tpool", "aio:///tmp/disk1.img")
+                            .await
+                            .is_err(),
+                        true
+                    )
+                });
+
+                // should fail to import the pool that is already imported
+                // similar to above, we use the import directly
+                Reactor::block_on(async {
+                    assert_eq!(
+                        Lvs::import("tpool", "aio:///tmp/disk1.img")
+                            .await
+                            .is_err(),
+                        true
+                    )
+                });
+
+                // should be able to find our new LVS
+                Reactor::block_on(async {
+                    assert_eq!(Lvs::iter().count(), 1);
+                    let pool = Lvs::lookup("tpool").unwrap();
+                    assert_eq!(pool.name(), "tpool");
+                    assert_eq!(pool.used(), 0);
+                    dbg!(pool.uuid());
+                    assert_eq!(pool.base_bdev().name(), "/tmp/disk1.img");
+                });
+
+                // export the pool keeping the bdev alive and then
+                // import the pool and validate the uuid
+
+                Reactor::block_on(async {
+                    let pool = Lvs::lookup("tpool").unwrap();
+                    let uuid = pool.uuid();
+                    pool.export().await.unwrap();
+
+                    // import and export implicitly destroy the base_bdev, for
+                    // testing import and create we
+                    // sometimes create the base_bdev manually
+                    bdev_create("aio:///tmp/disk1.img").await.unwrap();
+
+                    assert_eq!(
+                        Lvs::import("tpool", "aio:///tmp/disk1.img")
+                            .await
+                            .is_ok(),
+                        true
+                    );
+
+                    let pool = Lvs::lookup("tpool").unwrap();
+                    assert_eq!(pool.uuid(), uuid);
+                });
+
+                // destroy the pool, a import should now fail, creating a new
+                // pool should not having a matching UUID of the
+                // old pool
+                Reactor::block_on(async {
+                    let pool = Lvs::lookup("tpool").unwrap();
+                    let uuid = pool.uuid();
+                    pool.destroy().await.unwrap();
+
+                    bdev_create("aio:///tmp/disk1.img").await.unwrap();
+                    assert_eq!(
+                        Lvs::import("tpool", "aio:///tmp/disk1.img")
+                            .await
+                            .is_err(),
+                        true
+                    );
+
+                    assert_eq!(Lvs::iter().count(), 0);
+                    assert_eq!(
+                        Lvs::create("tpool", "aio:///tmp/disk1.img")
+                            .await
+                            .is_ok(),
+                        true
+                    );
+
+                    let pool = Lvs::lookup("tpool").unwrap();
+                    assert_ne!(uuid, pool.uuid());
+                    assert_eq!(Lvs::iter().count(), 1);
+                });
+
+                // create 10 lvol on this pool
+                Reactor::block_on(async {
+                    let pool = Lvs::lookup("tpool").unwrap();
+                    for i in 0 .. 10 {
+                        pool.create_lvol(&format!("vol-{}", i), 4 * 1024, true)
+                            .await
+                            .unwrap();
+                    }
+
+                    assert_eq!(pool.lvols().unwrap().count(), 10);
+                });
+
+                // create a second pool and ensure it filters correctly
+                Reactor::block_on(async {
+                    let pool2 = Lvs::create_or_import(CreatePoolRequest {
+                        name: "tpool2".to_string(),
+                        disks: vec!["malloc:///malloc0?size_mb=64".to_string()],
+                        block_size: 0,
+                        io_if: 0,
+                    })
+                    .await
+                    .unwrap();
+
+                    for i in 0 .. 5 {
+                        pool2
+                            .create_lvol(
+                                &format!("pool2-vol-{}", i),
+                                4 * 1024,
+                                false,
+                            )
+                            .await
+                            .unwrap();
+                    }
+
+                    assert_eq!(pool2.lvols().unwrap().count(), 5);
+
+                    let pool = Lvs::lookup("tpool").unwrap();
+                    assert_eq!(pool.lvols().unwrap().count(), 10);
+                });
+
+                // export the first pool and import it again, all replica's
+                // should be present, destroy  all of them by name to
+                // ensure they are all there
+
+                Reactor::block_on(async {
+                    let pool = Lvs::lookup("tpool").unwrap();
+                    pool.export().await.unwrap();
+                    let pool = Lvs::create_or_import(CreatePoolRequest {
+                        name: "tpool".to_string(),
+                        disks: vec!["aio:///tmp/disk1.img".to_string()],
+                        block_size: 0,
+                        io_if: 0,
+                    })
+                    .await
+                    .unwrap();
+
+                    assert_eq!(pool.lvols().unwrap().count(), 10);
+
+                    let df = pool
+                        .lvols()
+                        .unwrap()
+                        .map(|r| r.destroy())
+                        .collect::<Vec<_>>();
+                    assert_eq!(df.len(), 10);
+                    futures::future::join_all(df).await;
+                });
+
+                // share all the replica's on the pool tpool2
+                Reactor::block_on(async {
+                    let pool2 = Lvs::lookup("tpool2").unwrap();
+                    for l in pool2.lvols().unwrap() {
+                        l.share_nvmf().await.unwrap();
+                    }
+                });
+
+                // destroy the pool and verify that all nvmf shares are removed
+                Reactor::block_on(async {
+                    let p = Lvs::lookup("tpool2").unwrap();
+                    p.destroy().await.unwrap();
+                    assert_eq!(
+                        NvmfSubsystem::first().unwrap().into_iter().count(),
+                        1 // only the discovery system remains
+                    )
+                });
+
+                // test setting the share property that is stored on disk
+                Reactor::block_on(async {
+                    let pool = Lvs::lookup("tpool").unwrap();
+                    let lvol = pool
+                        .create_lvol("vol-1", 1024 * 4, false)
+                        .await
+                        .unwrap();
+
+                    lvol.set(PropValue::Shared(true)).await.unwrap();
+                    assert_eq!(
+                        lvol.get(PropName::Shared).await.unwrap(),
+                        PropValue::Shared(true)
+                    );
+
+                    lvol.set(PropValue::Shared(false)).await.unwrap();
+                    assert_eq!(
+                        lvol.get(PropName::Shared).await.unwrap(),
+                        PropValue::Shared(false)
+                    );
+
+                    // sharing should set the property on disk
+
+                    lvol.share_nvmf().await.unwrap();
+
+                    assert_eq!(
+                        lvol.get(PropName::Shared).await.unwrap(),
+                        PropValue::Shared(true)
+                    );
+
+                    lvol.unshare().await.unwrap();
+
+                    assert_eq!(
+                        lvol.get(PropName::Shared).await.unwrap(),
+                        PropValue::Shared(false)
+                    );
+
+                    lvol.destroy().await.unwrap();
+                });
+
+                // create 10 shares, 1 unshared lvol and export the pool
+                Reactor::block_on(async {
+                    let pool = Lvs::lookup("tpool").unwrap();
+
+                    for i in 0 .. 10 {
+                        pool.create_lvol(&format!("vol-{}", i), 4 * 1024, true)
+                            .await
+                            .unwrap();
+                    }
+
+                    for l in pool.lvols().unwrap() {
+                        l.share_nvmf().await.unwrap();
+                    }
+
+                    pool.create_lvol("notshared", 4 * 1024, true)
+                        .await
+                        .unwrap();
+
+                    pool.export().await.unwrap();
+                });
+
+                // import the pool all shares should be there, but also validate
+                // the share that not shared to be -- not shared
+                Reactor::block_on(async {
+                    bdev_create("aio:///tmp/disk1.img").await.unwrap();
+                    let pool = Lvs::import("tpool", "aio:///tmp/disk1.img")
+                        .await
+                        .unwrap();
+
+                    for l in pool.lvols().unwrap() {
+                        if l.name() == "notshared" {
+                            assert_eq!(l.shared(), None);
+                        } else {
+                            assert_eq!(l.shared().unwrap(), Protocol::Nvmf);
+                        }
+                    }
+
+                    assert_eq!(
+                        NvmfSubsystem::first().unwrap().into_iter().count(),
+                        1 + 10
+                    );
+                });
+
+                // lastly destroy the pool, import/create it again, no shares
+                // should be present
+                Reactor::block_on(async {
+                    let pool = Lvs::lookup("tpool").unwrap();
+                    pool.destroy().await.unwrap();
+                    assert_eq!(
+                        NvmfSubsystem::first().unwrap().into_iter().count(),
+                        1
+                    );
+
+                    let pool = Lvs::create_or_import(CreatePoolRequest {
+                        name: "tpool".into(),
+                        disks: vec!["aio:///tmp/disk1.img".into()],
+                        block_size: 0,
+                        io_if: 0,
+                    })
+                    .await
+                    .unwrap();
+
+                    assert_eq!(
+                        NvmfSubsystem::first().unwrap().into_iter().count(),
+                        1
+                    );
+
+                    assert_eq!(pool.lvols().unwrap().count(), 0);
+                    pool.destroy().await.unwrap();
+                });
+
+                // validate the expected state of mayastor
+                Reactor::block_on(async {
+                    // no shares left except for the discovery controller
+
+                    assert_eq!(
+                        NvmfSubsystem::first().unwrap().into_iter().count(),
+                        1
+                    );
+
+                    // all pools destroyed
+                    assert_eq!(Lvs::iter().count(), 0);
+
+                    // no bdevs left
+
+                    assert_eq!(Bdev::bdev_first().into_iter().count(), 0);
+                });
+
+                mayastor_env_stop(0);
+            })
+            .unwrap();
+    });
+
+    common::delete_file(&[DISKNAME1.into()]);
+    result.unwrap();
+}


### PR DESCRIPTION
In principle nothing changes, however the creation
of base_bdevs is implicitly done through bdev URI's
and lvols now Impl Share.

One new feature that has been added is that we can
can now set properties on lvols. This means that when
we create a lvol, and then share it, the fact that it
is shared is persisted on disk. On import the lvols are
automatically shared.