### PR TITLE
CAS-125: Restart rebuilds when Mayastor restarts

### DIFF
--- a/.github/workflows/nix-tests.yaml
+++ b/.github/workflows/nix-tests.yaml
@@ -24,3 +24,4 @@ jobs:
       - run: nix-build ./nix/test -A fio_nvme_basic
       - run: nix-build ./nix/test -A nvmf_distributed
       - run: nix-build ./nix/test -A nvmf_ports
+      - run: nix-build ./nix/test -A child_status

--- a/mayastor/src/bdev/mod.rs
+++ b/mayastor/src/bdev/mod.rs
@@ -11,6 +11,7 @@ pub use nexus::{
     },
     nexus_child::ChildStatus,
     nexus_child_error_store::{ActionType, NexusErrStore, QueryType},
+    nexus_child_status_config,
     nexus_label::{GPTHeader, GptEntry},
     nexus_metadata_content::{
         NexusConfig,

--- a/mayastor/src/bdev/nexus/mod.rs
+++ b/mayastor/src/bdev/nexus/mod.rs
@@ -19,6 +19,7 @@ pub mod nexus_bdev_snapshot;
 mod nexus_channel;
 pub(crate) mod nexus_child;
 pub(crate) mod nexus_child_error_store;
+pub mod nexus_child_status_config;
 mod nexus_config;
 pub mod nexus_fn_table;
 pub mod nexus_io;

--- a/mayastor/src/bdev/nexus/nexus_bdev_children.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev_children.rs
@@ -234,10 +234,10 @@ impl Nexus {
 
         let mut child = self.children.remove(idx);
         self.child_count -= 1;
-        self.reconfigure(DREvent::ChildRemove).await;
 
         // Update child status to remove this child
         NexusChild::save_state_change();
+        self.reconfigure(DREvent::ChildRemove).await;
 
         let result = child.destroy().await.context(DestroyChild {
             name: self.name.clone(),
@@ -321,7 +321,6 @@ impl Nexus {
                 child: name.to_owned(),
                 name: self.name.clone(),
             })?;
-            child.out_of_sync(true);
             self.start_rebuild(name).await.map(|_| {})?;
             Ok(self.status())
         } else {

--- a/mayastor/src/bdev/nexus/nexus_channel.rs
+++ b/mayastor/src/bdev/nexus/nexus_channel.rs
@@ -45,6 +45,8 @@ pub enum DREvent {
     ChildRemove,
     /// Child rebuild event
     ChildRebuild,
+    /// Child status information is being applied
+    ChildApplyStatus,
 }
 
 impl NexusChannelInner {
@@ -167,7 +169,8 @@ impl NexusChannel {
             | DREvent::ChildOnline
             | DREvent::ChildRemove
             | DREvent::ChildFault
-            | DREvent::ChildRebuild => unsafe {
+            | DREvent::ChildRebuild
+            | DREvent::ChildApplyStatus => unsafe {
                 spdk_for_each_channel(
                     device,
                     Some(NexusChannel::refresh_io_channels),

--- a/mayastor/src/bdev/nexus/nexus_channel.rs
+++ b/mayastor/src/bdev/nexus/nexus_channel.rs
@@ -46,7 +46,7 @@ pub enum DREvent {
     /// Child rebuild event
     ChildRebuild,
     /// Child status information is being applied
-    ChildApplyStatus,
+    ChildStatusSync,
 }
 
 impl NexusChannelInner {
@@ -170,7 +170,7 @@ impl NexusChannel {
             | DREvent::ChildRemove
             | DREvent::ChildFault
             | DREvent::ChildRebuild
-            | DREvent::ChildApplyStatus => unsafe {
+            | DREvent::ChildStatusSync => unsafe {
                 spdk_for_each_channel(
                     device,
                     Some(NexusChannel::refresh_io_channels),

--- a/mayastor/src/bdev/nexus/nexus_child.rs
+++ b/mayastor/src/bdev/nexus/nexus_child.rs
@@ -272,6 +272,7 @@ impl NexusChild {
         }
         self.open(parent_size).map(|s| {
             self.status_reasons.offline(false);
+            self.status_reasons.out_of_sync(true);
             NexusChild::save_state_change();
             s
         })

--- a/mayastor/src/bdev/nexus/nexus_child_status_config.rs
+++ b/mayastor/src/bdev/nexus/nexus_child_status_config.rs
@@ -1,0 +1,139 @@
+//! The purpose of this module is to persist child status information across
+//! Mayastor restarts.
+//!
+//! The load function should only be called when Mayastor is initialising. This
+//! will read in the child status information from the config file and use it to
+//! initialise the in-memory ChildStatusConfig structure. The apply function can
+//! then be called which will set the status of all children to match the
+//! configuration.
+//!
+//! The save function should be called whenever a child's status is updated.
+//! This will update the configuration file but WILL NOT update the in-memory
+//! ChildStatusConfig structure as this is only required on startup and not
+//! during runtime.
+
+use crate::bdev::nexus::{
+    instances,
+    nexus_channel::DREvent,
+    nexus_child::{NexusChild, StatusReasons},
+};
+use once_cell::sync::OnceCell;
+use serde::{Deserialize, Serialize};
+use std::{collections::HashMap, fs, fs::File, io::Write};
+
+type ChildName = String;
+pub const CONFIG_FILE: &str = "/tmp/child_status.yaml";
+pub static STATUS_CONFIG: OnceCell<ChildStatusConfig> = OnceCell::new();
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct ChildStatusConfig {
+    status: HashMap<ChildName, StatusReasons>,
+}
+
+impl Default for ChildStatusConfig {
+    fn default() -> Self {
+        Self {
+            status: Default::default(),
+        }
+    }
+}
+
+impl ChildStatusConfig {
+    /// Initialise the ChildStatusConfig structure by executing F and returning
+    /// a reference to the initialized data.
+    pub(crate) fn get_or_init<F>(f: F) -> &'static Self
+    where
+        F: FnOnce() -> ChildStatusConfig,
+    {
+        STATUS_CONFIG.get_or_init(f)
+    }
+
+    /// Similar to get_or_init above, but we do not need to pass a closure.
+    pub(crate) fn get() -> &'static Self {
+        STATUS_CONFIG.get().unwrap()
+    }
+
+    /// Load the configuration file if it exists otherwise use default values.
+    pub(crate) fn load() -> Result<ChildStatusConfig, ()> {
+        debug!("Loading configuration file from {}", CONFIG_FILE);
+        let cfg = fs::read(&CONFIG_FILE).unwrap_or_default();
+        if cfg.is_empty() {
+            Ok(ChildStatusConfig::default())
+        } else {
+            match serde_yaml::from_slice(&cfg) {
+                Ok(config) => Ok(config),
+                Err(e) => {
+                    error!("{}", e);
+                    Err(())
+                }
+            }
+        }
+    }
+
+    /// Apply the status in the configuration to each child.
+    pub(crate) async fn apply() {
+        debug!("Applying child status");
+        let store = &ChildStatusConfig::get().status;
+        for nexus in instances() {
+            nexus.children.iter_mut().for_each(|child| {
+                if let Some(status) = store.get(&child.name) {
+                    info!(
+                        "Apply state to child {}, reasons {:?}",
+                        child.name, status
+                    );
+                    child.status_reasons = *status;
+                }
+            });
+            nexus.reconfigure(DREvent::ChildApplyStatus).await;
+        }
+    }
+
+    /// A public wrapper around the actual save function.
+    pub(crate) fn save() -> Result<(), std::io::Error> {
+        ChildStatusConfig::do_save(None)
+    }
+
+    /// Save the status of all children to the configuration file.
+    fn do_save(cfg: Option<ChildStatusConfig>) -> Result<(), std::io::Error> {
+        debug!("Saving child status");
+        let mut status_cfg = match cfg {
+            Some(cfg) => cfg,
+            None => ChildStatusConfig {
+                status: HashMap::new(),
+            },
+        };
+
+        instances().iter().for_each(|nexus| {
+            nexus.children.iter().for_each(|child| {
+                status_cfg
+                    .status
+                    .insert(child.name.clone(), child.status_reasons);
+            });
+        });
+
+        match serde_yaml::to_string(&status_cfg) {
+            Ok(s) => {
+                let mut cfg_file = File::create(CONFIG_FILE)?;
+                cfg_file.write_all(s.as_bytes())
+            }
+            Err(_) => Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "failed to serialize status config",
+            )),
+        }
+    }
+
+    /// Add the child to the configuration and then save it.
+    /// The configuration is updated on a status change and expects the child to
+    /// already be listed as a nexus child. However, When a child is added,
+    /// the status is changed before it is added to the nexus children list.
+    /// Therefore, we have to explicitly add the child to the configuration
+    /// here.
+    pub(crate) fn add(child: &NexusChild) -> Result<(), std::io::Error> {
+        let mut cfg = ChildStatusConfig {
+            status: HashMap::new(),
+        };
+        cfg.status.insert(child.name.clone(), child.status_reasons);
+        ChildStatusConfig::do_save(Some(cfg))
+    }
+}

--- a/mayastor/src/bin/cli/cli.rs
+++ b/mayastor/src/bin/cli/cli.rs
@@ -14,6 +14,7 @@ use crate::context::Context;
 
 mod bdev_cli;
 mod context;
+mod nexus_child_cli;
 mod nexus_cli;
 mod pool_cli;
 mod rebuild_cli;

--- a/mayastor/src/bin/cli/nexus_child_cli.rs
+++ b/mayastor/src/bin/cli/nexus_child_cli.rs
@@ -1,0 +1,64 @@
+//!
+//! methods to interact with the nexus child
+
+use crate::context::Context;
+use ::rpc::mayastor as rpc;
+use clap::{App, AppSettings, Arg, ArgMatches, SubCommand};
+use tonic::Status;
+
+pub async fn handler(
+    ctx: Context,
+    matches: &ArgMatches<'_>,
+) -> Result<(), Status> {
+    match matches.subcommand() {
+        ("fault", Some(args)) => fault(ctx, &args).await,
+        (cmd, _) => {
+            Err(Status::not_found(format!("command {} does not exist", cmd)))
+        }
+    }
+}
+
+// TODO: Make subcommands use the name of the child rather than the uri
+pub fn subcommands<'a, 'b>() -> App<'a, 'b> {
+    let fault = SubCommand::with_name("fault")
+        .about("fault a child")
+        .arg(
+            Arg::with_name("uuid")
+                .required(true)
+                .index(1)
+                .help("uuid of the nexus"),
+        )
+        .arg(
+            Arg::with_name("uri")
+                .required(true)
+                .index(2)
+                .help("uri of the child"),
+        );
+
+    SubCommand::with_name("child")
+        .settings(&[
+            AppSettings::SubcommandRequiredElseHelp,
+            AppSettings::ColoredHelp,
+            AppSettings::ColorAlways,
+        ])
+        .about("Nexus child management")
+        .subcommand(fault)
+}
+
+async fn fault(
+    mut ctx: Context,
+    matches: &ArgMatches<'_>,
+) -> Result<(), Status> {
+    let uuid = matches.value_of("uuid").unwrap().to_string();
+    let uri = matches.value_of("uri").unwrap().to_string();
+
+    ctx.v2(&format!("Faulting child {} on nexus {}", uri, uuid));
+    ctx.client
+        .fault_nexus_child(rpc::FaultNexusChildRequest {
+            uuid: uuid.clone(),
+            uri: uri.clone(),
+        })
+        .await?;
+    ctx.v1(&format!("Faulted child {} on nexus {}", uri, uuid));
+    Ok(())
+}

--- a/mayastor/src/bin/cli/nexus_child_cli.rs
+++ b/mayastor/src/bin/cli/nexus_child_cli.rs
@@ -18,7 +18,6 @@ pub async fn handler(
     }
 }
 
-// TODO: Make subcommands use the name of the child rather than the uri
 pub fn subcommands<'a, 'b>() -> App<'a, 'b> {
     let fault = SubCommand::with_name("fault")
         .about("fault a child")

--- a/mayastor/src/bin/cli/nexus_cli.rs
+++ b/mayastor/src/bin/cli/nexus_cli.rs
@@ -1,4 +1,4 @@
-use crate::{context::Context, parse_size};
+use crate::{context::Context, nexus_child_cli, parse_size};
 use ::rpc::mayastor as rpc;
 use byte_unit::Byte;
 use clap::{App, AppSettings, Arg, ArgMatches, SubCommand};
@@ -124,6 +124,7 @@ pub fn subcommands<'a, 'b>() -> App<'a, 'b> {
         .subcommand(unpublish)
         .subcommand(list)
         .subcommand(children)
+        .subcommand(nexus_child_cli::subcommands())
 }
 
 pub async fn handler(
@@ -139,6 +140,7 @@ pub async fn handler(
         ("unpublish", Some(args)) => nexus_unpublish(ctx, &args).await,
         ("add", Some(args)) => nexus_add(ctx, &args).await,
         ("remove", Some(args)) => nexus_remove(ctx, &args).await,
+        ("child", Some(args)) => nexus_child_cli::handler(ctx, args).await,
         (cmd, _) => {
             Err(Status::not_found(format!("command {} does not exist", cmd)))
         }

--- a/mayastor/src/bin/cli/rebuild_cli.rs
+++ b/mayastor/src/bin/cli/rebuild_cli.rs
@@ -23,7 +23,6 @@ pub async fn handler(
     }
 }
 
-// TODO: Make subcommands use the name of the child rather than the uri
 pub fn subcommands<'a, 'b>() -> App<'a, 'b> {
     let start = SubCommand::with_name("start")
         .about("starts a rebuild")

--- a/mayastor/src/core/env.rs
+++ b/mayastor/src/core/env.rs
@@ -129,6 +129,9 @@ pub struct MayastorCliArgs {
     #[structopt(short = "y")]
     /// path to mayastor config file
     pub mayastor_config: Option<String>,
+    #[structopt(short = "C")]
+    /// path to child status config file
+    pub child_status_config: Option<String>,
     #[structopt(long = "huge-dir")]
     /// path to hugedir
     pub hugedir: Option<String>,
@@ -152,6 +155,7 @@ impl Default for MayastorCliArgs {
             log_components: vec![],
             config: None,
             mayastor_config: None,
+            child_status_config: None,
             hugedir: None,
         }
     }
@@ -208,6 +212,7 @@ pub struct MayastorEnvironment {
     nats_endpoint: Option<String>,
     grpc_endpoint: Option<String>,
     mayastor_config: Option<String>,
+    child_status_config: Option<String>,
     delay_subsystem_init: bool,
     enable_coredump: bool,
     env_context: Option<String>,
@@ -242,6 +247,7 @@ impl Default for MayastorEnvironment {
             nats_endpoint: None,
             grpc_endpoint: None,
             mayastor_config: None,
+            child_status_config: None,
             delay_subsystem_init: false,
             enable_coredump: true,
             env_context: None,
@@ -347,6 +353,7 @@ impl MayastorEnvironment {
             node_name: args.node_name.unwrap_or_else(|| "mayastor-node".into()),
             config: args.config,
             mayastor_config: args.mayastor_config,
+            child_status_config: args.child_status_config,
             log_component: args.log_components,
             mem_size: args.mem_size,
             no_pci: args.no_pci,
@@ -622,7 +629,7 @@ impl MayastorEnvironment {
                     cfg
                 } else {
                     // if the configuration is invalid exit early
-                    std::process::exit(-1);
+                    panic!("Failed to load the mayastor configuration")
                 }
             })
         } else {
@@ -634,11 +641,12 @@ impl MayastorEnvironment {
     // load the child status file
     fn load_child_status(&self) {
         ChildStatusConfig::get_or_init(|| {
-            if let Ok(cfg) = ChildStatusConfig::load() {
+            if let Ok(cfg) = ChildStatusConfig::load(&self.child_status_config)
+            {
                 cfg
             } else {
                 // if the configuration is invalid exit early
-                std::process::exit(-1);
+                panic!("Failed to load the child status configuration")
             }
         });
     }

--- a/mayastor/src/grpc/mayastor_grpc.rs
+++ b/mayastor/src/grpc/mayastor_grpc.rs
@@ -206,6 +206,26 @@ impl mayastor_server::Mayastor for MayastorSvc {
     }
 
     #[instrument(level = "debug", err)]
+    async fn fault_nexus_child(
+        &self,
+        request: Request<FaultNexusChildRequest>,
+    ) -> GrpcResult<Null> {
+        sync_config(async {
+            let args = request.into_inner();
+            trace!("{:?}", args);
+            let uuid = args.uuid.clone();
+            let uri = args.uri.clone();
+            debug!("Faulting child {} on nexus {}", uri, uuid);
+            locally! { async move {
+                nexus_lookup(&args.uuid)?.fault_child(&args.uri).await
+            }};
+            info!("Faulted child {} on nexus {}", uri, uuid);
+            Ok(Response::new(Null {}))
+        })
+        .await
+    }
+
+    #[instrument(level = "debug", err)]
     async fn publish_nexus(
         &self,
         request: Request<PublishNexusRequest>,

--- a/nix/test/basic/fio_nvme_basic.nix
+++ b/nix/test/basic/fio_nvme_basic.nix
@@ -11,13 +11,13 @@ in
   };
 
   nodes = {
-    target = common.defaultMayastorNode { ip = targetIp; mayatorConfigYaml = ./mayastor-config.yaml; };
+    target = common.defaultMayastorNode { ip = targetIp; mayastorConfigYaml = ./mayastor-config.yaml; };
     initiator = common.defaultMayastorNode { ip = initiatorIp; };
   };
 
   testScript = ''
     ${common.importMayastorUtils}
-    
+
     start_all()
     mayastorUtils.wait_for_mayastor_all(machines)
 

--- a/nix/test/child_status/child_status.nix
+++ b/nix/test/child_status/child_status.nix
@@ -10,7 +10,7 @@ in
   name = "child_status";
 
   nodes = {
-    node = common.defaultMayastorNode { ip = node_ip; };
+    node = common.defaultMayastorNode { ip = node_ip; childStatusConfigYaml = "/tmp/child-status.yaml"; };
   };
 
   testScript = ''

--- a/nix/test/child_status/child_status.nix
+++ b/nix/test/child_status/child_status.nix
@@ -1,0 +1,93 @@
+{ pkgs, lib, ... }:
+let
+  node_ip = "192.168.0.1";
+  nexus_uuid = "19b98ac8-c1ea-11ea-8e3b-d74f5d324a22";
+  child_1 = "malloc:///malloc0?blk_size=512&size_mb=20";
+  child_2 = "malloc:///malloc1?blk_size=512&size_mb=20";
+  common = import ../common.nix { inherit pkgs; };
+in
+{
+  name = "child_status";
+
+  nodes = {
+    node = common.defaultMayastorNode { ip = node_ip; };
+  };
+
+  testScript = ''
+    ${common.importMayastorUtils}
+
+    from time import sleep
+
+
+    def init():
+        start_all()
+        mayastorUtils.wait_for_mayastor_all(machines)
+        node.succeed(
+            "mayastor-client -a ${node_ip} nexus create ${nexus_uuid} 20MiB '${child_1}'"
+        )
+
+
+    def get_nexus_state():
+        result = node.succeed("mayastor-client -a ${node_ip} nexus list").split()
+        return result[7]
+
+
+    def check_nexus_state(expected_state):
+        state = get_nexus_state()
+        assert state == expected_state, "Nexus state {}, expected, {}".format(
+            state, expected_state
+        )
+
+
+    def get_children_states():
+        result = node.succeed(
+            "mayastor-client -a ${node_ip} nexus children ${nexus_uuid}"
+        ).split()
+        child1_state = result[3]
+        child2_state = result[5]
+        return [child1_state, child2_state]
+
+
+    def check_children_states(child1_expected_state, child2_expected_state):
+        states = get_children_states()
+        assert states[0] == child1_expected_state, "Child 1 state {}, expected {}".format(
+            states[0], child1_expected_state
+        )
+        assert states[1] == child2_expected_state, "Child 2 state {}, expected {}".format(
+            states[1], child2_expected_state
+        )
+
+
+    init()
+
+    with subtest("rebuild on mayastor restart"):
+        node.succeed(
+            "mayastor-client -a ${node_ip} nexus add ${nexus_uuid} '${child_2}' true"
+        )
+        check_nexus_state("degraded")
+        check_children_states("online", "degraded")
+
+        # Restart mayastor service
+        node.systemctl("restart mayastor")
+        sleep(1)
+
+        # Rebuild should have been completed and everything should be healthy
+        check_nexus_state("online")
+        check_children_states("online", "online")
+
+    with subtest("fault child"):
+        node.succeed(
+            "mayastor-client -a ${node_ip} nexus child fault ${nexus_uuid} '${child_2}'"
+        )
+        check_nexus_state("degraded")
+        check_children_states("online", "faulted")
+
+        # Restart mayastor service
+        node.systemctl("restart mayastor")
+        sleep(1)
+
+        # The faulted child should remain faulted causing the nexus to be in a degraded state
+        check_nexus_state("degraded")
+        check_children_states("online", "faulted")
+  '';
+}

--- a/nix/test/common.nix
+++ b/nix/test/common.nix
@@ -1,17 +1,18 @@
 { pkgs, ... }:
 {
-    importMayastorUtils = ''
-      import sys
-      
-      sys.path.insert(0, "${./pythonLibs}")
-      import mayastorUtils
-    '';
+  importMayastorUtils = ''
+    import sys
 
-    # We provide sensible defaults for these fields, so that tests can be decluttered.
-    # TODO Find a way to have the default IP just be DHCP
-    defaultMayastorNode = {
-      ip ? "192.168.0.1",
-      mayatorConfigYaml ? ./default-mayastor-config.yaml
+    sys.path.insert(0, "${./pythonLibs}")
+    import mayastorUtils
+  '';
+
+  # We provide sensible defaults for these fields, so that tests can be decluttered.
+  # TODO Find a way to have the default IP just be DHCP
+  defaultMayastorNode =
+    { ip ? "192.168.0.1"
+    , mayastorConfigYaml ? ./default-mayastor-config.yaml
+    , childStatusConfigYaml ? ""
     }: { config, lib, ... }: {
 
       virtualisation = {
@@ -43,7 +44,7 @@
 
         etc."mayastor-config.yaml" = {
           mode = "0664";
-          source = mayatorConfigYaml;
+          source = mayastorConfigYaml;
         };
       };
 
@@ -57,7 +58,10 @@
         };
 
         serviceConfig = {
-          ExecStart = "${pkgs.mayastor}/bin/mayastor -g 0.0.0.0:10124 -y /etc/mayastor-config.yaml";
+          ExecStart =
+            if childStatusConfigYaml == ""
+            then "${pkgs.mayastor}/bin/mayastor -g 0.0.0.0:10124 -y /etc/mayastor-config.yaml"
+            else "${pkgs.mayastor}/bin/mayastor -g 0.0.0.0:10124 -y /etc/mayastor-config.yaml -C ${childStatusConfigYaml}";
         };
       };
     };

--- a/nix/test/default.nix
+++ b/nix/test/default.nix
@@ -16,4 +16,5 @@ in
   nvmf_distributed = pkgs.nixosTest ./nvmf/nvmf_distributed.nix;
   rebuild = pkgs.nixosTest ./rebuild/rebuild.nix;
   disconnect = pkgs.nixosTest ./disconnect/disconnect.nix;
+  child_status = pkgs.nixosTest ./child_status/child_status.nix;
 }

--- a/nix/test/disconnect/disconnect.nix
+++ b/nix/test/disconnect/disconnect.nix
@@ -8,7 +8,7 @@ in
   name = "fio_against_nvmf_target";
 
   nodes = {
-    target = common.defaultMayastorNode { ip = targetIp; mayatorConfigYaml = ./mayastor-config.yaml; };
+    target = common.defaultMayastorNode { ip = targetIp; mayastorConfigYaml = ./mayastor-config.yaml; };
     initiator = common.defaultMayastorNode { ip = initiatorIp; };
   };
 

--- a/nix/test/rebuild/rebuild.nix
+++ b/nix/test/rebuild/rebuild.nix
@@ -14,8 +14,8 @@ in
   };
 
   nodes = {
-    node1 = common.defaultMayastorNode { ip = node1ip; mayatorConfigYaml = ./node1-mayastor-config.yaml; };
-    node2 = common.defaultMayastorNode { ip = node2ip; mayatorConfigYaml = ./node2-mayastor-config.yaml; };
+    node1 = common.defaultMayastorNode { ip = node1ip; mayastorConfigYaml = ./node1-mayastor-config.yaml; };
+    node2 = common.defaultMayastorNode { ip = node2ip; mayastorConfigYaml = ./node2-mayastor-config.yaml; };
   };
 
   testScript = ''

--- a/rpc/proto/mayastor.proto
+++ b/rpc/proto/mayastor.proto
@@ -44,6 +44,7 @@ service Mayastor {
   rpc ListNexus (Null) returns (ListNexusReply) {}
   rpc AddChildNexus (AddChildNexusRequest) returns (Child) {}
   rpc RemoveChildNexus (RemoveChildNexusRequest) returns (Null) {}
+  rpc FaultNexusChild (FaultNexusChildRequest) returns (Null) {}
 
   // This method is called by control plane to construct a block device
   // (/dev/...) that will be used to connect the nexus to the OS.
@@ -251,6 +252,11 @@ message AddChildNexusRequest {
 message RemoveChildNexusRequest {
   string uuid = 1;    // uuid of the nexus
   string uri = 2;     // URI of the child device to be removed
+}
+
+message FaultNexusChildRequest {
+  string uuid = 1;    // uuid of the nexus
+  string uri = 2;     // URI of the child device to be faulted
 }
 
 // this message will be subject to change as we will add support for remote


### PR DESCRIPTION
Child status information is now persisted to a configuration file (a
yaml file currently stored in the /tmp directory). Whenever the child
status changes, the configuration file is updated to reflect this.

When Mayastor starts, it reads in the configuration file and sets the
child status accordingly. Any children in the "degraded" state will be
automatically rebuilt (regardless of the state of the rebuild when
Mayastor was stopped).

Support has been added to the mayastor-client to fault a child. The
command looks like:

	mayastor-client nexus child fault <nexus_uuid> <child_uri>

**Note: For now the configuration file is saved in the /tmp directory. Where this should actually be saved will be subsequently addressed.**