### PR TITLE
CAS-488: message bus timeout and retry

### DIFF
--- a/mbus-api/examples/client/main.rs
+++ b/mbus-api/examples/client/main.rs
@@ -1,6 +1,7 @@
 use log::info;
 use mbus_api::{Message, *};
 use serde::{Deserialize, Serialize};
+use std::time::Duration;
 use structopt::StructOpt;
 use tokio::stream::StreamExt;
 
@@ -72,7 +73,12 @@ async fn main() {
         start_server_side().await;
     }
 
-    let reply = DummyRequest {}.request().await.unwrap();
+    let options = TimeoutOptions::new()
+        .with_timeout(Duration::from_secs(1))
+        .with_max_retries(Some(3));
+
+    // request() will use the bus default timeout and retries
+    let reply = DummyRequest {}.request_ext(options).await.unwrap();
     info!("Received reply: {:?}", reply);
 
     // We can also use the following api to specify a different channel and bus


### PR DESCRIPTION
Message bus requests can go unanswered. In fact, if no receiver was
listening in when the request was sent, it will not get it altogether.

This a default timeout of 5s with a default max number of 5 retries.
To avoid complicating things for the moment, each retry it spaced out by
 1s * nr of retries and capped at 10s - further down the line we might
want to customize this a bit.

By using request_ext one can specify timeout and max_retries explicitly.