### PR TITLE
CAS-407: moac pool resource ignored

### DIFF
--- a/csi/moac/test/node_stub.js
+++ b/csi/moac/test/node_stub.js
@@ -27,19 +27,18 @@ class NodeStub extends Node {
         return n;
       });
     }
+    // keep existing behaviour and set the fake node to synced by default
+    this.syncFailed = 0;
   }
 
   connect (endpoint) {
+    this.syncFailed = 0;
     this.endpoint = endpoint;
   }
 
   disconnect () {
+    this.syncFailed = this.syncBadLimit + 1;
     this.endpoint = null;
-  }
-
-  // the fake connect does not kick off sync so we pretend we are always in sync
-  isSynced () {
-    return true;
   }
 }
 


### PR DESCRIPTION
Sync Nodes with the pools on the 'mod' event as well as the 'sync'.

'sync' covers the case where the node has already been added to the
registry and synced which. In this case the event stream will replay
this and so we need to pre-populated the resource list.

'mod' is the other case where the pool custom resource gets processed
before the node is synced or when it is down.

Added a log message when resources are pre-populated which as otherwise
we might not see any indication of pools being processed.