### PR TITLE
terraform: Require the libvirt provider

### DIFF
--- a/terraform/README.adoc
+++ b/terraform/README.adoc
@@ -84,6 +84,7 @@ command and copy paste the output to `~/.kube/config`:
 ansible -i ansible-hosts -a 'sudo cat /etc/kubernetes/admin.conf' master
 ----
 
+Note that for libvirt the configuration works with Terraform versions 0.13 upwards.
 === Setting up libvirt on Nixos
 
 To use the libvirt provider, you must enable libvirtd

--- a/terraform/mod/libvirt/main.tf
+++ b/terraform/mod/libvirt/main.tf
@@ -147,5 +147,12 @@ output "node_list" {
 }
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+
+  required_providers {
+    libvirt = {
+      source  = "dmacvicar/libvirt"
+      version = "0.6.2"
+    }
+  }
 }


### PR DESCRIPTION
We need this field so that we work with terraform v0.13