### PR TITLE
Add a function to check if a nexus child is local

### DIFF
--- a/mayastor/src/bdev/nexus/nexus_child.rs
+++ b/mayastor/src/bdev/nexus/nexus_child.rs
@@ -439,4 +439,16 @@ impl NexusChild {
             .map(|j| j.stats().progress as i32)
             .unwrap_or_else(|| -1)
     }
+
+    /// Determines if a child is local to the nexus (i.e. on the same node)
+    pub fn is_local(&self) -> Option<bool> {
+        match &self.bdev {
+            Some(bdev) => {
+                // A local child is not exported over nvme or iscsi
+                let local = bdev.driver() != "nvme" && bdev.driver() != "iscsi";
+                Some(local)
+            }
+            None => None,
+        }
+    }
 }

--- a/mayastor/tests/common/compose.rs
+++ b/mayastor/tests/common/compose.rs
@@ -492,7 +492,7 @@ impl ComposeTest {
         Ok(())
     }
 
-    /// ge the logs from the container. It would be nice to make it implicit
+    /// get the logs from the container. It would be nice to make it implicit
     /// that is, when you make a rpc call, whatever logs where created due to
     /// that are returned
     pub async fn logs(&self, name: &str) -> Result<(), Error> {

--- a/mayastor/tests/nexus_child_location.rs
+++ b/mayastor/tests/nexus_child_location.rs
@@ -1,0 +1,94 @@
+use mayastor::{
+    bdev::{nexus_create, nexus_lookup},
+    core::MayastorCliArgs,
+};
+use rpc::mayastor::{BdevShareRequest, BdevUri, Null};
+
+pub mod common;
+use common::{Builder, MayastorTest};
+
+static NEXUS_NAME: &str = "child_location_nexus";
+
+#[tokio::test]
+async fn child_location() {
+    // create a new composeTest
+    let test = Builder::new()
+        .name("child_location_test")
+        .network("10.1.0.0/16")
+        .add_container("ms1")
+        .with_clean(true)
+        .build()
+        .await
+        .unwrap();
+
+    // Use GRPC handles to invoke methods on containers
+    let mut hdls = test.grpc_handles().await.unwrap();
+
+    // Create and share a bdev over nvmf
+    hdls[0].bdev.list(Null {}).await.unwrap();
+    hdls[0]
+        .bdev
+        .create(BdevUri {
+            uri: "malloc:///disk0?size_mb=100".into(),
+        })
+        .await
+        .unwrap();
+    hdls[0]
+        .bdev
+        .share(BdevShareRequest {
+            name: "disk0".into(),
+            proto: "nvmf".into(),
+        })
+        .await
+        .unwrap();
+
+    // Create and share a bdev over iscsi
+    hdls[0]
+        .bdev
+        .create(BdevUri {
+            uri: "malloc:///disk1?size_mb=100".into(),
+        })
+        .await
+        .unwrap();
+    hdls[0]
+        .bdev
+        .share(BdevShareRequest {
+            name: "disk1".into(),
+            proto: "iscsi".into(),
+        })
+        .await
+        .unwrap();
+
+    let mayastor = MayastorTest::new(MayastorCliArgs::default());
+    mayastor
+        .spawn(async move {
+            // Create a nexus with a local child, and two remote children (one
+            // exported over nvmf and the other over iscsi).
+            nexus_create(
+                NEXUS_NAME,
+                1024 * 1024 * 50,
+                None,
+                &[
+                    "malloc:///malloc0?blk_size=512&size_mb=100".into(),
+                    format!(
+                        "nvmf://{}:8420/nqn.2019-05.io.openebs:disk0",
+                        hdls[0].endpoint.ip()
+                    ),
+                    format!(
+                        "iscsi://{}:3260/iqn.2019-05.io.openebs:disk1/0",
+                        hdls[0].endpoint.ip()
+                    ),
+                ],
+            )
+            .await
+            .unwrap();
+
+            let nexus = nexus_lookup(NEXUS_NAME).expect("Failed to find nexus");
+            let children = &nexus.children;
+            assert_eq!(children.len(), 3);
+            assert_eq!(children[0].is_local().unwrap(), true);
+            assert_eq!(children[1].is_local().unwrap(), false);
+            assert_eq!(children[2].is_local().unwrap(), false);
+        })
+        .await;
+}


### PR DESCRIPTION
A nexus child is identified as being local if its bdev driver is neither
nvme nor iscsi. Therefore, nexus children with bdev drivers of type
"lvol", "aio" or "malloc" will be identified as local.