### PR TITLE
CAS-424: import volumes on startup

### DIFF
--- a/csi/moac/crds/mayastorvolume.yaml
+++ b/csi/moac/crds/mayastorvolume.yaml
@@ -75,6 +75,9 @@ spec:
               description: The maximum size of the volume (if zero then same as the requiredBytes).
               type: integer
               minimum: 0
+            protocol:
+              description: Share protocol of the nexus
+              type: string
         status:
           description: Properties related to current state of the volume.
           type: object

--- a/csi/moac/csi.js
+++ b/csi/moac/csi.js
@@ -373,7 +373,8 @@ class CsiServer {
         preferredNodes: shouldNodes,
         requiredNodes: mustNodes,
         requiredBytes: args.capacityRange.requiredBytes,
-        limitBytes: args.capacityRange.limitBytes
+        limitBytes: args.capacityRange.limitBytes,
+        protocol: protocol
       });
     } catch (err) {
       return cb(err);

--- a/csi/moac/test/csi_test.js
+++ b/csi/moac/test/csi_test.js
@@ -200,7 +200,8 @@ module.exports = function () {
         preferredNodes: [],
         requiredNodes: [],
         requiredBytes: 10,
-        limitBytes: 20
+        limitBytes: 20,
+        protocol: 'nbd'
       });
       sinon.stub(returnedVolume, 'getSize').returns(20);
       sinon.stub(returnedVolume, 'getNodeName').returns('some-node');
@@ -400,7 +401,8 @@ module.exports = function () {
           preferredNodes: [],
           requiredNodes: ['node'],
           requiredBytes: 50,
-          limitBytes: 0
+          limitBytes: 0,
+          protocol: 'nbd'
         });
       });
 
@@ -436,7 +438,8 @@ module.exports = function () {
           preferredNodes: ['node'],
           requiredNodes: [],
           requiredBytes: 50,
-          limitBytes: 50
+          limitBytes: 50,
+          protocol: 'nbd'
         });
       });
 
@@ -461,7 +464,8 @@ module.exports = function () {
           preferredNodes: [],
           requiredNodes: [],
           requiredBytes: 50,
-          limitBytes: 70
+          limitBytes: 70,
+          protocol: 'nbd'
         });
       });
 

--- a/csi/moac/volume.js
+++ b/csi/moac/volume.js
@@ -23,8 +23,10 @@ class Volume {
   // @params {string[]} spec.requiredNodes   Replicas must be on these nodes.
   // @params {number}   spec.requiredBytes   The volume must have at least this size.
   // @params {number}   spec.limitBytes      The volume should not be bigger than this.
+  // @params {string}   spec.protocol        The share protocol for the nexus.
+  // @params {object}   [size=0]             Current properties of the volume.
   //
-  constructor (uuid, registry, spec) {
+  constructor (uuid, registry, spec, size = 0) {
     assert(spec);
     // specification of the volume
     this.uuid = uuid;
@@ -34,7 +36,8 @@ class Volume {
     this.requiredNodes = _.clone(spec.requiredNodes || []).sort();
     this.requiredBytes = spec.requiredBytes;
     this.limitBytes = spec.limitBytes;
-    this.size = 0;
+    this.protocol = spec.protocol;
+    this.size = size;
     // state variables of the volume
     this.nexus = null;
     this.replicas = {}; // replicas indexed by node name
@@ -545,6 +548,7 @@ class Volume {
   // @params {string[]} spec.requiredNodes   Replicas must be on these nodes.
   // @params {number}   spec.requiredBytes   The volume must have at least this size.
   // @params {number}   spec.limitBytes      The volume should not be bigger than this.
+  // @params {string}   spec.protocol        The share protocol for the nexus.
   // @returns {boolean} True if the volume spec has changed, false otherwise.
   //
   update (spec) {
@@ -560,6 +564,12 @@ class Volume {
       throw new GrpcError(
         GrpcCode.INVALID_ARGUMENT,
         `Shrinking the volume "${this}" is not supported`
+      );
+    }
+    if (this.protocol !== spec.protocol) {
+      throw new GrpcError(
+        GrpcCode.INVALID_ARGUMENT,
+        `Changing the protocol for volume "${this}" is not supported`
       );
     }
 

--- a/mayastor-test/test_nexus.js
+++ b/mayastor-test/test_nexus.js
@@ -282,7 +282,7 @@ describe('nexus', function () {
             '-r',
             '/tmp/target.sock',
             '-s',
-            '128',
+            '128'
           ]);
           next();
         },

--- a/mayastor/src/subsys/config/mod.rs
+++ b/mayastor/src/subsys/config/mod.rs
@@ -246,7 +246,7 @@ impl Config {
             base_bdevs: None,
             nexus_bdevs: None,
             pools: None,
-            implicit_share_base: true,
+            implicit_share_base: self.implicit_share_base,
             err_store_opts: self.err_store_opts.get(),
             sync_disable: self.sync_disable,
         };


### PR DESCRIPTION
Moac should not attempt to recreate new volumes based on the existing
CRDs on startup as this could lead to having a completely new data.
Rather, it now simply imports them and attaches existing replicas.

If a replica is currently not online then at the moment it will be
removed. Unfortunately there is an issue when trying to add a replica
from the same node again, see cas-426