### PR TITLE
CAS-392: Add create snapshot support to RPC and CLI

### DIFF
--- a/mayastor-test/test_snapshot.js
+++ b/mayastor-test/test_snapshot.js
@@ -1,0 +1,212 @@
+// Unit tests for nexus snapshot grpc api.
+
+'use strict';
+
+const assert = require('chai').assert;
+const async = require('async');
+const fs = require('fs');
+const common = require('./test_common');
+const enums = require('./grpc_enums');
+const UUID = 'dbe4d7eb-118a-4d15-b789-a18d9af6ff21';
+
+const replicaUuid = '00000000-76b6-4fcf-864d-1027d4038756';
+const poolName = 'pool0';
+// backend file for pool
+const poolFile = '/tmp/pool-backend';
+// 128MB is the size of pool
+const diskSize = 128 * 1024 * 1024;
+// 64MB is the size of replica
+const replicaSize = 64 * 1024 * 1024;
+
+// The config just for nvmf target which cannot run in the same process as
+// the nvmf initiator (SPDK limitation).
+const config = `
+sync_disable: true
+nexus_opts:
+  nvmf_enable: true
+  nvmf_discovery_enable: true
+  nvmf_nexus_port: 8440
+  nvmf_replica_port: 8430
+  iscsi_enable: false
+  iscsi_nexus_port: 3260
+  iscsi_replica_port: 3262
+`;
+
+var client, client2;
+var disks;
+
+describe('snapshot', function () {
+  this.timeout(10000); // for network tests we need long timeouts
+
+  before((done) => {
+    client = common.createGrpcClient();
+    if (!client) {
+      return done(new Error('Failed to initialize grpc client'));
+    }
+    client2 = common.createGrpcClient('127.0.0.1:10125');
+    if (!client2) {
+      return done(new Error('Failed to initialize grpc client for 2nd Mayastor instance'));
+    }
+    disks = ['aio://' + poolFile];
+
+    async.series(
+      [
+        // start this as early as possible to avoid mayastor getting connection refused.
+        (next) => {
+          // Start another mayastor instance for the remote nvmf target of the
+          // shared replica.
+          // SPDK hangs if nvme initiator and target are in the same instance.
+          //
+          // Use -s option to limit hugepage allocation.
+          common.startMayastor(null, [
+            '-r',
+            '/tmp/target.sock',
+            '-s',
+            '128',
+            '-g',
+            '127.0.0.1:10125'
+          ],
+          null,
+          config,
+          '_tgt');
+          common.waitFor((pingDone) => {
+            // use harmless method to test if the mayastor is up and running
+            client2.listPools({}, pingDone);
+          }, next);
+        },
+        (next) => {
+          fs.writeFile(poolFile, '', next);
+        },
+        (next) => {
+          fs.truncate(poolFile, diskSize, next);
+        },
+        (next) => {
+          common.startMayastor(null, ['-r', common.SOCK, '-g', common.grpcEndpoint, '-s', 384]);
+
+          common.waitFor((pingDone) => {
+            // use harmless method to test if the mayastor is up and running
+            client.listPools({}, pingDone);
+          }, next);
+        }
+      ],
+      done
+    );
+  });
+
+  after((done) => {
+    async.series(
+      [
+        common.stopAll,
+        (next) => {
+          fs.unlink(poolFile, (err) => {
+            if (err) console.log('unlink failed:', poolFile, err);
+            next();
+          });
+        }
+      ],
+      (err) => {
+        if (client2 != null) {
+          client2.close();
+        }
+        if (client != null) {
+          client.close();
+        }
+        done(err);
+      }
+    );
+  });
+
+  it('should create a pool with aio bdevs', (done) => {
+    // explicitly specify aio as that always works
+    client2.createPool(
+      { name: poolName, disks: disks, io_if: enums.POOL_IO_AIO },
+      (err, res) => {
+        if (err) return done(err);
+        assert.equal(res.name, poolName);
+        assert.equal(res.used, 0);
+        assert.equal(res.state, 'POOL_ONLINE');
+        assert.equal(res.disks.length, disks.length);
+        for (let i = 0; i < res.disks.length; ++i) {
+          assert.equal(res.disks[i].includes(disks[i]), true);
+        }
+        done();
+      }
+    );
+  });
+
+  it('should create a replica exported over nvmf', (done) => {
+    client2.createReplica(
+      {
+        uuid: replicaUuid,
+        pool: poolName,
+        thin: true,
+        share: 'REPLICA_NVMF',
+        size: replicaSize
+      },
+      (err, res) => {
+        if (err) return done(err);
+        assert.match(res.uri, /^nvmf:\/\//);
+        done();
+      }
+    );
+  });
+
+  it('should create a nexus with 1 nvmf replica', (done) => {
+    const args = {
+      uuid: UUID,
+      size: 131072,
+      children: ['nvmf://' + common.getMyIp() + ':8430/nqn.2019-05.io.openebs:' + replicaUuid]
+    };
+
+    client.createNexus(args, (err) => {
+      if (err) return done(err);
+      done();
+    });
+  });
+
+  it('should list the created nexus', (done) => {
+    client.listNexus({}, (err, res) => {
+      if (err) return done(err);
+      assert.lengthOf(res.nexus_list, 1);
+      const nexus = res.nexus_list[0];
+
+      const expectedChildren = 1;
+      assert.equal(nexus.uuid, UUID);
+      assert.equal(nexus.state, 'NEXUS_ONLINE');
+      assert.lengthOf(nexus.children, expectedChildren);
+      done();
+    });
+  });
+
+  it('should create a snapshot on the nexus', (done) => {
+    const args = { uuid: UUID };
+    client.createSnapshot(args, (err) => {
+      if (err) return done(err);
+      done();
+    });
+  });
+
+  it('should list the snapshot as a replica', (done) => {
+    client2.listReplicas({}, (err, res) => {
+      if (err) return done(err);
+
+      res = res.replicas.filter((ent) => ent.pool === poolName);
+      assert.lengthOf(res, 2);
+      res = res[1];
+
+      assert.equal(res.uuid.startsWith(replicaUuid + '-snap-'), true);
+      assert.equal(res.share, 'REPLICA_NONE');
+      assert.match(res.uri, /^bdev:\/\/\//);
+      done();
+    });
+  });
+
+  it('should remove the nexus', (done) => {
+    const args = { uuid: UUID };
+
+    client.destroyNexus(args, (err) => {
+      if (err) return done(err);
+      done();
+    });
+  });
+});

--- a/mayastor/src/bdev/nexus/mod.rs
+++ b/mayastor/src/bdev/nexus/mod.rs
@@ -15,6 +15,7 @@ macro_rules! c_str {
 pub mod nexus_bdev;
 pub mod nexus_bdev_children;
 pub mod nexus_bdev_rebuild;
+pub mod nexus_bdev_snapshot;
 mod nexus_channel;
 pub(crate) mod nexus_child;
 pub(crate) mod nexus_child_error_store;

--- a/mayastor/src/bdev/nexus/nexus_bdev.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev.rs
@@ -227,6 +227,10 @@ pub enum Error {
         name: String,
         state: String,
     },
+    #[snafu(display("Failed to get BdevHandle for snapshot operation"))]
+    FailedGetHandle,
+    #[snafu(display("Failed to create snapshot"))]
+    FailedCreateSnapshot,
 }
 
 impl From<Error> for tonic::Status {

--- a/mayastor/src/bdev/nexus/nexus_bdev_snapshot.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev_snapshot.rs
@@ -1,0 +1,25 @@
+//! Implements snapshot operations on a nexus.
+
+use rpc::mayastor::CreateSnapshotReply;
+
+use crate::{
+    bdev::nexus::nexus_bdev::{Error, Nexus},
+    core::BdevHandle,
+    replica::Replica,
+};
+
+impl Nexus {
+    /// Create a snapshot on all children
+    pub async fn create_snapshot(&self) -> Result<CreateSnapshotReply, Error> {
+        if let Ok(h) = BdevHandle::open_with_bdev(&self.bdev, true) {
+            match h.create_snapshot().await {
+                Ok(t) => Ok(CreateSnapshotReply {
+                    name: Replica::format_snapshot_name(&self.bdev.name(), t),
+                }),
+                Err(_e) => Err(Error::FailedCreateSnapshot),
+            }
+        } else {
+            Err(Error::FailedGetHandle)
+        }
+    }
+}

--- a/mayastor/src/bin/cli/cli.rs
+++ b/mayastor/src/bin/cli/cli.rs
@@ -18,6 +18,7 @@ mod nexus_cli;
 mod pool_cli;
 mod rebuild_cli;
 mod replica_cli;
+mod snapshot_cli;
 
 type MayaClient = MayastorClient<Channel>;
 type BdevClient = BdevRpcClient<Channel>;
@@ -76,6 +77,7 @@ async fn main() -> Result<(), Status> {
         .subcommand(replica_cli::subcommands())
         .subcommand(bdev_cli::subcommands())
         .subcommand(rebuild_cli::subcommands())
+        .subcommand(snapshot_cli::subcommands())
         .get_matches();
 
     let ctx = Context::new(&matches).await;
@@ -86,6 +88,7 @@ async fn main() -> Result<(), Status> {
         ("pool", Some(args)) => pool_cli::handler(ctx, args).await?,
         ("replica", Some(args)) => replica_cli::handler(ctx, args).await?,
         ("rebuild", Some(args)) => rebuild_cli::handler(ctx, args).await?,
+        ("snapshot", Some(args)) => snapshot_cli::handler(ctx, args).await?,
 
         _ => eprintln!("Internal Error: Not implemented"),
     };

--- a/mayastor/src/bin/cli/snapshot_cli.rs
+++ b/mayastor/src/bin/cli/snapshot_cli.rs
@@ -1,0 +1,54 @@
+//!
+//! methods to interact with snapshot management
+
+use crate::context::Context;
+use ::rpc::mayastor as rpc;
+use clap::{App, AppSettings, Arg, ArgMatches, SubCommand};
+use tonic::Status;
+
+pub async fn handler(
+    ctx: Context,
+    matches: &ArgMatches<'_>,
+) -> Result<(), Status> {
+    match matches.subcommand() {
+        ("create", Some(args)) => create(ctx, &args).await,
+        (cmd, _) => {
+            Err(Status::not_found(format!("command {} does not exist", cmd)))
+        }
+    }
+}
+
+pub fn subcommands<'a, 'b>() -> App<'a, 'b> {
+    let create = SubCommand::with_name("create")
+        .about("create a snapshot")
+        .arg(
+            Arg::with_name("uuid")
+                .required(true)
+                .index(1)
+                .help("uuid of the nexus"),
+        );
+
+    SubCommand::with_name("snapshot")
+        .settings(&[
+            AppSettings::SubcommandRequiredElseHelp,
+            AppSettings::ColoredHelp,
+            AppSettings::ColorAlways,
+        ])
+        .about("Snapshot management")
+        .subcommand(create)
+}
+
+async fn create(
+    mut ctx: Context,
+    matches: &ArgMatches<'_>,
+) -> Result<(), Status> {
+    let uuid = matches.value_of("uuid").unwrap().to_string();
+
+    ctx.client
+        .create_snapshot(rpc::CreateSnapshotRequest {
+            uuid: uuid.clone(),
+        })
+        .await?;
+    ctx.v1(&format!("Creating snapshot on nexus {}", uuid));
+    Ok(())
+}

--- a/mayastor/src/replica.rs
+++ b/mayastor/src/replica.rs
@@ -280,6 +280,12 @@ impl Replica {
         Ok(())
     }
 
+    /// Format snapshot name
+    /// base_name is the nexus or replica UUID
+    pub fn format_snapshot_name(base_name: &str, snapshot_time: u64) -> String {
+        format!("{}-snap-{}", base_name, snapshot_time)
+    }
+
     /// Create a snapshot
     pub async fn create_snapshot(
         self,

--- a/mayastor/src/subsys/nvmf/admin_cmd.rs
+++ b/mayastor/src/subsys/nvmf/admin_cmd.rs
@@ -48,7 +48,8 @@ extern "C" fn nvmf_create_snapshot_hdlr(req: *mut spdk_nvmf_request) -> i32 {
             cmd.__bindgen_anon_1.cdw10 as u64
                 | (cmd.__bindgen_anon_2.cdw11 as u64) << 32
         };
-        let snapshot_name = format!("{}-snap-{}", bd.name(), snapshot_time);
+        let snapshot_name =
+            Replica::format_snapshot_name(&bd.name(), snapshot_time);
         // Blobfs operations must be on md_thread
         Reactors::master().send_future(async move {
             replica.create_snapshot(req, &snapshot_name).await;

--- a/rpc/proto/mayastor.proto
+++ b/rpc/proto/mayastor.proto
@@ -60,6 +60,9 @@ service Mayastor {
   rpc ResumeRebuild (ResumeRebuildRequest) returns (Null) {}
   rpc GetRebuildState (RebuildStateRequest) returns (RebuildStateReply) {}
   rpc GetRebuildProgress (RebuildProgressRequest) returns (RebuildProgressReply) {}
+
+  // Snapshot operations
+  rpc CreateSnapshot (CreateSnapshotRequest) returns (CreateSnapshotReply) {}
 }
 
 // Means no arguments or no return value.
@@ -313,6 +316,14 @@ message RebuildProgressRequest {
 
 message RebuildProgressReply {
   uint32 progress = 1;  // progress percentage
+}
+
+message CreateSnapshotRequest {
+  string uuid = 1;  // uuid of the nexus
+}
+
+message CreateSnapshotReply {
+  string name = 1; // name of snapshot created
 }
 
 // Anything what follows here are private interfaces used for interacting with

--- a/scripts/node-test.sh
+++ b/scripts/node-test.sh
@@ -7,4 +7,5 @@ cargo build --all
 ( cd mayastor-test && ./node_modules/mocha/bin/mocha test_nexus.js )
 ( cd mayastor-test && ./node_modules/mocha/bin/mocha test_csi.js )
 ( cd mayastor-test && ./node_modules/mocha/bin/mocha test_rebuild.js )
+( cd mayastor-test && ./node_modules/mocha/bin/mocha test_snapshot.js )
 ( cd mayastor-test && ./node_modules/mocha/bin/mocha test_nats.js )


### PR DESCRIPTION
Implement create_snapshot against a nexus over gRPC and the
mayastor-client CLI. This basically calls BdevHandle::create_snapshot
which sends our vendor-specific NVMe Admin command to all children.

Returns name of the snapshot over gRPC, derived from the nexus name
but is not used anywhere else at the moment.

Add a mocha test for create_snapshot against a nexus with 1 child
replica over gRPC. This requires changes to functions in test_common
to allow more than 1 instance of Mayastor to be started and to ensure
that those multiple instances are stopped.