### PR TITLE
CAS-477: snapshot creation fails on replicas which are not shared

### DIFF
--- a/mayastor/src/bdev/nexus/nexus_bdev_snapshot.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev_snapshot.rs
@@ -16,7 +16,10 @@ impl Nexus {
                 Ok(t) => Ok(CreateSnapshotReply {
                     name: Lvol::format_snapshot_name(&self.bdev.name(), t),
                 }),
-                Err(_e) => Err(Error::FailedCreateSnapshot),
+                Err(e) => Err(Error::FailedCreateSnapshot {
+                    name: self.bdev.name(),
+                    source: e,
+                }),
             }
         } else {
             Err(Error::FailedGetHandle)

--- a/mayastor/src/core/mod.rs
+++ b/mayastor/src/core/mod.rs
@@ -79,7 +79,7 @@ pub enum CoreError {
     ResetDispatch {
         source: Errno,
     },
-    #[snafu(display("Failed to dispatch NVMe Admin",))]
+    #[snafu(display("Failed to dispatch NVMe Admin command {:x}h", opcode))]
     NvmeAdminDispatch {
         source: Errno,
         opcode: u16,
@@ -96,7 +96,7 @@ pub enum CoreError {
     },
     #[snafu(display("Reset failed"))]
     ResetFailed {},
-    #[snafu(display("NVMe Admin failed"))]
+    #[snafu(display("NVMe Admin command {:x}h failed", opcode))]
     NvmeAdminFailed {
         opcode: u16,
     },

--- a/mayastor/src/lvs/lvol.rs
+++ b/mayastor/src/lvs/lvol.rs
@@ -25,7 +25,8 @@ use spdk_sys::{
 };
 
 use crate::{
-    core::{Bdev, CoreError, Protocol, Share},
+    bdev::nexus::nexus_bdev::Nexus,
+    core::{Bdev, CoreError, Mthread, Protocol, Share},
     ffihelper::{
         cb_arg,
         errno_result_from_i32,
@@ -377,7 +378,7 @@ impl Lvol {
             nvme_status.set_sc(match errno {
                 0 => 0,
                 _ => {
-                    debug!("vbdev_lvol_create_snapshot errno {}", errno);
+                    error!("vbdev_lvol_create_snapshot errno {}", errno);
                     0x06 // SPDK_NVME_SC_INTERNAL_DEVICE_ERROR
                 }
             });
@@ -398,6 +399,42 @@ impl Lvol {
             )
         };
 
-        info!("Creating snapshot {}", snapshot_name);
+        info!("Creating snapshot {} on {}", snapshot_name, &self);
+    }
+
+    /// Create snapshot for local replica
+    pub async fn create_snapshot_local(
+        &self,
+        io: *mut spdk_sys::spdk_bdev_io,
+        snapshot_name: &str,
+    ) {
+        extern "C" fn snapshot_done_cb(
+            bio_ptr: *mut c_void,
+            _lvol_ptr: *mut spdk_lvol,
+            errno: i32,
+        ) {
+            if errno != 0 {
+                error!("vbdev_lvol_create_snapshot errno {}", errno);
+            }
+            // Must complete IO on thread IO was submitted from
+            let thread = Mthread::from_null_checked(unsafe {
+                spdk_sys::spdk_bdev_io_get_thread(bio_ptr.cast())
+            })
+            .expect("bio must have been submitted from an spdk_thread");
+            thread.enter();
+            Nexus::io_completion_local(errno == 0, bio_ptr);
+        }
+
+        let c_snapshot_name = snapshot_name.into_cstring();
+        unsafe {
+            vbdev_lvol_create_snapshot(
+                self.0.as_ptr(),
+                c_snapshot_name.as_ptr(),
+                Some(snapshot_done_cb),
+                io.cast(),
+            )
+        };
+
+        info!("Creating snapshot {} on {}", snapshot_name, &self);
     }
 }

--- a/mayastor/src/subsys/mod.rs
+++ b/mayastor/src/subsys/mod.rs
@@ -10,6 +10,7 @@ pub use config::{
     Pool,
 };
 pub use nvmf::{
+    create_snapshot,
     set_snapshot_time,
     Error as NvmfError,
     NvmeCpl,

--- a/mayastor/src/subsys/nvmf/mod.rs
+++ b/mayastor/src/subsys/nvmf/mod.rs
@@ -13,7 +13,7 @@ use std::cell::RefCell;
 use nix::errno::Errno;
 use snafu::Snafu;
 
-pub use admin_cmd::{set_snapshot_time, NvmeCpl, NvmfReq};
+pub use admin_cmd::{create_snapshot, set_snapshot_time, NvmeCpl, NvmfReq};
 use poll_groups::PollGroup;
 use spdk_sys::{
     spdk_subsystem,

--- a/spdk-sys/nvme_helper.c
+++ b/spdk-sys/nvme_helper.c
@@ -15,6 +15,16 @@ nvme_cmd_cdw11_get(struct spdk_nvme_cmd *cmd) {
        return &cmd->cdw11;
 }
 
+uint32_t
+nvme_cmd_cdw10_get_val(const struct spdk_nvme_cmd *cmd) {
+       return cmd->cdw10;
+}
+
+uint32_t
+nvme_cmd_cdw11_get_val(const struct spdk_nvme_cmd *cmd) {
+       return cmd->cdw11;
+}
+
 struct spdk_nvme_status *
 nvme_status_get(struct spdk_nvme_cpl *cpl) {
 	return &cpl->status;

--- a/spdk-sys/nvme_helper.h
+++ b/spdk-sys/nvme_helper.h
@@ -7,6 +7,8 @@ struct spdk_nvme_cmd;
 struct spdk_nvme_cpl;
 struct spdk_nvme_status;
 
+uint32_t nvme_cmd_cdw10_get_val(const struct spdk_nvme_cmd *cmd);
+uint32_t nvme_cmd_cdw11_get_val(const struct spdk_nvme_cmd *cmd);
 uint32_t *nvme_cmd_cdw10_get(struct spdk_nvme_cmd *cmd);
 uint32_t *nvme_cmd_cdw11_get(struct spdk_nvme_cmd *cmd);
 


### PR DESCRIPTION
Implement create snapshots for local replicas by having a separate codepath for lvol bdevs that creates the snapshot.
