### PR TITLE
Correcting minor typo in nvmf target.rs

### DIFF
--- a/mayastor/src/subsys/nvmf/target.rs
+++ b/mayastor/src/subsys/nvmf/target.rs
@@ -369,7 +369,7 @@ impl Target {
     pub fn running(&mut self) {
         self.enable_discovery();
         info!(
-            "nvmf target accepting new connections and is ready to role..{}",
+            "nvmf target accepting new connections and is ready to roll..{}",
             '\u{1F483}'
         );
 


### PR DESCRIPTION
Correcting the log msg text emitted during the target's final init phase ("role" -> "roll")

Because it's Friday, we're on a commit roll and I want "in" on it :-)