### PR TITLE
Add mocha tests for CSI block volumes. CAS-379

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -441,6 +441,7 @@ dependencies = [
  "prost-types",
  "regex",
  "run_script",
+ "serde_json",
  "snafu",
  "sys-mount",
  "tokio",

--- a/csi/Cargo.toml
+++ b/csi/Cargo.toml
@@ -39,6 +39,7 @@ prost = "0.6"
 prost-derive = "0.6"
 prost-types = "0.6"
 regex = "1.3.6"
+serde_json = "1.0.40"
 snafu =  "0.6"
 sys-mount = "1.2"
 tokio = { version = "0.2", features = ["full"] }

--- a/csi/src/block_vol.rs
+++ b/csi/src/block_vol.rs
@@ -84,22 +84,7 @@ pub async fn publish_block_volume(
             }
         }
 
-        let devt = unsafe { libc::makedev(259, 254) };
-
-        let cstr_dst = std::ffi::CString::new(target_path.as_str()).unwrap();
-        let res =
-            unsafe { libc::mknod(cstr_dst.as_ptr(), libc::S_IFBLK, devt) };
-
-        if res != 0 {
-            let e = nix::errno::errno();
-            return Err(failure!(
-                Code::Internal,
-                "Failed to publish volume {}: mknod at {} failed: {}",
-                volume_id,
-                target_path,
-                e
-            ));
-        }
+        std::fs::File::create(&target_path)?;
 
         if let Err(error) = mount::blockdevice_mount(
             &device_path,

--- a/csi/src/block_vol.rs
+++ b/csi/src/block_vol.rs
@@ -233,6 +233,10 @@ fn equals_findmnt_device(findmnt_device_path: &str, device_path: &str) -> bool {
         if tmp == findmnt_device_path {
             return true;
         }
+        let tmp = format!("udev[/{}]", v[l - 1]);
+        if tmp == findmnt_device_path {
+            return true;
+        }
     }
     false
 }

--- a/csi/src/block_vol.rs
+++ b/csi/src/block_vol.rs
@@ -1,5 +1,8 @@
 //! Functions for CSI publish and unpublish block mode volumes.
 
