### PR TITLE
CAS-430: Use mayastor instead of spdk binary in mocha tests

### DIFF
--- a/mayastor-test/test_common.js
+++ b/mayastor-test/test_common.js
@@ -15,7 +15,6 @@ const sudo = require('./sudo');
 
 const SOCK = '/tmp/mayastor_test.sock';
 const MS_CONFIG_PATH = '/tmp/mayastor_test.cfg';
-const SPDK_CONFIG_PATH = '/tmp/spdk_test.cfg';
 const GRPC_PORT = 10124;
 const CSI_ENDPOINT = '/tmp/mayastor_csi_test.sock';
 const CSI_ID = 'test-node-id';
@@ -161,34 +160,6 @@ function startProcess (command, args, env, closeCb, psName, suffix) {
     if (closeCb) closeCb();
   });
   procs[procsIndex] = proc;
-}
-
-// Start spdk process and return immediately.
-function startSpdk (config, args, env) {
-  args = args || ['-r', SOCK];
-  env = env || {};
-
-  if (config) {
-    fs.writeFileSync(SPDK_CONFIG_PATH, config);
-    args = args.concat(['-c', SPDK_CONFIG_PATH]);
-  }
-
-  startProcess(
-    'spdk',
-    args,
-    _.assign(
-      {
-        MAYASTOR_DELAY: '1'
-      },
-      env
-    ),
-    () => {
-      try {
-        fs.unlinkSync(SPDK_CONFIG_PATH);
-      } catch (err) {}
-    },
-    'reactor_0'
-  );
 }
 
 // Start mayastor process and return immediately.
