### PR TITLE
add tini init system to the fio container

### DIFF
--- a/deploy/fio.yaml
+++ b/deploy/fio.yaml
@@ -9,7 +9,8 @@ spec:
        claimName: ms-volume-claim
   containers:
     - name: fio
-      image: nixery.dev/shell/fio
+      image: nixery.dev/shell/fio/tini
+      command: [ "tini", "--" ]
       args:
         - sleep
         - "1000000"


### PR DESCRIPTION
tini handles signals properly allowing k8s to kill the container
with SIGTERM and thus avoid the grace period followed by SIGKILL