### PR TITLE
Prevent faulting the last healthy child

### DIFF
--- a/mayastor/src/bdev/nexus/nexus_bdev.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev.rs
@@ -160,6 +160,12 @@ pub enum Error {
         name
     ))]
     RemoveLastChild { child: String, name: String },
+    #[snafu(display(
+        "Cannot fault the last healthy child {} of nexus {}",
+        child,
+        name
+    ))]
+    FaultingLastHealthyChild { child: String, name: String },
     #[snafu(display("Failed to destroy child {} of nexus {}", child, name))]
     DestroyChild {
         source: NexusBdevError,

--- a/mayastor/src/bdev/nexus/nexus_bdev_children.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev_children.rs
@@ -289,6 +289,20 @@ impl Nexus {
             });
         }
 
+        let healthy_children = self
+            .children
+            .iter()
+            .filter(|c| c.state() == ChildState::Open)
+            .collect::<Vec<_>>();
+
+        if healthy_children.len() == 1 && healthy_children[0].name == name {
+            // the last healthy child cannot be faulted
+            return Err(Error::FaultingLastHealthyChild {
+                name: self.name.clone(),
+                child: name.to_owned(),
+            });
+        }
+
         let cancelled_rebuilding_children =
             self.cancel_child_rebuild_jobs(name).await;
 

--- a/mayastor/tests/fault_child.rs
+++ b/mayastor/tests/fault_child.rs
@@ -1,0 +1,35 @@
+use mayastor::{
+    bdev::{nexus_create, nexus_lookup, Reason},
+    core::{mayastor_env_stop, MayastorCliArgs, MayastorEnvironment, Reactor},
+};
+
+pub mod common;
+
+static NEXUS_NAME: &str = "FaultChildNexus";
+static NEXUS_SIZE: u64 = 10 * 1024 * 1024;
+static CHILD_1: &str = "malloc:///malloc0?blk_size=512&size_mb=10";
+static CHILD_2: &str = "malloc:///malloc1?blk_size=512&size_mb=10";
+
+#[test]
+fn fault_child() {
+    common::mayastor_test_init();
+    let ms = MayastorEnvironment::new(MayastorCliArgs::default());
+    ms.start(|| {
+        Reactor::block_on(async {
+            nexus_create(NEXUS_NAME, NEXUS_SIZE, None, &[CHILD_1.to_string()])
+                .await
+                .unwrap();
+            let nexus = nexus_lookup(NEXUS_NAME).unwrap();
+            // child will stay in a degraded state because we are not rebuilding
+            nexus.add_child(CHILD_2, true).await.unwrap();
+
+            // it should not be possible to fault the only healthy child
+            assert!(nexus.fault_child(CHILD_1, Reason::Unknown).await.is_err());
+            // it should be possible to fault an unhealthy child
+            assert!(nexus.fault_child(CHILD_2, Reason::Unknown).await.is_ok());
+
+            mayastor_env_stop(0);
+        });
+    })
+    .unwrap();
+}


### PR DESCRIPTION
If a nexus has a single healthy child, prevent that child from being
faulted (otherwise it would make the nexus unusable).