@@ -470,7 +441,6 @@ module.exports = {
   CSI_ENDPOINT,
   CSI_ID,
   SOCK,
-  startSpdk,
   startMayastor,
   startMayastorCsi,
   stopAll,

--- a/mayastor-test/test_nexus.js
+++ b/mayastor-test/test_nexus.js
@@ -19,6 +19,7 @@ const url = require('url');
 // just some UUID used for nexus ID
 const UUID = 'dbe4d7eb-118a-4d15-b789-a18d9af6ff21';
 const UUID2 = 'dbe4d7eb-118a-4d15-b789-a18d9af6ff22';
+const TGTUUID = 'dbe4d7eb-118a-4d15-b789-a18d9af6ff29';
 
 // backend file for aio bdev
 const aioFile = '/tmp/aio-backend';
@@ -49,33 +50,20 @@ base_bdevs:
 // The config just for nvmf target which cannot run in the same process as
 // the nvmf initiator (SPDK limitation).
 const configNvmfTarget = `
-[Malloc]
-  NumberOfLuns 1
-  LunSizeInMB  64
-  BlockSize    4096
-
-[Nvmf]
-  AcceptorPollRate 10000
-  ConnectionScheduler RoundRobin
-
-[Transport]
-  Type TCP
-  # reduce memory requirements
-  NumSharedBuffers 64
-
-[Subsystem1]
-  NQN nqn.2019-05.io.openebs:disk2
-  Listen TCP 127.0.0.1:8420
-  AllowAnyHost Yes
-  SN MAYASTOR0000000001
-  MN NEXUSController1
-  MaxNamespaces 1
-  Namespace Malloc0 1
-
+sync_disable: true
+base_bdevs:
+  - uri: "malloc:///Malloc0?size_mb=64&blk_size=4096&uuid=${TGTUUID}"
+nexus_opts:
+  nvmf_nexus_port: 4422
+  nvmf_replica_port: 8420
+  iscsi_enable: false
+nvmf_tcp_tgt_conf:
+  max_namespaces: 2
 # although not used we still have to reduce mem requirements for iSCSI
-[iSCSI]
-  MaxSessions 1
-  MaxConnectionsPerSession 1
+iscsi_tgt_conf:
+  max_sessions: 1
+  max_connections_per_session: 1
+implicit_share_base: true
 `;
 
 var client;
@@ -254,7 +242,7 @@ describe('nexus', function () {
     uuid: UUID,
     size: 131072,
     children: [
-      'nvmf://127.0.0.1:8420/nqn.2019-05.io.openebs:disk2',
+      `nvmf://127.0.0.1:8420/nqn.2019-05.io.openebs:${TGTUUID}`,
       `aio://${aioFile}?blk_size=4096`
     ]
   };
@@ -271,19 +259,21 @@ describe('nexus', function () {
         common.ensureNbdWritable,
         // start this as early as possible to avoid mayastor getting connection refused.
         (next) => {
-          // Start two spdk instances. The first one will hold the remote
+          // Start two Mayastor instances. The first one will hold the remote
           // nvmf target and the second one everything including nexus.
           // We must do this because if nvme initiator and target are in
           // the same instance, the SPDK will hang.
           //
           // In order not to exceed available memory in hugepages when running
           // two instances we use the -s option to limit allocated mem.
-          common.startSpdk(configNvmfTarget, [
+          common.startMayastor(configNvmfTarget, [
             '-r',
             '/tmp/target.sock',
             '-s',
             '128'
-          ]);
+          ],
+          { MY_POD_IP: '127.0.0.1' },
+          '_tgt');
           common.waitFor((pingDone) => {
             // use harmless method to test if spdk is up and running
             common.jsonrpcCommand('/tmp/target.sock', 'bdev_get_bdevs', pingDone);
@@ -354,7 +344,7 @@ describe('nexus', function () {
       children: [
         'bdev:///Malloc0',
         `aio://${aioFile}?blk_size=4096`,
-        'nvmf://127.0.0.1:8420/nqn.2019-05.io.openebs:disk2'
+        `nvmf://127.0.0.1:8420/nqn.2019-05.io.openebs:${TGTUUID}`
       ]
     };
     if (doIscsiReplica) args.children.push(`iscsi://iscsi://${externIp}:${iscsiReplicaPort}/iqn.2019-05.io.openebs:disk1`);
@@ -377,7 +367,7 @@ describe('nexus', function () {
 
       assert.equal(
         nexus.children[2].uri,
-        'nvmf://127.0.0.1:8420/nqn.2019-05.io.openebs:disk2'
+        `nvmf://127.0.0.1:8420/nqn.2019-05.io.openebs:${TGTUUID}`
       );
       assert.equal(nexus.children[2].state, 'CHILD_ONLINE');
       if (doIscsiReplica) {
@@ -427,7 +417,7 @@ describe('nexus', function () {
 
       assert.equal(
         nexus.children[2].uri,
-        'nvmf://127.0.0.1:8420/nqn.2019-05.io.openebs:disk2'
+        `nvmf://127.0.0.1:8420/nqn.2019-05.io.openebs:${TGTUUID}`
       );
       assert.equal(nexus.children[2].state, 'CHILD_ONLINE');
       if (doIscsiReplica) {
@@ -453,7 +443,7 @@ describe('nexus', function () {
   it('should be able to remove one of its children', (done) => {
     const args = {
       uuid: UUID,
-      uri: 'nvmf://127.0.0.1:8420/nqn.2019-05.io.openebs:disk2'
+      uri: `nvmf://127.0.0.1:8420/nqn.2019-05.io.openebs:${TGTUUID}`
     };
 
     client.removeChildNexus(args, (err) => {
@@ -471,7 +461,7 @@ describe('nexus', function () {
   });
 
   it('should be able to add the child back', (done) => {
-    const uri = 'nvmf://127.0.0.1:8420/nqn.2019-05.io.openebs:disk2';
+    const uri = `nvmf://127.0.0.1:8420/nqn.2019-05.io.openebs:${TGTUUID}`;
     const args = {
       uuid: UUID,
       uri: uri,
@@ -498,7 +488,7 @@ describe('nexus', function () {
     const args = {
       uuid: UUID2,
       size: 131072,
-      children: ['nvmf://127.0.0.1:8420/nqn.2019-05.io.openebs:disk2']
+      children: [`nvmf://127.0.0.1:8420/nqn.2019-05.io.openebs:${TGTUUID}`]
     };
 
     client.createNexus(args, (err) => {
@@ -723,7 +713,7 @@ describe('nexus', function () {
         size: 2 * diskSize,
         children: [
         `aio://${aioFile}?blk_size=4096`,
-        'nvmf://127.0.0.1:8420/nqn.2019-05.io.openebs:disk2'
+        `nvmf://127.0.0.1:8420/nqn.2019-05.io.openebs:${TGTUUID}`
         ]
       };
 


### PR DESCRIPTION
Change test_nexus to start a 2nd instance of Mayastor to act as an
NVMf target instead of starting the SPDK binary. As this was the only
user, remove common.startSpdk.

This allows the default nvmf target in SPDK to be disabled.