### PR TITLE
CAS-402: Fix cancel_child_rebuild_jobs

### DIFF
--- a/mayastor/src/bdev/nexus/nexus_bdev_children.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev_children.rs
@@ -232,13 +232,13 @@ impl Nexus {
         self.child_count -= 1;
         self.reconfigure(DREvent::ChildRemove).await;
 
-        child.destroy().await.context(DestroyChild {
+        let result = child.destroy().await.context(DestroyChild {
             name: self.name.clone(),
             child: uri,
-        })?;
+        });
 
         self.start_rebuild_jobs(cancelled_rebuilding_children).await;
-        Ok(())
+        result
     }
 
     /// offline a child device and reconfigure the IO channels

--- a/mayastor/src/rebuild/rebuild_impl.rs
+++ b/mayastor/src/rebuild/rebuild_impl.rs
@@ -121,7 +121,7 @@ impl RebuildJob {
         })?;
         let destination_hdl = BdevHandle::open(
             &bdev_get_name(destination).context(BdevInvalidURI {
-                uri: source.to_string(),
+                uri: destination.to_string(),
             })?,
             true,
             false,

--- a/mayastor/tests/nexus_rebuild.rs
+++ b/mayastor/tests/nexus_rebuild.rs
@@ -463,7 +463,7 @@ fn rebuild_lookup() {
         }
 
         let _ = nexus.start_rebuild(&get_dev(children)).await.unwrap();
-        for child in 0 .. children - 1 {
+        for child in 0 .. children {
             RebuildJob::lookup(&get_dev(child))
                 .expect_err("rebuild job not created yet");
         }


### PR DESCRIPTION
The cancel_child_rebuild_jobs function was, among other things,
cancelling all rebuild jobs with the child as a source, and then
restarting them with the intention that they would use a different
source child. In reality, the same source child could be chosen as the
state of the child was typically updated after the call to this function.

This fix splits the function into two separate cancel and start
functions. The caller is responsible for first cancelling the rebuilds,
then updating the child state appropriately before finally restarting
any previously cancelled rebuild jobs.

Additional fixes:
1. Fix the rebuild_lookup test to iterate over all "non-added" children.
2. Fix the uri in the destination handle error message.