### PR TITLE
Update deployment YAML files to use 'latest' tag

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,7 +1,13 @@
-# Quickstart
+# Quickstart Guide
 
-### Relocated
+### Has been relocated
 
-As of v0.4.0, the Mayastor user's quickstart guide has moved.
+As of release 0.4.0-alpha the Mayastor user's quickstart guide has moved.
 
-It is now hosted by [GitBook](https://mayastor.gitbook.io/introduction/).
+It is now hosted at [GitBook](https://mayastor.gitbook.io/introduction/).
+
+# Deployment Files
+
+The files in this directory are provided as a convenience, a template for the successful test deployment of Mayastor to a cluster.
+
+**NOTE:** ALL versions of deployment files from v0.4.0 specify the 'latest' tag on Mayastor container images.  If you wish to deploy earlier versions, your own builds, or a nightly build, you must change the image tags accordingly.

--- a/deploy/csi-daemonset.yaml
+++ b/deploy/csi-daemonset.yaml
@@ -28,7 +28,7 @@ spec:
       # the same.
       containers:
       - name: mayastor-csi
-        image: mayadata/mayastor-csi:v0.3.0
+        image: mayadata/mayastor-csi:latest
         imagePullPolicy: Always
         # we need privileged because we mount filesystems and use mknod
         securityContext:

--- a/deploy/mayastor-daemonset.yaml
+++ b/deploy/mayastor-daemonset.yaml
@@ -31,7 +31,7 @@ spec:
       # the same.
       containers:
       - name: mayastor
-        image: mayadata/mayastor:v0.3.0
+        image: mayadata/mayastor:latest
         imagePullPolicy: Always
         env:
         - name: MY_NODE_NAME

--- a/deploy/moac-deployment.yaml
+++ b/deploy/moac-deployment.yaml
@@ -44,7 +44,7 @@ spec:
               mountPath: /var/lib/csi/sockets/pluginproxy/
 
         - name: moac
-          image: mayadata/moac:v0.3.0
+          image: mayadata/moac:latest
           imagePullPolicy: Always
           args:
             - "--csi-address=$(CSI_ENDPOINT)"


### PR DESCRIPTION
From v0.4.0, deployment files should use the 'latest' tag on Mayastor container image specifications, to avoid the need to update these with each release.  A note to users to that effect, and the need to change the tag as maybe required (e.g. if seeking to run an earlier version) has been added to the README.md file.