### PR TITLE
CAS-331: mayastor-tests: Remove ini file usage

### DIFF
--- a/mayastor-test/test_common.js
+++ b/mayastor-test/test_common.js
@@ -192,7 +192,7 @@ function startSpdk (config, args, env) {
 }
 
 // Start mayastor process and return immediately.
-function startMayastor (config, args, env, yaml, suffix) {
+function startMayastor (config, args, env, suffix) {
   args = args || ['-r', SOCK, '-g', grpcEndpoint];
   env = env || {};
   let configPath = MS_CONFIG_PATH;
@@ -200,14 +200,9 @@ function startMayastor (config, args, env, yaml, suffix) {
     configPath += suffix;
   }
 
-  if (yaml) {
-    fs.writeFileSync(configPath, yaml);
-    args = args.concat(['-y', configPath]);
-  }
-
   if (config) {
     fs.writeFileSync(configPath, config);
-    args = args.concat(['-c', configPath]);
+    args = args.concat(['-y', configPath]);
   }
 
   startProcess(

--- a/mayastor-test/test_csi.js
+++ b/mayastor-test/test_csi.js
@@ -149,7 +149,7 @@ describe('csi', function () {
   // NOTE: Don't use mayastor in setup - we test CSI interface and we don't want
   // to depend on correct function of mayastor iface in order to test CSI.
   before((done) => {
-    common.startMayastor(null, null, null, CONFIG);
+    common.startMayastor(CONFIG);
     common.startMayastorCsi();
 
     var client = common.createGrpcClient();

--- a/mayastor-test/test_nexus.js
+++ b/mayastor-test/test_nexus.js
@@ -41,10 +41,9 @@ const doIscsiReplica = false;
 // test the nexus with implementation of replicas which are used in the
 // production.
 const configNexus = `
-[Malloc]
-  NumberOfLuns 1
-  LunSizeInMB  64
-  BlockSize    4096
+sync_disable: true
+base_bdevs:
+  - uri: "malloc:///Malloc0?size_mb=64&blk_size=4096"
 `;
 
 // The config just for nvmf target which cannot run in the same process as

--- a/mayastor-test/test_rebuild.js
+++ b/mayastor-test/test_rebuild.js
@@ -19,49 +19,6 @@ const child2 = '/tmp/child2';
 const diskSize = 100 * 1024 * 1024;
 // nexus UUID
 const UUID = 'dbe4d7eb-118a-4d15-b789-a18d9af6ff21';
-// external IP address detected by common lib
-const externIp = common.getMyIp();
-
-// Instead of using mayastor grpc methods to create replicas we use a config
-// file to create them. Advantage is that we don't depend on bugs in replica
-// code (the nexus tests are more independent). Disadvantage is that we don't
-// test the nexus with implementation of replicas which are used in the
-// production.
-const configNexus = `
-[Malloc]
-  NumberOfLuns 2
-  LunSizeInMB  64
-  BlockSize    4096
-
-[iSCSI]
-  NodeBase "iqn.2019-05.io.openebs"
-  # Socket I/O timeout sec. (0 is infinite)
-  Timeout 30
-  DiscoveryAuthMethod None
-  DefaultTime2Wait 2
-  DefaultTime2Retain 60
-  ImmediateData Yes
-  ErrorRecoveryLevel 0
-  # Reduce mem requirements for iSCSI
-  MaxSessions 1
-  MaxConnectionsPerSession 1
-
-[PortalGroup1]
-  Portal GR1 0.0.0.0:3261
-
-[InitiatorGroup1]
-  InitiatorName Any
-  Netmask ${externIp}/24
-
-[TargetNode0]
-  TargetName "iqn.2019-05.io.openebs:disk1"
-  TargetAlias "Backend Malloc1"
-  Mapping PortalGroup1 InitiatorGroup1
-  AuthMethod None
-  UseDigest Auto
-  LUN0 Malloc1
-  QueueDepth 1
-`;
 
 const nexusArgs = {
   uuid: UUID,
@@ -190,7 +147,7 @@ describe('rebuild tests', function () {
           fs.truncate(child2, diskSize, next);
         },
         (next) => {
-          common.startMayastor(configNexus, ['-r', common.SOCK, '-g', common.grpcEndpoint, '-s', 386]);
+          common.startMayastor(null, ['-r', common.SOCK, '-g', common.grpcEndpoint, '-s', 384]);
           common.waitFor((pingDone) => {
             pingMayastor(pingDone);
           }, next);

--- a/mayastor-test/test_snapshot.js
+++ b/mayastor-test/test_snapshot.js
@@ -58,7 +58,7 @@ describe('snapshot', function () {
           // SPDK hangs if nvme initiator and target are in the same instance.
           //
           // Use -s option to limit hugepage allocation.
-          common.startMayastor(null, [
+          common.startMayastor(config, [
             '-r',
             '/tmp/target.sock',
             '-s',
@@ -67,7 +67,6 @@ describe('snapshot', function () {
             '127.0.0.1:10125'
           ],
           null,
-          config,
           '_tgt');
           common.waitFor((pingDone) => {
             // use harmless method to test if the mayastor is up and running


### PR DESCRIPTION
Legacy INI style configuration was been deprecated in SPDK 20.04 and
will be removed in a future release.

Remove use of ini style configuration when starting Mayastor by
converting them to yaml format Mayastor config (test_nexus) or
dropping it altogether (test_rebuild, as it was actually unused).

Change the first argument to common.startMayastor to take a Mayastor
config instead.

Note that test_nexus still has a standalone instance of SPDK that uses an ini file, this will be addressed in CAS-430.