### PR TITLE
CAS-410: Allow snapshots to be shared

### DIFF
--- a/mayastor/src/bdev/nexus/nexus_bdev_snapshot.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev_snapshot.rs
@@ -5,7 +5,7 @@ use rpc::mayastor::CreateSnapshotReply;
 use crate::{
     bdev::nexus::nexus_bdev::{Error, Nexus},
     core::BdevHandle,
-    replica::Replica,
+    lvs::Lvol,
 };
 
 impl Nexus {
@@ -14,7 +14,7 @@ impl Nexus {
         if let Ok(h) = BdevHandle::open_with_bdev(&self.bdev, true) {
             match h.create_snapshot().await {
                 Ok(t) => Ok(CreateSnapshotReply {
-                    name: Replica::format_snapshot_name(&self.bdev.name(), t),
+                    name: Lvol::format_snapshot_name(&self.bdev.name(), t),
                 }),
                 Err(_e) => Err(Error::FailedCreateSnapshot),
             }

--- a/mayastor/src/lvs/lvol.rs
+++ b/mayastor/src/lvs/lvol.rs
@@ -17,6 +17,10 @@ use spdk_sys::{
     spdk_blob_set_xattr,
     spdk_blob_sync_md,
     spdk_lvol,
+    spdk_nvme_cpl,
+    spdk_nvme_status,
+    spdk_nvmf_request,
+    vbdev_lvol_create_snapshot,
     vbdev_lvol_destroy,
     vbdev_lvol_get_from_bdev,
 };
@@ -329,5 +333,60 @@ impl Lvol {
                 }
             }
         }
+    }
+
+    /// Format snapshot name
+    /// base_name is the nexus or replica UUID
+    pub fn format_snapshot_name(base_name: &str, snapshot_time: u64) -> String {
+        format!("{}-snap-{}", base_name, snapshot_time)
+    }
+
+    /// Create a snapshot
+    pub async fn create_snapshot(
+        self,
+        nvmf_req: *mut spdk_nvmf_request,
+        snapshot_name: &str,
+    ) {
+        extern "C" fn snapshot_done_cb(
+            nvmf_req_ptr: *mut c_void,
+            _lvol_ptr: *mut spdk_lvol,
+            errno: i32,
+        ) {
+            let rsp: &mut spdk_nvme_cpl = unsafe {
+                &mut *spdk_sys::spdk_nvmf_request_get_response(
+                    nvmf_req_ptr as *mut spdk_nvmf_request,
+                )
+            };
+            let nvme_status: &mut spdk_nvme_status =
+                unsafe { &mut rsp.__bindgen_anon_1.status };
+
+            nvme_status.set_sct(0); // SPDK_NVME_SCT_GENERIC
+            nvme_status.set_sc(match errno {
+                0 => 0,
+                _ => {
+                    debug!("vbdev_lvol_create_snapshot errno {}", errno);
+                    0x06 // SPDK_NVME_SC_INTERNAL_DEVICE_ERROR
+                }
+            });
+
+            // From nvmf_bdev_ctrlr_complete_cmd
+            unsafe {
+                spdk_sys::spdk_nvmf_request_complete(
+                    nvmf_req_ptr as *mut spdk_nvmf_request,
+                );
+            }
+        }
+
+        let c_snapshot_name = snapshot_name.into_cstring();
+        unsafe {
+            vbdev_lvol_create_snapshot(
+                self.0.as_ptr(),
+                c_snapshot_name.as_ptr(),
+                Some(snapshot_done_cb),
+                nvmf_req as *mut c_void,
+            )
+        };
+
+        info!("Creating snapshot {}", snapshot_name);
     }
 }

