### PR TITLE
CAS-452: Add validation to add and remove operations

### DIFF
--- a/.github/workflows/nix-tests.yaml
+++ b/.github/workflows/nix-tests.yaml
@@ -25,3 +25,4 @@ jobs:
       - run: nix-build ./nix/test -A nvmf_distributed
       - run: nix-build ./nix/test -A nvmf_ports
       - run: nix-build ./nix/test -A child_status
+      - run: nix-build ./nix/test -A validation

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,6 +31,8 @@ pipeline {
             sh 'nix-build ./nix/test -A fio_nvme_basic'
             sh 'nix-build ./nix/test -A nvmf_distributed'
             sh 'nix-build ./nix/test -A nvmf_ports'
+            sh 'nix-build ./nix/test -A child_status'
+            sh 'nix-build ./nix/test -A validation'
           }
         }
         stage('moac unit tests') {

--- a/mayastor/src/bdev/nexus/nexus_bdev.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev.rs
@@ -54,6 +54,7 @@ use crate::{
     nexus_uri::{bdev_destroy, NexusBdevError},
     rebuild::RebuildError,
     subsys::Config,
+    validation::nexus_validator::NexusValidationError,
 };
 
 /// Obtain the full error chain
@@ -232,6 +233,8 @@ pub enum Error {
     FailedGetHandle,
     #[snafu(display("Failed to create snapshot"))]
     FailedCreateSnapshot,
+    #[snafu(display("Validation failed"))]
+    ValidationFailed { source: NexusValidationError },
 }
 
 impl From<Error> for tonic::Status {

--- a/mayastor/src/lib.rs
+++ b/mayastor/src/lib.rs
@@ -24,6 +24,7 @@ pub mod rebuild;
 pub mod replica;
 pub mod subsys;
 pub mod target;
+pub mod validation;
 
 #[macro_export]
 macro_rules! CPS_INIT {

--- a/mayastor/src/validation/mod.rs
+++ b/mayastor/src/validation/mod.rs
@@ -1,0 +1,1 @@
+pub mod nexus_validator;

--- a/mayastor/src/validation/nexus_validator.rs
+++ b/mayastor/src/validation/nexus_validator.rs
@@ -1,0 +1,174 @@
+//! Module responsible for validating that an operation can be performed on a
+//! nexus.
+
+use crate::bdev::{
+    nexus::{
+        nexus_bdev::{
+            Error,
+            Error::{NexusNotFound, ValidationFailed},
+        },
+        nexus_child::{NexusChild, StatusReasons},
+        nexus_child_status_config::ChildStatusConfig,
+    },
+    nexus_lookup,
+    ChildStatus,
+    Nexus,
+    NexusStatus,
+};
+use snafu::Snafu;
+use std::future::Future;
+
+#[derive(Debug, Snafu)]
+#[snafu(visibility = "pub(crate)")]
+pub enum NexusValidationError {
+    #[snafu(display("The nexus {} is in the faulted state", name))]
+    Faulted { name: String },
+    #[snafu(display("The nexus {} does not have any healthy children", name))]
+    NoHealthyChild { name: String },
+    #[snafu(display(
+        "Child {} of nexus {} is the only healthy child",
+        child_name,
+        nexus_name
+    ))]
+    LastHealthyChild {
+        child_name: String,
+        nexus_name: String,
+    },
+    #[snafu(display("Failed to update the child status configuration"))]
+    FailedUpdateChildStatusConfig,
+}
+
+/// Perform add child validation. If this passes, execute the future.
+pub(crate) async fn add_child<F>(
+    nexus_name: &str,
+    child_name: &str,
+    future: F,
+) -> Result<NexusStatus, Error>
+where
+    F: Future<Output = Result<NexusStatus, Error>>,
+{
+    let nexus = nexus_exists(nexus_name)?;
+    if is_nexus_faulted(&nexus) {
+        return Err(ValidationFailed {
+            source: NexusValidationError::Faulted {
+                name: nexus.name.clone(),
+            },
+        });
+    }
+
+    if !has_healthy_child(&nexus) {
+        return Err(ValidationFailed {
+            source: NexusValidationError::NoHealthyChild {
+                name: nexus.name.clone(),
+            },
+        });
+    }
+
+    // Add the child to the status configuration as out-of-sync before executing
+    // the future. The status configuration will be updated automatically
+    // when the newly added child comes online.
+    let mut status_reasons = StatusReasons::new();
+    status_reasons.out_of_sync(true);
+    if ChildStatusConfig::add(child_name, &status_reasons).is_err() {
+        return Err(ValidationFailed {
+            source: NexusValidationError::FailedUpdateChildStatusConfig {},
+        });
+    }
+
+    // Validation has passed, execute the "add child" future.
+    match future.await {
+        Ok(value) => Ok(value),
+        Err(e) => {
+            rollback_child_status_config();
+            Err(e)
+        }
+    }
+}
+
+/// Perform remove child validation. If this passes, execute the future.
+pub(crate) async fn remove_child<F>(
+    nexus_name: &str,
+    child_name: &str,
+    future: F,
+) -> Result<(), Error>
+where
+    F: Future<Output = Result<(), Error>>,
+{
+    let nexus = nexus_exists(nexus_name)?;
+    if nexus.child_count == 1 {
+        return Err(Error::DestroyLastChild {
+            name: nexus_name.to_string(),
+            child: child_name.to_string(),
+        });
+    }
+
+    if is_last_healthy_child(nexus, child_name) {
+        return Err(ValidationFailed {
+            source: NexusValidationError::LastHealthyChild {
+                child_name: child_name.to_string(),
+                nexus_name: nexus_name.to_string(),
+            },
+        });
+    }
+
+    // Remove the child from the configuration before executing the future
+    if ChildStatusConfig::remove(child_name).is_err() {
+        return Err(ValidationFailed {
+            source: NexusValidationError::FailedUpdateChildStatusConfig {},
+        });
+    }
+
+    // Validation has passed, execute the "remove child" future.
+    match future.await {
+        Ok(_) => Ok(()),
+        Err(e) => {
+            rollback_child_status_config();
+            Err(e)
+        }
+    }
+}
+
+// Checks if a given nexus exists
+fn nexus_exists(nexus_name: &str) -> Result<&Nexus, Error> {
+    match nexus_lookup(nexus_name) {
+        Some(nexus) => Ok(nexus),
+        None => Err(NexusNotFound {
+            name: nexus_name.to_string(),
+        }),
+    }
+}
+
+/// Checks if a nexus is in the faulted state
+fn is_nexus_faulted(nexus: &Nexus) -> bool {
+    nexus.status() == NexusStatus::Faulted
+}
+
+/// Checks if a nexus has at least one healthy child
+fn has_healthy_child(nexus: &Nexus) -> bool {
+    nexus
+        .children
+        .iter()
+        .any(|c| c.status() == ChildStatus::Online)
+}
+
+// Checks if the child is the last remaining healthy child
+fn is_last_healthy_child(nexus: &Nexus, child_name: &str) -> bool {
+    let healthy_children = nexus
+        .children
+        .iter()
+        .filter(|child| child.status() == ChildStatus::Online)
+        .collect::<Vec<&NexusChild>>();
+
+    healthy_children.len() == 1 && healthy_children[0].name == child_name
+}
+
+/// Attempt to rollback changes to the status configuration. This is called when
+/// an operation fails. The best we can do here is to save the current status of
+/// the running system as it is not known at what point the operation failed.
+fn rollback_child_status_config() {
+    // TODO: Determine what to do in this case. If the operation itself has
+    // succeeded the running system is still good.
+    if ChildStatusConfig::save().is_err() {
+        error!("Failed to save child status configuration");
+    }
+}

