### PR TITLE
Add common message bus code and kiiss example...

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2782,6 +2782,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "services"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "dyn-clonable",
+ "env_logger",
+ "futures",
+ "log",
+ "mbus_api",
+ "nats",
+ "serde",
+ "serde_json",
+ "smol",
+ "snafu",
+ "structopt",
+ "tokio",
+]
+
+[[package]]
 name = "sha2"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -961,6 +961,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "134951f4028bdadb9b84baf4232681efbf277da25144b9b0ad65df75946c422b"
 
 [[package]]
+name = "dyn-clonable"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e9232f0e607a262ceb9bd5141a3dfb3e4db6994b31989bbfd845878cba59fd4"
+dependencies = [
+ "dyn-clonable-impl",
+ "dyn-clone",
+]
+
+[[package]]
+name = "dyn-clonable-impl"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "558e40ea573c374cf53507fd240b7ee2f5477df7cfebdb97323ec61c719399c5"
+dependencies = [
+ "proc-macro2 1.0.24",
+ "quote 1.0.7",
+ "syn 1.0.44",
+]
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c53dc3a653e0f64081026e4bf048d48fec9fce90c66e8326ca7292df0ff2d82"
+
+[[package]]
 name = "ed25519"
 version = "1.0.0-pre.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1719,6 +1746,7 @@ dependencies = [
  "jsonrpc",
  "libc",
  "log",
+ "mbus_api",
  "nats",
  "nix 0.16.1",
  "once_cell",
