### PR TITLE
Create service associated with CSI plugin. CAS-480

### DIFF
--- a/csi/build.rs
+++ b/csi/build.rs
@@ -4,5 +4,9 @@ fn main() {
     tonic_build::configure()
         .build_server(true)
         .compile(&["proto/csi.proto"], &["proto"])
-        .unwrap_or_else(|e| panic!("csi protobuf compilation failed: {}", e));
+        .expect("csi protobuf compilation failed");
+    tonic_build::configure()
+        .build_server(true)
+        .compile(&["proto/mayastornodeplugin.proto"], &["proto"])
+        .expect("mayastor node grpc service protobuf compilation failed");
 }

--- a/csi/proto/mayastornodeplugin.proto
+++ b/csi/proto/mayastornodeplugin.proto
@@ -1,0 +1,44 @@
+// The definition of mayastor node plugin gRPC interface.
+// The node plugin service runs on all nodes running
+// the Mayastor CSI node plugin, and is complementary
+// to the CSI node plugin service.
+
+// This interface is supposed to be independent on particular computing
+// environment (i.e. kubernetes).
+
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "io.grpc.examples.mayastornodeplugin";
+option java_outer_classname = "MayastorNodePluginProto";
+
+package mayastornodeplugin;
+
+// Service for freezing and unfreezing file systems.
+service MayastorNodePlugin {
+  // Freeze the file system identified by the volume ID
+  // no check is made if the file system had been previously frozen.
+  rpc FreezeFS (FreezeFSRequest) returns (FreezeFSReply) {}
+  // Unfreeze the file system identified by the volume ID,
+  // no check is made if the file system had been previously frozen.
+  rpc UnfreezeFS (UnfreezeFSRequest) returns (UnfreezeFSReply) {}
+}
+
+// The request message containing ID of the volume to be frozen
+message FreezeFSRequest {
+  string volume_id = 1;
+}
+
+// The response message for the freeze request.
+message FreezeFSReply {
+}
+
+// The request message containing ID of the volume to be unfrozen
+message UnfreezeFSRequest {
+
+  string volume_id = 1;
+}
+
+// The response message for the unfreeze request.
+message UnfreezeFSReply {
+}

--- a/csi/src/freezefs.rs
+++ b/csi/src/freezefs.rs
@@ -1,0 +1,75 @@
+//! The files system freeze support using linux utility fsfreeze
+use crate::{
+    dev::{Device, DeviceError},
+    mount,
+};
+use snafu::{ResultExt, Snafu};
+use tokio::process::Command;
+use uuid::Uuid;
+
+#[derive(Debug, Snafu)]
+#[snafu(visibility = "pub(crate)")]
+pub enum FreezeFsError {
+    #[snafu(display("Cannot find volume: volume ID: {}", volid))]
+    VolumeNotFound { volid: String },
+    #[snafu(display("Invalid volume ID: {}, {}", volid, source))]
+    InvalidVolumeId {
+        source: uuid::parser::ParseError,
+        volid: String,
+    },
+    #[snafu(display("fsfreeze failed: volume ID: {}, {}", volid, error))]
+    FsfreezeFailed { volid: String, error: String },
+    #[snafu(display("Internal failure: volume ID:{}, {}", volid, source))]
+    InternalFailure { source: DeviceError, volid: String },
+    #[snafu(display("IO error: volume ID: {}, {}", volid, source))]
+    IOError {
+        source: std::io::Error,
+        volid: String,
+    },
+}
+
+const FSFREEZE: &str = "fsfreeze";
+
+async fn fsfreeze(
+    volume_id: &str,
+    freeze_op: &str,
+) -> Result<(), FreezeFsError> {
+    let uuid = Uuid::parse_str(volume_id).context(InvalidVolumeId {
+        volid: volume_id.to_string(),
+    })?;
+
+    if let Some(device) =
+        Device::lookup(&uuid).await.context(InternalFailure {
+            volid: volume_id.to_string(),
+        })?
+    {
+        let device_path = device.devname();
+        if let Some(mnt) = mount::find_mount(Some(&device_path), None) {
+            let args = [freeze_op, &mnt.dest];
+            let output =
+                Command::new(FSFREEZE).args(&args).output().await.context(
+                    IOError {
+                        volid: volume_id.to_string(),
+                    },
+                )?;
+            if output.status.success() {
+                return Ok(());
+            } else {
+                return Err(FreezeFsError::FsfreezeFailed {
+                    volid: volume_id.to_string(),
+                    error: String::from_utf8(output.stderr).unwrap(),
+                });
+            }
+        }
+    }
+    Err(FreezeFsError::VolumeNotFound {
+        volid: volume_id.to_string(),
+    })
+}
+pub async fn freeze_volume(volume_id: &str) -> Result<(), FreezeFsError> {
+    fsfreeze(volume_id, "--freeze").await
+}
+
+pub async fn unfreeze_volume(volume_id: &str) -> Result<(), FreezeFsError> {
+    fsfreeze(volume_id, "--unfreeze").await
+}

