### PR TITLE
Proper mayastor debug package and code cleanup.

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -17,11 +17,11 @@ jobs:
         with:
           name: mayastor
           skipNixBuild: true
-      - run: nix-build -A node-moacImage -o /tmp/node-moacImage
+      - run: nix-build -A images.moac-image -o /tmp/moac-image
       - uses: actions/upload-artifact@v2
         with:
           name: mayastor-moac-image
-          path: /tmp/node-moacImage
+          path: /tmp/moac-image
         if: ${{ github.event_name != 'pull_request' }}
   Mayastor:
     name: Build Mayastor image
@@ -36,4 +36,4 @@ jobs:
         with:
           name: mayastor
           skipNixBuild: true
-      - run: nix-build -A images.mayastor-develop -o /tmp/mayastorImage
+      - run: nix-build -A images.mayastor-image -o /tmp/mayastorImage

--- a/csi/moac/README.md
+++ b/csi/moac/README.md
@@ -169,25 +169,6 @@ it is rather simple:
    ./result/...
    ```
 
-## Building a Docker image
-
-In MOAC's directory run:
-
-```bash
-nix-build default.nix -A buildImage
-```
-
-At the end of the build is printed path to docker image tar archive. Import
-it to a docker (don't use _import_ command) and run bash to poke around:
-
-```bash
-docker load -i /nix/store/hash-docker-image-moac.tar.gz
-docker run --rm -it image-hash /bin/bash
-```
-
-TODO: The resulting image is insanely big because the nix includes false
-dependencies that are needed only at build time (npm and such).
-
 ## Architecture
 
 Unfortunately ASCII art is not good with colours. Left side of the picture

--- a/doc/build.md
+++ b/doc/build.md
@@ -209,6 +209,32 @@ Or, you can copy over the .so to `/usr/local/lib` or something similar.
 
 One this is done, you should be able to run `cargo build --all`
 
+## Building docker images
+
+Use NIX to build the images. Note that the images are based on NIX packages
+that are built as part of building the image. The tag of the image will be
+short commit hash of the top-most commit or a tag name of the commit if
+present. Example of building a moac package:
+
+```bash
+nix-build -A images.moac-image
+```
+
+At the end of the build is printed path to docker image tar archive. Load the
+image into Docker (don't use _import_ command) and run bash to poke around:
+
+```bash
+docker load -i /nix/store/hash-docker-image-moac.tar.gz
+docker run --rm -it image-hash /bin/bash
+```
+
+Mayastor and csi plugin images can have multiple flavours. Production image
+name does not contain the flavour name (i.e. `mayastor-image`). Debug image
+contains the `dev` in its name (i.e. `mayastor-dev-image`). Mayastor package
+has additional flavour called `adhoc` (`mayastor-adhoc-image`), that is handy
+for testing because it is not based on mayastor package but rather on whatever
+binaries are present in `target/debug` directory.
+
 ## Some background information
 
 MayaStor makes use of subsystems that are not yet part of major distributions, for example:
@@ -223,10 +249,10 @@ Mayastor, in all cases, **requires the nightly rust compiler with async support*
 You don't need to have a 5.x kernel unless you want to use NVMF.
 
 If you already have rust installed but not nightly, use rustup to install it before continuing.
+
 ### spdk-sys
+
 The crate that provides the glue between SPDK and Mayastor is hosted in this [repo](https://github.com/openebs/spdk-sys)
 feel free to go through it and determine if you want to install libspdk using those instructions or directly from
 [here](https://github.com/openebs/spdk). If you chose either of these methods, make sure you install such that
 during linking, it can be found.
-
-

--- a/nix/lib/version.nix
+++ b/nix/lib/version.nix
@@ -1,0 +1,23 @@
+{ lib, stdenv, git }:
+let
+  whitelistSource = src: allowedPrefixes:
+    builtins.filterSource
+      (path: type:
+        lib.any
+          (allowedPrefix:
+            lib.hasPrefix (toString (src + "/${allowedPrefix}")) path)
+          allowedPrefixes)
+      src;
+in
+stdenv.mkDerivation {
+  name = "mayastor-version";
+  src = whitelistSource ../../. [ ".git" ];
+  buildCommand = ''
+    cd $src
+    vers=`${git}/bin/git tag --points-at HEAD`
+    if [ -z "$vers" ]; then
+      vers=`${git}/bin/git rev-parse --short HEAD`
+    fi
+    echo -n $vers >$out
+  '';
+}

--- a/nix/mayastor-overlay.nix
+++ b/nix/mayastor-overlay.nix
@@ -1,19 +1,14 @@
 self: super: {
-
   libiscsi = super.callPackage ./pkgs/libiscsi { };
   liburing = super.callPackage ./pkgs/liburing { };
   nvmet-cli = super.callPackage ./pkgs/nvmet-cli { };
   libspdk = super.callPackage ./pkgs/libspdk { };
-  mayastor = super.callPackage ./pkgs/mayastor { };
+  mayastor = (super.callPackage ./pkgs/mayastor { }).release;
+  mayastor-dev = (super.callPackage ./pkgs/mayastor { }).debug;
+  mayastor-adhoc = (super.callPackage ./pkgs/mayastor { }).adhoc;
+  moac = (import ./../csi/moac { pkgs = super; }).package;
   images = super.callPackage ./pkgs/images { };
-
 
   ms-buildenv = super.callPackage ./pkgs/ms-buildenv { };
   mkContainerEnv = super.callPackage ./lib/mkContainerEnv.nix { };
-
-
-  node-moac = (import ./../csi/moac { pkgs = super; }).package;
-  node-moacImage = (import ./../csi/moac { pkgs = super; }).buildImage;
-  nodePackages = (import ./pkgs/nodePackages { pkgs = super; });
-
 }

--- a/nix/pkgs/mayastor/default.nix
+++ b/nix/pkgs/mayastor/default.nix
@@ -1,6 +1,8 @@
 { stdenv
 , clang
 , dockerTools
+, e2fsprogs
+, git
 , lib
 , libaio
 , libiscsi
@@ -13,8 +15,8 @@
 , openssl
 , pkg-config
 , protobuf
-, release ? true
 , sources
+, xfsprogs
 , utillinux
 }:
 let
@@ -23,7 +25,6 @@ let
     rustc = channel.stable.rust;
     cargo = channel.stable.cargo;
   };
-
   whitelistSource = src: allowedPrefixes:
     builtins.filterSource
       (path: type:
@@ -32,53 +33,91 @@ let
             lib.hasPrefix (toString (src + "/${allowedPrefix}")) path)
           allowedPrefixes)
       src;
+
+  version_drv = import ../../lib/version.nix { inherit lib stdenv git; };
+  version = builtins.readFile "${version_drv}";
+
+  buildProps = rec {
+    name = "mayastor";
+    #cargoSha256 = "0000000000000000000000000000000000000000000000000000";
+    cargoSha256 = "0kwyr8jq2j6qy9635rc2r9v41gybc9r3z3s4vpzd3h0xcsa3lvff";
+    inherit version;
+    src = whitelistSource ../../../. [
+      "Cargo.lock"
+      "Cargo.toml"
+      "cli"
+      "csi"
+      "devinfo"
+      "jsonrpc"
+      "mayastor"
+      "nvmeadm"
+      "rpc"
+      "spdk-sys"
+      "sysfs"
+    ];
+
+    LIBCLANG_PATH = "${llvmPackages.libclang}/lib";
+    PROTOC = "${protobuf}/bin/protoc";
+    PROTOC_INCLUDE = "${protobuf}/include";
+    SPDK_PATH = "${libspdk}";
+
+    nativeBuildInputs = [
+      clang
+      pkg-config
+    ];
+    buildInputs = [
+      llvmPackages.libclang
+      protobuf
+      libaio
+      libiscsi.lib
+      libspdk
+      libudev
+      liburing
+      numactl
+      openssl
+      utillinux
+    ];
+    verifyCargoDeps = false;
+    doCheck = false;
+    meta = { platforms = stdenv.lib.platforms.linux; };
+  };
 in
-rustPlatform.buildRustPackage rec {
-  name = "mayastor";
-  #cargoSha256 = "0000000000000000000000000000000000000000000000000000";
-  cargoSha256 = "0kwyr8jq2j6qy9635rc2r9v41gybc9r3z3s4vpzd3h0xcsa3lvff";
-  version = sources.mayastor.branch;
-  src = if release then sources.mayastor else
-  whitelistSource ../../../. [
-    "Cargo.lock"
-    "Cargo.toml"
-    "cli"
-    "csi"
-    "devinfo"
-    "jsonrpc"
-    "mayastor"
-    "nvmeadm"
-    "rpc"
-    "spdk-sys"
-    "sysfs"
-  ];
+{
+  release = rustPlatform.buildRustPackage (buildProps // { buildType = "release"; });
+  # TODO: We want more changes for debug flavour, i.e. spdk configured with debug
+  debug = rustPlatform.buildRustPackage (buildProps // { buildType = "debug"; });
+  # this is for image that does not do a build of mayastor
+  adhoc = stdenv.mkDerivation {
+    name = "mayastor-adhoc";
+    inherit version;
+    src = [
+      ../../../target/debug/mayastor
+      ../../../target/debug/mayastor-csi
+      ../../../target/debug/mayastor-client
+      ../../../target/debug/jsonrpc
+    ];
 
-  LIBCLANG_PATH = "${llvmPackages.libclang}/lib";
+    buildInputs = [
+      libaio
+      libiscsi.lib
+      libspdk
+      liburing
+      libudev
+      openssl
+      xfsprogs
+      e2fsprogs
+    ];
 
-  PROTOC = "${protobuf}/bin/protoc";
-  PROTOC_INCLUDE = "${protobuf}/include";
-  SPDK_PATH = "${libspdk}";
-  nativeBuildInputs = [
-    clang
-    pkg-config
-  ];
-
-  buildInputs = [
-    llvmPackages.libclang
-    protobuf
-    libaio
-    libiscsi.lib
-    libspdk
-    libudev
-    liburing
-    numactl
-    openssl
-    utillinux
-  ];
-
-  buildType = if release then "release" else "debug";
-  verifyCargoDeps = false;
-
-  doCheck = false;
-  meta = { platforms = stdenv.lib.platforms.linux; };
+    unpackPhase = ''
+      for srcFile in $src; do
+         cp $srcFile $(stripHash $srcFile)
+      done
+    '';
+    dontBuild = true;
+    dontConfigure = true;
+    installPhase = ''
+      mkdir -p $out/bin
+      install * $out/bin
+    '';
+  };
 }

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -23,20 +23,6 @@
         "url": "https://github.com/axboe/liburing/archive/f0c5c54945ae92a00cdbb43bdf3abaeab6bd3a23.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
-    "mayastor": {
-        "branch": "v0.3.0",
-        "cargosha256": "1234",
-        "description": "A cloud native declarative data plane in containers for containers",
-        "homepage": null,
-        "owner": "openebs",
-        "repo": "mayastor",
-        "rev": "8470ac075112aca9533db5ffb8367b8e3f8d14c1",
-        "sha256": "1g9n6rhiggirmw2gjas7wig0p8jgkqnnbvfcqknn7257clc3pp5q",
-        "type": "tarball",
-        "url": "https://github.com/openebs/mayastor/archive/8470ac075112aca9533db5ffb8367b8e3f8d14c1.tar.gz",
-        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz",
-        "version": "0.3.0"
-    },
     "niv": {
         "branch": "master",
         "description": "Easy dependency management for Nix projects",

--- a/nix/test/basic/fio_nvme_basic.nix
+++ b/nix/test/basic/fio_nvme_basic.nix
@@ -31,7 +31,7 @@ in
 
       environment = {
         systemPackages = with pkgs; [
-          images.mayastor-develop
+          mayastor
         ];
 
         etc."mayastor-config.yaml" = {
@@ -50,7 +50,7 @@ in
         };
 
         serviceConfig = {
-          ExecStart = "${pkgs.images.mayastor-develop}/bin/mayastor -g 0.0.0.0:10124 -y /etc/mayastor-config.yaml";
+          ExecStart = "${pkgs.mayastor}/bin/mayastor -g 0.0.0.0:10124 -y /etc/mayastor-config.yaml";
         };
       };
     };

--- a/nix/test/rebuild/rebuild.nix
+++ b/nix/test/rebuild/rebuild.nix
@@ -34,7 +34,7 @@ in
 
       environment = {
         systemPackages = with pkgs; [
-          images.mayastor-develop
+          mayastor
         ];
 
         etc."mayastor-config.yaml" = {
@@ -53,7 +53,7 @@ in
         };
 
         serviceConfig = {
-          ExecStart = "${pkgs.images.mayastor-develop}/bin/mayastor -g 0.0.0.0:10124 -y /etc/mayastor-config.yaml";
+          ExecStart = "${pkgs.mayastor}/bin/mayastor -g 0.0.0.0:10124 -y /etc/mayastor-config.yaml";
         };
       };
     };
@@ -78,7 +78,7 @@ in
 
       environment = {
         systemPackages = with pkgs; [
-          images.mayastor-develop
+          mayastor
         ];
 
         etc."mayastor-config.yaml" = {
@@ -97,7 +97,7 @@ in
         };
 
         serviceConfig = {
-          ExecStart = "${pkgs.images.mayastor-develop}/bin/mayastor -g 0.0.0.0:10124 -y /etc/mayastor-config.yaml";
+          ExecStart = "${pkgs.mayastor}/bin/mayastor -g 0.0.0.0:10124 -y /etc/mayastor-config.yaml";
         };
       };
     };

--- a/terraform/README.adoc
+++ b/terraform/README.adoc
@@ -271,7 +271,7 @@ mayastor-csi images. Replace "hostname" by the name of your registry host.
 
 [source,bash]
 ----
-nix-build '<nixpkgs>' -A node-moacImage
+nix-build '<nixpkgs>' -A images.moac-image
 docker load <result
 docker tag mayadata/moac hostname:5000/moac:latest
 docker push hostname:5000/moac:latest
@@ -279,7 +279,7 @@ docker push hostname:5000/moac:latest
 
 [source,bash]
 ----
-nix-build '<nixpkgs>' -A node-moacImage
+nix-build '<nixpkgs>' -A images.moac-image
 skopeo copy --dest-tls-verify=false docker-archive:result docker://hostname:5000/mayadata/moac:latest
 ----
 


### PR DESCRIPTION
There are two flavours of mayastor nix package: mayastor and
mayastor-dev. The same for csi plugin package mayastor-csi and
mayastor-csi-dev. They don't get accidentaly confused by the build
system as was happening before with "release" parameter that made
creating the release packages very error-prone.

Overhaul of nix code for creating docker images. No code duplication
and intuitive target names. All image targets end with "-image" suffix.
The flavour of the package that the image is based on (if any) preceeds
the suffix (i.e. dev or adhoc). Nix code for moac image is part of
images now and follows the same rules.

We are able to derive the accurate version number of mayastor package
in fully automated way. It uses a git command to lookup a tag of the
top-most commit and if the tag does not exist, it uses short commit hash.
We don't need to update the files by hand to change the tag anymore.

Example of how to create release images for v0.3.0:
```
git checkout v0.3.0
nix-build --no-out-link -A images.mayastor-image
nix-build --no-out-link -A images.mayastor-csi-image
nix-build --no-out-link -A images.moac-image
```

and debug images for the same release:
```
git checkout v0.3.0
nix-build --no-out-link -A images.mayastor-dev-image
nix-build --no-out-link -A images.mayastor-csi-dev-image
nix-build --no-out-link -A images.moac-image
```