--- a/nix/test/child_status/child_status.nix
+++ b/nix/test/child_status/child_status.nix
@@ -58,6 +58,11 @@ in
         )
 
 
+    def wait_for_mayastor():
+        # A simple grpc call which will return success when mayastor is running
+        node.wait_until_succeeds("mayastor-client -a ${node_ip} nexus list")
+
+
     init()
 
     with subtest("rebuild on mayastor restart"):
@@ -69,7 +74,7 @@ in
 
         # Restart mayastor service
         node.systemctl("restart mayastor")
-        sleep(1)
+        wait_for_mayastor()
 
         # Rebuild should have been completed and everything should be healthy
         check_nexus_state("online")
@@ -84,7 +89,7 @@ in
 
         # Restart mayastor service
         node.systemctl("restart mayastor")
-        sleep(1)
+        wait_for_mayastor()
 
         # The faulted child should remain faulted causing the nexus to be in a degraded state
         check_nexus_state("degraded")

--- a/nix/test/default.nix
+++ b/nix/test/default.nix
@@ -17,4 +17,5 @@ in
   rebuild = pkgs.nixosTest ./rebuild/rebuild.nix;
   disconnect = pkgs.nixosTest ./disconnect/disconnect.nix;
   child_status = pkgs.nixosTest ./child_status/child_status.nix;
+  validation = pkgs.nixosTest ./validation/validation.nix;
 }

