### PR TITLE
CAS-474: Use child status config in Mayastor deployment

### DIFF
--- a/deploy/mayastor-daemonset-config.yaml
+++ b/deploy/mayastor-daemonset-config.yaml
@@ -1,0 +1,102 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  namespace: mayastor
+  name: mayastor
+  labels:
+    openebs/engine: mayastor
+spec:
+  selector:
+    matchLabels:
+      app: mayastor
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  minReadySeconds: 10
+  template:
+    metadata:
+      labels:
+        app: mayastor
+    spec:
+      hostNetwork: true
+      # To resolve services from mayastor namespace
+      dnsPolicy: ClusterFirstWithHostNet
+      nodeSelector:
+        openebs.io/engine: mayastor
+        kubernetes.io/arch: amd64
+      # NOTE: Each container must have mem/cpu limits defined in order to
+      # belong to Guaranteed QoS class, hence can never get evicted in case of
+      # pressure unless they exceed those limits. limits and requests must be
+      # the same.
+      containers:
+        - name: mayastor
+          image: 192.168.1.119:5000/mayastor:dev
+          imagePullPolicy: Always
+          env:
+            - name: MY_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: IMPORT_NEXUSES
+              value: "false"
+          args:
+            - "-N$(MY_NODE_NAME)"
+            - "-g$(MY_POD_IP)"
+            - "-nnats"
+            - "-y/var/local/mayastor/config.yaml"
+            - "-C/var/local/mayastor/child-status-config.yaml"
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - name: device
+              mountPath: /dev
+            - name: dshm
+              mountPath: /dev/shm
+            - name: configlocation
+              mountPath: /var/local/mayastor/
+            - name: config
+              mountPath: /var/local/mayastor/config.yaml
+            - name: child-status-config
+              mountPath: /var/local/mayastor/child-status-config.yaml
+          resources:
+            limits:
+              cpu: "1"
+              memory: "500Mi"
+              hugepages-2Mi: "1Gi"
+            requests:
+              cpu: "1"
+              memory: "500Mi"
+              hugepages-2Mi: "1Gi"
+          ports:
+            - containerPort: 10124
+              protocol: TCP
+              name: mayastor
+      volumes:
+        - name: device
+          hostPath:
+            path: /dev
+            type: Directory
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: "1Gi"
+        - name: hugepage
+          emptyDir:
+            medium: HugePages
+        - name: configlocation
+          hostPath:
+            path: /var/local/mayastor/
+            type: DirectoryOrCreate
+        - name: config
+          hostPath:
+            path: /var/local/mayastor/config.yaml
+            type: FileOrCreate
+        - name: child-status-config
+          hostPath:
+            path: /var/local/mayastor/child-status-config.yaml
+            type: FileOrCreate

--- a/deploy/mayastor-daemonset.yaml
+++ b/deploy/mayastor-daemonset.yaml
@@ -48,7 +48,6 @@ spec:
         - "-N$(MY_NODE_NAME)"
         - "-g$(MY_POD_IP)"
         - "-nnats"
-        - "-y/var/local/mayastor/config.yaml"
         securityContext:
           privileged: true
         volumeMounts:
@@ -56,10 +55,6 @@ spec:
           mountPath: /dev
         - name: dshm
           mountPath: /dev/shm
-        - name: configlocation
-          mountPath: /var/local/mayastor/
-        - name: config
-          mountPath: /var/local/mayastor/config.yaml
         resources:
           limits:
             cpu: "1"
@@ -85,11 +80,3 @@ spec:
       - name: hugepage
         emptyDir:
           medium: HugePages
-      - name: configlocation
-        hostPath:
-          path: /var/local/mayastor/
-          type: DirectoryOrCreate
-      - name: config
-        hostPath:
-          path: /var/local/mayastor/config.yaml
-          type: FileOrCreate

--- a/mayastor/src/bdev/nexus/nexus_bdev.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev.rs
@@ -573,6 +573,8 @@ impl Nexus {
         }
 
         if r.await.unwrap() {
+            // Update the child states to remove them from the config file.
+            NexusChild::save_state_change();
             Ok(())
         } else {
             Err(Error::NexusDestroy {


### PR DESCRIPTION
Add support for using the child status config file when deploying Mayastor
on K8s. This allows child states to be correctly set when a Mayastor pod
is restarted on the same node.

Bug fix:
    - Update child states when a nexus is destroyed to ensure that their
      entries in the child status config file are removed.