### PR TITLE
snapshots: Perform snapshot operations on the management reactor

### DIFF
--- a/mayastor-test/test_replica.js
+++ b/mayastor-test/test_replica.js
@@ -619,33 +619,6 @@ describe('replica', function () {
       );
     });
 
-    // FIXME: test is disabled for now as it crashes
-
-    // it('should take snapshot on nvmf replica', (done) => {
-    //   common.execAsRoot(
-    //     common.getCmdPath('initiator'),
-    //     [uri, 'create-snapshot'],
-    //     done
-    //   );
-    // });
-    //
-    // it('should list the snapshot of the replica', (done) => {
-    //   client.listReplicas({}, (err, res) => {
-    //     if (err) return done(err);
-    //     res = res.replicas.filter((ent) => {
-    //       return ent.uuid.startsWith(UUID + '-snap-');
-    //     });
-    //     assert.lengthOf(res, 1);
-    //     res = res[0];
-    //     assert.equal(res.pool, POOL);
-    //     assert.equal(res.thin, false);
-    //     assert.equal(res.size, 96 * 1024 * 1024);
-    //     assert.equal(res.share, 'REPLICA_NONE');
-    //     assert.equal(res.uri.startsWith('bdev:///' + UUID + '-snap-'), true);
-    //     done();
-    //   });
-    // });
-
     it('should destroy nvmf replica', (done) => {
       client.destroyReplica({ uuid: UUID }, (err, res) => {
         if (err) return done(err);
@@ -700,6 +673,31 @@ describe('replica', function () {
         ],
         done
       );
+    });
+
+    it('should take snapshot on nvmf replica', (done) => {
+      common.execAsRoot(
+        common.getCmdPath('initiator'),
+        [uri, 'create-snapshot'],
+        done
+      );
+    });
+
+    it('should list the snapshot of the replica', (done) => {
+      client.listReplicas({}, (err, res) => {
+        if (err) return done(err);
+        res = res.replicas.filter((ent) => {
+          return ent.uuid.startsWith(UUID + '-snap-');
+        });
+        assert.lengthOf(res, 1);
+        res = res[0];
+        assert.equal(res.pool, POOL);
+        assert.equal(res.thin, false);
+        assert.equal(res.size, 4 * 1024 * 1024);
+        assert.equal(res.share, 'REPLICA_NONE');
+        assert.equal(res.uri.startsWith('bdev:///' + UUID + '-snap-'), true);
+        done();
+      });
     });
 
     it('should destroy nvmf replica', (done) => {

--- a/mayastor/src/replica.rs
+++ b/mayastor/src/replica.rs
@@ -281,7 +281,7 @@ impl Replica {
     }
 
     /// Create a snapshot
-    pub fn create_snapshot(
+    pub async fn create_snapshot(
         self,
         nvmf_req: *mut spdk_nvmf_request,
         snapshot_name: &str,

--- a/mayastor/src/subsys/nvmf/admin_cmd.rs
+++ b/mayastor/src/subsys/nvmf/admin_cmd.rs
@@ -4,7 +4,7 @@ use spdk_sys::{spdk_bdev, spdk_bdev_desc, spdk_io_channel, spdk_nvmf_request};
 
 use crate::{
     bdev::nexus::nexus_io::nvme_admin_opc,
-    core::{Bdev, Cores, Reactors},
+    core::{Bdev, Reactors},
     replica::Replica,
 };
 
@@ -50,8 +50,7 @@ extern "C" fn nvmf_create_snapshot_hdlr(req: *mut spdk_nvmf_request) -> i32 {
         };
         let snapshot_name = format!("{}-snap-{}", bd.name(), snapshot_time);
         // Blobfs operations must be on md_thread
-        let mgmt_reactor = Reactors::get_by_core(Cores::first()).unwrap();
-        mgmt_reactor.send_future(async move {
+        Reactors::master().send_future(async move {
             replica.create_snapshot(req, &snapshot_name).await;
         });
         1 // SPDK_NVMF_REQUEST_EXEC_STATUS_ASYNCHRONOUS

--- a/mayastor/tests/replica_snapshot.rs
+++ b/mayastor/tests/replica_snapshot.rs
@@ -1,0 +1,143 @@
+use std::{io, io::Write, process::Command, thread, time};
+
+use common::{bdev_io, ms_exec::MayastorProcess};
+use mayastor::{
+    bdev::nexus_create,
+    core::{
+        mayastor_env_stop,
+        BdevHandle,
+        CoreError,
+        MayastorCliArgs,
+        MayastorEnvironment,
+        Reactor,
+    },
+    subsys,
+    subsys::Config,
+};
+
+pub mod common;
+
+static DISKNAME1: &str = "/tmp/disk1.img";
+
+static DISKSIZE_KB: u64 = 128 * 1024;
+
+static CFGNAME1: &str = "/tmp/child1.yaml";
+static UUID1: &str = "00000000-76b6-4fcf-864d-1027d4038756";
+
+static NXNAME: &str = "replica_snapshot_test";
+
+fn generate_config() {
+    let mut config = Config::default();
+
+    config.implicit_share_base = true;
+    config.nexus_opts.iscsi_enable = false;
+    config.nexus_opts.nvmf_replica_port = 8430;
+    config.nexus_opts.nvmf_nexus_port = 8440;
+    let pool = subsys::Pool {
+        name: "pool0".to_string(),
+        disks: vec![DISKNAME1.to_string()],
+        blk_size: 512,
+        io_if: 1, // AIO
+        replicas: Default::default(),
+    };
+    config.pools = Some(vec![pool]);
+    config.write(CFGNAME1).unwrap();
+}
+
+fn start_mayastor(cfg: &str) -> MayastorProcess {
+    let args = vec![
+        "-s".to_string(),
+        "128".to_string(),
+        "-g".to_string(),
+        "127.0.0.1:10125".to_string(),
+        "-y".to_string(),
+        cfg.to_string(),
+    ];
+
+    MayastorProcess::new(Box::from(args)).unwrap()
+}
+
+fn conf_mayastor() {
+    // configuration yaml does not yet support creating replicas
+    let msc = "../target/debug/mayastor-client";
+    let output = Command::new(msc)
+        .args(&[
+            "-p",
+            "10125",
+            "replica",
+            "create",
+            "--protocol",
+            "nvmf",
+            "pool0",
+            UUID1,
+            "--size",
+            "64M",
+        ])
+        .output()
+        .expect("could not exec mayastor-client");
+
+    if !output.status.success() {
+        io::stderr().write_all(&output.stderr).unwrap();
+        panic!("failed to configure mayastor");
+    }
+}
+
+#[test]
+fn replica_snapshot() {
+    generate_config();
+
+    // Start with a fresh pool
+    common::delete_file(&[DISKNAME1.to_string()]);
+    common::truncate_file(DISKNAME1, DISKSIZE_KB);
+
+    let _ms1 = start_mayastor(CFGNAME1);
+    // Allow Mayastor process to start listening on NVMf port
+    thread::sleep(time::Duration::from_millis(250));
+
+    conf_mayastor();
+
+    test_init!();
+
+    Reactor::block_on(async {
+        create_nexus().await;
+        bdev_io::write_some(NXNAME).await.unwrap();
+        custom_nvme_admin(0xc1)
+            .await
+            .expect_err("unexpectedly succeeded invalid nvme admin command");
+        bdev_io::read_some(NXNAME).await.unwrap();
+        create_snapshot().await.unwrap();
+        // Check that IO to the replica still works after creating a snapshot
+        // Checking the snapshot itself is tbd
+        bdev_io::read_some(NXNAME).await.unwrap();
+        bdev_io::write_some(NXNAME).await.unwrap();
+        bdev_io::read_some(NXNAME).await.unwrap();
+    });
+    mayastor_env_stop(0);
+
+    common::delete_file(&[DISKNAME1.to_string()]);
+}
+
+async fn create_nexus() {
+    let ch = vec![
+        "nvmf://127.0.0.1:8430/nqn.2019-05.io.openebs:".to_string()
+            + &UUID1.to_string(),
+    ];
+
+    nexus_create(NXNAME, 64 * 1024 * 1024, None, &ch)
+        .await
+        .unwrap();
+}
+
+async fn create_snapshot() -> Result<(), CoreError> {
+    let h = BdevHandle::open(NXNAME, true, false).unwrap();
+    h.create_snapshot()
+        .await
+        .expect("failed to create snapshot");
+    Ok(())
+}
+
+async fn custom_nvme_admin(opc: u8) -> Result<(), CoreError> {
+    let h = BdevHandle::open(NXNAME, true, false).unwrap();
+    h.nvme_admin_custom(opc).await?;
+    Ok(())
+}


### PR DESCRIPTION
The call to vbdev_lvol_create_snapshot ultimately ends up in
spdk_bs_open_blob where it asserts that the current spdk thread is the
md_thread, which in Mayastor terms is the management reactor.

Ensure that by having nvmf_create_snapshot_hdlr call
Replica::create_snapshot via the management reactor. Addresses:

mayastor: blobstore.c:6677: bs_open_blob: Assertion `spdk_get_thread() == bs->md_thread' failed.

when running against a debug build of SPDK.

Re-enable the mocha test disabled in 0c1687ca and re-add the Rust
integration removed in 2e9acb9.

Resolves: CAS-404

Fixes: d909c1e ("replica: Implement create_snapshot")