--- a/mayastor/src/subsys/mod.rs
+++ b/mayastor/src/subsys/mod.rs
@@ -11,6 +11,8 @@ pub use config::{
 };
 pub use nvmf::{
     Error as NvmfError,
+    NvmeCpl,
+    NvmfReq,
     NvmfSubsystem,
     SubType,
     Target as NvmfTarget,

--- a/mayastor/src/subsys/nvmf/mod.rs
+++ b/mayastor/src/subsys/nvmf/mod.rs
@@ -13,6 +13,7 @@ use std::cell::RefCell;
 use nix::errno::Errno;
 use snafu::Snafu;
 
+pub use admin_cmd::{NvmeCpl, NvmfReq};
 use poll_groups::PollGroup;
 use spdk_sys::{
     spdk_subsystem,

--- a/mayastor/tests/common/bdev_io.rs
+++ b/mayastor/tests/common/bdev_io.rs
@@ -1,33 +1,41 @@
 use mayastor::core::{BdevHandle, CoreError};
 
-pub async fn write_some(nexus_name: &str) -> Result<(), CoreError> {
+pub async fn write_some(
+    nexus_name: &str,
+    offset: u64,
+    fill: u8,
+) -> Result<(), CoreError> {
     let h = BdevHandle::open(nexus_name, true, false).unwrap();
     let mut buf = h.dma_malloc(512).expect("failed to allocate buffer");
-    buf.fill(0xff);
+    buf.fill(fill);
 
     let s = buf.as_slice();
-    assert_eq!(s[0], 0xff);
+    assert_eq!(s[0], fill);
 
-    h.write_at(0, &buf).await?;
+    h.write_at(offset, &buf).await?;
     Ok(())
 }
 
-pub async fn read_some(nexus_name: &str) -> Result<(), CoreError> {
+pub async fn read_some(
+    nexus_name: &str,
+    offset: u64,
+    fill: u8,
+) -> Result<(), CoreError> {
     let h = BdevHandle::open(nexus_name, true, false).unwrap();
     let mut buf = h.dma_malloc(1024).expect("failed to allocate buffer");
     let slice = buf.as_mut_slice();
 
     assert_eq!(slice[0], 0);
-    slice[512] = 0xff;
-    assert_eq!(slice[512], 0xff);
+    slice[512] = fill;
+    assert_eq!(slice[512], fill);
 
-    let len = h.read_at(0, &mut buf).await?;
+    let len = h.read_at(offset, &mut buf).await?;
     assert_eq!(len, 1024);
 
     let slice = buf.as_slice();
 
     for &it in slice.iter().take(512) {
-        assert_eq!(it, 0xff);
+        assert_eq!(it, fill);
     }
     assert_eq!(slice[512], 0);
     Ok(())

--- a/mayastor/tests/io.rs
+++ b/mayastor/tests/io.rs
@@ -41,7 +41,7 @@ fn io_test() {
 // only execute one future per reactor loop.
 async fn start() {
     bdev_create(BDEVNAME).await.expect("failed to create bdev");
-    bdev_io::write_some(BDEVNAME).await.unwrap();
-    bdev_io::read_some(BDEVNAME).await.unwrap();
+    bdev_io::write_some(BDEVNAME, 0, 0xff).await.unwrap();
+    bdev_io::read_some(BDEVNAME, 0, 0xff).await.unwrap();
     mayastor_env_stop(0);
 }

--- a/mayastor/tests/replica_snapshot.rs
+++ b/mayastor/tests/replica_snapshot.rs
@@ -123,6 +123,7 @@ fn replica_snapshot() {
     Reactor::block_on(async {
         create_nexus(0).await;
         bdev_io::write_some(NXNAME, 0, 0xff).await.unwrap();
+        // Issue an unimplemented vendor command
         custom_nvme_admin(0xc1)
             .await
             .expect_err("unexpectedly succeeded invalid nvme admin command");

--- a/mayastor/tests/replica_timeout.rs
+++ b/mayastor/tests/replica_timeout.rs
@@ -75,8 +75,8 @@ fn replica_stop_cont() {
 
     Reactor::block_on(async {
         create_nexus(true).await;
-        bdev_io::write_some(NXNAME).await.unwrap();
-        bdev_io::read_some(NXNAME).await.unwrap();
+        bdev_io::write_some(NXNAME, 0, 0xff).await.unwrap();
+        bdev_io::read_some(NXNAME, 0, 0xff).await.unwrap();
         ms.sig_stop();
         let handle = thread::spawn(move || {
             // Sufficiently long to cause a controller reset
@@ -85,11 +85,11 @@ fn replica_stop_cont() {
             ms.sig_cont();
             ms
         });
-        bdev_io::read_some(NXNAME)
+        bdev_io::read_some(NXNAME, 0, 0xff)
             .await
             .expect_err("should fail read after controller reset");
         ms = handle.join().unwrap();
-        bdev_io::read_some(NXNAME)
+        bdev_io::read_some(NXNAME, 0, 0xff)
             .await
             .expect("should read again after Nexus child continued");
         nexus_lookup(NXNAME).unwrap().destroy().await.unwrap();
@@ -116,20 +116,20 @@ fn replica_term() {
 
     Reactor::block_on(async {
         create_nexus(false).await;
-        bdev_io::write_some(NXNAME).await.unwrap();
-        bdev_io::read_some(NXNAME).await.unwrap();
+        bdev_io::write_some(NXNAME, 0, 0xff).await.unwrap();
+        bdev_io::read_some(NXNAME, 0, 0xff).await.unwrap();
     });
     ms1.sig_term();
     thread::sleep(time::Duration::from_secs(1));
     Reactor::block_on(async {
-        bdev_io::read_some(NXNAME)
+        bdev_io::read_some(NXNAME, 0, 0xff)
             .await
             .expect("should read with 1 Nexus child terminated");
     });
     ms2.sig_term();
     thread::sleep(time::Duration::from_secs(1));
     Reactor::block_on(async {
-        bdev_io::read_some(NXNAME)
+        bdev_io::read_some(NXNAME, 0, 0xff)
             .await
             .expect_err("should fail read with 2 Nexus children terminated");
     });

--- a/spdk-sys/build.rs
+++ b/spdk-sys/build.rs
@@ -31,6 +31,10 @@ fn build_wrapper() {
         .include("spdk/include")
         .file("logwrapper.c")
         .compile("logwrapper");
+    cc::Build::new()
+        .include("spdk/include")
+        .file("nvme_helper.c")
+        .compile("nvme_helper");
 }
 
 fn main() {
@@ -77,6 +81,7 @@ fn main() {
         .whitelist_function("^bdev.*")
         .whitelist_function("^nbd_.*")
         .whitelist_function("^vbdev_.*")
+        .whitelist_function("^get_nvme.*")
         .blacklist_type("^longfunc")
         .whitelist_var("^NVMF.*")
         .whitelist_var("^SPDK.*")
@@ -117,4 +122,5 @@ fn main() {
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed=wrapper.h");
     println!("cargo:rerun-if-changed=logwrapper.c");
+    println!("cargo:rerun-if-changed=nvme_helper.c");
 }

--- a/spdk-sys/nvme_helper.c
+++ b/spdk-sys/nvme_helper.c
@@ -1,0 +1,13 @@
+#include "nvme_helper.h"
+
+#include <spdk/nvme_spec.h>
+
+struct spdk_nvme_status *
+get_nvme_status(struct spdk_nvme_cpl *cpl) {
+	return &cpl->status;
+}
+
+uint16_t *
+get_nvme_status_raw(struct spdk_nvme_cpl *cpl) {
+	return &cpl->status_raw;
+}

--- a/spdk-sys/nvme_helper.h
+++ b/spdk-sys/nvme_helper.h
@@ -1,0 +1,7 @@
+#include <stdint.h>
+
+struct spdk_nvme_cpl;
+struct spdk_nvme_status;
+
+struct spdk_nvme_status *get_nvme_status(struct spdk_nvme_cpl *cpl);
+uint16_t *get_nvme_status_raw(struct spdk_nvme_cpl *cpl);

--- a/spdk-sys/wrapper.h
+++ b/spdk-sys/wrapper.h
@@ -35,4 +35,4 @@
 #include <spdk_internal/lvolstore.h>
 
 #include "logwrapper.h"
-
+#include "nvme_helper.h"


### PR DESCRIPTION
The pool layer rework in e6f7517 introduced lvs and is the preferred
home for new functionality on pools/replicas so move snapshot creation
there.

Sharing a snapshot, which is essentially a replica or lvol, causes
the shared property to be written to the blob's extended attributes,
which fails because a snapshot is read-only. Simply return early and
log a warning instead of an error and failing the RPC call.

Update the Rust integration test to share the snapshot, create a nexus
with the snapshot as its child, and extend the IO tests to verify that
the snapshot behaves as one.