### PR TITLE
nexus publish hangs if kernel inits nbd dev for too long (CAS-453)

### DIFF
--- a/mayastor/src/bin/cli/nexus_cli.rs
+++ b/mayastor/src/bin/cli/nexus_cli.rs
@@ -17,7 +17,7 @@ pub fn subcommands<'a, 'b>() -> App<'a, 'b> {
             Arg::with_name("size")
                 .required(true)
                 .index(2)
-                .help("size in mb"),
+                .help("size with optional unit suffix"),
         )
         .arg(
             Arg::with_name("children")


### PR DESCRIPTION
If the initialization takes time or never finishes (i.e. a bug in code
or misconfiguration) the atomic variable was never updated and the
receiver in the main thread waited forever. Operation was hung - unable
to complete.

Besides the fix of the hang, the fix improves the situation in a
couple of ways:
* the timeout has been increased from 100ms to ~1s
* exponential backoff prevents crazy many loops for slow systems
* log messages give insight without flooding the screen