### PR TITLE
core: rework main.rs

### DIFF
--- a/mayastor/src/bin/cli/context.rs
+++ b/mayastor/src/bin/cli/context.rs
@@ -74,8 +74,11 @@ impl Context {
                 headers
                     .iter()
                     .map(|h| {
-                        (if h.starts_with('>') { &h[1 ..] } else { h })
-                            .to_string()
+                        if let Some(stripped) = h.strip_prefix('>') {
+                            stripped.to_string()
+                        } else {
+                            h.to_string()
+                        }
                     })
                     .collect(),
             );

--- a/mayastor/src/bin/main.rs
+++ b/mayastor/src/bin/main.rs
@@ -1,20 +1,25 @@
 #[macro_use]
 extern crate tracing;
 
-use std::path::Path;
-
-use structopt::StructOpt;
-
+use futures::FutureExt;
 use mayastor::{
     bdev::util::uring,
-    core::{MayastorCliArgs, MayastorEnvironment},
+    core::{MayastorCliArgs, MayastorEnvironment, Reactors},
+    grpc,
     logger,
+    subsys,
 };
-
+use std::path::Path;
+use structopt::StructOpt;
 mayastor::CPS_INIT!();
-
-fn main() -> Result<(), std::io::Error> {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = MayastorCliArgs::from_args();
+
+    let mut rt = tokio::runtime::Builder::new()
+        .basic_scheduler()
+        .enable_all()
+        .build()
+        .unwrap();
 
     // setup our logger first if -L is passed, raise the log level
     // automatically. trace maps to debug at FFI level. If RUST_LOG is
@@ -44,10 +49,22 @@ fn main() -> Result<(), std::io::Error> {
         if uring_supported { "yes" } else { "no" }
     );
     info!("free_pages: {} nr_pages: {}", free_pages, nr_pages);
-    let env = MayastorEnvironment::new(args);
-    env.start(|| {
-        info!("Mayastor started {} ...", '\u{1F680}');
-    })
-    .unwrap();
+
+    let grpc_endpoint = grpc::endpoint(args.grpc_endpoint.clone());
+
+    let ms = rt.enter(|| MayastorEnvironment::new(args).init());
+
+    let master = Reactors::master();
+    master.send_future(async { info!("Mayastor started {} ...", '\u{1F680}') });
+    let mut futures = Vec::new();
+
+    futures.push(master.boxed_local());
+    futures.push(subsys::Registration::run().boxed_local());
+    futures.push(grpc::MayastorGrpcServer::run(grpc_endpoint).boxed_local());
+
+    rt.block_on(futures::future::try_join_all(futures))
+        .expect_err("reactor exit in abnormal state");
+
+    ms.fini();
     Ok(())
 }

--- a/mayastor/src/grpc/nexus_grpc.rs
+++ b/mayastor/src/grpc/nexus_grpc.rs
@@ -80,8 +80,8 @@ impl Nexus {
 /// unconventional name that likely means it was not created using nexus
 /// rpc api, we return the whole name without modifications as it is.
 fn name_to_uuid(name: &str) -> &str {
-    if name.starts_with("nexus-") {
-        &name[6 ..]
+    if let Some(stripped) = name.strip_prefix("nexus-") {
+        stripped
     } else {
         name
     }

--- a/mayastor/src/subsys/mbus/mbus_nats.rs
+++ b/mayastor/src/subsys/mbus/mbus_nats.rs
@@ -12,8 +12,7 @@ pub(super) static NATS_MSG_BUS: OnceCell<NatsMessageBus> = OnceCell::new();
 pub(super) fn message_bus_init(server: String) {
     NATS_MSG_BUS.get_or_init(|| {
         // Waits for the message bus to become ready
-        tokio::runtime::Runtime::new()
-            .unwrap()
+        tokio::runtime::Handle::current()
             .block_on(async { NatsMessageBus::new(&server).await })
     });
 }


### PR DESCRIPTION
A lot of the "main" code is done with in the start closure of
mayastor. This PR moves this into main.rs where it should be. The
older .start() method is still present as they are used by tests but
over time we can phase it out.

The need for this - is mostly to avoid spawning runtimes during init