+use serde_json::Value;
+use std::process::Command;
+
 use tonic::{Code, Status};
 
 macro_rules! failure {
@@ -10,6 +13,7 @@ macro_rules! failure {
 use crate::{
     csi::*,
     dev::Device,
+    error::DeviceError,
     mount::{self},
 };
 
@@ -49,6 +53,37 @@ pub async fn publish_block_volume(
             error
         )
     })? {
+        // Idempotency, if we have done this already just return success.
+        match findmnt_device(target_path) {
+            Ok(findmnt_dev) => {
+                if let Some(fm_devpath) = findmnt_dev {
+                    if equals_findmnt_device(&fm_devpath, &device_path) {
+                        debug!(
+                            "{}({}) is already mounted onto {}",
+                            fm_devpath, device_path, target_path
+                        );
+                        return Ok(());
+                    } else {
+                        failure!(
+                Code::Internal,
+                "Failed to publish volume {}: found device {} mounted at {}, not {}",
+                volume_id,
+                fm_devpath,
+                target_path,
+                device_path);
+                    }
+                }
+            }
+            Err(err) => {
+                failure!(
+            Code::Internal,
+            "Failed to publish volume {}: error whilst checking mount on {} : {}",
+            volume_id,
+            target_path,
+            err);
+            }
+        }
+
         let devt = unsafe { libc::makedev(259, 254) };
 
         let cstr_dst = std::ffi::CString::new(target_path.as_str()).unwrap();
@@ -56,11 +91,13 @@ pub async fn publish_block_volume(
             unsafe { libc::mknod(cstr_dst.as_ptr(), libc::S_IFBLK, devt) };
 
         if res != 0 {
+            let e = nix::errno::errno();
             return Err(failure!(
                 Code::Internal,
-                "Failed to publish volume {}: mknod at {} failed",
+                "Failed to publish volume {}: mknod at {} failed: {}",
                 volume_id,
-                target_path
+                target_path,
+                e
             ));
         }
 
@@ -80,8 +117,9 @@ pub async fn publish_block_volume(
     } else {
         Err(failure!(
             Code::Internal,
-            "Failed to publish volume {}: unable to retrieve device path",
-            volume_id
+            "Failed to publish volume {}: unable to retrieve device path for {}",
+            volume_id,
+            uri
         ))
     }
 }
@@ -117,4 +155,97 @@ pub fn unpublish_block_volume(
 
     info!("Volume {} unpublished from {}", volume_id, target_path);
     Ok(())
+}
+
+/// Keys of interest we expect to find in the JSON output generated
+/// by findmnt.
+const TARGET_KEY: &str = "target";
+const SOURCE_KEY: &str = "source";
+
+/// This function recurses over the de-serialised JSON returned by findmnt
+/// and searches for a target (file or directory) and returns the associated
+/// device if found.
+/// The assumptions made on the structure are:
+///  1. An object has keys named "target" and "source" for a mount point.
+///  2. An object may contain nested arrays of objects.
+///
+/// The search is deliberately generic (and hence slower) in an attempt to
+/// be more robust to future changes in findmnt.
+fn find_findmnt_target_device(
+    json_val: &serde_json::value::Value,
+    mountpoint: &str,
+) -> Result<Option<String>, DeviceError> {
+    if let Some(json_array) = json_val.as_array() {
+        for val in json_array {
+            if let Some(found) = find_findmnt_target_device(&val, mountpoint)? {
+                return Ok(Some(found));
+            }
+        }
+    }
+    if let Some(json_map) = json_val.as_object() {
+        if let Some(target) = json_map.get(TARGET_KEY) {
+            if let Some(source) = json_map.get(SOURCE_KEY) {
+                if mountpoint == target {
+                    if let Some(source_str) = source.as_str() {
+                        return Ok(Some(source_str.to_string()));
+                    } else {
+                        return Err(DeviceError {
+                            message: "findmnt empty source field".to_string(),
+                        });
+                    }
+                }
+            } else {
+                return Err(DeviceError {
+                    message: "findmnt missing source field".to_string(),
+                });
+            }
+        }
+        // If the object has arrays, then the assumption is that they are arrays
+        // of objects.
+        for (_, value) in json_map {
+            if value.is_array() {
+                if let Some(found) =
+                    find_findmnt_target_device(value, mountpoint)?
+                {
+                    return Ok(Some(found));
+                }
+            }
+        }
+    }
+    Ok(None)
+}
+
+/// findmnt command and arguments.
+const FINDMNT: &str = "findmnt";
+const FINDMNT_ARGS: [&str; 1] = ["-J"];
+
+/// Use the Linux utility findmnt to find the name of the device mounted at a
+/// directory or block special file, if any.
+fn findmnt_device(mountpoint: &str) -> Result<Option<String>, DeviceError> {
+    let output = Command::new(FINDMNT).args(&FINDMNT_ARGS).output()?;
+    if output.status.success() {
+        let json_str = String::from_utf8(output.stdout)?;
+        let json: Value = serde_json::from_str(&json_str)?;
+        if let Some(device) = find_findmnt_target_device(&json, mountpoint)? {
+            return Ok(Some(device));
+        }
+    }
+    Ok(None)
+}
+
+/// Unfortunately findmnt may return device names in a format different
+/// to that returned by udev.
+fn equals_findmnt_device(findmnt_device_path: &str, device_path: &str) -> bool {
+    if device_path == findmnt_device_path {
+        return true;
+    } else {
+        let v: Vec<&str> = device_path.split('/').collect();
+        let l = v.len();
+        assert_eq!(v[l - 2], "dev");
+        let tmp = format!("dev[/{}]", v[l - 1]);
+        if tmp == findmnt_device_path {
+            return true;
+        }
+    }
+    false
 }

--- a/csi/src/block_vol.rs
+++ b/csi/src/block_vol.rs
@@ -64,23 +64,25 @@ pub async fn publish_block_volume(
                         );
                         return Ok(());
                     } else {
-                        failure!(
-                Code::Internal,
-                "Failed to publish volume {}: found device {} mounted at {}, not {}",
-                volume_id,
-                fm_devpath,
-                target_path,
-                device_path);
+                        return Err(Status::new(
+                                Code::Internal,
+                                format!(
+                                    "Failed to publish volume {}: found device {} mounted at {}, not {}",
+                                    volume_id,
+                                    fm_devpath,
+                                    target_path,
+                                    device_path)));
                     }
                 }
             }
             Err(err) => {
-                failure!(
-            Code::Internal,
-            "Failed to publish volume {}: error whilst checking mount on {} : {}",
-            volume_id,
-            target_path,
-            err);
+                return Err(Status::new(
+                        Code::Internal,
+                        format!(
+                            "Failed to publish volume {}: error whilst checking mount on {} : {}",
+                            volume_id,
+                            target_path,
+                            err)));
             }
         }
 