@@ -1756,6 +1784,24 @@ name = "maybe-uninit"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
+
+[[package]]
+name = "mbus_api"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "dyn-clonable",
+ "env_logger",
+ "log",
+ "nats",
+ "once_cell",
+ "serde",
+ "serde_json",
+ "smol",
+ "snafu",
+ "structopt",
+ "tokio",
+]
 
 [[package]]
 name = "memchr"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2789,6 +2789,7 @@ dependencies = [
  "dyn-clonable",
  "env_logger",
  "futures",
+ "lazy_static",
  "log",
  "mbus_api",
  "nats",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,5 @@ members = [
 	"nvmeadm",
 	"rpc",
 	"sysfs",
+	"mbus-api"
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,6 @@ members = [
 	"nvmeadm",
 	"rpc",
 	"sysfs",
+	"services",
 	"mbus-api"
 ]

--- a/csi/moac/mbus.js
+++ b/csi/moac/mbus.js
@@ -51,17 +51,26 @@ const opts = yargs
 const nc = nats.connect(opts.s);
 nc.on('connect', () => {
   if (opts._[0] === 'register') {
-    nc.publish('register', JSON.stringify({
+    nc.publish('registry', JSON.stringify({
+      id: "register",
+      sender: "moac",
+      data: {
       id: opts.node,
       grpcEndpoint: opts.grpc
+      }
     }));
   } else if (opts._[0] === 'deregister') {
-    nc.publish('deregister', JSON.stringify({
+    nc.publish('registry', JSON.stringify({
+      id: "deregister",
+      sender: "moac",
+      data: {
       id: opts.node
+      }
     }));
   } else if (opts._[0] === 'raw') {
     nc.publish(opts.name, opts.payload);
   }
+  nc.flush();
   nc.close();
   process.exit(0);
 });

--- a/csi/moac/test/nats_test.js
+++ b/csi/moac/test/nats_test.js
@@ -90,9 +90,9 @@ module.exports = function () {
   });
 
   it('should register a node', async () => {
-    nc.publish('register', JSON.stringify({
-      id: NODE_NAME,
-      grpcEndpoint: GRPC_ENDPOINT
+    nc.publish('registry', JSON.stringify({
+      id: 'register',
+      data: { id: NODE_NAME, grpcEndpoint: GRPC_ENDPOINT }
     }));
     await waitUntil(async () => {
       return registry.getNode(NODE_NAME);
@@ -103,16 +103,18 @@ module.exports = function () {
   });
 
   it('should ignore register request with missing node name', async () => {
-    nc.publish('register', JSON.stringify({
-      grpcEndpoint: GRPC_ENDPOINT
+    nc.publish('registry', JSON.stringify({
+      id: 'register',
+      data: { grpcEndpoint: GRPC_ENDPOINT }
     }));
     // small delay to wait for a possible crash of moac
     await sleep(10);
   });
 
   it('should ignore register request with missing grpc endpoint', async () => {
-    nc.publish('register', JSON.stringify({
-      id: NODE_NAME
+    nc.publish('registry', JSON.stringify({
+      id: 'register',
+      data: { id: NODE_NAME }
     }));
     // small delay to wait for a possible crash of moac
     await sleep(10);
@@ -125,8 +127,9 @@ module.exports = function () {
   });
 
   it('should deregister a node', async () => {
-    nc.publish('deregister', JSON.stringify({
-      id: NODE_NAME
+    nc.publish('registry', JSON.stringify({
+      id: 'deregister',
+      data: { id: NODE_NAME }
     }));
     await waitUntil(async () => {
       return !registry.getNode(NODE_NAME);

--- a/mayastor-test/test_nats.js
+++ b/mayastor-test/test_nats.js
@@ -6,6 +6,7 @@ const assert = require('chai').assert;
 const { spawn } = require('child_process');
 const common = require('./test_common');
 const nats = require('nats');
+const util = require('util')
 
 const HB_INTERVAL = 1;
 const NATS_PORT = 14222;
@@ -52,7 +53,8 @@ function stopNats (done) {
 }
 
 function assertRegisterMessage (msg) {
-  const args = JSON.parse(msg);
+  assert(JSON.parse(msg).id == "register" );
+  const args = JSON.parse(msg).data;
   assert.hasAllKeys(args, ['id', 'grpcEndpoint']);
   assert.strictEqual(args.id, NODE_NAME);
   assert.strictEqual(args.grpcEndpoint, common.grpcEndpoint);
@@ -89,7 +91,7 @@ describe('nats', function () {
         MAYASTOR_HB_INTERVAL: HB_INTERVAL
       });
       // wait for the register message
-      const sid = client.subscribe('register', (msg) => {
+      const sid = client.subscribe('registry', (msg) => {
         client.unsubscribe(sid);
         assertRegisterMessage(msg);
         done();
@@ -98,7 +100,7 @@ describe('nats', function () {
   });
 
   it('should keep sending registration messages', (done) => {
-    const sid = client.subscribe('register', (msg) => {
+    const sid = client.subscribe('registry', (msg) => {
       client.unsubscribe(sid);
       assertRegisterMessage(msg);
       done();
@@ -109,7 +111,7 @@ describe('nats', function () {
     // simulate outage of NATS server for a duration of two heartbeats
     stopNats(() => {
       setTimeout(() => {
-        const sid = client.subscribe('register', (msg) => {
+        const sid = client.subscribe('registry', (msg) => {
           client.unsubscribe(sid);
           assertRegisterMessage(msg);
           done();
@@ -122,9 +124,10 @@ describe('nats', function () {
   });
 
   it('should send a deregistration message when mayastor is shut down', (done) => {
-    const sid = client.subscribe('deregister', (msg) => {
+    const sid = client.subscribe('registry', (msg) => {
       client.unsubscribe(sid);
-      const args = JSON.parse(msg);
+      assert(JSON.parse(msg).id == "deregister" );
+      const args = JSON.parse(msg).data;
       assert.hasAllKeys(args, ['id']);
       assert.strictEqual(args.id, NODE_NAME);
       done();

--- a/mayastor/Cargo.toml
+++ b/mayastor/Cargo.toml
@@ -79,6 +79,8 @@ smol = "1.0.0"
 dns-lookup = "1.0.4"
 ipnetwork = "0.17.0"
 bollard = "0.8.0"
+mbus_api = { path = "../mbus-api" }
+
 [dependencies.rpc]
 path = "../rpc"
 

--- a/mayastor/src/subsys/mod.rs
+++ b/mayastor/src/subsys/mod.rs
@@ -28,7 +28,6 @@ pub use mbus::{
     mbus_endpoint,
     message_bus_init,
     registration::Registration,
-    MessageBus,
     MessageBusSubsystem,
 };
 

--- a/mbus-api/Cargo.toml
+++ b/mbus-api/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "mbus_api"
+version = "0.1.0"
+authors = ["Tiago Castro <tiago.castro@mayadata.io>"]
+edition = "2018"
+
+[dependencies]
+nats = "0.8"
+structopt = "0.3.15"
+log = "0.4.11"
+tokio = { version = "0.2", features = ["full"] }
+env_logger = "0.7"
+serde_json = "1.0"
+async-trait = "0.1.36"
+dyn-clonable = "0.9.0"
+smol = "1.0.0"
+once_cell = "1.4.1"
+snafu = "0.6"
+
+[dependencies.serde]
+features = ["derive"]
+version = "1.0"

--- a/mbus-api/examples/client/main.rs
+++ b/mbus-api/examples/client/main.rs
@@ -1,0 +1,84 @@
+use log::info;
+use mbus_api::{Message, *};
+use serde::{Deserialize, Serialize};
+use structopt::StructOpt;
+use tokio::stream::StreamExt;
+
+#[derive(Debug, StructOpt)]
+struct CliArgs {
+    /// The Nats Server URL to connect to
+    /// (supports the nats schema)
+    /// Default: nats://127.0.0.1:4222
+    #[structopt(long, short, default_value = "nats://127.0.0.1:4222")]
+    url: String,
+
+    /// Channel to send to
+    #[structopt(long, short, default_value = "default")]
+    channel: Channel,
+
+    /// With server in this binary
+    #[structopt(long, short)]
+    server: bool,
+}
+
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
+struct DummyRequest {}
+
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
+struct DummyReply {
+    name: String,
+}
+
+// note: in this example we use the default message id
+// because we're adding the message types outside of the
+// library which should not be done so we have to fake
+// out the message id as `Default`.
+bus_impl_message_all!(DummyRequest, Default, DummyReply, Default);
+
+async fn start_server_side() {
+    let cli_args = CliArgs::from_args();
+
+    let mut sub = bus().subscribe(cli_args.channel).await.unwrap();
+
+    tokio::spawn(async move {
+        // server side
+        let mut count = 1;
+        loop {
+            let message = &sub.next().await.unwrap();
+            let message: ReceivedRawMessage = message.into();
+            message
+                .respond(DummyReply {
+                    name: format!("example {}", count),
+                })
+                .await
+                .unwrap();
+            count += 1;
+        }
+    });
+}
+
+#[tokio::main]
+async fn main() {
+    env_logger::init_from_env(
+        env_logger::Env::default()
+            .filter_or(env_logger::DEFAULT_FILTER_ENV, "info"),
+    );
+    let cli_args = CliArgs::from_args();
+    message_bus_init(cli_args.url).await;
+
+    if cli_args.server {
+        // server side needs to subscribe first, unless a streaming model is
+        // used
+        start_server_side().await;
+    }
+
+    let reply = DummyRequest {}.request().await.unwrap();
+    info!("Received reply: {:?}", reply);
+
+    // We can also use the following api to specify a different channel and bus
+    let reply =
+        DummyRequest::Request(&DummyRequest {}, Channel::Default, bus())
+            .await
+            .unwrap();
+    info!("Received reply: {:?}", reply);
+}

--- a/mbus-api/examples/server/main.rs
+++ b/mbus-api/examples/server/main.rs
@@ -1,0 +1,125 @@
+use mbus_api::*;
+use serde::{Deserialize, Serialize};
+use std::{convert::TryInto, str::FromStr};
+use structopt::StructOpt;
+use tokio::stream::StreamExt;
+
+#[derive(Debug, StructOpt)]
+struct CliArgs {
+    /// The Nats Server URL to connect to
+    /// (supports the nats schema)
+    /// Default: nats://127.0.0.1:4222
+    #[structopt(long, short, default_value = "nats://127.0.0.1:4222")]
+    url: String,
+
+    /// Channel to listen on
+    #[structopt(long, short, default_value = "default")]
+    channel: Channel,
+
+    /// Receiver version
+    #[structopt(long, short, default_value = "1")]
+    version: Version,
+}
+
+#[derive(Clone, Debug)]
+enum Version {
+    V1,
+    V2,
+    V3,
+}
+
+impl FromStr for Version {
+    type Err = String;
+
+    fn from_str(source: &str) -> Result<Self, Self::Err> {
+        match source {
+            "1" => Ok(Self::V1),
+            "2" => Ok(Self::V2),
+            "3" => Ok(Self::V3),
+            _ => Err(format!("Could not parse the version: {}", source)),
+        }
+    }
+}
+
+impl Default for Version {
+    fn default() -> Self {
+        Version::V1
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
+struct DummyRequest {}
+
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
+struct DummyReply {
+    name: String,
+}
+
+// note: in this example we use the default message id
+// because we're adding the message types outside of the
+// library which should not be done so we have to fake
+// out the message id as `Default`.
+bus_impl_message_all!(DummyRequest, Default, DummyReply, Default);
+
+#[tokio::main]
+async fn main() {
+    env_logger::init_from_env(
+        env_logger::Env::default()
+            .filter_or(env_logger::DEFAULT_FILTER_ENV, "info"),
+    );
+    let cli_args = CliArgs::from_args();
+    message_bus_init(cli_args.url).await;
+
+    let mut sub = bus().subscribe(cli_args.channel).await.unwrap();
+
+    let mut count = 1;
+    loop {
+        match cli_args.version {
+            Version::V1 => receive_v1(&mut sub, count).await,
+            Version::V2 => receive_v2(&mut sub, count).await,
+            Version::V3 => receive_v3(&mut sub, count).await,
+        }
+        count += 1;
+    }
+}
+
+async fn receive_v1(sub: &mut nats::asynk::Subscription, count: u64) {
+    let message = &sub.next().await.unwrap();
+    let message: ReceivedRawMessage = message.into();
+    // notice that there is no type validation until we
+    // use something like:
+    // let data: DummyRequest = message.payload().unwrap();
+    message
+        .respond(DummyReply {
+            name: format!("example {}", count),
+        })
+        .await
+        .unwrap();
+}
+
+async fn receive_v2(sub: &mut nats::asynk::Subscription, count: u64) {
+    let message = &sub.next().await.unwrap();
+    // notice that try_into can fail if the received type does not
+    // match the received message
+    let message: ReceivedMessage<DummyRequest, DummyReply> =
+        message.try_into().unwrap();
+    message
+        .reply(DummyReply {
+            name: format!("example {}", count),
+        })
+        .await
+        .unwrap();
+}
+
+async fn receive_v3(sub: &mut nats::asynk::Subscription, count: u64) {
+    let message = &sub.next().await.unwrap();
+    let message: ReceivedMessage<DummyRequest, DummyReply> =
+        message.try_into().unwrap();
+    message
+        // same function can receive an error
+        .reply(Err(Error::WithMessage {
+            message: format!("Fake Error {}", count),
+        }))
+        .await
+        .unwrap();
+}

--- a/mbus-api/src/lib.rs
+++ b/mbus-api/src/lib.rs
@@ -1,0 +1,242 @@
+#![warn(missing_docs)]
+//! All the different messages which can be sent/received to/from the control
+//! plane services and mayastor
+//! We could split these out further into categories when they start to grow
+
+mod mbus_nats;
+/// received message traits
+pub mod receive;
+/// send messages traits
+pub mod send;
+
+use async_trait::async_trait;
+use dyn_clonable::clonable;
+pub use mbus_nats::{bus, message_bus_init, message_bus_init_tokio};
+pub use receive::*;
+pub use send::*;
+use serde::{Deserialize, Serialize};
+use smol::io;
+use snafu::Snafu;
+use std::{fmt::Debug, marker::PhantomData, str::FromStr};
+
+/// Available Message Bus channels
+#[derive(Clone, Debug)]
+pub enum Channel {
+    /// Default
+    Default,
+    /// Registration of mayastor instances with the control plane
+    Registry,
+    /// Keep it In Sync Service
+    Kiiss,
+    /// Reply to requested Channel
+    Reply(String),
+}
+
+impl FromStr for Channel {
+    type Err = String;
+
+    fn from_str(source: &str) -> Result<Self, Self::Err> {
+        match source {
+            "default" => Ok(Self::Default),
+            "registry" => Ok(Self::Registry),
+            "kiiss" => Ok(Self::Kiiss),
+            _ => Err(format!("Could not parse the channel: {}", source)),
+        }
+    }
+}
+
+impl Default for Channel {
+    fn default() -> Self {
+        Channel::Default
+    }
+}
+
+impl std::fmt::Display for Channel {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Channel::Default => write!(f, "default"),
+            Channel::Registry => write!(f, "registry"),
+            Channel::Kiiss => write!(f, "kiiss"),
+            Channel::Reply(ch) => write!(f, "{}", ch),
+        }
+    }
+}
+
+/// Message id which uniquely identifies every type of unsolicited message
+/// The solicited (replies) message do not currently carry an id as they
+/// are sent to a specific requested channel
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[serde(rename_all = "camelCase")]
+pub enum MessageId {
+    /// Default
+    Default,
+    /// Update Config
+    ConfigUpdate,
+    /// Request current Config
+    ConfigGetCurrent,
+    /// Register mayastor
+    Register,
+    /// Deregister mayastor
+    Deregister,
+}
+
+/// Sender identification (eg which mayastor instance sent the message)
+pub type SenderId = String;
+
+/// Mayastor configurations
+/// Currently, we have the global mayastor config and the child states config
+#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq, Hash)]
+pub enum Config {
+    /// Mayastor global config
+    MayastorConfig,
+    /// Mayastor child states config
+    ChildStatesConfig,
+}
+impl Default for Config {
+    fn default() -> Self {
+        Config::MayastorConfig
+    }
+}
+
+/// Config Messages
+
+/// Update mayastor configuration
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
+pub struct ConfigUpdate {
+    /// type of config being updated
+    pub kind: Config,
+    /// actual config data
+    pub data: Vec<u8>,
+}
+bus_impl_message_all!(ConfigUpdate, ConfigUpdate, (), Kiiss);
+
+/// Request message configuration used by mayastor to request configuration
+/// from a control plane service
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
+pub struct ConfigGetCurrent {
+    /// type of config requested
+    pub kind: Config,
+}
+/// Reply message configuration returned by a controle plane service to mayastor
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
+pub struct ReplyConfig {
+    /// config data
+    pub config: Vec<u8>,
+}
+bus_impl_message_all!(
+    ConfigGetCurrent,
+    ConfigGetCurrent,
+    ReplyConfig,
+    Kiiss,
+    GetConfig
+);
+
+/// Registration
+
+/// Register message payload
+#[derive(Serialize, Deserialize, Default, Debug, Clone)]
+pub struct Register {
+    /// id of the mayastor instance
+    pub id: String,
+    /// grpc_endpoint of the mayastor instance
+    #[serde(rename = "grpcEndpoint")]
+    pub grpc_endpoint: String,
+}
+bus_impl_message_all!(Register, Register, (), Registry);
+
+/// Deregister message payload
+#[derive(Serialize, Deserialize, Default, Debug, Clone)]
+pub struct Deregister {
+    /// id of the mayastor instance
+    pub id: String,
+}
+bus_impl_message_all!(Deregister, Deregister, (), Registry);
+
+/// This trait defines all Bus Messages which must:
+/// 1 - be uniquely identifiable via MessageId
+/// 2 - have a default Channel on which they are sent/received
+#[async_trait(?Send)]
+pub trait Message {
+    /// type which is sent back in response to a request
+    type Reply;
+
+    /// identification of this object according to the `MessageId`
+    fn id(&self) -> MessageId;
+    /// default channel where this object is sent to
+    fn channel(&self) -> Channel;
+
+    /// publish a message with no delivery guarantees
+    async fn publish(&self) -> io::Result<()>;
+    /// publish a message with a request for a `Self::Reply` reply
+    async fn request(&self) -> io::Result<Self::Reply>;
+}
+
+/// The preamble is used to peek into messages so allowing for them to be routed
+/// by their identifier
+#[derive(Serialize, Deserialize, Debug)]
+struct Preamble {
+    pub(crate) id: MessageId,
+}
+
+/// Unsolicited (send) messages carry the message identifier, the sender
+/// identifier and finally the message payload itself
+#[derive(Serialize, Deserialize)]
+struct SendPayload<T> {
+    pub(crate) id: MessageId,
+    pub(crate) sender: SenderId,
+    pub(crate) data: T,
+}
+
+/// Error type which is returned over the bus
+/// todo: Use this Error not just for the "transport" but also
+/// for any other operation
+#[derive(Serialize, Deserialize, Debug, Snafu)]
+#[allow(missing_docs)]
+pub enum Error {
+    #[snafu(display("Generic Failure, message={}", message))]
+    WithMessage { message: String },
+    #[snafu(display("Ill formed request when deserializing the request"))]
+    InvalidFormat,
+}
+
+/// Payload returned to the sender
+/// Includes an error as the operations may be fallible
+#[derive(Serialize, Deserialize)]
+pub struct ReplyPayload<T>(pub Result<T, Error>);
+
+// todo: implement thin wrappers on these
+/// MessageBus raw Message
+pub type BusMessage = nats::asynk::Message;
+/// MessageBus subscription
+pub type BusSubscription = nats::asynk::Subscription;
+/// MessageBus configuration options
+pub type BusOptions = nats::Options;
+/// Save on typing
+pub type DynBus = Box<dyn Bus>;
+
+/// Messaging Bus trait with "generic" publish and request/reply semantics
+#[async_trait]
+#[clonable]
+pub trait Bus: Clone + Send + Sync {
+    /// publish a message - not guaranteed to be sent or received (fire and
+    /// forget)
+    async fn publish(
+        &self,
+        channel: Channel,
+        message: &[u8],
+    ) -> std::io::Result<()>;
+    /// Send a message and wait for it to be received by the target component
+    async fn send(&self, channel: Channel, message: &[u8]) -> io::Result<()>;
+    /// Send a message and request a reply from the target component
+    async fn request(
+        &self,
+        channel: Channel,
+        message: &[u8],
+    ) -> io::Result<BusMessage>;
+    /// Flush queued messages to the server
+    async fn flush(&self) -> io::Result<()>;
+    /// Create a subscription on the given channel which can be
+    /// polled for messages until it is either explicitly closed or
+    /// when the bus is closed
+    async fn subscribe(&self, channel: Channel) -> io::Result<BusSubscription>;
+}

--- a/mbus-api/src/receive.rs
+++ b/mbus-api/src/receive.rs
@@ -1,0 +1,161 @@
+use super::*;
+
+/// Type safe wrapper over a message bus message which decodes the raw
+/// message into the actual payload `S` and allows only for a response type `R`.
+///
+/// # Example:
+/// ```
+/// let raw_msg = &subscriber.next().await?;
+/// let msg: ReceivedMessage<RequestConfig, ReplyConfig> =
+///             raw_msg.try_into()?;
+///
+/// msg.respond(ReplyConfig {}).await.unwrap();
+/// // or we can also use the same fn to return an error
+/// msg.respond(Err(Error::Message("failure".into()))).await.unwrap();
+/// ```
+pub struct ReceivedMessage<'a, S, R> {
+    request: SendPayload<S>,
+    bus_message: &'a BusMessage,
+    reply_type: PhantomData<R>,
+}
+
+impl<'a, S, R> ReceivedMessage<'a, S, R>
+where
+    for<'de> S: Deserialize<'de> + 'a + Debug + Clone + Message,
+    R: Serialize,
+{
+    /// Get a clone of the actual payload data which was received.
+    pub fn inner(&self) -> S {
+        self.request.data.clone()
+    }
+    /// Get the sender identifier
+    pub fn sender(&self) -> SenderId {
+        self.request.sender.clone()
+    }
+
+    /// Reply back to the sender with the `reply` payload wrapped by
+    /// a Result-like type.
+    /// May fail if serialization of the reply fails or if the
+    /// message bus fails to respond.
+    /// Can receive either `R`, `Err()` or `ReplyPayload<R>`.
+    pub async fn reply<T: Into<ReplyPayload<R>>>(
+        &self,
+        reply: T,
+    ) -> io::Result<()> {
+        let reply: ReplyPayload<R> = reply.into();
+        let payload = serde_json::to_vec(&reply)?;
+        self.bus_message.respond(&payload).await
+    }
+
+    /// Create a new received message object which wraps the send and
+    /// receive types around a raw bus message.
+    fn new(bus_message: &'a BusMessage) -> Result<Self, io::Error> {
+        let request: SendPayload<S> =
+            serde_json::from_slice(&bus_message.data)?;
+        if request.id == request.data.id() {
+            log::info!(
+                "We have a message from '{}': {:?}",
+                request.sender,
+                request.data
+            );
+            Ok(Self {
+                request,
+                bus_message,
+                reply_type: Default::default(),
+            })
+        } else {
+            Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "invalid message id!",
+            ))
+        }
+    }
+}
+
+/// Message received over the message bus with a reply serialization wrapper
+/// For type safety refer to `ReceivedMessage<'a,S,R>`.
+pub struct ReceivedRawMessage<'a> {
+    bus_msg: &'a BusMessage,
+}
+
+impl<'a> ReceivedRawMessage<'a> {
+    /// Get a copy of the actual payload data which was sent
+    /// May fail if the raw data cannot be deserialized into `S`
+    pub fn inner<S: Deserialize<'a>>(&self) -> io::Result<S> {
+        let request: SendPayload<S> =
+            serde_json::from_slice(&self.bus_msg.data)?;
+        Ok(request.data)
+    }
+
+    /// Get the identifier of this message.
+    /// May fail if the raw data cannot be deserialized into the preamble.
+    pub fn id(&self) -> io::Result<MessageId> {
+        let preamble: Preamble = serde_json::from_slice(&self.bus_msg.data)?;
+        Ok(preamble.id)
+    }
+
+    /// Channel where this message traversed
+    pub fn channel(&self) -> Channel {
+        self.bus_msg.subject.clone().parse().unwrap()
+    }
+
+    /// Respond back to the sender with the `reply` payload wrapped by
+    /// a Result-like type.
+    /// May fail if serialization of the reply fails or if the
+    /// message bus fails to respond.
+    /// Can receive either `Serialize`, `Err()` or `ReplyPayload<Serialize>`.
+    pub async fn respond<T: Serialize, R: Serialize + Into<ReplyPayload<T>>>(
+        &self,
+        reply: R,
+    ) -> io::Result<()> {
+        let reply: ReplyPayload<T> = reply.into();
+        let payload = serde_json::to_vec(&reply)?;
+        self.bus_msg.respond(&payload).await
+    }
+}
+
+impl<'a> std::convert::From<&'a BusMessage> for ReceivedRawMessage<'a> {
+    fn from(value: &'a BusMessage) -> Self {
+        Self {
+            bus_msg: value,
+        }
+    }
+}
+
+impl<'a, S, R> std::convert::TryFrom<&'a BusMessage>
+    for ReceivedMessage<'a, S, R>
+where
+    for<'de> S: Deserialize<'de> + 'a + Debug + Clone + Message,
+    R: Serialize,
+{
+    type Error = io::Error;
+
+    fn try_from(value: &'a BusMessage) -> Result<Self, Self::Error> {
+        ReceivedMessage::<S, R>::new(value)
+    }
+}
+
+impl<'a, S, R> std::convert::TryFrom<ReceivedRawMessage<'a>>
+    for ReceivedMessage<'a, S, R>
+where
+    for<'de> S: Deserialize<'de> + 'a + Debug + Clone + Message,
+    R: Serialize,
+{
+    type Error = io::Error;
+
+    fn try_from(value: ReceivedRawMessage<'a>) -> Result<Self, Self::Error> {
+        ReceivedMessage::<S, R>::new(value.bus_msg)
+    }
+}
+
+impl<T> From<T> for ReplyPayload<T> {
+    fn from(val: T) -> Self {
+        ReplyPayload(Ok(val))
+    }
+}
+
+impl<T> From<Result<T, Error>> for ReplyPayload<T> {
+    fn from(val: Result<T, Error>) -> Self {
+        ReplyPayload(val)
+    }
+}

--- a/mbus-api/src/send.rs
+++ b/mbus-api/src/send.rs
@@ -1,0 +1,266 @@
+use super::*;
+
+// todo: replace with proc-macros
+
+/// Main Message trait, which should tipically be used to send
+/// MessageBus messages.
+/// Implements Message trait for the type `S` with the reply type
+/// `R`, the message id `I`, the default channel `C`.
+/// If specified it makes use of the Request/Publish traits exported
+/// by type `T`, otherwise it defaults to using `S`.
+/// Also implements the said Request/Publish traits for type `T`, if
+/// specified, otherwise it implements them for type `S`.
+///
+/// # Example
+/// ```
+/// #[derive(Serialize, Deserialize, Debug, Default, Clone)]
+/// struct DummyRequest {}
+/// bus_impl_message_all!(DummyRequest, DummyId, (), DummyChan);
+///
+/// let reply = DummyRequest { }.request().await.unwrap();
+/// ```
+#[macro_export]
+macro_rules! bus_impl_message_all {
+    ($S:ident, $I:ident, $R:tt, $C:ident) => {
+        bus_impl_all!($S, $R);
+        bus_impl_message!($S, $I, $R, $C);
+    };
+    ($S:ident, $I:ident, $R:tt, $C:ident, $T:ident) => {
+        bus_impl_all!($T, $S, $R);
+        bus_impl_message!($S, $I, $R, $C, $T);
+    };
+}
+
+/// Implement Request/Reply traits for type `S`.
+/// Otherwise, if `T` is specified, then it creates `T` and
+/// implements said types for `T`.
+/// `S` is the request payload and `R` is the reply payload.
+/// # Example
+/// ```
+/// #[derive(Serialize, Deserialize, Debug, Default, Clone)]
+/// struct DummyRequest {}
+/// #[derive(Serialize, Deserialize, Debug, Default, Clone)]
+/// struct DummyReply {}
+///
+/// bus_impl_all!(DummyRequest,DummyReply);
+///
+/// let reply = DummyRequest::request(DummyRequest {}, channel, &bus)
+///             .await
+///             .unwrap();
+///
+/// bus_impl_all!(Dummy, DummyRequest,DummyReply);
+///
+/// let reply = Dummy::request(DummyRequest {}, channel, &bus)
+///             .await
+///             .unwrap();
+/// ```
+#[macro_export]
+macro_rules! bus_impl_all {
+    ($S:ident,$R:ty) => {
+        bus_impl_request!($S, $R);
+        bus_impl_publish!($S);
+    };
+    ($T:ident,$S:ident,$R:ty) => {
+        /// place holder for the message traits, example:
+        /// $T::request(..).await
+        #[derive(Serialize, Deserialize, Debug, Clone)]
+        pub struct $T {}
+
+        bus_impl_request!($T, $S, $R);
+        bus_impl_publish!($T, $S);
+    };
+}
+
+/// Implement the bus trait for requesting a response back from `T` where
+/// `S` is the payload request type and `R` is the reply payload type.
+/// Can optionally implement the trait for `S`.
+/// # Example
+/// ```
+/// #[derive(Serialize, Deserialize, Debug, Default, Clone)]
+/// struct DummyRequest {}
+/// #[derive(Serialize, Deserialize, Debug, Default, Clone)]
+/// struct DummyReply {}
+///
+/// bus_impl_request!(DummyRequest,DummyReply);
+///
+/// let reply = DummyRequest::request(DummyRequest {}, channel, &bus)
+///             .await
+///             .unwrap();
+/// ```
+#[macro_export]
+macro_rules! bus_impl_request {
+    ($S:ident,$R:ty) => {
+        impl<'a> MessageRequest<'a, $S, $R> for $S {}
+    };
+    ($T:ty,$S:ident,$R:ty) => {
+        impl<'a> MessageRequest<'a, $S, $R> for $T {}
+    };
+}
+
+/// Implement the publish bus trait for type `T` which
+/// publishes the payload type `S`.
+/// Can optionally implement the trait for `S`.
+/// # Example
+/// ```
+/// #[derive(Serialize, Deserialize, Debug, Default, Clone)]
+/// struct DummyPublish {}
+///
+/// bus_impl_publish!(DummyPublish);
+///
+/// DummyPublish::request(DummyPublish {}, channel, &bus).await.unwrap()
+/// ```
+#[macro_export]
+macro_rules! bus_impl_publish {
+    ($S:ty) => {
+        bus_impl_publish!($S, $S);
+    };
+    ($T:ty,$S:tt) => {
+        impl<'a> MessagePublish<'a, $S, ()> for $T {}
+    };
+}
+
+/// Implement Message trait for the type `S` with the reply type
+/// `R`, the message id `I`, the default channel `C`.
+/// If specified it makes use of the Request/Publish traits exported
+/// by type `T`, otherwise it defaults to using `S`.
+/// # Example
+/// ```
+/// #[derive(Serialize, Deserialize, Debug, Default, Clone)]
+/// struct DummyRequest {}
+/// bus_impl_message!(DummyRequest, DummyId, (), DummyChan);
+/// ```
+#[macro_export]
+macro_rules! bus_impl_message {
+    ($S:ident, $I:ident, $R:tt, $C:ident) => {
+        bus_impl_message!($S, $I, $R, $C, $S);
+    };
+    ($S:ident, $I:ident, $R:tt, $C:ident, $T:ident) => {
+        #[async_trait::async_trait(?Send)]
+        impl Message for $S {
+            type Reply = $R;
+
+            fn id(&self) -> MessageId {
+                MessageId::$I
+            }
+            fn channel(&self) -> Channel {
+                Channel::$C
+            }
+            async fn publish(&self) -> smol::io::Result<()> {
+                $T::Publish(self, self.channel(), bus()).await
+            }
+            async fn request(&self) -> smol::io::Result<$R> {
+                $T::Request(self, self.channel(), bus()).await
+            }
+        }
+    };
+}
+
+/// Trait to send a message `bus` request with the `payload` type `S` via a
+/// a `channel` and requesting a response back with the payload type `R`
+/// via a specific reply channel.
+/// Trait can be implemented using the macro helper `bus_impl_request`.
+#[async_trait(?Send)]
+pub trait MessageRequest<'a, S, R>
+where
+    S: 'a + Sync + Message + Serialize,
+    for<'de> R: Deserialize<'de> + Default + 'a + Sync,
+{
+    /// Sends the message and requests a reply
+    /// May fail if the bus fails to publish the message.
+    #[allow(non_snake_case)]
+    async fn Request(
+        payload: &'a S,
+        channel: Channel,
+        bus: DynBus,
+    ) -> io::Result<R> {
+        let msg = SendMessage::<S, R>::new(payload, channel, bus);
+        msg.request().await
+    }
+}
+
+/// Trait to send a message `bus` publish with the `payload` type `S` via a
+/// a `channel`. No reply is requested.
+/// Trait can be implemented using the macro helper `bus_impl_publish`.
+#[async_trait(?Send)]
+pub trait MessagePublish<'a, S, R>
+where
+    S: 'a + Sync + Message + Serialize,
+    for<'de> R: Deserialize<'de> + Default + 'a + Sync,
+{
+    /// Publishes the Message - not guaranteed to be sent or received (fire and
+    /// forget)
+    /// May fail if the bus fails to publish the message
+    #[allow(non_snake_case)]
+    async fn Publish(
+        payload: &'a S,
+        channel: Channel,
+        bus: DynBus,
+    ) -> io::Result<()> {
+        let msg = SendMessage::<S, R>::new(payload, channel, bus);
+        msg.publish().await
+    }
+}
+
+/// Type specific Message Bus api used to send a message of type `S` over the
+/// message bus with an additional type `R` use for request/reply semantics
+/// # Example:
+/// ```
+/// let msg = RequestToSend::<S, R>::new(payload, channel, bus);
+///         msg.request().await.unwrap();
+/// ```
+struct SendMessage<'a, S, R> {
+    payload: SendPayload<&'a S>,
+    bus: DynBus,
+    channel: Channel,
+    reply_type: PhantomData<R>,
+}
+
+impl<'a, S, R> SendMessage<'a, S, R>
+where
+    S: Message + Serialize,
+    for<'de> R: Deserialize<'de> + 'a,
+{
+    /// each client needs a unique identification
+    /// should this be a creation argument?
+    fn name() -> SenderId {
+        match std::env::var("NODE_NAME") {
+            Ok(val) => val,
+            _ => "default".into(),
+        }
+    }
+
+    /// Creates a new request `Message` with the required payload
+    /// using an existing `bus` which is used to sent the payload
+    /// via the `channel`.
+    pub(crate) fn new(payload: &'a S, channel: Channel, bus: DynBus) -> Self {
+        Self {
+            payload: SendPayload {
+                id: payload.id(),
+                data: payload,
+                sender: Self::name(),
+            },
+            reply_type: Default::default(),
+            bus,
+            channel,
+        }
+    }
+
+    /// Publishes the Message - not guaranteed to be sent or received (fire and
+    /// forget).
+    pub(crate) async fn publish(&self) -> io::Result<()> {
+        let payload = serde_json::to_vec(&self.payload)?;
+        self.bus.publish(self.channel.clone(), &payload).await
+    }
+
+    /// Sends the message and requests a reply.
+    /// todo: add timeout with retry logic?
+    pub(crate) async fn request(&self) -> io::Result<R> {
+        let payload = serde_json::to_vec(&self.payload)?;
+        let reply =
+            self.bus.request(self.channel.clone(), &payload).await?.data;
+        let reply: ReplyPayload<R> = serde_json::from_slice(&reply)?;
+        reply.0.map_err(|error| {
+            io::Error::new(io::ErrorKind::Other, format!("{:?}", error))
+        })
+    }
+}

--- a/nix/pkgs/images/default.nix
+++ b/nix/pkgs/images/default.nix
@@ -47,6 +47,17 @@ let
       mkdir -p var/tmp
     '';
   };
+  servicesImageProps = {
+    tag = version;
+    created = "now";
+    config = {
+      Env = [ "PATH=${env}" ];
+    };
+    extraCommands = ''
+      mkdir tmp
+      mkdir -p var/tmp
+    '';
+  };
 in
 rec {
   mayastor-image = dockerTools.buildImage (mayastorImageProps // {
@@ -99,4 +110,16 @@ rec {
       chmod u-w bin
     '';
   };
+
+  services-kiiss-image = dockerTools.buildLayeredImage (servicesImageProps // {
+    name = "mayadata/services-kiiss";
+    contents = [ busybox mayastor ];
+    config = { Entrypoint = [ "/bin/kiiss" ]; };
+  });
+
+  services-kiiss-dev-image = dockerTools.buildImage (servicesImageProps // {
+    name = "mayadata/services-kiiss-dev";
+    contents = [ busybox mayastor ];
+    config = { Entrypoint = [ "/bin/kiiss" ]; };
+  });
 }

--- a/nix/pkgs/mayastor/default.nix
+++ b/nix/pkgs/mayastor/default.nix
@@ -41,7 +41,7 @@ let
   buildProps = rec {
     name = "mayastor";
     #cargoSha256 = "0000000000000000000000000000000000000000000000000000";
-    cargoSha256 = "0mr03cr6i1n5g4dx8v651rq3zblym71cb2vkvg5nqgb34li4br9j";
+    cargoSha256 = "0r6cix3s60c3qaj3lsr3bbr6by28rhapclcs4jw5d68s882i2lh8";
     inherit version;
     src = whitelistSource ../../../. [
       "Cargo.lock"
@@ -55,6 +55,8 @@ let
       "rpc"
       "spdk-sys"
       "sysfs"
+      "mbus-api"
+      "services"
     ];
 
     LIBCLANG_PATH = "${llvmPackages.libclang}/lib";
@@ -92,7 +94,7 @@ in
     buildInputs = buildProps.buildInputs ++ [ libspdk-dev ];
     SPDK_PATH = "${libspdk-dev}";
   });
-  # this is for image that does not do a build of mayastor
+  # this is for an image that does not do a build of mayastor
   adhoc = stdenv.mkDerivation {
     name = "mayastor-adhoc";
     inherit version;
@@ -101,6 +103,7 @@ in
       ../../../target/debug/mayastor-csi
       ../../../target/debug/mayastor-client
       ../../../target/debug/jsonrpc
+      ../../../target/debug/kiiss
     ];
 
     buildInputs = [

--- a/services/Cargo.toml
+++ b/services/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "services"
+version = "0.1.0"
+authors = ["Tiago Castro <tiago.castro@mayadata.io>"]
+edition = "2018"
+
+[lib]
+name = "common"
+path = "common/src/lib.rs"
+
+[dependencies]
+mbus_api = { path = "../mbus-api" }
+nats = "0.8"
+structopt = "0.3.15"
+log = "0.4.11"
+tokio = { version = "0.2", features = ["full"] }
+futures = "0.3.6"
+env_logger = "0.7"
+serde_json = "1.0"
+async-trait = "0.1.36"
+dyn-clonable = "0.9.0"
+smol = "1.0.0"
+snafu = "0.6"
+
+
+[dependencies.serde]
+features = ["derive"]
+version = "1.0"

--- a/services/Cargo.toml
+++ b/services/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.1.0"
 authors = ["Tiago Castro <tiago.castro@mayadata.io>"]
 edition = "2018"
 
+[[bin]]
+name = "kiiss"
+path = "kiiss/src/server.rs"
+
 [lib]
 name = "common"
 path = "common/src/lib.rs"
@@ -21,7 +25,7 @@ async-trait = "0.1.36"
 dyn-clonable = "0.9.0"
 smol = "1.0.0"
 snafu = "0.6"
-
+lazy_static = "1.4.0"
 
 [dependencies.serde]
 features = ["derive"]

--- a/services/common/src/lib.rs
+++ b/services/common/src/lib.rs
@@ -1,0 +1,253 @@
+#![warn(missing_docs)]
+//! Control Plane Services library with emphasis on the message bus interaction.
+//!
+//! It's meant to facilitate the creation of services with a helper builder to
+//! subscribe handlers for different message identifiers.
+
+use async_trait::async_trait;
+use dyn_clonable::clonable;
+use futures::{future::join_all, stream::StreamExt};
+use mbus_api::*;
+use smol::io;
+use snafu::{OptionExt, ResultExt, Snafu};
+use std::collections::HashMap;
+
+#[derive(Debug, Snafu)]
+#[allow(missing_docs)]
+pub enum ServiceError {
+    #[snafu(display("Channel {} has been closed.", channel))]
+    GetMessage {
+        channel: Channel,
+    },
+    #[snafu(display("Failed to subscribe on Channel {}", channel))]
+    Subscribe {
+        channel: Channel,
+        source: io::Error,
+    },
+    GetMessageId {
+        channel: Channel,
+        source: io::Error,
+    },
+    FindSubscription {
+        channel: Channel,
+        id: MessageId,
+    },
+    HandleMessage {
+        channel: Channel,
+        id: MessageId,
+        source: io::Error,
+    },
+}
+
+/// Runnable service with N subscriptions which listen on a given
+/// message bus channel on a specific ID
+#[derive(Default)]
+pub struct Service {
+    server: String,
+    channel: Channel,
+    subscriptions: HashMap<String, Vec<Box<dyn ServiceSubscriber>>>,
+}
+
+/// Service Arguments for the service handler callback
+pub struct Arguments<'a> {
+    /// Service context, like access to the message bus
+    pub context: Context<'a>,
+    /// Access to the actual message bus request
+    pub request: Request<'a>,
+}
+
+impl<'a> Arguments<'a> {
+    /// Returns a new Service Argument to be use by a Service Handler
+    pub fn new(bus: &'a DynBus, msg: &'a BusMessage) -> Self {
+        Self {
+            context: bus.into(),
+            request: msg.into(),
+        }
+    }
+}
+
+/// Service handling context
+/// the message bus which triggered the service callback
+#[derive(Clone)]
+pub struct Context<'a> {
+    bus: &'a DynBus,
+}
+
+impl<'a> From<&'a DynBus> for Context<'a> {
+    fn from(bus: &'a DynBus) -> Self {
+        Self {
+            bus,
+        }
+    }
+}
+
+impl<'a> Context<'a> {
+    /// get the message bus from the context
+    pub fn get_bus_as_ref(&self) -> &'a DynBus {
+        self.bus
+    }
+}
+
+/// Service Request received via the message bus
+pub type Request<'a> = ReceivedRawMessage<'a>;
+
+#[async_trait]
+#[clonable]
+/// Trait which must be implemented by each subscriber with the handler
+/// which processes the messages and a filter to match message types
+pub trait ServiceSubscriber: Clone + Send + Sync {
+    /// async handler which processes the messages
+    async fn handler(&self, args: Arguments<'_>) -> Result<(), io::Error>;
+    /// filter which identifies which messages may be routed to the handler
+    fn filter(&self) -> Vec<MessageId>;
+}
+
+impl Service {
+    /// Setup default service connecting to `server` on subject `channel`
+    pub fn builder(server: String, channel: Channel) -> Self {
+        Self {
+            server,
+            channel,
+            ..Default::default()
+        }
+    }
+
+    /// Setup default `channel`
+    pub fn with_channel(mut self, channel: Channel) -> Self {
+        self.channel = channel;
+        self
+    }
+
+    /// Add a new subscriber on the default channel
+    pub fn with_subscription(
+        self,
+        service_subscriber: impl ServiceSubscriber + 'static,
+    ) -> Self {
+        let channel = self.channel.clone();
+        self.with_subscription_channel(channel, service_subscriber)
+    }
+
+    /// Add a new subscriber on the given `channel`
+    pub fn with_subscription_channel(
+        mut self,
+        channel: Channel,
+        service_subscriber: impl ServiceSubscriber + 'static,
+    ) -> Self {
+        match self.subscriptions.get_mut(&channel.to_string()) {
+            Some(entry) => {
+                entry.push(Box::from(service_subscriber));
+            }
+            None => {
+                self.subscriptions.insert(
+                    channel.to_string(),
+                    vec![Box::from(service_subscriber)],
+                );
+            }
+        };
+        self
+    }
+
+    async fn run_channel(
+        bus: DynBus,
+        channel: Channel,
+        subscriptions: &[Box<dyn ServiceSubscriber>],
+    ) -> Result<(), ServiceError> {
+        let mut handle =
+            bus.subscribe(channel.clone()).await.context(Subscribe {
+                channel: channel.clone(),
+            })?;
+
+        loop {
+            let message = handle.next().await.context(GetMessage {
+                channel: channel.clone(),
+            })?;
+            let args = Arguments::new(&bus, &message);
+
+            if let Err(error) =
+                Self::process_message(args, &subscriptions).await
+            {
+                log::error!("Error processing message: {}", error);
+            }
+        }
+    }
+
+    async fn process_message<'a>(
+        arguments: Arguments<'a>,
+        subscriptions: &[Box<dyn ServiceSubscriber>],
+    ) -> Result<(), ServiceError> {
+        let channel = arguments.request.channel();
+        let id = &arguments.request.id().context(GetMessageId {
+            channel: channel.clone(),
+        })?;
+
+        let subscription = subscriptions
+            .iter()
+            .find(|&subscriber| {
+                subscriber.filter().iter().any(|find_id| find_id == id)
+            })
+            .context(FindSubscription {
+                channel: channel.clone(),
+                id: id.clone(),
+            })?;
+
+        let result =
+            subscription
+                .handler(arguments)
+                .await
+                .context(HandleMessage {
+                    channel: channel.clone(),
+                    id: id.clone(),
+                });
+
+        if let Err(error) = result.as_ref() {
+            // todo: should an error be returned to the sender?
+            log::error!(
+                "Error handling message id {:?}: {:?}",
+                subscription.filter(),
+                error
+            );
+        }
+
+        result
+    }
+
+    /// Runs the server which services all subscribers asynchronously until all
+    /// subscribers are closed
+    ///
+    /// subscribers are sorted according to the channel they subscribe on
+    /// each channel benefits from a tokio thread which routes messages
+    /// accordingly todo: only one subscriber per message id supported at
+    /// the moment
+    pub async fn run(&self) {
+        let mut threads = vec![];
+        // todo: parse connection options when nats has better support for it
+        mbus_api::message_bus_init(self.server.clone()).await;
+        let bus = mbus_api::bus();
+
+        for subscriptions in self.subscriptions.iter() {
+            let bus = bus.clone();
+            let channel = subscriptions.0.clone();
+            let subscriptions = subscriptions.1.clone();
+
+            let handle = tokio::spawn(async move {
+                Self::run_channel(bus, channel.parse().unwrap(), &subscriptions)
+                    .await
+            });
+
+            threads.push(handle);
+        }
+
+        join_all(threads)
+            .await
+            .iter()
+            .for_each(|result| match result {
+                Err(error) => {
+                    log::error!("Failed to wait for thread: {:?}", error)
+                }
+                Ok(Err(error)) => {
+                    log::error!("Error running channel thread: {:?}", error)
+                }
+                _ => {}
+            });
+    }
+}

--- a/services/examples/kiiss-client/main.rs
+++ b/services/examples/kiiss-client/main.rs
@@ -1,0 +1,50 @@
+use log::info;
+use mbus_api::*;
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+struct CliArgs {
+    /// The Nats Server URL to connect to
+    /// (supports the nats schema)
+    /// Default: nats://127.0.0.1:4222
+    #[structopt(long, short, default_value = "nats://127.0.0.1:4222")]
+    url: String,
+}
+
+#[tokio::main]
+async fn main() {
+    env_logger::init_from_env(
+        env_logger::Env::default()
+            .filter_or(env_logger::DEFAULT_FILTER_ENV, "info"),
+    );
+
+    client().await;
+}
+
+async fn client() {
+    let cli_args = CliArgs::from_args();
+    mbus_api::message_bus_init(cli_args.url).await;
+
+    ConfigUpdate {
+        kind: Config::MayastorConfig,
+        data: "My config...".into(),
+    }
+    .request()
+    .await
+    .unwrap();
+
+    let config = GetConfig::Request(
+        &ConfigGetCurrent {
+            kind: Config::MayastorConfig,
+        },
+        Channel::Kiiss,
+        bus(),
+    )
+    .await
+    .unwrap();
+
+    info!(
+        "Received config: {:?}",
+        std::str::from_utf8(&config.config).unwrap()
+    );
+}

--- a/services/examples/service/main.rs
+++ b/services/examples/service/main.rs
@@ -1,0 +1,80 @@
+use async_trait::async_trait;
+use common::*;
+use mbus_api::*;
+use serde::{Deserialize, Serialize};
+use smol::io;
+use std::{convert::TryInto, marker::PhantomData};
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+struct CliArgs {
+    /// The Nats Server URL to connect to
+    /// (supports the nats schema)
+    /// Default: nats://127.0.0.1:4222
+    #[structopt(long, short, default_value = "nats://127.0.0.1:4222")]
+    url: String,
+
+    /// Act as a Server or a test client
+    #[structopt(long, short)]
+    client: bool,
+}
+
+/// Needed so we can implement the ServiceSubscriber trait for
+/// the message types external to the crate
+#[derive(Clone, Default)]
+struct ServiceHandler<T> {
+    data: PhantomData<T>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
+struct GetSvcName {}
+
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
+struct SvcName(String);
+
+bus_impl_message_all!(GetSvcName, Default, SvcName, Default);
+
+#[async_trait]
+impl ServiceSubscriber for ServiceHandler<GetSvcName> {
+    async fn handler(&self, args: Arguments<'_>) -> Result<(), io::Error> {
+        let msg: ReceivedMessage<GetSvcName, SvcName> =
+            args.request.try_into()?;
+
+        let reply = SvcName("example".into());
+
+        println!("Received {:?} and replying {:?}", msg.inner(), reply);
+
+        msg.reply(reply).await
+    }
+    fn filter(&self) -> Vec<MessageId> {
+        vec![GetSvcName::default().id()]
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    let cli_args = CliArgs::from_args();
+
+    if cli_args.client {
+        client().await;
+    } else {
+        server().await;
+    }
+}
+
+async fn client() {
+    let cli_args = CliArgs::from_args();
+    message_bus_init(cli_args.url).await;
+
+    let svc_name = GetSvcName {}.request().await.unwrap().0;
+    println!("Svc Name: {}", svc_name);
+}
+
+async fn server() {
+    let cli_args = CliArgs::from_args();
+
+    Service::builder(cli_args.url, Channel::Default)
+        .with_subscription(ServiceHandler::<GetSvcName>::default())
+        .run()
+        .await;
+}

--- a/services/kiiss/src/server.rs
+++ b/services/kiiss/src/server.rs
@@ -1,0 +1,151 @@
+#[macro_use]
+extern crate lazy_static;
+
+use async_trait::async_trait;
+use common::*;
+use log::info;
+use mbus_api::*;
+use smol::io;
+use std::{collections::HashMap, convert::TryInto, marker::PhantomData};
+use structopt::StructOpt;
+use tokio::sync::Mutex;
+
+#[derive(Debug, StructOpt)]
+struct CliArgs {
+    /// The Nats Server URL to connect to
+    /// (supports the nats schema)
+    /// Default: nats://127.0.0.1:4222
+    #[structopt(long, short, default_value = "nats://127.0.0.1:4222")]
+    url: String,
+}
+
+/// Needed so we can implement the ServiceSubscriber trait for
+/// the message types external to the crate
+#[derive(Clone, Default)]
+struct ServiceHandler<T> {
+    data: PhantomData<T>,
+}
+
+#[derive(Default)]
+struct ConfigState {
+    state: Mutex<HashMap<SenderId, HashMap<Config, Vec<u8>>>>,
+}
+
+lazy_static! {
+    static ref CONFIGS: ConfigState = Default::default();
+}
+
+#[async_trait]
+impl ServiceSubscriber for ServiceHandler<ConfigUpdate> {
+    async fn handler(&self, args: Arguments<'_>) -> Result<(), io::Error> {
+        let data: ConfigUpdate = args.request.inner()?;
+        info!("Received: {:?}", data);
+
+        let msg: ReceivedMessage<ConfigUpdate, ()> = args.request.try_into()?;
+        let config = msg.inner();
+
+        let mut state = CONFIGS.state.lock().await;
+
+        match state.get_mut(&msg.sender()) {
+            Some(map) => {
+                map.insert(config.kind, config.data);
+            }
+            None => {
+                let mut config_map = HashMap::new();
+                config_map.insert(config.kind, config.data);
+                state.insert(msg.sender(), config_map);
+            }
+        }
+
+        msg.reply(()).await
+    }
+    fn filter(&self) -> Vec<MessageId> {
+        vec![ConfigUpdate::default().id()]
+    }
+}
+
+#[async_trait]
+impl ServiceSubscriber for ServiceHandler<ConfigGetCurrent> {
+    async fn handler(&self, args: Arguments<'_>) -> Result<(), io::Error> {
+        let data: ConfigGetCurrent = args.request.inner()?;
+        info!("Received: {:?}", data);
+
+        let msg: ReceivedMessage<ConfigGetCurrent, ReplyConfig> =
+            args.request.try_into()?;
+        let request = msg.inner();
+
+        let state = CONFIGS.state.lock().await;
+
+        match state.get(&msg.sender()) {
+            Some(config) => match config.get(&request.kind) {
+                Some(data) => {
+                    msg.reply(ReplyConfig {
+                        config: data.clone(),
+                    })
+                    .await
+                }
+                None => {
+                    msg.reply(Err(Error::WithMessage {
+                        message: "Config is missing".into(),
+                    }))
+                    .await
+                }
+            },
+            None => {
+                msg.reply(Err(Error::WithMessage {
+                    message: "Config is missing".into(),
+                }))
+                .await
+            }
+        }
+    }
+    fn filter(&self) -> Vec<MessageId> {
+        vec![ConfigGetCurrent::default().id()]
+    }
+}
+
+#[async_trait]
+impl ServiceSubscriber for ServiceHandler<Register> {
+    async fn handler(&self, args: Arguments<'_>) -> Result<(), io::Error> {
+        let _: ReceivedMessage<Register, ()> = args.request.try_into()?;
+        Ok(())
+    }
+    fn filter(&self) -> Vec<MessageId> {
+        vec![Register::default().id()]
+    }
+}
+
+#[async_trait]
+impl ServiceSubscriber for ServiceHandler<Deregister> {
+    async fn handler(&self, args: Arguments<'_>) -> Result<(), io::Error> {
+        let _: ReceivedMessage<Deregister, ()> = args.request.try_into()?;
+        Ok(())
+    }
+    fn filter(&self) -> Vec<MessageId> {
+        vec![Deregister::default().id()]
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    env_logger::init_from_env(
+        env_logger::Env::default()
+            .filter_or(env_logger::DEFAULT_FILTER_ENV, "info"),
+    );
+
+    let cli_args = CliArgs::from_args();
+    info!("Using options: {:?}", &cli_args);
+
+    server(cli_args).await;
+}
+
+async fn server(cli_args: CliArgs) {
+    Service::builder(cli_args.url, Channel::Kiiss)
+        .with_subscription(ServiceHandler::<ConfigUpdate>::default())
+        .with_subscription(ServiceHandler::<ConfigGetCurrent>::default())
+        .with_channel(Channel::Registry)
+        .with_subscription(ServiceHandler::<Register>::default())
+        .with_subscription(ServiceHandler::<Deregister>::default())
+        .run()
+        .await;
+}


### PR DESCRIPTION
...service

Common message bus api to be shared between services and mayastor
Common service api for the services

Kiiss service as an example to show case the service api.

I've split this in 3 commits, which should make reviewing easier.
I also added a few cargo examples which might be useful.