--- a/nix/test/validation/validation.nix
+++ b/nix/test/validation/validation.nix
@@ -1,0 +1,123 @@
+{ pkgs, lib, ... }:
+let
+  node_ip = "192.168.0.1";
+  nexus_uuid = "19b98ac8-c1ea-11ea-8e3b-d74f5d324a22";
+  child_1 = "malloc:///malloc0?blk_size=512&size_mb=20";
+  child_2 = "malloc:///malloc1?blk_size=512&size_mb=20";
+  child_3 = "malloc:///malloc2?blk_size=512&size_mb=20";
+  common = import ../common.nix { inherit pkgs; };
+in
+{
+  name = "validation";
+
+  nodes = {
+    node = common.defaultMayastorNode { ip = node_ip; childStatusConfigYaml = "/tmp/child-status.yaml"; };
+  };
+
+  testScript = ''
+    ${common.importMayastorUtils}
+
+    from time import sleep
+
+
+    def init():
+        start_all()
+        mayastorUtils.wait_for_mayastor_all(machines)
+        node.succeed(
+            "mayastor-client -a ${node_ip} nexus create ${nexus_uuid} 20MiB '${child_1}'"
+        )
+
+
+    def get_nexus_state():
+        result = node.succeed("mayastor-client -a ${node_ip} nexus list").split()
+        return result[7]
+
+
+    def check_nexus_state(expected_state):
+        state = get_nexus_state()
+        assert state == expected_state, "Nexus state {}, expected, {}".format(
+            state, expected_state
+        )
+
+
+    def get_children_states():
+        result = node.succeed(
+            "mayastor-client -a ${node_ip} nexus children ${nexus_uuid}"
+        ).split()
+        child1_state = result[3]
+        child2_state = result[5]
+        return [child1_state, child2_state]
+
+
+    def check_children_states(child1_expected_state, child2_expected_state):
+        states = get_children_states()
+        assert states[0] == child1_expected_state, "Child 1 state {}, expected {}".format(
+            states[0], child1_expected_state
+        )
+        assert states[1] == child2_expected_state, "Child 2 state {}, expected {}".format(
+            states[1], child2_expected_state
+        )
+
+
+    init()
+
+    with subtest("add child validation"):
+        # Create nexus with a single child
+        node.succeed(
+            "mayastor-client -a ${node_ip} nexus create ${nexus_uuid} 20MiB '${child_1}'"
+        )
+
+        # Add child but don't rebuild - this will keep the child in a degraded state
+        node.succeed(
+            "mayastor-client -a ${node_ip} nexus add ${nexus_uuid} '${child_2}' true"
+        )
+        check_nexus_state("degraded")
+        check_children_states("online", "degraded")
+
+        # Fault the only healthy child
+        node.succeed(
+            "mayastor-client -a ${node_ip} nexus child fault ${nexus_uuid} '${child_1}'"
+        )
+        check_nexus_state("faulted")
+        check_children_states("faulted", "degraded")
+
+        # Attempt to add an additional child.
+        # This is expected to fail because the nexus is not in a healthy state.
+        node.fail(
+            "mayastor-client -a ${node_ip} nexus add ${nexus_uuid} '${child_3}' true"
+        )
+
+        # Destroy nexus
+        node.succeed(
+            "mayastor-client -a ${node_ip} nexus destroy ${nexus_uuid}"
+        )
+
+    with subtest("remove child validation"):
+        # Create nexus with 2 children
+        node.succeed(
+            "mayastor-client -a ${node_ip} nexus create ${nexus_uuid} 20MiB '${child_1} ${child_2}'"
+        )
+
+        # Fault child 1
+        node.succeed(
+            "mayastor-client -a ${node_ip} nexus child fault ${nexus_uuid} '${child_1}'"
+        )
+
+        # Attempt to remove child 2.
+        # This is expected to fail because it is the last remaining healthy child.
+        node.fail(
+            "mayastor-client -a ${node_ip} nexus remove ${nexus_uuid} '${child_2}'"
+        )
+
+        # Attempt to remove child 1.
+        # This is expected to succeed because it is in a faulted state and there is another healthy child.
+        node.succeed(
+            "mayastor-client -a ${node_ip} nexus remove ${nexus_uuid} '${child_1}'"
+        )
+
+        # Destroy nexus
+        node.succeed(
+            "mayastor-client -a ${node_ip} nexus destroy ${nexus_uuid}"
+        )
+  '';
+}


### PR DESCRIPTION
The validation layer takes an operation such as add or remove as a
future. It performs a number of checks to determine if the operation
should be permitted. If all checks pass, the child status configuration
is updated and the future (representing the operation) is executed. If
the future returns an error, the child status configuration is rolled
back. At the moment this simply means updating it with the state of the
running system.

As part of this change nexus_child_status_config.rs has been refactored
to make it easier to use.