--- a/csi/src/error.rs
+++ b/csi/src/error.rs
@@ -1,7 +1,8 @@
 //! Definition of DeviceError used by the attach and detach code.
+use std::string::FromUtf8Error;
 
 pub struct DeviceError {
-    message: String,
+    pub message: String,
 }
 
 impl DeviceError {
@@ -66,6 +67,22 @@ impl From<String> for DeviceError {
     fn from(message: String) -> DeviceError {
         DeviceError {
             message,
+        }
+    }
+}
+
+impl From<serde_json::error::Error> for DeviceError {
+    fn from(error: serde_json::error::Error) -> DeviceError {
+        DeviceError {
+            message: format!("{}", error),
+        }
+    }
+}
+
+impl From<FromUtf8Error> for DeviceError {
+    fn from(error: FromUtf8Error) -> DeviceError {
+        DeviceError {
+            message: format!("{}", error),
         }
     }
 }

--- a/mayastor-test/test_csi.js
+++ b/mayastor-test/test_csi.js
@@ -1006,7 +1006,6 @@ function csiProtocolTest (protoname, shareType, timeoutMillis) {
         var stagingPath2 = '/tmp/target4';
         var publishPath1 = '/tmp/blockvol1';
         var publishPath2 = '/tmp/blockvol2';
-        var publishPath3 = '/tmp/blockvol3';
 
         before((done) => {
           const stageArgs = {
@@ -1048,9 +1047,6 @@ function csiProtocolTest (protoname, shareType, timeoutMillis) {
               },
               (next) => {
                 cleanBlockMount(publishPath2, next);
-              },
-              (next) => {
-                cleanBlockMount(publishPath3, next);
               },
               (next) => {
                 cleanPublishDir(stagingPath, () => {
@@ -1099,9 +1095,6 @@ function csiProtocolTest (protoname, shareType, timeoutMillis) {
               },
               (next) => {
                 cleanBlockMount(publishPath2, next);
-              },
-              (next) => {
-                cleanBlockMount(publishPath3, next);
               }
             ],
             done
@@ -1138,7 +1131,7 @@ function csiProtocolTest (protoname, shareType, timeoutMillis) {
             volume_id: UUID5,
             publish_context: publishedUris[UUID5],
             staging_target_path: stagingPath2,
-            target_path: publishPath3,
+            target_path: publishPath1,
             volume_capability: {
               access_mode: {
                 mode: 'MULTI_NODE_READER_ONLY'

--- a/mayastor-test/test_csi.js
+++ b/mayastor-test/test_csi.js
@@ -81,10 +81,8 @@ function createPublishDir (mountTarget) {
 }
 
 function cleanBlockMount (blockfile, done) {
-  const proc = common.runAsRoot('umount', ['-f', blockfile]);
-  proc.once('close', (code, signal) => {
-    const proc = common.runAsRoot('rm', ['-f', blockfile]);
-    proc.once('close', (code, signal) => {
+  common.execAsRoot('umount', ['-f', blockfile], () => {
+    common.execAsRoot('rm', ['-f', blockfile], () => {
       done();
     });
   });

--- a/nix/pkgs/images/default.nix
+++ b/nix/pkgs/images/default.nix
@@ -14,11 +14,12 @@
 , mayastor
 , mayastor-dev
 , mayastor-adhoc
+, utillinux
 }:
 let
   versionDrv = import ../../lib/version.nix { inherit lib stdenv git; };
   version = builtins.readFile "${versionDrv}";
-  env = stdenv.lib.makeBinPath [ busybox xfsprogs e2fsprogs ];
+  env = stdenv.lib.makeBinPath [ busybox xfsprogs e2fsprogs utillinux ];
 
   # common props for all mayastor images
   mayastorImageProps = {

--- a/nix/pkgs/mayastor/default.nix
+++ b/nix/pkgs/mayastor/default.nix
@@ -41,7 +41,7 @@ let
   buildProps = rec {
     name = "mayastor";
     #cargoSha256 = "0000000000000000000000000000000000000000000000000000";
-    cargoSha256 = "1vqbspm30wwb9a7d8kjdwjsv3fq40k6qjsppcaddhdnc3v94i3n8";
+    cargoSha256 = "11jvjadvmy9gr206fgcd81zy7c0yni3zs510dcaic87rmnmij19s";
     inherit version;
     src = whitelistSource ../../../. [
       "Cargo.lock"


### PR DESCRIPTION
Also add an idempotency fix to block volume publishing.
We now use the findmnt utility to check if the device is already
mounted.
A side effect of that change is that we return an error in the
unlikely case that another device is mounted at the same location.