### PR TITLE
Lazy instance has previously been poisoned in rust tests (CAS-432)

### DIFF
--- a/mayastor/tests/reactor.rs
+++ b/mayastor/tests/reactor.rs
@@ -14,11 +14,12 @@ use pin_utils::core_reexport::time::Duration;
 
 pub mod common;
 
+// This test requires the system to have at least 2 cpus
 #[test]
 fn reactor_start_stop() {
     common::mayastor_test_init();
     let mut args = MayastorCliArgs::default();
-    args.reactor_mask = "0xF".to_string();
+    args.reactor_mask = "0x1".to_string();
     let ms = MayastorEnvironment::new(args);
 
     static mut WAIT_FOR: Lazy<AtomicUsize> =
@@ -51,6 +52,8 @@ fn reactor_start_stop() {
                 std::thread::sleep(Duration::from_secs(1));
 
                 let cpu = unsafe { libc::sched_getcpu() };
+                // TODO: The main thread does not know when this assertion
+                // triggers and the test will hapilly pass.
                 assert_eq!(cpu as u32 > Cores::last().id(), true)
             });
         });


### PR DESCRIPTION
Reactor test required the test system to have more than 4 cpus
otherwise test threads panic'd but not the main thread. Most of
the time the test passed while producing strange panic stacks in
the log, but sometimes the test failed with cryptic error message
in the description.

The requirement has changed to having at least 2 vcpus that most
likely all test machines will have. The problem with an error that
is not propagated to the main thread will be solved on behalf of
a different ticket.