### PR TITLE
Want simple performance tool

### DIFF
--- a/mayastor/Cargo.toml
+++ b/mayastor/Cargo.toml
@@ -28,6 +28,10 @@ path = "src/bin/cli/cli.rs"
 name = "jsonrpc"
 path = "src/bin/jsonrpc.rs"
 
+[[bin]]
+name = "casperf"
+path = "src/bin/casperf.rs"
+
 [dependencies]
 async-task = "3.0"
 async-trait = "0.1.36"

--- a/mayastor/src/bdev/dev.rs
+++ b/mayastor/src/bdev/dev.rs
@@ -56,12 +56,10 @@ impl Uri {
 
             // retain this for the time being for backwards compatibility
             "bdev" => Ok(Box::new(loopback::Loopback::try_from(&url)?)),
-
-            // backend iSCSI target - most stable
-            "iscsi" => Ok(Box::new(iscsi::Iscsi::try_from(&url)?)),
-
             // arbitrary bdev found in spdk (used for local replicas)
             "loopback" => Ok(Box::new(loopback::Loopback::try_from(&url)?)),
+            // backend iSCSI target - most stable
+            "iscsi" => Ok(Box::new(iscsi::Iscsi::try_from(&url)?)),
 
             // backend NVMF target - fairly unstable (as of Linux 5.2)
             "nvmf" => Ok(Box::new(nvmf::Nvmf::try_from(&url)?)),

--- a/mayastor/src/bdev/nexus/nexus_bdev_children.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev_children.rs
@@ -419,7 +419,7 @@ impl Nexus {
                         self.name, *s, self.bdev.alignment()
                     );
                     unsafe {
-                        (*self.bdev.as_ptr()).required_alignment = *s;
+                        (*self.bdev.as_ptr()).required_alignment = *s as u8;
                     }
                 }
             })

