### PR TITLE
Jenkins should not update status of commit if all stages were skipped (CAS-459)

### DIFF
--- a/doc/jenkins.md
+++ b/doc/jenkins.md
@@ -114,6 +114,9 @@ for system configuration of nodes (as opposed to using ansible, salt, etc.).
    * ssh agent
    * multibranch scan webhook trigger
    * embeddable build status
+   * pipeline stage view
+   * slack
+   * disable GitHub Multibranch Status
 
 7. Enable read-only access for unauthenticated clients.
 


### PR DESCRIPTION
Bonus feature are slack messages sent to mayastor-backend channel
when nightly tests break/recover. Otherwise it would be very easy
to go unnoticed.