### PR TITLE
CAS-466: Simplify the nexus child state management

### DIFF
--- a/mayastor/src/bdev/mod.rs
+++ b/mayastor/src/bdev/mod.rs
@@ -9,7 +9,7 @@ pub use nexus::{
         NexusStatus,
         VerboseError,
     },
-    nexus_child::ChildStatus,
+    nexus_child::{ChildState, Reason},
     nexus_child_error_store::{ActionType, NexusErrStore, QueryType},
     nexus_child_status_config,
     nexus_label::{GPTHeader, GptEntry},

--- a/mayastor/src/bdev/nexus/nexus_bdev.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev.rs
@@ -40,7 +40,7 @@ use crate::{
         nexus::{
             instances,
             nexus_channel::{DREvent, NexusChannel, NexusChannelInner},
-            nexus_child::{ChildError, ChildState, ChildStatus, NexusChild},
+            nexus_child::{ChildError, ChildState, NexusChild},
             nexus_io::{io_status, nvme_admin_opc, Bio},
             nexus_iscsi::{NexusIscsiError, NexusIscsiTarget},
             nexus_label::LabelError,
@@ -505,7 +505,7 @@ impl Nexus {
 
         trace!("{}: closing, from state: {:?} ", self.name, self.state);
         self.children.iter_mut().for_each(|c| {
-            if c.state == ChildState::Open {
+            if c.state() == ChildState::Open {
                 c.close();
             }
         });
@@ -900,14 +900,14 @@ impl Nexus {
                     .children
                     .iter()
                     // All children are online, so the Nexus is also online
-                    .all(|c| c.status() == ChildStatus::Online)
+                    .all(|c| c.state() == ChildState::Open)
                 {
                     NexusStatus::Online
                 } else if self
                     .children
                     .iter()
                     // at least one child online, so the Nexus is also online
-                    .any(|c| c.status() == ChildStatus::Online)
+                    .any(|c| c.state() == ChildState::Open)
                 {
                     NexusStatus::Degraded
                 } else {

--- a/mayastor/src/bdev/nexus/nexus_bdev_children.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev_children.rs
@@ -39,7 +39,7 @@ use crate::{
                 OpenChild,
             },
             nexus_channel::DREvent,
-            nexus_child::{ChildState, ChildStatus, NexusChild},
+            nexus_child::{ChildState, NexusChild},
             nexus_child_status_config::ChildStatusConfig,
             nexus_label::{
                 LabelError,
@@ -48,6 +48,7 @@ use crate::{
                 NexusLabelStatus,
             },
         },
+        Reason,
         VerboseError,
     },
     core::Bdev,
@@ -115,7 +116,7 @@ impl Nexus {
                     e.verbose()
                 );
                 match self.get_child_by_name(uri) {
-                    Ok(child) => child.fault(),
+                    Ok(child) => child.fault(Reason::RebuildFailed),
                     Err(e) => error!(
                         "Failed to find newly added child {}, error: {}",
                         uri,
@@ -181,7 +182,7 @@ impl Nexus {
 
                 // it can never take part in the IO path
                 // of the nexus until it's rebuilt from a healthy child.
-                child.out_of_sync(true);
+                child.fault(Reason::OutOfSync);
                 if ChildStatusConfig::add(&child).is_err() {
                     error!("Failed to add child status information");
                 }
@@ -230,7 +231,7 @@ impl Nexus {
         };
 
         self.children[idx].close();
-        assert_eq!(self.children[idx].state, ChildState::Closed);
+        assert_eq!(self.children[idx].state(), ChildState::Closed);
 
         let mut child = self.children.remove(idx);
         self.child_count -= 1;
@@ -274,7 +275,11 @@ impl Nexus {
     }
 
     /// fault a child device and reconfigure the IO channels
-    pub async fn fault_child(&mut self, name: &str) -> Result<(), Error> {
+    pub async fn fault_child(
+        &mut self,
+        name: &str,
+        reason: Reason,
+    ) -> Result<(), Error> {
         trace!("{}: fault child request for {}", self.name, name);
 
         if self.child_count < 2 {
@@ -289,9 +294,13 @@ impl Nexus {
 
         let result = match self.children.iter_mut().find(|c| c.name == name) {
             Some(child) => {
-                if child.status() != ChildStatus::Faulted {
-                    child.fault();
-                    self.reconfigure(DREvent::ChildFault).await;
+                match child.state() {
+                    ChildState::Faulted(_) => {}
+                    _ => {
+                        child.fault(reason);
+                        NexusChild::save_state_change();
+                        self.reconfigure(DREvent::ChildFault).await;
+                    }
                 }
                 Ok(())
             }
@@ -348,7 +357,7 @@ impl Nexus {
     pub fn examine_child(&mut self, name: &str) -> bool {
         self.children
             .iter_mut()
-            .filter(|c| c.state == ChildState::Init && c.name == name)
+            .filter(|c| c.state() == ChildState::Init && c.name == name)
             .any(|c| {
                 if let Some(bdev) = Bdev::lookup_by_name(name) {
                     c.bdev = Some(bdev);
@@ -515,7 +524,7 @@ impl Nexus {
         let mut blockcnt = std::u64::MAX;
         self.children
             .iter()
-            .filter(|c| c.state == ChildState::Open)
+            .filter(|c| c.state() == ChildState::Open)
             .map(|c| c.bdev.as_ref().unwrap().num_blocks())
             .collect::<Vec<_>>()
             .iter()

--- a/mayastor/src/bdev/nexus/nexus_channel.rs
+++ b/mayastor/src/bdev/nexus/nexus_channel.rs
@@ -12,7 +12,7 @@ use spdk_sys::{
 };
 
 use crate::{
-    bdev::{nexus::nexus_child::ChildStatus, Nexus},
+    bdev::{nexus::nexus_child::ChildState, Nexus},
     core::BdevHandle,
 };
 
@@ -90,7 +90,7 @@ impl NexusChannelInner {
         nexus
             .children
             .iter_mut()
-            .filter(|c| c.status() == ChildStatus::Online)
+            .filter(|c| c.state() == ChildState::Open)
             .for_each(|c| {
                 self.ch.push(
                     BdevHandle::try_from(c.get_descriptor().unwrap()).unwrap(),
@@ -143,7 +143,7 @@ impl NexusChannel {
         nexus
             .children
             .iter_mut()
-            .filter(|c| c.status() == ChildStatus::Online)
+            .filter(|c| c.state() == ChildState::Open)
             .map(|c| {
                 channels.ch.push(
                     BdevHandle::try_from(c.get_descriptor().unwrap()).unwrap(),

--- a/mayastor/src/bdev/nexus/nexus_child.rs
+++ b/mayastor/src/bdev/nexus/nexus_child.rs
@@ -8,7 +8,10 @@ use spdk_sys::{spdk_bdev_module_release_bdev, spdk_io_channel};
 
 use crate::{
     bdev::{
-        nexus::nexus_child_status_config::ChildStatusConfig,
+        nexus::{
+            nexus_child::ChildState::Faulted,
+            nexus_child_status_config::ChildStatusConfig,
+        },
         NexusErrStore,
     },
     core::{Bdev, BdevHandle, CoreError, Descriptor, DmaBuf},
@@ -55,81 +58,63 @@ pub enum ChildIoError {
     InvalidDescriptor { name: String },
 }
 
-#[derive(Debug, Clone, Copy, Serialize, PartialEq)]
-pub enum ChildStatus {
-    /// available for RW
-    Online,
-    /// temporarily unavailable for R, out of sync with nexus (needs rebuild)
-    Degraded,
-    /// permanently unavailable for RW
-    Faulted,
-}
-
-#[derive(Debug, Serialize, Deserialize, Default, Copy, Clone)]
-pub(crate) struct StatusReasons {
-    /// Degraded
-    ///
+#[derive(Debug, Serialize, PartialEq, Deserialize, Copy, Clone)]
+pub enum Reason {
+    /// no particular reason for the child to be in this state
+    /// this is typically the init state
+    Unknown,
     /// out of sync - needs to be rebuilt
-    out_of_sync: bool,
-    /// temporarily closed
-    offline: bool,
-
-    /// Faulted
-    /// fatal error, cannot be recovered
-    fatal_error: bool,
+    OutOfSync,
+    /// cannot open
+    CantOpen,
+    /// the child failed to rebuild successfully
+    RebuildFailed,
+    /// the child has been faulted due to I/O error(s)
+    IoError,
+    /// the child has been explicitly faulted due to a rpc call
+    Rpc,
 }
 
-impl StatusReasons {
-    /// a fault occurred, it is not recoverable
-    fn fatal_error(&mut self) {
-        self.fatal_error = true;
-    }
-
-    /// set offline
-    fn offline(&mut self, offline: bool) {
-        self.offline = offline;
-    }
-
-    /// out of sync with nexus, needs a rebuild
-    fn out_of_sync(&mut self, out_of_sync: bool) {
-        self.out_of_sync = out_of_sync;
+impl Display for Reason {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Unknown => write!(f, "Unknown"),
+            Self::OutOfSync => {
+                write!(f, "The child is out of sync and requires a rebuild")
+            }
+            Self::CantOpen => write!(f, "The child bdev could not be opened"),
+            Self::RebuildFailed => {
+                write!(f, "The child failed to rebuild successfully")
+            }
+            Self::IoError => write!(f, "The child had too many I/O errors"),
+            Self::Rpc => write!(f, "The child is faulted due to a rpc call"),
+        }
     }
 }
 
-#[derive(Debug, Clone, Copy, Serialize, PartialEq)]
-pub(crate) enum ChildState {
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
+pub enum ChildState {
     /// child has not been opened, but we are in the process of opening it
     Init,
     /// cannot add this bdev to the parent as its incompatible property wise
     ConfigInvalid,
     /// the child is open for RW
     Open,
-    /// unusable by the nexus for RW
+    /// the child has been closed by the nexus
     Closed,
+    /// the child is faulted
+    Faulted(Reason),
 }
 
-impl ToString for ChildState {
-    fn to_string(&self) -> String {
-        match *self {
-            ChildState::Init => "init",
-            ChildState::ConfigInvalid => "configInvalid",
-            ChildState::Open => "open",
-            ChildState::Closed => "closed",
+impl Display for ChildState {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Faulted(r) => write!(f, "Faulted with reason {}", r),
+            Self::Init => write!(f, "Init"),
+            Self::ConfigInvalid => write!(f, "Config parameters are invalid"),
+            Self::Open => write!(f, "Child is open"),
+            Self::Closed => write!(f, "Closed"),
         }
-        .parse()
-        .unwrap()
-    }
-}
-
-impl ToString for ChildStatus {
-    fn to_string(&self) -> String {
-        match *self {
-            ChildStatus::Degraded => "degraded",
-            ChildStatus::Faulted => "faulted",
-            ChildStatus::Online => "online",
-        }
-        .parse()
-        .unwrap()
     }
 }
 
@@ -149,8 +134,8 @@ pub struct NexusChild {
     #[serde(skip_serializing)]
     pub(crate) desc: Option<Arc<Descriptor>>,
     /// current state of the child
-    pub(crate) state: ChildState,
-    pub(crate) status_reasons: StatusReasons,
+    #[serde(skip_serializing)]
+    state: ChildState,
     /// descriptor obtained after opening a device
     #[serde(skip_serializing)]
     pub(crate) bdev_handle: Option<BdevHandle>,
@@ -165,46 +150,60 @@ impl Display for NexusChild {
             let bdev = self.bdev.as_ref().unwrap();
             writeln!(
                 f,
-                "{}: {:?}/{:?}, blk_cnt: {}, blk_size: {}",
+                "{}: {:?}, blk_cnt: {}, blk_size: {}",
                 self.name,
-                self.state,
-                self.status(),
+                self.state(),
                 bdev.num_blocks(),
                 bdev.block_len(),
             )
         } else {
-            writeln!(
-                f,
-                "{}: state {:?}/{:?}",
-                self.name,
-                self.state,
-                self.status()
-            )
+            writeln!(f, "{}: state {:?}", self.name, self.state())
         }
     }
 }
 
 impl NexusChild {
+    pub(crate) fn set_state(&mut self, state: ChildState) {
+        trace!(
+            "{}: child {}: state change from {} to {}",
+            self.parent,
+            self.name,
+            self.state.to_string(),
+            state.to_string(),
+        );
+
+        self.state = state;
+    }
+
     /// Open the child in RW mode and claim the device to be ours. If the child
     /// is already opened by someone else (i.e one of the targets) it will
     /// error out.
     ///
     /// only devices in the closed or Init state can be opened.
+    ///
+    /// A child can only be opened if:
+    ///  - it's not faulted
+    ///  - it's not already opened
     pub(crate) fn open(
         &mut self,
         parent_size: u64,
     ) -> Result<String, ChildError> {
         trace!("{}: Opening child device {}", self.parent, self.name);
 
-        if self.status() == ChildStatus::Faulted {
-            return Err(ChildError::ChildFaulted {});
-        }
-        if self.state != ChildState::Closed && self.state != ChildState::Init {
-            return Err(ChildError::ChildNotClosed {});
-        }
-
-        if self.bdev.is_none() {
-            return Err(ChildError::OpenWithoutBdev {});
+        // verify the state of the child before we open it
+        match self.state() {
+            ChildState::Faulted(reason) => {
+                error!(
+                    "{}: can not open child {} reason {}",
+                    self.parent, self.name, reason
+                );
+                return Err(ChildError::ChildFaulted {});
+            }
+            ChildState::Open => {
+                // the child (should) already be open
+                assert_eq!(self.bdev.is_some(), true);
+            }
+            _ => {}
         }
 
         let bdev = self.bdev.as_ref().unwrap();
@@ -212,23 +211,28 @@ impl NexusChild {
         let child_size = bdev.size_in_bytes();
         if parent_size > child_size {
             error!(
-                "{}: child too small, parent size: {} child size: {}",
-                self.name, parent_size, child_size
+                "{}: child {} too small, parent size: {} child size: {}",
+                self.parent, self.name, parent_size, child_size
             );
-            self.state = ChildState::ConfigInvalid;
+
+            self.set_state(ChildState::ConfigInvalid);
             return Err(ChildError::ChildTooSmall {
                 parent_size,
                 child_size,
             });
         }
 
-        self.desc = Some(Arc::new(
-            Bdev::open_by_name(&bdev.name(), true).context(OpenChild {})?,
-        ));
+        let desc = Arc::new(Bdev::open_by_name(&bdev.name(), true).map_err(
+            |source| {
+                self.set_state(Faulted(Reason::CantOpen));
+                ChildError::OpenChild {
+                    source,
+                }
+            },
+        )?);
 
-        self.bdev_handle = Some(
-            BdevHandle::try_from(self.desc.as_ref().unwrap().clone()).unwrap(),
-        );
+        self.bdev_handle = Some(BdevHandle::try_from(desc.clone()).unwrap());
+        self.desc = Some(desc);
 
         let cfg = Config::get();
         if cfg.err_store_opts.enable_err_store {
@@ -236,46 +240,46 @@ impl NexusChild {
                 Some(NexusErrStore::new(cfg.err_store_opts.err_store_size));
         };
 
-        self.state = ChildState::Open;
+        self.set_state(ChildState::Open);
 
         debug!("{}: child {} opened successfully", self.parent, self.name);
-
         Ok(self.name.clone())
     }
 
-    /// Fault the child following an unrecoverable error
-    pub(crate) fn fault(&mut self) {
-        self.close();
-        self.status_reasons.fatal_error();
+    /// Fault the child with a specific reason.
+    /// We do not close the child if it is out-of-sync because it will
+    /// subsequently be rebuilt.
+    pub(crate) fn fault(&mut self, reason: Reason) {
+        match reason {
+            Reason::OutOfSync => {
+                self.set_state(ChildState::Faulted(reason));
+            }
+            _ => {
+                self._close();
+                self.set_state(ChildState::Faulted(reason));
+            }
+        }
         NexusChild::save_state_change();
     }
-    /// Set the child as out of sync with the nexus
-    /// It requires a full rebuild before it can service IO
-    /// and remains degraded until such time
-    pub(crate) fn out_of_sync(&mut self, out_of_sync: bool) {
-        self.status_reasons.out_of_sync(out_of_sync);
-        NexusChild::save_state_change();
-    }
+
     /// Set the child as temporarily offline
+    /// TODO: channels need to be updated when bdevs are closed
     pub(crate) fn offline(&mut self) {
         self.close();
-        self.status_reasons.offline(true);
         NexusChild::save_state_change();
     }
-    /// Online a previously offlined child
+
+    /// Online a previously offlined child.
+    /// The child is set out-of-sync so that it will be rebuilt.
+    /// TODO: channels need to be updated when bdevs are opened
     pub(crate) fn online(
         &mut self,
         parent_size: u64,
     ) -> Result<String, ChildError> {
-        if !self.status_reasons.offline {
-            return Err(ChildError::ChildNotOffline {});
-        }
-        self.open(parent_size).map(|s| {
-            self.status_reasons.offline(false);
-            self.status_reasons.out_of_sync(true);
-            NexusChild::save_state_change();
-            s
-        })
+        let result = self.open(parent_size);
+        self.set_state(ChildState::Faulted(Reason::OutOfSync));
+        NexusChild::save_state_change();
+        result
     }
 
     /// Save the state of the children to the config file
@@ -285,50 +289,14 @@ impl NexusChild {
         }
     }
 
-    /// Status of the child
-    /// Init
-    /// Degraded as it cannot service IO, temporarily
-    ///
-    /// ConfigInvalid
-    /// Faulted as it cannot ever service IO
-    ///
-    /// Open
-    /// Degraded if temporarily out of sync
-    /// Online otherwise
-    ///
-    /// Closed
-    /// Degraded if offline
-    /// otherwise Faulted as it cannot ever service IO
-    /// todo: better cater for the online/offline "states"
-    pub fn status(&self) -> ChildStatus {
-        match self.state {
-            ChildState::Init => ChildStatus::Degraded,
-            ChildState::ConfigInvalid => ChildStatus::Faulted,
-            ChildState::Closed => {
-                if self.status_reasons.fatal_error {
-                    ChildStatus::Faulted
-                } else {
-                    ChildStatus::Degraded
-                }
-            }
-            ChildState::Open => {
-                if self.status_reasons.out_of_sync {
-                    ChildStatus::Degraded
-                } else if self.status_reasons.fatal_error {
-                    ChildStatus::Faulted
-                } else {
-                    ChildStatus::Online
-                }
-            }
-        }
+    /// returns the state of the child
+    pub fn state(&self) -> ChildState {
+        self.state
     }
 
     pub(crate) fn rebuilding(&self) -> bool {
         match RebuildJob::lookup(&self.name) {
-            Ok(_) => {
-                self.state == ChildState::Open
-                    && self.status_reasons.out_of_sync
-            }
+            Ok(_) => self.state() == ChildState::Faulted(Reason::OutOfSync),
             Err(_) => false,
         }
     }
@@ -344,8 +312,8 @@ impl NexusChild {
         }
     }
 
-    /// close the bdev -- we have no means of determining if this succeeds
-    pub(crate) fn close(&mut self) -> ChildState {
+    /// closed the descriptor and handle, does not destroy the bdev
+    fn _close(&mut self) {
         trace!("{}: Closing child {}", self.parent, self.name);
         if let Some(bdev) = self.bdev.as_ref() {
             unsafe {
@@ -354,16 +322,18 @@ impl NexusChild {
                 }
             }
         }
-
         // just to be explicit
         let hdl = self.bdev_handle.take();
         let desc = self.desc.take();
         drop(hdl);
         drop(desc);
+    }
 
-        // we leave the child structure around for when we want reopen it
-        self.state = ChildState::Closed;
-        self.state
+    /// close the bdev -- we have no means of determining if this succeeds
+    pub(crate) fn close(&mut self) -> ChildState {
+        self._close();
+        self.set_state(ChildState::Closed);
+        ChildState::Closed
     }
 
     /// create a new nexus child
@@ -375,7 +345,6 @@ impl NexusChild {
             desc: None,
             ch: std::ptr::null_mut(),
             state: ChildState::Init,
-            status_reasons: Default::default(),
             bdev_handle: None,
             err_store: None,
         }
@@ -384,7 +353,7 @@ impl NexusChild {
     /// destroy the child bdev
     pub(crate) async fn destroy(&mut self) -> Result<(), NexusBdevError> {
         trace!("destroying child {:?}", self);
-        assert_eq!(self.state, ChildState::Closed);
+        assert_eq!(self.state(), ChildState::Closed);
         if let Some(_bdev) = &self.bdev {
             bdev_destroy(&self.name).await
         } else {
@@ -395,7 +364,7 @@ impl NexusChild {
 
     /// returns if a child can be written to
     pub fn can_rw(&self) -> bool {
-        self.state == ChildState::Open && self.status() != ChildStatus::Faulted
+        self.state() == ChildState::Open
     }
 
     /// return references to child's bdev and descriptor

--- a/mayastor/src/grpc/mayastor_grpc.rs
+++ b/mayastor/src/grpc/mayastor_grpc.rs
@@ -17,6 +17,7 @@ use crate::{
     bdev::{
         nexus::{instances, nexus_bdev},
         nexus_create,
+        Reason,
     },
     grpc::{
         nexus_grpc::{
@@ -217,7 +218,7 @@ impl mayastor_server::Mayastor for MayastorSvc {
             let uri = args.uri.clone();
             debug!("Faulting child {} on nexus {}", uri, uuid);
             locally! { async move {
-                nexus_lookup(&args.uuid)?.fault_child(&args.uri).await
+                nexus_lookup(&args.uuid)?.fault_child(&args.uri, Reason::Rpc).await
             }};
             info!("Faulted child {} on nexus {}", uri, uuid);
             Ok(Response::new(Null {}))

--- a/mayastor/src/subsys/config/mod.rs
+++ b/mayastor/src/subsys/config/mod.rs
@@ -32,11 +32,10 @@ use crate::{
     bdev::{
         nexus::{
             instances,
-            nexus_child::NexusChild,
+            nexus_child::{ChildState, NexusChild, Reason},
             nexus_child_status_config::ChildStatusConfig,
         },
         nexus_create,
-        ChildStatus,
         VerboseError,
     },
     core::{Bdev, Cores, Reactor, Share},
@@ -399,7 +398,10 @@ impl Config {
                     let degraded_children: Vec<&NexusChild> = nexus_instance
                         .children
                         .iter()
-                        .filter(|child| child.status() == ChildStatus::Degraded)
+                        .filter(|child| {
+                            child.state()
+                                == ChildState::Faulted(Reason::OutOfSync)
+                        })
                         .collect::<Vec<_>>();
 
                     // Get a mutable reference to the nexus instance. We can't

--- a/mayastor/tests/nexus_rebuild.rs
+++ b/mayastor/tests/nexus_rebuild.rs
@@ -6,7 +6,7 @@ use tracing::error;
 
 use common::error_bdev;
 use mayastor::{
-    bdev::{nexus_lookup, ChildStatus, VerboseError},
+    bdev::{nexus_lookup, ChildState, Reason, VerboseError},
     core::{MayastorCliArgs, MayastorEnvironment, Mthread, Reactor},
     rebuild::{RebuildJob, RebuildState, SEGMENT_SIZE},
 };
@@ -635,7 +635,10 @@ fn rebuild_fault_src() {
         .unwrap();
         // allow the nexus futures to run
         reactor_poll!(10);
-        assert_eq!(nexus.children[1].status(), ChildStatus::Faulted);
+        assert_eq!(
+            nexus.children[1].state(),
+            ChildState::Faulted(Reason::RebuildFailed)
+        );
 
         nexus_lookup(nexus_name()).unwrap().destroy().await.unwrap();
     });
@@ -669,7 +672,10 @@ fn rebuild_fault_dst() {
         .unwrap();
         // allow the nexus futures to run
         reactor_poll!(10);
-        assert_eq!(nexus.children[1].status(), ChildStatus::Faulted);
+        assert_eq!(
+            nexus.children[1].state(),
+            ChildState::Faulted(Reason::RebuildFailed)
+        );
 
         nexus_lookup(nexus_name()).unwrap().destroy().await.unwrap();
     });


### PR DESCRIPTION
The nexus child state information is now managed simply by the
ChildState enum. The faulted state makes use of enum variants to
distinguish between the different types of fault conditions.

The use of ChildStatus has been completely removed. This was meant to
map internal Mayastor child state information to states required by the
control plane. This conversion is now performed when the child object is
mapped to its grpc representation.