--- a/csi/src/nodeplugin_grpc.rs
+++ b/csi/src/nodeplugin_grpc.rs
@@ -1,0 +1,85 @@
+//! The mayastor node plugin gRPC service
+//! This provides access to functionality that needs to be executed on the same
+//! node as a Mayastor CSI node plugin, but it is not possible to do so within
+//! the CSI framework. This service must be deployed on all nodes the
+//! Mayastor CSI node plugin is deployed.
+use crate::freezefs;
+use freezefs::{freeze_volume, unfreeze_volume, FreezeFsError};
+use mayastor_node_plugin::*;
+use tonic::{transport::Server, Code, Request, Response, Status};
+
+pub mod mayastor_node_plugin {
+    tonic::include_proto!("mayastornodeplugin");
+}
+
+#[derive(Debug, Default)]
+pub struct MayastorNodePluginSvc {}
+
+impl From<FreezeFsError> for Status {
+    fn from(err: FreezeFsError) -> Self {
+        match err {
+            FreezeFsError::VolumeNotFound {
+                ..
+            } => Status::new(Code::NotFound, err.to_string()),
+            FreezeFsError::FsfreezeFailed {
+                ..
+            } => Status::new(Code::Internal, err.to_string()),
+            FreezeFsError::InvalidVolumeId {
+                ..
+            } => Status::new(Code::InvalidArgument, err.to_string()),
+            FreezeFsError::InternalFailure {
+                ..
+            } => Status::new(Code::Internal, err.to_string()),
+            FreezeFsError::IOError {
+                ..
+            } => Status::new(Code::Unknown, err.to_string()),
+        }
+    }
+}
+
+#[tonic::async_trait]
+impl mayastor_node_plugin_server::MayastorNodePlugin for MayastorNodePluginSvc {
+    async fn freeze_fs(
+        &self,
+        request: Request<FreezeFsRequest>,
+    ) -> Result<Response<FreezeFsReply>, Status> {
+        let volume_id = request.into_inner().volume_id;
+        debug!("freeze_fs({})", volume_id);
+        freeze_volume(&volume_id).await?;
+        Ok(Response::new(mayastor_node_plugin::FreezeFsReply {}))
+    }
+
+    async fn unfreeze_fs(
+        &self,
+        request: Request<UnfreezeFsRequest>,
+    ) -> Result<Response<UnfreezeFsReply>, Status> {
+        let volume_id = request.into_inner().volume_id;
+        debug!("unfreeze_fs({})", volume_id);
+        unfreeze_volume(&volume_id).await?;
+        Ok(Response::new(mayastor_node_plugin::UnfreezeFsReply {}))
+    }
+}
+
+pub struct MayastorNodePluginGrpcServer {}
+
+impl MayastorNodePluginGrpcServer {
+    pub async fn run(endpoint: std::net::SocketAddr) -> Result<(), ()> {
+        info!(
+            "Mayastor node plugin gRPC server configured at address {:?}",
+            endpoint
+        );
+        if let Err(e) = Server::builder()
+            .add_service(
+                mayastor_node_plugin_server::MayastorNodePluginServer::new(
+                    MayastorNodePluginSvc {},
+                ),
+            )
+            .serve(endpoint)
+            .await
+        {
+            error!("gRPC server failed with error: {}", e);
+            return Err(());
+        }
+        Ok(())
+    }
+}

--- a/deploy/csi-daemonset.yaml
+++ b/deploy/csi-daemonset.yaml
@@ -38,11 +38,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: MY_POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         - name: RUST_BACKTRACE
           value: "1"
         args:
         - "--csi-socket=/csi/csi.sock"
         - "--node-name=$(MY_NODE_NAME)"
+        - "--grpc-endpoint=$(MY_POD_IP):10199"
         - "-v"
         volumeMounts:
         - name: device
@@ -87,6 +92,11 @@ spec:
           requests:
             cpu: "100m"
             memory: "50Mi"
+        # Mayastor node plugin gRPC server
+        ports:
+        - containerPort: 10199
+          protocol: TCP
+          name: mayastor-node
       volumes:
       - name: device
         hostPath:

--- a/mayastor-test/test_common.js
+++ b/mayastor-test/test_common.js
@@ -203,7 +203,9 @@ function startMayastorCsi () {
     '-n',
     'test-node-id',
     '-c',
-    CSI_ENDPOINT
+    CSI_ENDPOINT,
+    '-g',
+    LOCALHOST
   ]);
 }
 


### PR DESCRIPTION
Create service associated with CSI plugin to service
filesystem freeze unfreeze requests.

To properly snapshot an filesystem volume,
the FS must be frozen prior to creating the
lvol snapshot and then be unfrozen.
To do this use the linux utililty fsfreeze which
must be run on the node on which the volume has
been mounted.
MOAC will make remote calls to the service running
on the node to do this.