### PR TITLE
Disable Nix tests from CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -117,15 +117,6 @@ pipeline {
             }
           }
         }
-        stage('nix tests') {
-          agent { label 'nixos-mayastor-kvm' }
-          steps {
-            sh 'nix-build ./nix/test -A rebuild'
-            sh 'nix-build ./nix/test -A fio_nvme_basic'
-            sh 'nix-build ./nix/test -A nvmf_distributed'
-            sh 'nix-build ./nix/test -A nvmf_ports'
-          }
-        }
         stage('moac unit tests') {
           agent { label 'nixos-mayastor' }
           steps {


### PR DESCRIPTION
The NixOS KVM in the lab keeps loosing connectivity and we now have the
 docker compose tests which should be used instead.
The existing tests are still kept, we're just not running them on CI.