### PR TITLE
CAS-17: auto pool names

### DIFF
--- a/deploy/pool.yaml
+++ b/deploy/pool.yaml
@@ -1,7 +1,8 @@
 apiVersion: "openebs.io/v1alpha1"
 kind: MayastorPool
 metadata:
-  name: pool
+  #name: unique
+  generateName: pool-
   namespace: mayastor
 spec:
   node: MYHOSTNAME


### PR DESCRIPTION
Use `generateName` in the msp example in the deployment directory.
With this users won't have to give their pools unique names