### PR TITLE
CAS-491-Remove-stored-handle

### DIFF
--- a/mayastor/src/bdev/nexus/nexus_child.rs
+++ b/mayastor/src/bdev/nexus/nexus_child.rs
@@ -44,7 +44,7 @@ pub enum ChildError {
     ChildInvalid {},
     #[snafu(display("Opening child bdev without bdev pointer"))]
     OpenWithoutBdev {},
-    #[snafu(display("Failed to create a BdevHandle for child: {}", source))]
+    #[snafu(display("Failed to create a BdevHandle for child"))]
     HandleCreate { source: CoreError },
 }
 

--- a/mayastor/src/bdev/nexus/nexus_label.rs
+++ b/mayastor/src/bdev/nexus/nexus_label.rs
@@ -79,9 +79,9 @@ use crate::{
 pub enum LabelError {
     #[snafu(display("{}", source))]
     NexusChildError { source: ChildError },
-    #[snafu(display("Error reading {}: {}", name, source))]
+    #[snafu(display("Error reading {}", name))]
     ReadError { name: String, source: CoreError },
-    #[snafu(display("Write error: {}", source))]
+    #[snafu(display("Write error"))]
     WriteError { name: String, source: CoreError },
     #[snafu(display(
         "Failed to allocate buffer for reading {}: {}",
@@ -130,11 +130,7 @@ pub enum LabelError {
     BackupLocation {},
     #[snafu(display("GPT partition table location is incorrect"))]
     PartitionTableLocation {},
-    #[snafu(display(
-        "Could not get handle for child bdev {}: {}",
-        name,
-        source
-    ))]
+    #[snafu(display("Could not get handle for child bdev {}", name,))]
     HandleCreate { name: String, source: ChildError },
 }
 

--- a/mayastor/tests/nexus_label.rs
+++ b/mayastor/tests/nexus_label.rs
@@ -133,10 +133,10 @@ async fn label_child() {
     let mut buffer = hdl.dma_malloc(34 * 512).unwrap();
     file.read_exact(&mut buffer.as_mut_slice()).unwrap();
     // write out the MBR + primary GPT header + GPT partition table
-    child.write_at(0, &buffer).await.unwrap();
+    hdl.write_at(0, &buffer).await.unwrap();
 
     let mut read_buffer = hdl.dma_malloc(34 * 512).unwrap();
-    child.read_at(0, &mut read_buffer).await.unwrap();
+    hdl.read_at(0, &mut read_buffer).await.unwrap();
     for (i, o) in buffer.as_slice().iter().zip(read_buffer.as_slice().iter()) {
         assert_eq!(i, o)
     }
@@ -146,13 +146,10 @@ async fn label_child() {
     let mut buffer = hdl.dma_malloc(33 * 512).unwrap();
     file.read_exact(&mut buffer.as_mut_slice()).unwrap();
     // write out the secondary GPT partition table + GPT header
-    child.write_at(131_039 * 512, &buffer).await.unwrap();
+    hdl.write_at(131_039 * 512, &buffer).await.unwrap();
 
     let mut read_buffer = hdl.dma_malloc(33 * 512).unwrap();
-    child
-        .read_at(131_039 * 512, &mut read_buffer)
-        .await
-        .unwrap();
+    hdl.read_at(131_039 * 512, &mut read_buffer).await.unwrap();
     for (i, o) in buffer.as_slice().iter().zip(read_buffer.as_slice().iter()) {
         assert_eq!(i, o)
     }


### PR DESCRIPTION
No longer store a BdevHandle in each NexusChild. Instead, generate a new BdevHandle object each time get_dev() is called for the child. Remove the NexusChild::read_at() and write_at() methods from NexusChild and use the BdevHandle methods instead using an explicit BdevHandle.
One NexusChild::write_at() method is retained to keep the code tidy, but this is used only in the nexus_label code and uses a transient BdevHandle internally.