### PR TITLE
CAS-481: wait for message bus

### DIFF
--- a/deploy/mayastor-daemonset-config.yaml
+++ b/deploy/mayastor-daemonset-config.yaml
@@ -29,9 +29,13 @@ spec:
       # belong to Guaranteed QoS class, hence can never get evicted in case of
       # pressure unless they exceed those limits. limits and requests must be
       # the same.
+      initContainers:
+      - name: message-bus-probe
+        image: busybox:latest
+        command: ['sh', '-c', 'until nc -vz nats 4222; do echo "Waiting for message bus..."; sleep 1; done;']
       containers:
         - name: mayastor
-          image: 192.168.1.119:5000/mayastor:dev
+          image: mayadata/mayastor:latest
           imagePullPolicy: Always
           env:
             - name: MY_NODE_NAME

--- a/deploy/mayastor-daemonset.yaml
+++ b/deploy/mayastor-daemonset.yaml
@@ -29,6 +29,10 @@ spec:
       # belong to Guaranteed QoS class, hence can never get evicted in case of
       # pressure unless they exceed those limits. limits and requests must be
       # the same.
+      initContainers:
+      - name: message-bus-probe
+        image: busybox:latest
+        command: ['sh', '-c', 'until nc -vz nats 4222; do echo "Waiting for message bus..."; sleep 1; done;']
       containers:
       - name: mayastor
         image: mayadata/mayastor:latest
@@ -42,8 +46,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
-        - name: IMPORT_NEXUSES
-          value: "false"
         args:
         - "-N$(MY_NODE_NAME)"
         - "-g$(MY_POD_IP)"


### PR DESCRIPTION
On k8s, even before even attempting to start mayastor we should make
sure that the nats service is ready.