### PR TITLE
Re-enable io_uring support

### DIFF
--- a/mayastor-test/test_nexus.js
+++ b/mayastor-test/test_nexus.js
@@ -205,6 +205,7 @@ var doUring = (function () {
         if (error) {
           return;
         }
+        // FIXME enable once a fixed Ubuntu kernel 5.4 is released
         supportsUring = false;
       });
     }
@@ -703,7 +704,7 @@ describe('nexus', function () {
         uuid: UUID,
         size: 131072,
         children: [
-        'malloc:///malloc1?size_mb=64',
+          'malloc:///malloc1?size_mb=64',
         `aio://${aioFile}?blk_size=4096`
         ]
       };

--- a/mayastor-test/test_replica.js
+++ b/mayastor-test/test_replica.js
@@ -445,15 +445,16 @@ describe('replica', function () {
       exec(URING_SUPPORT_CMD, (error) => {
         if (error) {
           self.skip();
-        } else {
-          self.skip();
         }
+        self.skip();
+        // FIXME enable once a fixed Ubuntu kernel 5.4 is released
+        // done();
       });
     });
 
     it('should create a pool with uring io_if', (done) => {
       client.createPool(
-        { name: POOL, disks: disks, io_if: enums.POOL_IO_URING },
+        { name: POOL, disks: disks.map((d) => `uring://${d}`), io_if: enums.POOL_IO_URING },
         (err, res) => {
           if (err) return done(err);
           assert.equal(res.name, POOL);
@@ -466,7 +467,7 @@ describe('replica', function () {
           assert.equal(res.state, 'POOL_ONLINE');
           assert.equal(res.disks.length, disks.length);
           for (let i = 0; i < res.disks.length; ++i) {
-            assert.equal(res.disks[i], 'uring://' + disks[i]);
+            assert.equal(res.disks[i].includes('uring://' + disks[i]), true);
           }
           done();
         }
@@ -487,7 +488,7 @@ describe('replica', function () {
         assert.equal(res.state, 'POOL_ONLINE');
         assert.equal(res.disks.length, disks.length);
         for (let i = 0; i < res.disks.length; ++i) {
-          assert.equal(res.disks[i], 'uring://' + disks[i]);
+          assert.equal(res.disks[i].includes('uring://' + disks[i]), true);
         }
         done();
       });

--- a/mayastor/src/bdev/dev.rs
+++ b/mayastor/src/bdev/dev.rs
@@ -66,13 +66,7 @@ impl Uri {
             "pcie" => Ok(Box::new(nvme::NVMe::try_from(&url)?)),
 
             // also for testing - requires Linux 5.1 or higher
-            // "uring" => Ok(Box::new(uring::Uring::try_from(&url)?)),
-
-            // Uring has been temporarily disabled.
-            // We should not enable it by default until we can
-            // be sure that most users are at 5.5 or later.
-            // Just fake it for now by substituting AIO.
-            "uring" => Ok(Box::new(aio::Aio::try_from(&url)?)),
+            "uring" => Ok(Box::new(uring::Uring::try_from(&url)?)),
 
             scheme => Err(NexusBdevError::UriSchemeUnsupported {
                 scheme: scheme.to_string(),

--- a/mayastor/src/pool.rs
+++ b/mayastor/src/pool.rs
@@ -14,9 +14,10 @@ use url::Url;
 
 use rpc::mayastor as rpc;
 use spdk_sys::{
-    bdev_aio_delete as delete_uring_bdev,
     bdev_aio_delete,
-    create_aio_bdev as create_uring_bdev,
+    create_aio_bdev,
+    create_uring_bdev,
+    delete_uring_bdev,
     lvol_store_bdev,
     spdk_bs_free_cluster_count,
     spdk_bs_get_cluster_size,
@@ -179,8 +180,17 @@ pub fn create_base_bdev(
     };
     debug!("Creating {} bdev {} ...", bdev_type.0, file);
     let cstr_file = CString::new(file).unwrap();
-    let rc = unsafe {
+    let rc = if !do_uring {
+        unsafe {
+            create_aio_bdev(cstr_file.as_ptr(), cstr_file.as_ptr(), block_size)
+        }
+    } else if unsafe {
         create_uring_bdev(cstr_file.as_ptr(), cstr_file.as_ptr(), block_size)
+            .is_null()
+    } {
+        -1
+    } else {
+        0
     };
     if rc != 0 {
         Err(Error::BadBdev {

--- a/mayastor/tests/core.rs
+++ b/mayastor/tests/core.rs
@@ -37,7 +37,9 @@ fn do_uring() -> bool {
                 && uring::fs_type_supported(DISKNAME3)
                 && uring::kernel_support();
         });
-        DO_URING
+        false
+        // FIXME enable once a fixed Ubuntu kernel 5.4 is released
+        // DO_URING
     }
 }
 

--- a/nix/pkgs/libspdk/default.nix
+++ b/nix/pkgs/libspdk/default.nix
@@ -24,8 +24,8 @@ let
     src = fetchFromGitHub {
       owner = "openebs";
       repo = "spdk";
-      rev = "5e21f145309129f0fba95652eba7363ba3c92007";
-      sha256 = "1rk1sncwpx9yy46mlp802ijxgsxi3v4i7lz36q199axw7i46pijq";
+      rev = "b09bed5edaca1d827a6432ca602639d43e3e93a0";
+      sha256 = "0y26p4m99gbnf6iz2vbai26msnry7m428g8q3icpg28izmnk00d1";
       #sha256 = stdenv.lib.fakeSha256;
       fetchSubmodules = true;
     };
@@ -55,6 +55,7 @@ let
       "--without-vhost"
       "--with-iscsi-initiator"
       "--with-crypto"
+      "--with-uring"
     ];
 
 
@@ -78,6 +79,7 @@ let
 
       $CC -shared -o libspdk.so \
       -lc  -laio -liscsi -lnuma -ldl -lrt -luuid -lpthread -lcrypto \
+      -luring \
       -Wl,--whole-archive \
       $(find build/lib -type f -name 'libspdk_*.a*' -o -name 'librte_*.a*') \
       $(find dpdk/build/lib -type f -name 'librte_*.a*') \

--- a/nix/test/rebuild/node1-mayastor-config.yaml
+++ b/nix/test/rebuild/node1-mayastor-config.yaml
@@ -14,6 +14,6 @@ pools:
     disks:
       - "/dev/vdb"
     blk_size: 4096
-    io_if: 0
+    io_if: 1
     replicas: []
 implicit_share_base: true

--- a/nix/test/rebuild/node2-mayastor-config.yaml
+++ b/nix/test/rebuild/node2-mayastor-config.yaml
@@ -14,6 +14,6 @@ pools:
     disks:
       - "/dev/vdb"
     blk_size: 4096
-    io_if: 0
+    io_if: 1
     replicas: []
 implicit_share_base: true

--- a/shell.nix
+++ b/shell.nix
@@ -31,6 +31,7 @@ mkShell {
     libiscsi
     libiscsi.bin
     libudev
+    liburing
     llvmPackages.libclang
     nats-server
     nodejs-12_x

--- a/spdk-sys/build.rs
+++ b/spdk-sys/build.rs
@@ -112,6 +112,7 @@ fn main() {
     println!("cargo:rustc-link-lib=uuid");
     println!("cargo:rustc-link-lib=numa");
     println!("cargo:rustc-link-lib=crypto");
+    println!("cargo:rustc-link-lib=uring");
 
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed=wrapper.h");

--- a/spdk-sys/build.sh
+++ b/spdk-sys/build.sh
@@ -16,6 +16,7 @@ pushd spdk || { echo "Can not find spdk directory"; exit; }
 	--without-vhost \
 	--with-iscsi-initiator \
 	--with-crypto \
+	--with-uring \
 	--disable-unit-tests
 
 make -j $(nproc)
@@ -29,6 +30,7 @@ find . -type f -name 'libspdk_ut_mock.a' -delete
 
 $CC -shared -o libspdk.so \
 	-lc  -laio -liscsi -lnuma -ldl -lrt -luuid -lpthread -lcrypto \
+	-luring \
 	-Wl,--whole-archive \
 	$(find build/lib -type f -name 'libspdk_*.a*' -o -name 'librte_*.a*') \
 	$(find dpdk/build/lib -type f -name 'librte_*.a*') \


### PR DESCRIPTION
Re-enable io_uring support for bdev but not sockets as the latter requires kernel 5.5.

Keep uring bdev tests disabled to avoid a kernel 5.4 bug that is still present in the latest Ubuntu 20.04 kernel.

Resolves: CAS-408, CAS-129