### PR TITLE
test: add framework to start mayastor instances

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,9 +44,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.32"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b602bfe940d21c130f3895acd65221e8a61270debe89d628b9cb4e3ccb8569b"
+checksum = "a1fd36ffbb1fb7c834eac128ea8d0e310c5aeb635548f9d58861e1308d46e71c"
 
 [[package]]
 name = "arc-swap"
@@ -55,26 +55,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d25d88fd6b8041580a654f9d0c581a047baee2b3efee13275f2fc392fc75034"
 
 [[package]]
-name = "assert_matches"
-version = "1.3.0"
+name = "arrayref"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7deb0a829ca7bcfaf5da70b073a8d128619259a7be8216a355e23f00763059e5"
+checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
 
 [[package]]
-name = "async-barrier"
-version = "1.0.1"
+name = "arrayvec"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06293698675eb72e1155867e5982f199d6b6c230dca35bc5ffd9852f470c22a"
-dependencies = [
- "async-mutex",
- "event-listener",
-]
+checksum = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
+
+[[package]]
+name = "assert_matches"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "695579f0f2520f3774bb40461e5adb066459d4e0af4d59d20175484fb8e9edf1"
 
 [[package]]
 name = "async-channel"
-version = "1.4.2"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21279cfaa4f47df10b1816007e738ca3747ef2ee53ffc51cdbf57a8bb266fee3"
+checksum = "59740d83946db6a5af71ae25ddf9562c2b176b2ca42cf99a455f09f4a220d6b9"
 dependencies = [
  "concurrent-queue",
  "event-listener",
@@ -83,9 +85,9 @@ dependencies = [
 
 [[package]]
 name = "async-dup"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c23bdd6ada8f5f586141f56fd8ea7f60700be462154325cfbbb674126688a51a"
+checksum = "7427a12b8dc09291528cfb1da2447059adb4a257388c2acd6497a79d55cf6f7c"
 dependencies = [
  "futures-io",
  "simple-mutex",
@@ -97,7 +99,7 @@ version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d373d78ded7d0b3fa8039375718cde0aace493f2e34fb60f51cbf567562ca801"
 dependencies = [
- "async-task 4.0.2",
+ "async-task",
  "concurrent-queue",
  "fastrand",
  "futures-lite",
@@ -107,23 +109,25 @@ dependencies = [
 
 [[package]]
 name = "async-fs"
-version = "1.3.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3572236ba37147ca2b674a0bd5afd20aec0cd925ab125ab6fad6543960f9002"
+checksum = "8b3ca4f8ff117c37c278a2f7415ce9be55560b846b5bc4412aaa5d29c1c3dae2"
 dependencies = [
+ "async-lock",
  "blocking",
  "futures-lite",
 ]
 
 [[package]]
 name = "async-io"
-version = "1.1.5"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e727cebd055ab2861a854f79def078c4b99ea722d54c6800a0e274389882d4c"
+checksum = "d54bc4c1c7292475efb2253227dbcfad8fe1ca4c02bc62c510cc2f3da5c4704e"
 dependencies = [
  "concurrent-queue",
  "fastrand",
  "futures-lite",
+ "libc",
  "log",
  "nb-connect",
  "once_cell",
@@ -131,34 +135,32 @@ dependencies = [
  "polling",
  "vec-arena",
  "waker-fn",
+ "winapi 0.3.9",
 ]
 
 [[package]]
 name = "async-lock"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76000290eb3c67dfe4e2bdf6b6155847f8e16fc844377a7bd0b5e97622656362"
+checksum = "1996609732bde4a9988bc42125f55f2af5f3c36370e27c778d5191a4a1b63bfb"
 dependencies = [
- "async-barrier",
- "async-mutex",
- "async-rwlock",
- "async-semaphore",
+ "event-listener",
 ]
 
 [[package]]
 name = "async-mutex"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66941c2577c4fa351e4ce5fdde8f86c69b88d623f3b955be1bc7362a23434632"
+checksum = "479db852db25d9dbf6204e6cb6253698f175c15726470f78af0d918e99d6156e"
 dependencies = [
  "event-listener",
 ]
 
 [[package]]
 name = "async-net"
-version = "1.4.6"
+version = "1.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14a5335056541826f855bf95b936df9788adbacf94b15ef7104029f7fff3e82a"
+checksum = "ee4c3668eb091d781e97f0026b5289b457c77d407a85749a9bb4c057456c428f"
 dependencies = [
  "async-io",
  "blocking",
@@ -168,37 +170,18 @@ dependencies = [
 
 [[package]]
 name = "async-process"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bb915df28b8309139bd9c9c700d84c20e5c21385d05378caa84912332d0f6a1"
+checksum = "4c8cea09c1fb10a317d1b5af8024eeba256d6554763e85ecd90ff8df31c7bbda"
 dependencies = [
  "async-io",
  "blocking",
- "cfg-if",
+ "cfg-if 0.1.10",
  "event-listener",
  "futures-lite",
  "once_cell",
  "signal-hook",
  "winapi 0.3.9",
-]
-
-[[package]]
-name = "async-rwlock"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "806b1cc0828c2b1611ccbdd743fc0cc7af09009e62c95a0501c1e5da7b142a22"
-dependencies = [
- "async-mutex",
- "event-listener",
-]
-
-[[package]]
-name = "async-semaphore"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "538c756e85eb6ffdefaec153804afb6da84b033e2e5ec3e9d459c34b4bf4d3f6"
-dependencies = [
- "event-listener",
 ]
 
 [[package]]
@@ -217,16 +200,10 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25f9db3b38af870bf7e5cc649167533b493928e50744e2c30ae350230b414670"
 dependencies = [
- "proc-macro2 1.0.19",
+ "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.38",
+ "syn 1.0.44",
 ]
-
-[[package]]
-name = "async-task"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17772156ef2829aadc587461c7753af20b7e8db1529bc66855add962a3b35d3"
 
 [[package]]
 name = "async-task"
@@ -249,13 +226,13 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.38"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1a4a2f97ce50c9d0282c1468816208588441492b40d813b2e0419c22c05e7f"
+checksum = "b246867b8b3b6ae56035f1eb1ed557c1d8eae97f0d53696138a50fa0e3a3b8c0"
 dependencies = [
- "proc-macro2 1.0.19",
+ "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.38",
+ "syn 1.0.44",
 ]
 
 [[package]]
@@ -289,12 +266,12 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "backtrace"
-version = "0.3.50"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46254cf2fdcdf1badb5934448c1bcbe046a56537b3987d96c51a7afc5d03f293"
+checksum = "707b586e0e2f247cbde68cdd2c3ce69ea7b7be43e1c5b426e37c9319c4b9838e"
 dependencies = [
  "addr2line",
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "miniz_oxide",
  "object",
@@ -337,13 +314,13 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.54.1"
+version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4d49b80beb70d76cdac92f5681e666f9a697c737c4f4117a67229a0386dc736"
+checksum = "66c0bb6167449588ff70803f4127f0684f9063097eca5016f37eb52b92c2cf36"
 dependencies = [
  "bitflags",
  "cexpr",
- "cfg-if",
+ "cfg-if 0.1.10",
  "clang-sys",
  "clap",
  "env_logger",
@@ -351,7 +328,7 @@ dependencies = [
  "lazycell",
  "log",
  "peeking_take_while",
- "proc-macro2 1.0.19",
+ "proc-macro2 1.0.24",
  "quote 1.0.7",
  "regex",
  "rustc-hash",
@@ -364,6 +341,17 @@ name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+
+[[package]]
+name = "blake2b_simd"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8fb2d74254a3a0b5cac33ac9f8ed0e44aa50378d9dbb2e5d83bd21ed1dc2c8a"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "constant_time_eq",
+]
 
 [[package]]
 name = "blkid"
@@ -406,16 +394,63 @@ dependencies = [
 
 [[package]]
 name = "blocking"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2640778f8053e72c11f621b0a5175a0560a269282aa98ed85107773ab8e2a556"
+checksum = "c5e170dbede1f740736619b776d7251cb1b9095c435c34d8ca9f57fcd2f335e9"
 dependencies = [
  "async-channel",
+ "async-task",
  "atomic-waker",
  "fastrand",
  "futures-lite",
  "once_cell",
- "waker-fn",
+]
+
+[[package]]
+name = "bollard"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98e70e4f2f2dec6396a87cd2a9acc0ac14d5aa0941a5f4a287bb25ae3a9ca183"
+dependencies = [
+ "base64 0.12.3",
+ "bollard-stubs",
+ "bytes 0.5.6",
+ "chrono",
+ "ct-logs",
+ "dirs",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "http 0.2.1",
+ "hyper",
+ "hyper-rustls",
+ "hyper-unix-connector",
+ "log",
+ "mio-named-pipes",
+ "pin-project",
+ "rustls",
+ "rustls-native-certs",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_urlencoded",
+ "thiserror",
+ "tokio",
+ "tokio-util 0.3.1",
+ "url",
+ "webpki-roots",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "bollard-stubs"
+version = "1.40.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c0039b619b9795bb6203a1ad7156b8418e38d4fdb857bf60984746b5a0fdb04"
+dependencies = [
+ "chrono",
+ "serde",
+ "serde_with",
 ]
 
 [[package]]
@@ -478,9 +513,9 @@ checksum = "631ae5198c9be5e753e5cc215e1bd73c2b466a3565173db433f52bb9d3e66dba"
 
 [[package]]
 name = "cc"
-version = "1.0.59"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66120af515773fb005778dc07c261bd201ec8ce50bd6e7144c927753fe013381"
+checksum = "ed67cbde08356238e75fc4656be4749481eeffb09e19f320a25237d5221c985d"
 
 [[package]]
 name = "cexpr"
@@ -498,14 +533,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
-name = "chrono"
-version = "0.4.15"
+name = "cfg-if"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "942f72db697d8767c22d46a598e01f2d3b475501ea43d0db4f16d90259182d0b"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
 dependencies = [
+ "libc",
  "num-integer",
  "num-traits 0.2.12",
+ "serde",
  "time",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -575,6 +619,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "constant_time_eq"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+
+[[package]]
 name = "core-foundation"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -605,7 +655,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69323bff1fb41c635347b8ead484a5ca6c3f11914d784170b158d8449ab07f8e"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-epoch",
@@ -615,12 +665,12 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ee0cc8804d5393478d743b035099520087a5186f3b93fa58cec08fa62407b6"
+checksum = "b153fe7cbef478c567df0f972e02e6d736db11affe43dfc9c56a9374d1adfb87"
 dependencies = [
- "cfg-if",
  "crossbeam-utils",
+ "maybe-uninit",
 ]
 
 [[package]]
@@ -641,7 +691,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
 dependencies = [
  "autocfg 1.0.1",
- "cfg-if",
+ "cfg-if 0.1.10",
  "crossbeam-utils",
  "lazy_static",
  "maybe-uninit",
@@ -655,7 +705,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "774ba60a54c213d409d5353bda12d49cd68d14e45036a285234c8d6f91f92570"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "crossbeam-utils",
  "maybe-uninit",
 ]
@@ -673,7 +723,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
 dependencies = [
  "autocfg 1.0.1",
- "cfg-if",
+ "cfg-if 0.1.10",
  "lazy_static",
 ]
 
@@ -725,6 +775,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ct-logs"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c8e13110a84b6315df212c045be706af261fd364791cad863285439ebba672e"
+dependencies = [
+ "sct",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -743,8 +802,18 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcfbcb0c5961907597a7d1148e3af036268f2b773886b8bb3eeb1e1281d3d3d6"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.9.0",
+ "darling_macro 0.9.0",
+]
+
+[[package]]
+name = "darling"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d706e75d87e35569db781a9b5e2416cff1236a47ed380831f959382ccd5f858"
+dependencies = [
+ "darling_core 0.10.2",
+ "darling_macro 0.10.2",
 ]
 
 [[package]]
@@ -762,14 +831,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c960ae2da4de88a91b2d920c2a7233b400bc33cb28453a2987822d8392519b"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2 1.0.24",
+ "quote 1.0.7",
+ "strsim 0.9.3",
+ "syn 1.0.44",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6d8dac1c6f1d29a41c4712b4400f878cb4fcc4c7628f298dd75038e024998d1"
 dependencies = [
- "darling_core",
+ "darling_core 0.9.0",
  "quote 0.6.13",
  "syn 0.15.44",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
+dependencies = [
+ "darling_core 0.10.2",
+ "quote 1.0.7",
+ "syn 1.0.44",
 ]
 
 [[package]]
@@ -784,7 +878,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ac53fa6a3cda160df823a9346442525dcaf1e171999a1cf23e67067e4fd64d4"
 dependencies = [
- "darling",
+ "darling 0.9.0",
  "derive_builder_core",
  "proc-macro2 0.4.30",
  "quote 0.6.13",
@@ -797,7 +891,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0288a23da9333c246bb18c143426074a6ae96747995c5819d2947b64cd942b37"
 dependencies = [
- "darling",
+ "darling 0.9.0",
  "proc-macro2 0.4.30",
  "quote 0.6.13",
  "syn 0.15.44",
@@ -823,12 +917,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142995ed02755914747cc6ca76fc7e4583cd18578746716d0508ea6ed558b9ff"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e93d7f5705de3e49895a2b5e0b8855a1c27f080192ae9c32a6432d50741a57a"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "dns-lookup"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f69635ffdfbaea44241d7cca30a5e3a2e1c892613a6a8ad8ef03deeb6803480"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "socket2",
  "winapi 0.3.9",
@@ -871,9 +985,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd56b59865bce947ac5958779cfa508f6c3b9497cc762b7e24a12d11ccde2c4f"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "enum-primitive-derive"
@@ -906,10 +1020,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22deed3a8124cff5fa835713fa105621e43bbdc46690c3a6b68328a012d350d4"
 dependencies = [
  "proc-macro-error",
- "proc-macro2 1.0.19",
+ "proc-macro2 1.0.24",
  "quote 1.0.7",
  "rustversion",
- "syn 1.0.38",
+ "syn 1.0.44",
  "synstructure",
 ]
 
@@ -936,9 +1050,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "2.4.0"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1cd41440ae7e4734bbd42302f63eaba892afc93a3912dad84006247f0dedb0e"
+checksum = "f7531096570974c3a9dcf9e4b8e1cede1ec26cf5046219fb3b9d897503b9be59"
 
 [[package]]
 name = "failure"
@@ -956,9 +1070,9 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 dependencies = [
- "proc-macro2 1.0.19",
+ "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.38",
+ "syn 1.0.44",
  "synstructure",
 ]
 
@@ -970,9 +1084,12 @@ checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 
 [[package]]
 name = "fastrand"
-version = "1.3.5"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c85295147490b8fcf2ea3d104080a105a8b2c63f9c319e82c02d8e952388919"
+checksum = "ca5faf057445ce5c9d4329e382b2ce7ca38550ef3b73a5348362d5f24e0c7fe3"
+dependencies = [
+ "instant",
+]
 
 [[package]]
 name = "fixedbitset"
@@ -1020,9 +1137,9 @@ checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
 name = "futures"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e05b85ec287aac0dc34db7d4a569323df697f9c55b99b15d6b4ef8cde49f613"
+checksum = "5d8e3078b7b2a8a671cb7a3d17b4760e4181ea243227776ba83fd043b4ca034e"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1035,9 +1152,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f366ad74c28cca6ba456d95e6422883cfb4b252a83bed929c83abfdbbf2967d5"
+checksum = "a7a4d35f7401e948629c9c3d6638fb9bf94e0b2121e96c3b428cc4e631f3eb74"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1045,15 +1162,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59f5fff90fd5d971f936ad674802482ba441b6f09ba5e15fd8b39145582ca399"
+checksum = "d674eaa0056896d5ada519900dbf97ead2e46a7b6621e8160d79e2f2e1e2784b"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10d6bb888be1153d3abeb9006b11b02cf5e9b209fda28693c31ae1e4e012e314"
+checksum = "cc709ca1da6f66143b8c9bec8e6260181869893714e9b5a490b169b0414144ab"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1062,15 +1179,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de27142b013a8e869c14957e6d2edeef89e97c289e69d042ee3a49acd8b51789"
+checksum = "5fc94b64bb39543b4e432f1790b6bf18e3ee3b74653c5449f63310e9a74b123c"
 
 [[package]]
 name = "futures-lite"
-version = "1.8.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0db18c5f58083b54b0c416638ea73066722c2815c1e54dd8ba85ee3def593c3a"
+checksum = "381a7ad57b1bad34693f63f6f377e1abded7a9c85c9d3eb6771e11c60aaadab9"
 dependencies = [
  "fastrand",
  "futures-core",
@@ -1083,27 +1200,27 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0b5a30a4328ab5473878237c447333c093297bded83a4983d10f4deea240d39"
+checksum = "f57ed14da4603b2554682e9f2ff3c65d7567b53188db96cb71538217fc64581b"
 dependencies = [
  "proc-macro-hack",
- "proc-macro2 1.0.19",
+ "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.38",
+ "syn 1.0.44",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f2032893cb734c7a05d85ce0cc8b8c4075278e93b24b66f9de99d6eb0fa8acc"
+checksum = "0d8764258ed64ebc5d9ed185cf86a95db5cac810269c5d20ececb32e0088abbd"
 
 [[package]]
 name = "futures-task"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdb66b5f09e22019b1ab0830f7785bcea8e7a42148683f99214f73f8ec21a626"
+checksum = "4dd26820a9f3637f1302da8bceba3ff33adbe53464b54ca24d4e2d4f1db30f94"
 dependencies = [
  "once_cell",
 ]
@@ -1116,9 +1233,9 @@ checksum = "a1de7508b218029b0f01662ed8f61b1c964b3ae99d6f25462d0f55a595109df6"
 
 [[package]]
 name = "futures-util"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8764574ff08b701a084482c3c7031349104b07ac897393010494beaa18ce32c6"
+checksum = "8a894a0acddba51a2d49a6f4263b1e64b8c579ece8af50fa86503d52cd1eea34"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1151,13 +1268,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
+checksum = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
- "wasi",
+ "wasi 0.9.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -1183,9 +1300,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34a97a52fdee1870a34fa6e4b77570cba531b27d1838874fef4429a791a3d657"
 dependencies = [
  "proc-macro-hack",
- "proc-macro2 1.0.19",
+ "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.38",
+ "syn 1.0.44",
 ]
 
 [[package]]
@@ -1215,12 +1332,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.8.2"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91b62f79061a0bc2e046024cb7ba44b08419ed238ecbd9adbd787434b9e8c25"
-dependencies = [
- "autocfg 1.0.1",
-]
+checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
 
 [[package]]
 name = "heck"
@@ -1233,12 +1347,18 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.15"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3deed196b6e7f9e44a2ae8d94225d80302d81208b1bb673fd21fe634645c85a9"
+checksum = "5aca5565f760fb5b220e499d72710ed156fdb74e631659e99377d9ebfbd13ae8"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "hex"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
 
 [[package]]
 name = "http"
@@ -1289,6 +1409,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"
 
 [[package]]
+name = "httpdate"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
+
+[[package]]
 name = "humantime"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1299,9 +1425,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.13.7"
+version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e68a8dd9716185d9e64ea473ea6ef63529252e3e27623295a0378a19665d5eb"
+checksum = "2f3afcfae8af5ad0576a31e768415edb627824129e8e5a29b8bfccb2f234e835"
 dependencies = [
  "bytes 0.5.6",
  "futures-channel",
@@ -1311,14 +1437,46 @@ dependencies = [
  "http 0.2.1",
  "http-body 0.3.1",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project",
  "socket2",
- "time",
  "tokio",
  "tower-service",
  "tracing",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37743cc83e8ee85eacfce90f2f4102030d9ff0a95244098d781e9bee4a90abb6"
+dependencies = [
+ "bytes 0.5.6",
+ "ct-logs",
+ "futures-util",
+ "hyper",
+ "log",
+ "rustls",
+ "rustls-native-certs",
+ "tokio",
+ "tokio-rustls",
+ "webpki",
+]
+
+[[package]]
+name = "hyper-unix-connector"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b66be14087ec25c5150c9d1228a1e9bbbfe7fe2506ff85daed350724980319"
+dependencies = [
+ "anyhow",
+ "futures-util",
+ "hex",
+ "hyper",
+ "pin-project",
+ "tokio",
 ]
 
 [[package]]
@@ -1340,12 +1498,21 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.5.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b45e59b16c76b11bf9738fd5d38879d3bd28ad292d7b313608becb17ae2df9"
+checksum = "55e2e4c765aa53a0424761bf9f41aa7a6ac1efa87238f59560640e27fca028f2"
 dependencies = [
  "autocfg 1.0.1",
  "hashbrown",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63312a18f7ea8760cdd0a7c5aac1a619752a246b833545e3e36d1f81f7cd9e66"
+dependencies = [
+ "cfg-if 0.1.10",
 ]
 
 [[package]]
@@ -1374,6 +1541,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnetwork"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02c3eaab3ac0ede60ffa41add21970a7df7d91772c03383aac6c2c3d53cc716b"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "itertools"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1399,9 +1575,9 @@ checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
 
 [[package]]
 name = "js-sys"
-version = "0.3.44"
+version = "0.3.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a7e2c92a4804dd459b86c339278d0fe87cf93757fae222c3fa3ae75458bc73"
+checksum = "ca059e81d9486668f12d455a4ea6daa600bd408134cd17e3d3fb5a32d1f016f8"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1451,9 +1627,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.77"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f96b10ec2560088a8e76961b00d47107b3a625fecb76dedb29ee7ccbf98235"
+checksum = "2448f6066e80e3bfc792e9c98bf705b4b0fc6e8ef5b43e5889aff0eaa9c58743"
 
 [[package]]
 name = "libloading"
@@ -1487,7 +1663,7 @@ version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
 ]
 
 [[package]]
@@ -1520,9 +1696,10 @@ name = "mayastor"
 version = "0.1.0"
 dependencies = [
  "assert_matches",
- "async-task 3.0.0",
+ "async-task",
  "async-trait",
  "bincode",
+ "bollard",
  "byte-unit",
  "bytes 0.4.12",
  "chrono",
@@ -1538,6 +1715,7 @@ dependencies = [
  "git-version",
  "io-uring",
  "ioctl-gen",
+ "ipnetwork",
  "jsonrpc",
  "libc",
  "log",
@@ -1587,20 +1765,21 @@ checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 
 [[package]]
 name = "memoffset"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c198b026e1bbf08a937e94c6c60f9ec4a2267f5b0d2eec9c1b21b061ce2be55f"
+checksum = "043175f069eda7b85febe4a74abbaeff828d9f8b448515d3151a14a3542811aa"
 dependencies = [
  "autocfg 1.0.1",
 ]
 
 [[package]]
 name = "miniz_oxide"
-version = "0.4.0"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be0f75932c1f6cfae3c04000e40114adf955636e19040f9c0a2c380702aa1c7f"
+checksum = "0f2d26ec3309788e423cfbf68ad1800f061638098d76a83681af979dc4eda19d"
 dependencies = [
  "adler",
+ "autocfg 1.0.1",
 ]
 
 [[package]]
@@ -1609,7 +1788,7 @@ version = "0.6.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fce347092656428bc8eaf6201042cb551b8d67855af7374542a92a0fbfcac430"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "fuchsia-zircon",
  "fuchsia-zircon-sys",
  "iovec",
@@ -1669,9 +1848,9 @@ dependencies = [
 
 [[package]]
 name = "multimap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8883adfde9756c1d30b0f519c9b8c502a94b41ac62f696453c37c7fc0a958ce"
+checksum = "1255076139a83bb467426e7f8d0134968a8118844faa755985e077cf31850333"
 
 [[package]]
 name = "nats"
@@ -1702,9 +1881,9 @@ dependencies = [
 
 [[package]]
 name = "nb-connect"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "701f47aeb98466d0a7fea67e2c2f667c33efa1f2e4fd7f76743aac1153196f72"
+checksum = "8123a81538e457d44b933a02faf885d3fe8408806b23fa700e8f01c6c3a98998"
 dependencies = [
  "libc",
  "winapi 0.3.9",
@@ -1712,11 +1891,11 @@ dependencies = [
 
 [[package]]
 name = "net2"
-version = "0.2.34"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ba7c918ac76704fb42afcbbb43891e72731f3dcca3bef2a19786297baf14af7"
+checksum = "3ebc3ec692ed7c9a255596c67808dee269f64655d8baf7b4f0638e51ba1d6853"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "winapi 0.3.9",
 ]
@@ -1729,7 +1908,7 @@ checksum = "6c722bee1037d430d0f8e687bbdbf222f27cc6e4e68d5caf630857bb2b6dbdce"
 dependencies = [
  "bitflags",
  "cc",
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "void",
 ]
@@ -1742,7 +1921,7 @@ checksum = "dd0eaf8df8bab402257e0a5c17a254e4cc1f72a93588a1ddfb5d356c801aa7cb"
 dependencies = [
  "bitflags",
  "cc",
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "void",
 ]
@@ -1839,9 +2018,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.20.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ab52be62400ca80aa00285d25253d7f7c437b7375c4de678f5405d3afe82ca5"
+checksum = "37fd5004feb2ce328a52b0b3d01dbf4ffff72583493900ed15f22d4111c51693"
 
 [[package]]
 name = "once_cell"
@@ -1905,29 +2084,29 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "0.4.23"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca4433fff2ae79342e497d9f8ee990d174071408f28f726d6d83af93e58e48aa"
+checksum = "2ffbc8e94b38ea3d2d8ba92aea2983b503cd75d0888d75b86bb37970b5698e15"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "0.4.23"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c0e815c3ee9a031fdf5af21c10aa17c573c9c6a566328d99e3936c34e36461f"
+checksum = "65ad2ae56b6abe3a1ee25f15ee605bacadb9a764edaba9c2bf4103800d4a1895"
 dependencies = [
- "proc-macro2 1.0.19",
+ "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.38",
+ "syn 1.0.44",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.1.7"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282adbf10f2698a7a77f8e983a74b2d18176c19a7fd32a45446139ae7b02b715"
+checksum = "e555d9e657502182ac97b539fb3dae8b79cda19e3e4f8ffb5e8de4f18df93c95"
 
 [[package]]
 name = "pin-utils"
@@ -1943,14 +2122,14 @@ checksum = "d36492546b6af1463394d46f0c834346f31548646f6ba10849802c9c9a27ac33"
 
 [[package]]
 name = "polling"
-version = "1.1.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0720e0b9ea9d52451cf29d3413ba8a9303f8815d9d9653ef70e03ff73e65566"
+checksum = "ab773feb154f12c49ffcfd66ab8bdcf9a1843f950db48b0d8be9d4393783b058"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "log",
- "wepoll-sys-stjepang",
+ "wepoll-sys",
  "winapi 0.3.9",
 ]
 
@@ -1967,9 +2146,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.19",
+ "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.38",
+ "syn 1.0.44",
  "version_check",
 ]
 
@@ -1979,7 +2158,7 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.19",
+ "proc-macro2 1.0.24",
  "quote 1.0.7",
  "version_check",
 ]
@@ -2007,9 +2186,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.19"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04f5f085b5d71e2188cb8271e5da0161ad52c3f227a661a3c135fdf28e258b12"
+checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
 dependencies = [
  "unicode-xid 0.2.1",
 ]
@@ -2060,9 +2239,9 @@ checksum = "537aa19b95acde10a12fec4301466386f757403de4cd4e5b4fa78fb5ecb18f72"
 dependencies = [
  "anyhow",
  "itertools 0.8.2",
- "proc-macro2 1.0.19",
+ "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.38",
+ "syn 1.0.44",
 ]
 
 [[package]]
@@ -2102,7 +2281,7 @@ version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
 dependencies = [
- "proc-macro2 1.0.19",
+ "proc-macro2 1.0.24",
 ]
 
 [[package]]
@@ -2278,10 +2457,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
-name = "regex"
-version = "1.3.9"
+name = "redox_users"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3780fcf44b193bc4d09f36d2a3c87b251da4a046c87795a0d35f4f927ad8e6"
+checksum = "de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d"
+dependencies = [
+ "getrandom",
+ "redox_syscall",
+ "rust-argon2",
+]
+
+[[package]]
+name = "regex"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36f45b719a674bf4b828ff318906d6c133264c793eff7a41e30074a45b5099e2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2301,9 +2491,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.18"
+version = "0.6.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26412eb97c6b088a6997e05f69403a802a92d520de2f8e63c2b65f9e0f47c4e8"
+checksum = "c17be88d9eaa858870aa5e48cc406c206e4600e983fc4f06bbe5750d93d09761"
 
 [[package]]
 name = "remove_dir_all"
@@ -2354,10 +2544,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc-demangle"
-version = "0.1.16"
+name = "rust-argon2"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
+checksum = "9dab61250775933275e84053ac235621dfb739556d5c54a2f2e9313b7cf43a19"
+dependencies = [
+ "base64 0.12.3",
+ "blake2b_simd",
+ "constant_time_eq",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2610b7f643d18c87dff3b489950269617e6601a51f1f05aa5daefee36f64f0b"
 
 [[package]]
 name = "rustc-hash"
@@ -2396,9 +2598,9 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9bdc5e856e51e685846fb6c13a1f5e5432946c2c90501bdc76a1319f19e29da"
 dependencies = [
- "proc-macro2 1.0.19",
+ "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.38",
+ "syn 1.0.44",
 ]
 
 [[package]]
@@ -2458,33 +2660,67 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.115"
+version = "1.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e54c9a88f2da7238af84b5101443f0c0d0a3bbdc455e34a5c9497b1903ed55d5"
+checksum = "96fe57af81d28386a513cbc6858332abc6117cfdb5999647c6444b8f43a370a5"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.115"
+version = "1.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "609feed1d0a73cc36a0182a840a9b37b4a82f0b1150369f0536a9e3f2a31dc48"
+checksum = "f630a6370fd8e457873b4bd2ffdae75408bc291ba72be773772a4c2a065d9ae8"
 dependencies = [
- "proc-macro2 1.0.19",
+ "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.38",
+ "syn 1.0.44",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.57"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "164eacbdb13512ec2745fb09d51fd5b22b0d65ed294a1dcf7285a360c80a675c"
+checksum = "a230ea9107ca2220eea9d46de97eddcb04cd00e92d13dda78e478dd33fa82bd4"
 dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ec5d77e2d4c73717816afac02670d5c4f534ea95ed430442cad02e7a6e32c97"
+dependencies = [
+ "dtoa",
+ "itoa",
+ "serde",
+ "url",
+]
+
+[[package]]
+name = "serde_with"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bac272128fb3b1e98872dca27a05c18d8b78b9bd089d3edb7b5871501b50bce"
+dependencies = [
+ "serde",
+ "serde_with_macros",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c747a9ab2e833b807f74f6b6141530655010bfa9c9c06d5508bce75c8f8072f"
+dependencies = [
+ "darling 0.10.2",
+ "proc-macro2 1.0.24",
+ "quote 1.0.7",
+ "syn 1.0.44",
 ]
 
 [[package]]
@@ -2603,9 +2839,9 @@ checksum = "fbee7696b84bbf3d89a1c2eccff0850e3047ed46bfcd2e92c29a2d074d57e252"
 
 [[package]]
 name = "smol"
-version = "1.2.2"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ca2722989073e89917a575862fb49dba3321af152f0cf4a4164d9482aabdf28"
+checksum = "aaf8ded16994c0ae59596c6e4733c76faeb0533c26fd5ca1b1bc89271a049a66"
 dependencies = [
  "async-channel",
  "async-executor",
@@ -2621,9 +2857,9 @@ dependencies = [
 
 [[package]]
 name = "snafu"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f5aed652511f5c9123cf2afbe9c244c29db6effa2abb05c866e965c82405ce"
+checksum = "9c4e6046e4691afe918fd1b603fd6e515bcda5388a1092a9edbada307d159f09"
 dependencies = [
  "doc-comment",
  "snafu-derive",
@@ -2631,22 +2867,22 @@ dependencies = [
 
 [[package]]
 name = "snafu-derive"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebf8f7d5720104a9df0f7076a8682024e958bba0fe9848767bb44f251f3648e9"
+checksum = "7073448732a89f2f3e6581989106067f403d378faeafb4a50812eb814170d3e5"
 dependencies = [
- "proc-macro2 1.0.19",
+ "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.38",
+ "syn 1.0.44",
 ]
 
 [[package]]
 name = "socket2"
-version = "0.3.12"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03088793f677dce356f3ccc2edb1b314ad191ab702a5de3faf49304f7e104918"
+checksum = "b1fa70dc5c8104ec096f4fe7ede7a221d35ae13dcd19ba1ad9a81d2cab9a1c44"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "redox_syscall",
  "winapi 0.3.9",
@@ -2679,10 +2915,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
-name = "structopt"
-version = "0.3.16"
+name = "strsim"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de5472fb24d7e80ae84a7801b7978f95a19ec32cb1876faea59ab711eb901976"
+checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
+
+[[package]]
+name = "structopt"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7a7159e7d0dbcab6f9c980d7971ef50f3ff5753081461eeda120d5974a4ee95"
 dependencies = [
  "clap",
  "lazy_static",
@@ -2691,15 +2933,15 @@ dependencies = [
 
 [[package]]
 name = "structopt-derive"
-version = "0.4.9"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0eb37335aeeebe51be42e2dc07f031163fbabfa6ac67d7ea68b5c2f68d5f99"
+checksum = "8fc47de4dfba76248d1e9169ccff240eea2a4dc1e34e309b95b2393109b4b383"
 dependencies = [
  "heck",
  "proc-macro-error",
- "proc-macro2 1.0.19",
+ "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.38",
+ "syn 1.0.44",
 ]
 
 [[package]]
@@ -2741,11 +2983,11 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.38"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e69abc24912995b3038597a7a593be5053eb0fb44f3cc5beec0deb421790c1f4"
+checksum = "e03e57e4fcbfe7749842d53e24ccb9aa12b7252dbe5e91d2acad31834c8b8fdd"
 dependencies = [
- "proc-macro2 1.0.19",
+ "proc-macro2 1.0.24",
  "quote 1.0.7",
  "unicode-xid 0.2.1",
 ]
@@ -2765,9 +3007,9 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
 dependencies = [
- "proc-macro2 1.0.19",
+ "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.38",
+ "syn 1.0.44",
  "unicode-xid 0.2.1",
 ]
 
@@ -2792,7 +3034,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "rand 0.7.3",
  "redox_syscall",
@@ -2819,6 +3061,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "318234ffa22e0920fe9a40d7b8369b5f649d490980cf7aadcf1eb91594869b42"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cae2447b6282786c3493999f40a9be2a6ad20cb8bd268b0a0dbf5a065535c0ab"
+dependencies = [
+ "proc-macro2 1.0.24",
+ "quote 1.0.7",
+ "syn 1.0.44",
+]
+
+[[package]]
 name = "thread_local"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2829,11 +3091,12 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.43"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
+checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
 dependencies = [
  "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi 0.3.9",
 ]
 
@@ -2873,9 +3136,21 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0c3acc6aa564495a0f2e1d59fab677cd7f81a19994cfc7f3ad0e64301560389"
 dependencies = [
- "proc-macro2 1.0.19",
+ "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.38",
+ "syn 1.0.44",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e12831b255bcfa39dc0436b01e19fea231a37db570686c06ee72c423479f889a"
+dependencies = [
+ "futures-core",
+ "rustls",
+ "tokio",
+ "webpki",
 ]
 
 [[package]]
@@ -2942,10 +3217,10 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0436413ba71545bcc6c2b9a0f9d78d72deb0123c6a75ccdfe7c056f9930f5e52"
 dependencies = [
- "proc-macro2 1.0.19",
+ "proc-macro2 1.0.24",
  "prost-build",
  "quote 1.0.7",
- "syn 1.0.38",
+ "syn 1.0.44",
 ]
 
 [[package]]
@@ -3128,12 +3403,13 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.19"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d79ca061b032d6ce30c660fded31189ca0b9922bf483cd70759f13a2d86786c"
+checksum = "b0987850db3733619253fe60e17cb59b82d37c7e6c0236bb81e4d6b87c879f27"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "log",
+ "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
 ]
@@ -3144,16 +3420,16 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80e0ccfc3378da0cce270c946b676a376943f5cd16aeba64568e7939806f4ada"
 dependencies = [
- "proc-macro2 1.0.19",
+ "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.38",
+ "syn 1.0.44",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.14"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db63662723c316b43ca36d833707cc93dff82a02ba3d7e354f342682cc8b3545"
+checksum = "f50de3927f93d202783f4513cda820ab47ef17f624b03c096e86ef00c67e6b5f"
 dependencies = [
  "lazy_static",
 ]
@@ -3191,9 +3467,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.11"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abd165311cc4d7a555ad11cc77a37756df836182db0d81aac908c8184c584f40"
+checksum = "4ef0a5e15477aa303afbfac3a44cba9b6430fdaad52423b1e6c0dbbe28c3eedd"
 dependencies = [
  "ansi_term 0.12.1",
  "chrono",
@@ -3205,6 +3481,7 @@ dependencies = [
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
  "tracing-serde",
@@ -3363,35 +3640,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.67"
+name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0563a9a4b071746dd5aedbc3a28c6fe9be4586fb3fbadb67c400d4f53c6b16c"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac64ead5ea5f05873d7c12b545865ca2b8d28adfc50a49b84770a3a97265d42"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.67"
+version = "0.2.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc71e4c5efa60fb9e74160e89b93353bc24059999c0ae0fb03affc39770310b0"
+checksum = "f22b422e2a757c35a73774860af8e112bff612ce6cb604224e8e47641a9e4f68"
 dependencies = [
  "bumpalo",
  "lazy_static",
  "log",
- "proc-macro2 1.0.19",
+ "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.38",
+ "syn 1.0.44",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.67"
+version = "0.2.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97c57cefa5fa80e2ba15641578b44d36e7a64279bc5ed43c6dbaf329457a2ed2"
+checksum = "6b13312a745c08c469f0b292dd2fcd6411dba5f7160f593da6ef69b64e407038"
 dependencies = [
  "quote 1.0.7",
  "wasm-bindgen-macro-support",
@@ -3399,28 +3682,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.67"
+version = "0.2.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841a6d1c35c6f596ccea1f82504a192a60378f64b3bb0261904ad8f2f5657556"
+checksum = "f249f06ef7ee334cc3b8ff031bfc11ec99d00f34d86da7498396dc1e3b1498fe"
 dependencies = [
- "proc-macro2 1.0.19",
+ "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.38",
+ "syn 1.0.44",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.67"
+version = "0.2.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93b162580e34310e5931c4b792560108b10fd14d64915d7fff8ff00180e70092"
+checksum = "1d649a3145108d7d3fbcde896a468d1bd636791823c9921135218ad89be08307"
 
 [[package]]
 name = "web-sys"
-version = "0.3.44"
+version = "0.3.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dda38f4e5ca63eda02c059d243aa25b5f35ab98451e518c51612cd0f1bd19a47"
+checksum = "4bf6ef87ad7ae8008e15a355ce696bed26012b7caa21605188cfd8214ab51e2d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3446,10 +3729,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wepoll-sys-stjepang"
-version = "1.0.6"
+name = "wepoll-sys"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fd319e971980166b53e17b1026812ad66c6b54063be879eb182342b55284694"
+checksum = "142bc2cba3fe88be1a8fcb55c727fa4cd5b0cf2d7438722792e22f26f04bc1e0"
 dependencies = [
  "cc",
 ]
@@ -3528,6 +3811,6 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cbac2ed2ba24cc90f5e06485ac8c7c1e5449fe8911aef4d8877218af021a5b8"
+checksum = "05f33972566adbd2d3588b0491eb94b98b43695c4ef897903470ede4f3f5a28a"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,9 @@
 h2 = { git = "https://github.com/gila/h2", branch = "v0.2.6"}
 partition-identity = { git = "https://github.com/openebs/partition-identity.git" }
 
+[profile.dev]
+panic = "abort"
+
 [workspace]
 members = [
 	"csi",

--- a/mayastor/Cargo.toml
+++ b/mayastor/Cargo.toml
@@ -33,7 +33,7 @@ name = "casperf"
 path = "src/bin/casperf.rs"
 
 [dependencies]
-async-task = "3.0"
+async-task = "4.0.2"
 async-trait = "0.1.36"
 bincode = "1.2"
 byte-unit = "3.0.1"
@@ -77,7 +77,8 @@ udev = "0.4"
 url = "2.1"
 smol = "1.0.0"
 dns-lookup = "1.0.4"
-
+ipnetwork = "0.17.0"
+bollard = "0.8.0"
 [dependencies.rpc]
 path = "../rpc"
 

--- a/mayastor/src/bdev/nexus/nexus_channel.rs
+++ b/mayastor/src/bdev/nexus/nexus_channel.rs
@@ -70,7 +70,7 @@ impl NexusChannelInner {
         info!(
             "{}(tid:{:?}), refreshing IO channels",
             nexus.name,
-            std::thread::current().name().unwrap()
+            std::thread::current().name().unwrap_or("none")
         );
 
         trace!(

--- a/mayastor/src/core/thread.rs
+++ b/mayastor/src/core/thread.rs
@@ -196,7 +196,7 @@ impl Mthread {
         })
     }
 
-    fn unaffinitize() {
+    pub fn unaffinitize() {
         unsafe {
             let mut set: libc::cpu_set_t = std::mem::zeroed();
             for i in 0 .. libc::sysconf(libc::_SC_NPROCESSORS_ONLN) {

--- a/mayastor/src/grpc/bdev_grpc.rs
+++ b/mayastor/src/grpc/bdev_grpc.rs
@@ -135,7 +135,6 @@ impl BdevRpc for BdevSvc {
                 _ => unreachable!(),
             }
             .await
-            .unwrap()
             .map(|share| {
                 let bdev = Bdev::lookup_by_name(&name).unwrap();
                 Response::new(BdevShareReply {
@@ -158,7 +157,7 @@ impl BdevRpc for BdevSvc {
                     .map_err(|e| Status::internal(e.to_string()));
             });
 
-            hdl.await.unwrap();
+            hdl.await;
             Ok(Response::new(Null {}))
         })
         .await

--- a/mayastor/src/grpc/mayastor_grpc.rs
+++ b/mayastor/src/grpc/mayastor_grpc.rs
@@ -11,7 +11,7 @@
 use tonic::{Request, Response, Status};
 use tracing::instrument;
 
-use rpc::mayastor::*;
+use ::rpc::mayastor::*;
 
 use crate::{
     bdev::{

--- a/mayastor/src/grpc/mod.rs
+++ b/mayastor/src/grpc/mod.rs
@@ -32,7 +32,7 @@ fn print_error_chain(err: &dyn std::error::Error) -> String {
 macro_rules! locally {
     ($body:expr) => {{
         let hdl = crate::core::Reactors::current().spawn_local($body);
-        match hdl.await.unwrap() {
+        match hdl.await {
             Ok(res) => res,
             Err(err) => {
                 error!("{}", crate::grpc::print_error_chain(&err));
@@ -56,8 +56,8 @@ pub fn rpc_call<G, I, L, A>(future: G) -> Result<Response<A>, tonic::Status>
 where
     G: Future<Output = Result<I, L>> + 'static,
     I: 'static,
-    A: 'static + From<I>,
     L: Into<Status> + Error + 'static,
+    A: 'static + From<I>,
 {
     assert_eq!(Cores::current(), Cores::first());
     Reactor::block_on(future)

--- a/mayastor/src/grpc/nexus_grpc.rs
+++ b/mayastor/src/grpc/nexus_grpc.rs
@@ -1,6 +1,6 @@
 //! Helpers related to nexus grpc methods.
 
-use rpc::mayastor as rpc;
+use ::rpc::mayastor as rpc;
 use std::convert::From;
 use uuid::Uuid;
 

--- a/mayastor/src/pool.rs
+++ b/mayastor/src/pool.rs
@@ -5,7 +5,7 @@
 
 use std::{ffi::CStr, os::raw::c_char};
 
-use rpc::mayastor as rpc;
+use ::rpc::mayastor as rpc;
 use spdk_sys::{
     lvol_store_bdev,
     spdk_bs_free_cluster_count,

--- a/mayastor/src/replica.rs
+++ b/mayastor/src/replica.rs
@@ -5,7 +5,7 @@
 #![allow(dead_code)]
 use std::ffi::CStr;
 
-use rpc::mayastor as rpc;
+use ::rpc::mayastor as rpc;
 use snafu::{ResultExt, Snafu};
 
 use spdk_sys::{spdk_lvol, vbdev_lvol_get_from_bdev};

--- a/mayastor/tests/common/bdev_io.rs
+++ b/mayastor/tests/common/bdev_io.rs
@@ -5,7 +5,7 @@ pub async fn write_some(
     offset: u64,
     fill: u8,
 ) -> Result<(), CoreError> {
-    let h = BdevHandle::open(nexus_name, true, false).unwrap();
+    let h = BdevHandle::open(nexus_name, true, false)?;
     let mut buf = h.dma_malloc(512).expect("failed to allocate buffer");
     buf.fill(fill);
 
@@ -21,7 +21,7 @@ pub async fn read_some(
     offset: u64,
     fill: u8,
 ) -> Result<(), CoreError> {
-    let h = BdevHandle::open(nexus_name, true, false).unwrap();
+    let h = BdevHandle::open(nexus_name, true, false)?;
     let mut buf = h.dma_malloc(1024).expect("failed to allocate buffer");
     let slice = buf.as_mut_slice();
 

--- a/mayastor/tests/common/compose.rs
+++ b/mayastor/tests/common/compose.rs
@@ -1,0 +1,658 @@
+use std::{
+    collections::HashMap,
+    future::Future,
+    net::{Ipv4Addr, SocketAddr, TcpStream},
+    thread,
+    time::Duration,
+};
+
+use crossbeam::crossbeam_channel::bounded;
+
+use bollard::{
+    container::{
+        Config,
+        CreateContainerOptions,
+        ListContainersOptions,
+        LogsOptions,
+        NetworkingConfig,
+        RemoveContainerOptions,
+        StopContainerOptions,
+    },
+    errors::Error,
+    network::{CreateNetworkOptions, ListNetworksOptions},
+    service::{
+        ContainerSummaryInner,
+        EndpointIpamConfig,
+        EndpointSettings,
+        HostConfig,
+        Ipam,
+        Mount,
+        MountTypeEnum,
+        Network,
+    },
+    Docker,
+};
+use futures::TryStreamExt;
+use ipnetwork::Ipv4Network;
+use tokio::sync::oneshot::channel;
+use tonic::transport::Channel;
+
+use crate::common;
+use ::rpc::mayastor::{
+    bdev_rpc_client::BdevRpcClient,
+    mayastor_client::MayastorClient,
+};
+use bollard::models::ContainerInspectResponse;
+use mayastor::core::{
+    mayastor_env_stop,
+    MayastorCliArgs,
+    MayastorEnvironment,
+    Reactor,
+    Reactors,
+};
+
+#[derive(Clone)]
+pub struct RpcHandle {
+    pub name: String,
+    pub endpoint: SocketAddr,
+    mayastor: MayastorClient<Channel>,
+    pub bdev: BdevRpcClient<Channel>,
+}
+
+impl RpcHandle {
+    /// connect to the containers and construct a handle
+    async fn connect(name: String, endpoint: SocketAddr) -> Self {
+        loop {
+            if TcpStream::connect_timeout(&endpoint, Duration::from_millis(100))
+                .is_ok()
+            {
+                break;
+            } else {
+                thread::sleep(Duration::from_millis(101));
+            }
+        }
+
+        let mayastor =
+            MayastorClient::connect(format!("http://{}", endpoint.to_string()))
+                .await
+                .unwrap();
+        let bdev =
+            BdevRpcClient::connect(format!("http://{}", endpoint.to_string()))
+                .await
+                .unwrap();
+
+        Self {
+            name,
+            mayastor,
+            bdev,
+            endpoint,
+        }
+    }
+}
+
+pub struct Builder {
+    /// name of the experiment this name will be used as a network and labels
+    /// this way we can "group" all objects within docker to match this test
+    /// test. It is highly recommend you use a sane name for this as it will
+    /// help you during debugging
+    name: String,
+    /// containers we want to create, note these are mayastor containers
+    /// only
+    containers: Vec<ContainerName>,
+    /// the network for the tests used
+    network: String,
+    /// delete the container and network when dropped
+    clean: bool,
+}
+
+impl Default for Builder {
+    fn default() -> Self {
+        Builder::new()
+    }
+}
+
+impl Builder {
+    /// construct a new builder for `[ComposeTest']
+    pub fn new() -> Self {
+        Self {
+            name: "".to_string(),
+            containers: Default::default(),
+            network: "10.1.0.0".to_string(),
+            clean: false,
+        }
+    }
+
+    /// set the network for this test
+    pub fn network(mut self, network: &str) -> Builder {
+        self.network = network.to_owned();
+        self
+    }
+
+    /// the name to be used as labels and network name
+    pub fn name(mut self, name: &str) -> Builder {
+        self.name = name.to_owned();
+        self
+    }
+
+    /// add a mayastor container with a name
+    pub fn add_container(mut self, name: &str) -> Builder {
+        self.containers.push(name.to_owned());
+        self
+    }
+
+    /// clean on drop?
+    pub fn with_clean(mut self, enable: bool) -> Builder {
+        self.clean = enable;
+        self
+    }
+
+    /// build the config and start the containers
+    pub async fn build(
+        self,
+    ) -> Result<ComposeTest, Box<dyn std::error::Error>> {
+        let net: Ipv4Network = self.network.parse()?;
+
+        let path = std::path::PathBuf::from(std::env!("CARGO_MANIFEST_DIR"));
+        let srcdir = path.parent().unwrap().to_string_lossy().into();
+        let binary = format!("{}/target/debug/mayastor", srcdir);
+
+        let docker = Docker::connect_with_unix_defaults()?;
+
+        let mut cfg = HashMap::new();
+        cfg.insert(
+            "Subnet".to_string(),
+            format!("{}/{}", net.network().to_string(), net.prefix()),
+        );
+        cfg.insert("Gateway".into(), net.nth(1).unwrap().to_string());
+
+        let ipam = Ipam {
+            driver: Some("default".into()),
+            config: Some(vec![cfg]),
+            options: None,
+        };
+
+        let mut compose = ComposeTest {
+            name: self.name.clone(),
+            srcdir,
+            binary,
+            docker,
+            network_id: "".to_string(),
+            containers: Default::default(),
+            ipam,
+            label: format!("io.mayastor.test.{}", self.name),
+            clean: self.clean,
+        };
+
+        compose.network_id =
+            compose.network_create().await.map_err(|e| e.to_string())?;
+
+        // containers are created where the IPs are ordinal
+        for (i, name) in self.containers.iter().enumerate() {
+            compose
+                .create_container(
+                    name,
+                    &net.nth((i + 2) as u32).unwrap().to_string(),
+                )
+                .await?;
+        }
+
+        compose.start_all().await?;
+        Ok(compose)
+    }
+}
+
+///
+/// Some types to avoid confusion when
+///
+/// different networks are referred to, internally as networkId in docker
+type NetworkId = String;
+/// container name
+type ContainerName = String;
+/// container ID
+type ContainerId = String;
+
+#[derive(Clone)]
+pub struct ComposeTest {
+    /// used as the network name
+    name: String,
+    /// the source dir the tests are run in
+    srcdir: String,
+    /// the binary we are using relative to srcdir
+    binary: String,
+    /// handle to the docker daemon
+    docker: Docker,
+    /// the network id is used to attach containers to networks
+    network_id: NetworkId,
+    /// the name of containers and their (IDs, Ipv4) we have created
+    /// perhaps not an ideal data structure, but we can improve it later
+    /// if we need to
+    containers: HashMap<ContainerName, (ContainerId, Ipv4Addr)>,
+    /// the default network configuration we use for our test cases
+    ipam: Ipam,
+    /// set on containers and networks
+    label: String,
+    /// automatically clean up the things we have created for this test
+    clean: bool,
+}
+
+impl Drop for ComposeTest {
+    /// destroy the containers and network. Notice that we use sync code here
+    fn drop(&mut self) {
+        if self.clean {
+            self.containers.keys().for_each(|c| {
+                std::process::Command::new("docker")
+                    .args(&["stop", c])
+                    .output()
+                    .unwrap();
+                std::process::Command::new("docker")
+                    .args(&["rm", c])
+                    .output()
+                    .unwrap();
+            });
+
+            std::process::Command::new("docker")
+                .args(&["network", "rm", &self.name])
+                .output()
+                .unwrap();
+        }
+    }
+}
+
+impl ComposeTest {
+    /// Create a new network, with default settings. If a network with the same
+    /// name already exists it will be reused. Note that we do not check the
+    /// networking IP and/or subnets
+    async fn network_create(&mut self) -> Result<NetworkId, Error> {
+        let mut net = self.network_list().await?;
+
+        if !net.is_empty() {
+            let first = net.pop().unwrap();
+            self.network_id = first.id.unwrap();
+            return Ok(self.network_id.clone());
+        }
+
+        let create_opts = CreateNetworkOptions {
+            name: self.name.as_str(),
+            check_duplicate: true,
+            driver: "bridge",
+            internal: true,
+            attachable: true,
+            ingress: false,
+            ipam: self.ipam.clone(),
+            enable_ipv6: false,
+            options: vec![("com.docker.network.bridge.name", "mayabridge0")]
+                .into_iter()
+                .collect(),
+            labels: vec![(self.label.as_str(), "true")].into_iter().collect(),
+        };
+
+        self.docker.create_network(create_opts).await.map(|r| {
+            self.network_id = r.id.unwrap();
+            self.network_id.clone()
+        })
+    }
+
+    async fn network_remove(&mut self) -> Result<(), Error> {
+        // if the network is not found, its not an error, any other error is
+        // reported as such. Networks can only be destroyed when all containers
+        // attached to it are removed. To get a list of attached
+        // containers, use network_list()
+        if let Err(e) = self.docker.remove_network(&self.name).await {
+            if !matches!(e, Error::DockerResponseNotFoundError{..}) {
+                return Err(e);
+            }
+        }
+
+        Ok(())
+    }
+
+    /// list all the docker networks
+    pub async fn network_list(&self) -> Result<Vec<Network>, Error> {
+        self.docker
+            .list_networks(Some(ListNetworksOptions {
+                filters: vec![("name", vec![self.name.as_str()])]
+                    .into_iter()
+                    .collect(),
+            }))
+            .await
+    }
+
+    /// list containers
+    pub async fn list_containers(
+        &self,
+    ) -> Result<Vec<ContainerSummaryInner>, Error> {
+        self.docker
+            .list_containers(Some(ListContainersOptions {
+                all: true,
+                filters: vec![(
+                    "label",
+                    vec![format!("{}=true", self.label).as_str()],
+                )]
+                .into_iter()
+                .collect(),
+                ..Default::default()
+            }))
+            .await
+    }
+
+    /// remove a container from the configuration
+    async fn remove_container(&self, name: &str) -> Result<(), Error> {
+        self.docker
+            .remove_container(
+                name,
+                Some(RemoveContainerOptions {
+                    v: true,
+                    force: true,
+                    link: false,
+                }),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    /// remove all containers
+    pub async fn remove_all(&mut self) -> Result<(), Error> {
+        for k in &self.containers {
+            self.stop(&k.0).await?;
+            self.remove_container(&k.0).await?;
+        }
+        self.network_remove().await?;
+        Ok(())
+    }
+
+    /// we need to construct several objects to create a setup that meets our
+    /// liking:
+    ///
+    /// (1) hostconfig: that configures the host side of the container, i.e what
+    /// features/settings from the host perspective do we want too setup
+    /// for the container. (2) endpoints: this allows us to plugin in the
+    /// container into our network configuration (3) config: the actual
+    /// config which includes the above objects
+    async fn create_container(
+        &mut self,
+        name: &str,
+        ipv4: &str,
+    ) -> Result<(), Error> {
+        let host_config = HostConfig {
+            binds: Some(vec![
+                format!("{}:{}", self.srcdir, self.srcdir),
+                "/nix:/nix:ro".into(),
+                "/dev/hugepages:/dev/hugepages:rw".into(),
+            ]),
+            mounts: Some(vec![
+                // DPDK needs to have a /tmp
+                Mount {
+                    target: Some("/tmp".into()),
+                    typ: Some(MountTypeEnum::TMPFS),
+                    ..Default::default()
+                },
+                // mayastor needs to have a /var/tmp
+                Mount {
+                    target: Some("/var/tmp".into()),
+                    typ: Some(MountTypeEnum::TMPFS),
+                    ..Default::default()
+                },
+            ]),
+            cap_add: Some(vec![
+                "SYS_ADMIN".to_string(),
+                "IPC_LOCK".into(),
+                "SYS_NICE".into(),
+            ]),
+            security_opt: Some(vec!["seccomp:unconfined".into()]),
+            ..Default::default()
+        };
+
+        let mut endpoints_config = HashMap::new();
+        endpoints_config.insert(
+            self.name.as_str(),
+            EndpointSettings {
+                network_id: Some(self.network_id.to_string()),
+                ipam_config: Some(EndpointIpamConfig {
+                    ipv4_address: Some(ipv4.into()),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+        );
+
+        let env = format!("MY_POD_IP={}", ipv4);
+
+        let config = Config {
+            cmd: Some(vec![self.binary.as_str(), "-g", "0.0.0.0"]),
+            env: Some(vec![&env]),
+            image: None, // notice we do not have a base image here
+            hostname: Some(name),
+            host_config: Some(host_config),
+            networking_config: Some(NetworkingConfig {
+                endpoints_config,
+            }),
+            working_dir: Some(self.srcdir.as_str()),
+            volumes: Some(
+                vec![
+                    ("/dev/hugepages", HashMap::new()),
+                    ("/nix", HashMap::new()),
+                    (self.srcdir.as_str(), HashMap::new()),
+                ]
+                .into_iter()
+                .collect(),
+            ),
+            labels: Some(
+                vec![(self.label.as_str(), "true")].into_iter().collect(),
+            ),
+            ..Default::default()
+        };
+
+        let container = self
+            .docker
+            .create_container(
+                Some(CreateContainerOptions {
+                    name,
+                }),
+                config,
+            )
+            .await
+            .unwrap();
+
+        self.containers
+            .insert(name.to_string(), (container.id, ipv4.parse().unwrap()));
+
+        Ok(())
+    }
+
+    /// start the container
+    async fn start(&self, name: &str) -> Result<(), Error> {
+        let id = self.containers.get(name).unwrap();
+        self.docker
+            .start_container::<&str>(id.0.as_str(), None)
+            .await?;
+
+        Ok(())
+    }
+
+    /// stop the container
+    async fn stop(&self, name: &str) -> Result<(), Error> {
+        let id = self.containers.get(name).unwrap();
+        if let Err(e) = self
+            .docker
+            .stop_container(
+                id.0.as_str(),
+                Some(StopContainerOptions {
+                    t: 5,
+                }),
+            )
+            .await
+        {
+            // where already stopped
+            if !matches!(e, Error::DockerResponseNotModifiedError{..}) {
+                return Err(e);
+            }
+        }
+
+        Ok(())
+    }
+
+    /// ge the logs from the container. It would be nice to make it implicit
+    /// that is, when you make a rpc call, whatever logs where created due to
+    /// that are returned
+    pub async fn logs(&self, name: &str) -> Result<(), Error> {
+        let logs = self
+            .docker
+            .logs(
+                name,
+                Some(LogsOptions {
+                    follow: false,
+                    stdout: true,
+                    stderr: true,
+                    since: 0, // TODO log lines since last call?
+                    until: 0,
+                    timestamps: false,
+                    tail: "all",
+                }),
+            )
+            .try_collect::<Vec<_>>()
+            .await?;
+
+        logs.iter().for_each(|l| print!("{}:{}", name, l));
+        Ok(())
+    }
+
+    /// start all the containers
+    async fn start_all(&mut self) -> Result<(), Error> {
+        for k in &self.containers {
+            self.start(&k.0).await?;
+        }
+
+        Ok(())
+    }
+
+    /// inspect the given container
+    pub async fn inspect(
+        &self,
+        name: &str,
+    ) -> Result<ContainerInspectResponse, Error> {
+        self.docker.inspect_container(name, None).await
+    }
+
+    /// pause the container; unfortunately, when the API returns it does not
+    /// mean that the container indeed is frozen completely, in the sense
+    /// that it's not to be assumed that right after a call -- the container
+    /// stops responding.
+    pub async fn pause(&self, name: &str) -> Result<(), Error> {
+        let id = self.containers.get(name).unwrap();
+        self.docker.pause_container(id.0.as_str()).await?;
+
+        Ok(())
+    }
+
+    /// un_pause the container
+    pub async fn thaw(&self, name: &str) -> Result<(), Error> {
+        let id = self.containers.get(name).unwrap();
+        self.docker.unpause_container(id.0.as_str()).await
+    }
+
+    /// return grpc handles to the containers
+    pub async fn grpc_handles(&self) -> Result<Vec<RpcHandle>, ()> {
+        let mut handles = Vec::new();
+        for v in &self.containers {
+            handles.push(
+                RpcHandle::connect(
+                    v.0.clone(),
+                    format!("{}:10124", v.1.1).parse::<SocketAddr>().unwrap(),
+                )
+                .await,
+            );
+        }
+
+        Ok(handles)
+    }
+}
+
+/// Mayastor test structure that simplifies sending futures. Mayastor has
+/// its own reactor, which is not tokio based, so we need to handle properly
+pub struct MayastorTest<'a> {
+    reactor: &'a Reactor,
+    thdl: Option<std::thread::JoinHandle<()>>,
+}
+
+impl<'a> MayastorTest<'a> {
+    /// spawn a future on this mayastor instance collecting the output
+    /// notice that rust will not allow sending Bdevs as they are !Send
+    pub async fn spawn<F, T>(&self, future: F) -> T
+    where
+        F: Future<Output = T> + 'static,
+        T: Send + 'static,
+    {
+        let (tx, rx) = channel::<T>();
+        self.reactor.send_future(async move {
+            let arg = future.await;
+            let _ = tx.send(arg);
+        });
+
+        rx.await.unwrap()
+    }
+
+    pub fn send<F>(&self, future: F)
+    where
+        F: Future<Output = ()> + 'static,
+    {
+        self.reactor.send_future(future);
+    }
+
+    /// starts mayastor, notice we start mayastor on a thread and return a
+    /// handle to the management core. This handle is used to spawn futures,
+    /// and the thread handle can be used to synchronize the shutdown
+    async fn _new(args: MayastorCliArgs) -> MayastorTest<'static> {
+        let (tx, rx) = channel::<&'static Reactor>();
+
+        let thdl = std::thread::spawn(|| {
+            MayastorEnvironment::new(args).init();
+            tx.send(Reactors::master()).unwrap();
+            Reactors::master().running();
+            Reactors::master().poll_reactor();
+        });
+
+        let reactor = rx.await.unwrap();
+        MayastorTest {
+            reactor,
+            thdl: Some(thdl),
+        }
+    }
+
+    pub fn new(args: MayastorCliArgs) -> MayastorTest<'static> {
+        common::mayastor_test_init();
+        let (tx, rx) = bounded(1);
+
+        let thdl = std::thread::Builder::new()
+            .name("mayastor_master".into())
+            .spawn(move || {
+                MayastorEnvironment::new(args).init();
+                tx.send(Reactors::master()).unwrap();
+                Reactors::master().running();
+                Reactors::master().poll_reactor();
+            })
+            .unwrap();
+
+        let reactor = rx.recv().unwrap();
+        MayastorTest {
+            reactor,
+            thdl: Some(thdl),
+        }
+    }
+
+    /// explicitly stop mayastor
+    pub async fn stop(mut self) {
+        self.spawn(async { mayastor_env_stop(0) }).await;
+        let hdl = self.thdl.take().unwrap();
+        hdl.join().unwrap()
+    }
+}
+
+impl<'a> Drop for MayastorTest<'a> {
+    fn drop(&mut self) {
+        self.reactor.send_future(async { mayastor_env_stop(0) });
+        // wait for mayastor to stop
+        let hdl = self.thdl.take().unwrap();
+        hdl.join().unwrap()
+    }
+}

--- a/mayastor/tests/common/mod.rs
+++ b/mayastor/tests/common/mod.rs
@@ -4,7 +4,7 @@
 //! panic macros. The caller can decide how to handle the error appropriately.
 //! Panics and asserts in this file are still ok for usage & programming errors.
 
-use std::{env, io, io::Write, process::Command, time::Duration};
+use std::{io, io::Write, process::Command, time::Duration};
 
 use crossbeam::channel::{after, select, unbounded};
 use once_cell::sync::OnceCell;
@@ -21,9 +21,10 @@ use mayastor::{
 use spdk_sys::spdk_get_thread;
 
 pub mod bdev_io;
+mod compose;
 pub mod error_bdev;
 pub mod ms_exec;
-
+pub use compose::{Builder, ComposeTest, MayastorTest, RpcHandle};
 /// call F cnt times, and sleep for a duration between each invocation
 pub fn retry<F, T, E>(mut cnt: u32, timeout: Duration, mut f: F) -> T
 where
@@ -132,9 +133,7 @@ pub fn mayastor_test_init() {
                 panic!("binary: {} not present in path", binary);
             }
         });
-
     logger::init("DEBUG");
-    env::set_var("MAYASTOR_LOGLEVEL", "4");
     mayastor::CPS_INIT!();
 }
 

--- a/nix/pkgs/mayastor/default.nix
+++ b/nix/pkgs/mayastor/default.nix
@@ -41,7 +41,7 @@ let
   buildProps = rec {
     name = "mayastor";
     #cargoSha256 = "0000000000000000000000000000000000000000000000000000";
-    cargoSha256 = "1m8097h48zz4d20gk9q1aw25548m2aqfxjlr6nck7chrqccvwr54";
+    cargoSha256 = "0mr03cr6i1n5g4dx8v651rq3zblym71cb2vkvg5nqgb34li4br9j";
     inherit version;
     src = whitelistSource ../../../. [
       "Cargo.lock"

--- a/spdk-sys/build.rs
+++ b/spdk-sys/build.rs
@@ -33,6 +33,7 @@ fn build_wrapper() {
         .compile("logwrapper");
     cc::Build::new()
         .include("spdk/include")
+        .include(".")
         .file("nvme_helper.c")
         .compile("nvme_helper");
 }


### PR DESCRIPTION
Its been rather complicated to start/stop multiple mayastors within a
single test case. This is true for the BDD tests as well as the unit
tests.

The bookkeeping of the processes itself is a PITA, but things get more
complicated when we want to send signals, pause instances and
the likes. We need to be able to do this simply and easily for more
sophisticated recovery logic.

So using containers seems to be a logical, and instead of using YAML
files to compose targets, I've opted for using the docker remote API
directly. Note, this API  can be used on anything that runs docker
local or remote. However, we use "FROM SCRATCH" and do not make use of
a basic image, and start the artefact located in /target directly.

This docker API rather verbose, and so you will see alot of Some() and
Default but once you get over that is surprisingly well written. The
reason for not simply do a fork of compose up down is that we
need/want to "do things" with the containers as well.

Consider the case where we want to emulate a nexus loosing its
replica. To do this we would need to call pause -- but pause who?

What if we want to send a grpc command to one of the targets, send it
to who?

We could have gone the easy route, which is to hard code everything
but that would get us into duplicated constants between config files
and exec calls.

The test suites are now driven by tokio, and have a fundamental
difference compared to the previous test. Before this commit, when you
did something like mayastor_start(||  whatever()) the test thread
itself, was running mayastor. That now is changed, and the test thread
itself is not running mayastor and you keep control over it without
the need for polling or blocking calls at all.

An example is given in mayastor_compose_basic.rs and i've adapted an
existing test as well.