### PR TITLE
spdk: Reinstate linking to event_nvmf.a

### DIFF
--- a/nix/pkgs/libspdk/default.nix
+++ b/nix/pkgs/libspdk/default.nix
@@ -74,7 +74,7 @@ let
 
     buildPhase = ''
       make -j`nproc`
-      find . -type f -name 'libspdk_event_nvmf.a' -delete
+      #find . -type f -name 'libspdk_event_nvmf.a' -delete
       find . -type f -name 'libspdk_ut_mock.a' -delete
       #find . -type f -name 'librte_vhost.a' -delete
 

--- a/spdk-sys/build.sh
+++ b/spdk-sys/build.sh
@@ -22,7 +22,7 @@ pushd spdk || { echo "Can not find spdk directory"; exit; }
 make -j $(nproc)
 
 # delete things we for sure do not want link
-find . -type f -name 'libspdk_event_nvmf.a' -delete
+#find . -type f -name 'libspdk_event_nvmf.a' -delete
 find . -type f -name 'libspdk_ut_mock.a' -delete
 #find . -type f -name 'librte_vhost.a' -delete
 


### PR DESCRIPTION
This re-enables the default nvmf target in SPDK to hopefully address
CI test failures that cannot be reproduced locally.