--- a/mayastor/src/bdev/nexus/nexus_child.rs
+++ b/mayastor/src/bdev/nexus/nexus_child.rs
@@ -423,7 +423,7 @@ impl NexusChild {
         &self,
         offset: u64,
         buf: &mut DmaBuf,
-    ) -> Result<usize, ChildIoError> {
+    ) -> Result<u64, ChildIoError> {
         match self.bdev_handle.as_ref() {
             Some(desc) => {
                 Ok(desc.read_at(offset, buf).await.context(ReadError {

--- a/mayastor/src/bdev/nexus/nexus_label.rs
+++ b/mayastor/src/bdev/nexus/nexus_label.rs
@@ -237,13 +237,11 @@ impl Nexus {
             block_size,
         );
         // allocate 2 extra blocks for the MBR and GPT header respectively
-        let mut buf = DmaBuf::new(
-            ((blocks + 2) * block_size) as usize,
-            self.bdev.alignment(),
-        )
-        .context(WriteAlloc {
-            name: String::from("primary"),
-        })?;
+        let mut buf =
+            DmaBuf::new((blocks + 2) * block_size, self.bdev.alignment())
+                .context(WriteAlloc {
+                    name: String::from("primary"),
+                })?;
         let mut writer = Cursor::new(buf.as_mut_slice());
 
         // Protective MBR
@@ -281,13 +279,11 @@ impl Nexus {
             block_size,
         );
         // allocate 1 extra block for the GPT header
-        let mut buf = DmaBuf::new(
-            ((blocks + 1) * block_size) as usize,
-            self.bdev.alignment(),
-        )
-        .context(WriteAlloc {
-            name: String::from("secondary"),
-        })?;
+        let mut buf =
+            DmaBuf::new((blocks + 1) * block_size, self.bdev.alignment())
+                .context(WriteAlloc {
+                    name: String::from("secondary"),
+                })?;
         let mut writer = Cursor::new(buf.as_mut_slice());
 
         // Secondary partition table
@@ -923,10 +919,9 @@ impl NexusChild {
 
         //
         // Protective MBR
-        let mut buf =
-            desc.dma_malloc(block_size as usize).context(ReadAlloc {
-                name: String::from("header"),
-            })?;
+        let mut buf = desc.dma_malloc(block_size).context(ReadAlloc {
+            name: String::from("header"),
+        })?;
         self.read_at(0, &mut buf).await.context(ReadError {
             name: String::from("MBR"),
         })?;
@@ -1027,11 +1022,10 @@ impl NexusChild {
             (active.entry_size * active.num_entries) as u64,
             block_size,
         );
-        let mut buf = desc.dma_malloc((blocks * block_size) as usize).context(
-            ReadAlloc {
+        let mut buf =
+            desc.dma_malloc(blocks * block_size).context(ReadAlloc {
                 name: String::from("partition table"),
-            },
-        )?;
+            })?;
         let offset = active.lba_table * block_size;
         self.read_at(offset, &mut buf).await.context(ReadError {
             name: String::from("partition table"),

--- a/mayastor/src/bdev/nexus/nexus_metadata.rs
+++ b/mayastor/src/bdev/nexus/nexus_metadata.rs
@@ -328,11 +328,10 @@ impl NexusChild {
             MetaDataHeader::METADATA_HEADER_SIZE as u64,
             block_size,
         );
-        let mut buf = desc.dma_malloc((blocks * block_size) as usize).context(
-            ReadAlloc {
+        let mut buf =
+            desc.dma_malloc(blocks * block_size).context(ReadAlloc {
                 name: String::from("header"),
-            },
-        )?;
+            })?;
         self.read_at((partition_lba + 1) * block_size, &mut buf)
             .await
             .context(ReadError {
@@ -347,9 +346,8 @@ impl NexusChild {
                 (header.used_entries * header.entry_size) as u64,
                 block_size,
             );
-            let mut buf = desc
-                .dma_malloc((blocks * block_size) as usize)
-                .context(ReadAlloc {
+            let mut buf =
+                desc.dma_malloc(blocks * block_size).context(ReadAlloc {
                     name: String::from("index"),
                 })?;
             self.read_at(
@@ -390,11 +388,10 @@ impl NexusChild {
         let block_size = bdev.block_len() as u64;
 
         let blocks = entry.data_end - entry.data_start + 1;
-        let mut buf = desc.dma_malloc((blocks * block_size) as usize).context(
-            ReadAlloc {
+        let mut buf =
+            desc.dma_malloc(blocks * block_size).context(ReadAlloc {
                 name: String::from("object"),
-            },
-        )?;
+            })?;
         self.read_at(
             (metadata.header.self_lba + entry.data_start) * block_size,
             &mut buf,
@@ -419,9 +416,8 @@ impl NexusChild {
 
         for entry in &metadata.index {
             let blocks = entry.data_end - entry.data_start + 1;
-            let mut buf = desc
-                .dma_malloc((blocks * block_size) as usize)
-                .context(ReadAlloc {
+            let mut buf =
+                desc.dma_malloc(blocks * block_size).context(ReadAlloc {
                     name: String::from("object"),
                 })?;
             self.read_at(
@@ -452,11 +448,10 @@ impl NexusChild {
                     as u64,
                 block_size,
             );
-        let mut buf =
-            DmaBuf::new((blocks * block_size) as usize, bdev.alignment())
-                .context(WriteAlloc {
-                    name: String::from("index"),
-                })?;
+        let mut buf = DmaBuf::new(blocks * block_size, bdev.alignment())
+            .context(WriteAlloc {
+                name: String::from("index"),
+            })?;
         let mut writer = Cursor::new(buf.as_mut_slice());
 
         // Header
@@ -525,11 +520,10 @@ impl NexusChild {
             return Err(MetaDataError::PartitionSizeExceeded {});
         }
 
-        let mut buf =
-            DmaBuf::new((blocks * block_size) as usize, bdev.alignment())
-                .context(WriteAlloc {
-                    name: String::from("object"),
-                })?;
+        let mut buf = DmaBuf::new(block_size * blocks, bdev.alignment())
+            .context(WriteAlloc {
+                name: String::from("object"),
+            })?;
         let mut writer = Cursor::new(buf.as_mut_slice());
 
         serialize_into(&mut writer, config).context(SerializeError {})?;
@@ -596,9 +590,8 @@ impl NexusChild {
                 return Err(MetaDataError::PartitionSizeExceeded {});
             }
 
-            let mut buf =
-                DmaBuf::new((blocks * block_size) as usize, bdev.alignment())
-                    .context(WriteAlloc {
+            let mut buf = DmaBuf::new(blocks * block_size, bdev.alignment())
+                .context(WriteAlloc {
                     name: String::from("object"),
                 })?;
             let mut writer = Cursor::new(buf.as_mut_slice());
@@ -661,13 +654,10 @@ impl NexusChild {
         for entry in &mut metadata.index {
             if entry.data_start > start {
                 let blocks = entry.data_end - entry.data_start;
-                let mut buf = DmaBuf::new(
-                    ((blocks + 1) * block_size) as usize,
-                    alignment,
-                )
-                .context(ReadAlloc {
-                    name: String::from("object"),
-                })?;
+                let mut buf = DmaBuf::new((blocks + 1) * block_size, alignment)
+                    .context(ReadAlloc {
+                        name: String::from("object"),
+                    })?;
                 self.read_at(
                     (self_lba + entry.data_start) * block_size,
                     &mut buf,

--- a/mayastor/src/bin/casperf.rs
+++ b/mayastor/src/bin/casperf.rs
@@ -1,0 +1,403 @@
+use std::{cell::RefCell, os::raw::c_void, ptr::NonNull};
+
+use clap::{value_t, App, AppSettings, Arg};
+use rand::Rng;
+
+use mayastor::{
+    core::{
+        mayastor_env_stop,
+        Bdev,
+        Cores,
+        Descriptor,
+        DmaBuf,
+        IoChannel,
+        MayastorCliArgs,
+        MayastorEnvironment,
+        Mthread,
+        Reactors,
+    },
+    logger,
+    nexus_uri::bdev_create,
+    subsys::Config,
+};
+use spdk_sys::{
+    spdk_bdev_free_io,
+    spdk_bdev_read,
+    spdk_bdev_write,
+    spdk_poller,
+    spdk_poller_unregister,
+};
+
+#[derive(Debug)]
+enum IoType {
+    /// perform random read operations
+    READ,
+    /// perform random write operations
+    #[allow(dead_code)]
+    WRITE,
+}
+
+/// default queue depth
+const QD: u64 = 64;
+/// default io_size
+const IO_SIZE: u64 = 512;
+
+/// a Job refers to a set of work typically defined by either time or size
+/// that drives IO to a bdev using its own channel.
+#[derive(Debug)]
+struct Job {
+    bdev: Bdev,
+    /// descriptor to the bdev
+    desc: Descriptor,
+    /// io channel being used to submit IO
+    ch: Option<IoChannel>,
+    /// queue depth configured for this job
+    qd: u64,
+    /// io_size the io_size is the number of blocks submit per IO
+    io_size: u64,
+    /// blk_size of the underlying device
+    blk_size: u32,
+    /// num_blocks the device has
+    num_blocks: u64,
+    /// aligned set of IOs we can do
+    io_blocks: u64,
+    /// io queue
+    queue: Vec<Io>,
+    /// number of IO's completed
+    n_io: u64,
+    /// number of IO's currently inflight
+    n_inflight: u32,
+    /// generate random number between 0 and num_block
+    rng: rand::rngs::ThreadRng,
+    /// drain the job which means that we wait for all pending IO to complete
+    /// and stop the run
+    drain: bool,
+    /// number of seconds we are running
+    period: u64,
+}
+thread_local! {
+    #[allow(clippy::vec_box)]
+    static JOBLIST: RefCell<Vec<Box<Job>>> = RefCell::new(Vec::new());
+    static PERF_TICK: RefCell<Option<NonNull<spdk_poller>>> = RefCell::new(None);
+}
+
+impl Job {
+    /// io completion callback
+    extern "C" fn io_completion(
+        bdev_io: *mut spdk_sys::spdk_bdev_io,
+        success: bool,
+        arg: *mut std::ffi::c_void,
+    ) {
+        let ioq: &mut Io = unsafe { &mut *arg.cast() };
+        let job = unsafe { ioq.job.as_mut() };
+
+        if !success {
+            eprintln!(
+                "IO error for bdev {}, LBA {}",
+                job.bdev.name(),
+                ioq.offset
+            );
+        }
+
+        job.n_io += 1;
+        job.n_inflight -= 1;
+
+        unsafe { spdk_bdev_free_io(bdev_io) }
+
+        if job.drain && job.n_inflight == 0 {
+            JOBLIST.with(|l| {
+                let mut list = l.borrow_mut();
+                list.retain(|this| job.bdev.name() != this.bdev.name());
+                if list.is_empty() {
+                    Reactors::master().send_future(async {
+                        mayastor_env_stop(0);
+                    });
+                }
+            });
+        }
+
+        if job.drain {
+            return;
+        }
+
+        let offset = (job.rng.gen::<u64>() % job.io_size) * job.io_blocks;
+        ioq.next(offset);
+    }
+
+    /// construct a new job
+    async fn new(bdev: &str, size: u64, qd: u64) -> Box<Self> {
+        let bdev = bdev_create(&bdev)
+            .await
+            .map_err(|e| {
+                eprintln!("Failed to open URI {}: {}", bdev, e.to_string());
+                std::process::exit(1);
+            })
+            .map(|name| Bdev::lookup_by_name(&name).unwrap())
+            .unwrap();
+
+        let desc = bdev.open(true).unwrap();
+
+        let blk_size = bdev.block_len();
+        let num_blocks = bdev.num_blocks();
+
+        let io_size = size / blk_size as u64;
+        let io_blocks = num_blocks / io_size;
+
+        let mut queue = Vec::new();
+
+        (0 ..= qd).for_each(|offset| {
+            queue.push(Io {
+                buf: DmaBuf::new(size, bdev.alignment()).unwrap(),
+                iot: IoType::READ,
+                offset,
+                job: NonNull::dangling(),
+            });
+        });
+
+        Box::new(Self {
+            bdev,
+            desc,
+            ch: None,
+            qd,
+            io_size: size,
+            blk_size,
+            num_blocks,
+            queue,
+            io_blocks,
+            n_io: 0,
+            n_inflight: 0,
+            rng: Default::default(),
+            drain: false,
+            period: 0,
+        })
+    }
+
+    fn as_ptr(&self) -> *mut Job {
+        self as *const _ as *mut _
+    }
+
+    /// start the job that will dispatch an IO up to the provided queue depth
+    fn run(mut self: Box<Self>) {
+        self.ch = self.desc.get_channel();
+        let ptr = self.as_ptr();
+        self.queue.iter_mut().for_each(|q| q.run(ptr));
+        JOBLIST.with(|l| l.borrow_mut().push(self));
+    }
+}
+
+#[derive(Debug)]
+struct Io {
+    /// buffer we read/write from/to
+    buf: DmaBuf,
+    /// type of IO we are supposed to issue
+    iot: IoType,
+    /// current offset where we are reading from
+    offset: u64,
+    /// pointer to our the job we belong too
+    job: NonNull<Job>,
+}
+
+impl Io {
+    /// start submitting
+    fn run(&mut self, job: *mut Job) {
+        self.job = NonNull::new(job).unwrap();
+        match self.iot {
+            IoType::READ => self.read(0),
+            IoType::WRITE => self.write(0),
+        };
+    }
+
+    /// dispatch the next IO, this is called from within the completion callback
+    pub fn next(&mut self, offset: u64) {
+        match self.iot {
+            IoType::READ => self.read(offset),
+            IoType::WRITE => self.write(offset),
+        }
+    }
+
+    /// dispatch the read IO at given offset
+    fn read(&mut self, offset: u64) {
+        unsafe {
+            if spdk_bdev_read(
+                self.job.as_ref().desc.as_ptr(),
+                self.job.as_ref().ch.as_ref().unwrap().as_ptr(),
+                *self.buf,
+                offset,
+                self.buf.len(),
+                Some(Job::io_completion),
+                self as *const _ as *mut _,
+            ) == 0
+            {
+                self.job.as_mut().n_inflight += 1;
+            } else {
+                eprintln!(
+                    "failed to submit read IO to {}",
+                    self.job.as_ref().bdev.name()
+                );
+            }
+        };
+    }
+
+    /// dispatch write IO at given offset
+    fn write(&mut self, offset: u64) {
+        unsafe {
+            if spdk_bdev_write(
+                self.job.as_ref().desc.as_ptr(),
+                self.job.as_ref().ch.as_ref().unwrap().as_ptr(),
+                *self.buf,
+                offset,
+                self.buf.len(),
+                Some(Job::io_completion),
+                self as *const _ as *mut _,
+            ) == 0
+            {
+                self.job.as_mut().n_inflight += 1;
+            } else {
+                eprintln!(
+                    "failed to submit write IO to {}",
+                    self.job.as_ref().bdev.name()
+                );
+            }
+        };
+    }
+}
+
+/// override the default signal handler as we need to stop the jobs first
+/// before we can shut down
+fn sig_override() {
+    let handler = || {
+        Mthread::get_init().msg((), |_| {
+            PERF_TICK.with(|t| {
+                let ticker = t.borrow_mut().take().unwrap();
+                unsafe { spdk_poller_unregister(&mut ticker.as_ptr()) }
+            });
+
+            println!("Draining jobs....");
+            JOBLIST.with(|l| {
+                l.borrow_mut().iter_mut().for_each(|j| j.drain = true);
+            });
+        });
+    };
+
+    unsafe {
+        signal_hook::register(signal_hook::SIGTERM, handler)
+            .expect("failed to set SIGTERM");
+        signal_hook::register(signal_hook::SIGINT, handler)
+            .expect("failed to set SIGINT");
+    };
+}
+
+/// prints the performance statistics to stdout on every tick (1s)
+extern "C" fn perf_tick(_: *mut c_void) -> i32 {
+    let mut total_io_per_second = 0;
+    let mut total_mb_per_second = 0;
+    JOBLIST.with(|l| {
+        for j in l.borrow_mut().iter_mut() {
+            j.period += 1;
+            let io_per_second = j.n_io / j.period;
+            let mb_per_second = io_per_second * j.io_size / (1024 * 1024);
+            println!(
+                "\r {:20}: {:10} IO/s {:10}: MB/s",
+                j.bdev.name(),
+                io_per_second,
+                mb_per_second
+            );
+            total_io_per_second += io_per_second;
+            total_mb_per_second += mb_per_second;
+        }
+
+        println!("\r ==================================================== +");
+        println!(
+            "\r {:20}: {:10} IO/s {:10}: MB/s\n",
+            "Total", total_io_per_second, total_mb_per_second
+        );
+    });
+    0
+}
+
+fn main() {
+    logger::init("INFO");
+
+    // dont not start the target(s)
+    Config::get_or_init(|| {
+        let mut cfg = Config::default();
+        cfg.nexus_opts.iscsi_enable = false;
+        cfg.nexus_opts.nvmf_enable = false;
+        cfg.sync_disable = true;
+        cfg
+    });
+
+    let matches = App::new("\nMayastor performance tool")
+        .version("0.1")
+        .settings(&[AppSettings::ColoredHelp, AppSettings::ColorAlways])
+        .about("Perform IO to storage URIs")
+        .arg(
+            Arg::with_name("io_size")
+                .value_name("io_size")
+                .short("b")
+                .help("block size in bytes")
+                .takes_value(true),
+        )
+        .arg(
+            Arg::with_name("queue_depth")
+                .value_name("queue_depth")
+                .short("q")
+                .help("queue depth")
+                .takes_value(true),
+        )
+        .arg(
+            Arg::with_name("URI")
+                .value_name("URI")
+                .help("storage URI's")
+                .index(1)
+                .multiple(true)
+                .takes_value(true),
+        )
+        .get_matches();
+
+    let mut uris = matches
+        .values_of("URI")
+        .unwrap()
+        .map(|u| u.to_string())
+        .collect::<Vec<_>>();
+
+    let io_size = value_t!(matches.value_of("io_size"), u64).unwrap_or(IO_SIZE);
+    let qd = value_t!(matches.value_of("queue_depth"), u64).unwrap_or(QD);
+    let mut args = MayastorCliArgs::default();
+
+    args.reactor_mask = "0x2".to_string();
+    //args.grpc_endpoint = Some("0.0.0.0".to_string());
+
+    let ms = MayastorEnvironment::new(args);
+    ms.start(move || {
+        sig_override();
+
+        Reactors::master().send_future(async move {
+            let jobs = uris
+                .iter_mut()
+                .map(|u| Job::new(u, io_size, qd))
+                .collect::<Vec<_>>();
+
+            for j in jobs {
+                let job = j.await;
+                let thread =
+                    Mthread::new(job.bdev.name(), Cores::current()).unwrap();
+                thread.msg(job, |job| {
+                    job.run();
+                });
+            }
+
+            unsafe {
+                PERF_TICK.with(|p| {
+                    *p.borrow_mut() =
+                        NonNull::new(spdk_sys::spdk_poller_register(
+                            Some(perf_tick),
+                            std::ptr::null_mut(),
+                            1_000_000,
+                        ))
+                });
+            }
+        });
+    })
+    .unwrap();
+}

--- a/mayastor/src/bin/initiator.rs
+++ b/mayastor/src/bin/initiator.rs
@@ -91,7 +91,7 @@ async fn read(uri: &str, offset: u64, file: &str) -> Result<()> {
     let bdev = create_bdev(uri).await?;
     let desc = Bdev::open(&bdev, false).unwrap().into_handle().unwrap();
     let mut buf = desc
-        .dma_malloc(desc.get_bdev().block_len() as usize)
+        .dma_malloc(desc.get_bdev().block_len() as usize as u64)
         .unwrap();
     let n = desc.read_at(offset, &mut buf).await?;
     fs::write(file, buf.as_slice())?;
@@ -104,11 +104,9 @@ async fn write(uri: &str, offset: u64, file: &str) -> Result<()> {
     let bdev = create_bdev(uri).await?;
     let bytes = fs::read(file)?;
     let desc = Bdev::open(&bdev, true).unwrap().into_handle().unwrap();
-    let mut buf = desc
-        .dma_malloc(desc.get_bdev().block_len() as usize)
-        .unwrap();
+    let mut buf = desc.dma_malloc(desc.get_bdev().block_len() as u64).unwrap();
     let mut n = buf.as_mut_slice().write(&bytes[..]).unwrap();
-    if n < buf.len() {
+    if n < buf.len() as usize {
         warn!("Writing a buffer which was not fully initialized from a file");
     }
     n = desc.write_at(offset, &buf).await?;

--- a/mayastor/src/core/bdev.rs
+++ b/mayastor/src/core/bdev.rs
@@ -15,6 +15,7 @@ use spdk_sys::{
     spdk_bdev_first,
     spdk_bdev_get_aliases,
     spdk_bdev_get_block_size,
+    spdk_bdev_get_buf_align,
     spdk_bdev_get_by_name,
     spdk_bdev_get_device_stat,
     spdk_bdev_get_name,
@@ -276,8 +277,8 @@ impl Bdev {
     }
 
     /// returns the alignment of the bdev
-    pub fn alignment(&self) -> u8 {
-        unsafe { self.0.as_ref().required_alignment }
+    pub fn alignment(&self) -> u64 {
+        unsafe { spdk_bdev_get_buf_align(self.0.as_ptr()) }
     }
 
     /// returns the configured product name

--- a/mayastor/src/core/handle.rs
+++ b/mayastor/src/core/handle.rs
@@ -75,7 +75,7 @@ impl BdevHandle {
 
     /// Allocate memory from the memory pool (the mem is zeroed out)
     /// with given size and proper alignment for the bdev.
-    pub fn dma_malloc(&self, size: usize) -> Result<DmaBuf, DmaError> {
+    pub fn dma_malloc(&self, size: u64) -> Result<DmaBuf, DmaError> {
         DmaBuf::new(size, self.desc.get_bdev().alignment())
     }
 
@@ -141,7 +141,7 @@ impl BdevHandle {
         &self,
         offset: u64,
         buffer: &mut DmaBuf,
-    ) -> Result<usize, CoreError> {
+    ) -> Result<u64, CoreError> {
         let (s, r) = oneshot::channel::<bool>();
         let errno = unsafe {
             spdk_bdev_read(

--- a/mayastor/src/core/mod.rs
+++ b/mayastor/src/core/mod.rs
@@ -63,7 +63,7 @@ pub enum CoreError {
     WriteDispatch {
         source: Errno,
         offset: u64,
-        len: usize,
+        len: u64,
     },
     #[snafu(display(
         "Failed to dispatch read at offset {} length {}",
@@ -73,7 +73,7 @@ pub enum CoreError {
     ReadDispatch {
         source: Errno,
         offset: u64,
-        len: usize,
+        len: u64,
     },
     #[snafu(display("Failed to dispatch reset",))]
     ResetDispatch {
@@ -87,12 +87,12 @@ pub enum CoreError {
     #[snafu(display("Write failed at offset {} length {}", offset, len))]
     WriteFailed {
         offset: u64,
-        len: usize,
+        len: u64,
     },
     #[snafu(display("Read failed at offset {} length {}", offset, len))]
     ReadFailed {
         offset: u64,
-        len: usize,
+        len: u64,
     },
     #[snafu(display("Reset failed"))]
     ResetFailed {},

--- a/mayastor/src/core/reactor.rs
+++ b/mayastor/src/core/reactor.rs
@@ -475,6 +475,7 @@ impl Reactor {
 
         self.receive_futures();
         self.run_futures();
+        drop(threads);
 
         while let Ok(i) = self.incoming.pop() {
             self.threads.borrow_mut().push_back(i);

--- a/mayastor/src/rebuild/rebuild_impl.rs
+++ b/mayastor/src/rebuild/rebuild_impl.rs
@@ -156,7 +156,7 @@ impl RebuildJob {
 
         for _ in 0 .. tasks.total {
             let copy_buffer = destination_hdl
-                .dma_malloc((segment_size_blks * block_size) as usize)
+                .dma_malloc(segment_size_blks * block_size)
                 .context(NoCopyBuffer {})?;
             tasks.tasks.push(RebuildTask {
                 buffer: copy_buffer,
@@ -323,7 +323,7 @@ impl RebuildJob {
 
             copy_buffer = self
                 .destination_hdl
-                .dma_malloc((segment_size_blks * self.block_size) as usize)
+                .dma_malloc(segment_size_blks * self.block_size)
                 .context(NoCopyBuffer {})?;
 
             &mut copy_buffer

--- a/spdk-sys/logwrapper.h
+++ b/spdk-sys/logwrapper.h
@@ -7,4 +7,3 @@ typedef void maya_logger(int level, const char *file, const int line,
 
 // pointer is set from within rust to point to our logging trampoline
 maya_logger *logfn = NULL;
-


### PR DESCRIPTION
This tool allows us to pump IO full speed to supported storage URI's.
The intent of this is to be able to test performance without the need
for setting up any targets and, subsequently, benchmark tools.

Its nowhere near as sophisticated as fio, but that's also not the
intent. The intent is to get good numbers but also, to assist in
testing/developing the handling of IO errors and rebuild.


The PR is a bit noisy as I removed some of the (needless) cast operations. This was an artifact still of the many upgraded we have done in the past. 

Right now, only READs are implemented (it is safer to develop)