### PR TITLE
CAS-493 Separate Nexus read and write channels.

### DIFF
--- a/mayastor/src/bdev/nexus/nexus_bdev.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev.rs
@@ -708,7 +708,7 @@ impl Nexus {
         }
 
         let ch = NexusChannel::inner_from_channel(ch);
-        let (desc, ch) = ch.read_ch[ch.previous].io_tuple();
+        let (desc, ch) = ch.readers[ch.previous].io_tuple();
         let ret = Self::readv_impl(io, desc, ch);
         if ret != 0 {
             let bio = Bio::from(io);
@@ -735,7 +735,7 @@ impl Nexus {
             return;
         }
 
-        let (desc, ch) = channels.read_ch[child].io_tuple();
+        let (desc, ch) = channels.readers[child].io_tuple();
 
         let ret = Self::readv_impl(io.as_ptr(), desc, ch);
 
@@ -777,7 +777,7 @@ impl Nexus {
     pub(crate) fn reset(&self, io: &Bio, channels: &NexusChannelInner) {
         // in case of resets, we want to reset all underlying children
         let results = channels
-            .write_ch
+            .writers
             .iter()
             .map(|c| unsafe {
                 let (bdev, chan) = c.io_tuple();
@@ -805,7 +805,7 @@ impl Nexus {
     pub(crate) fn writev(&self, io: &Bio, channels: &NexusChannelInner) {
         // in case of writes, we want to write to all underlying children
         let results = channels
-            .write_ch
+            .writers
             .iter()
             .map(|c| unsafe {
                 let (desc, chan) = c.io_tuple();
@@ -834,7 +834,7 @@ impl Nexus {
 
     pub(crate) fn unmap(&self, io: &Bio, channels: &NexusChannelInner) {
         let results = channels
-            .write_ch
+            .writers
             .iter()
             .map(|c| unsafe {
                 let (desc, chan) = c.io_tuple();
@@ -860,7 +860,7 @@ impl Nexus {
 
     pub(crate) fn write_zeroes(&self, io: &Bio, channels: &NexusChannelInner) {
         let results = channels
-            .write_ch
+            .writers
             .iter()
             .map(|c| unsafe {
                 let (b, c) = c.io_tuple();
@@ -892,7 +892,7 @@ impl Nexus {
         // for replicas, passthru only works with our vendor commands as the
         // underlying bdev is not nvmf
         let results = channels
-            .write_ch
+            .writers
             .iter()
             .map(|c| unsafe {
                 debug!("nvme_admin on {}", c.get_bdev().driver());

--- a/mayastor/src/bdev/nexus/nexus_channel.rs
+++ b/mayastor/src/bdev/nexus/nexus_channel.rs
@@ -26,8 +26,8 @@ pub(crate) struct NexusChannel {
 #[repr(C)]
 #[derive(Debug)]
 pub(crate) struct NexusChannelInner {
-    pub(crate) ch: Vec<BdevHandle>,
-    pub(crate) write_only: usize,
+    pub(crate) write_ch: Vec<BdevHandle>,
+    pub(crate) read_ch: Vec<BdevHandle>,
     pub(crate) previous: usize,
     device: *mut c_void,
 }
@@ -52,7 +52,8 @@ pub enum DREvent {
 impl NexusChannelInner {
     /// very simplistic routine to rotate between children for read operations
     pub(crate) fn child_select(&mut self) -> usize {
-        if self.previous != self.ch.len() - self.write_only - 1 {
+        debug_assert!(self.read_ch.len() > 0);
+        if self.previous < self.read_ch.len() - 1 {
             self.previous += 1;
         } else {
             self.previous = 0;
@@ -74,37 +75,41 @@ impl NexusChannelInner {
         );
 
         trace!(
-            "{}: Current number of IO channels {}",
+            "{}: Current number of IO channels write: {} read: {}",
             nexus.name,
-            self.ch.len(),
+            self.write_ch.len(),
+            self.read_ch.len(),
         );
 
         // clear the vector of channels and reset other internal values,
         // clearing the values will drop any existing handles in the
         // channel
-        self.ch.clear();
+        self.write_ch.clear();
+        self.read_ch.clear();
         self.previous = 0;
-        self.write_only = 0;
 
-        // iterate to over all our children which are in the open state
+        // iterate over all our children which are in the open state
         nexus
             .children
             .iter_mut()
             .filter(|c| c.state() == ChildState::Open)
             .for_each(|c| {
-                self.ch.push(
+                self.write_ch.push(
                     BdevHandle::try_from(c.get_descriptor().unwrap()).unwrap(),
-                )
+                );
+                self.read_ch.push(
+                    BdevHandle::try_from(c.get_descriptor().unwrap()).unwrap(),
+                );
             });
 
-        if !self.ch.is_empty() {
+        // then add write-only children
+        if !self.read_ch.is_empty() {
             nexus
                 .children
                 .iter_mut()
                 .filter(|c| c.rebuilding())
                 .map(|c| {
-                    self.write_only += 1;
-                    self.ch.push(
+                    self.write_ch.push(
                         BdevHandle::try_from(c.get_descriptor().unwrap())
                             .unwrap(),
                     )
@@ -113,9 +118,10 @@ impl NexusChannelInner {
         }
 
         trace!(
-            "{}: New number of IO channels {} out of {} children",
+            "{}: New number of IO channels write:{} read:{} out of {} children",
             nexus.name,
-            self.ch.len(),
+            self.write_ch.len(),
+            self.read_ch.len(),
             nexus.children.len()
         );
 
@@ -134,9 +140,9 @@ impl NexusChannel {
 
         let ch = NexusChannel::from_raw(ctx);
         let mut channels = Box::new(NexusChannelInner {
-            ch: Vec::new(),
+            write_ch: Vec::new(),
+            read_ch: Vec::new(),
             previous: 0,
-            write_only: 0,
             device,
         });
 
@@ -145,9 +151,12 @@ impl NexusChannel {
             .iter_mut()
             .filter(|c| c.state() == ChildState::Open)
             .map(|c| {
-                channels.ch.push(
+                channels.write_ch.push(
                     BdevHandle::try_from(c.get_descriptor().unwrap()).unwrap(),
-                )
+                );
+                channels.read_ch.push(
+                    BdevHandle::try_from(c.get_descriptor().unwrap()).unwrap(),
+                );
             })
             .for_each(drop);
         ch.inner = Box::into_raw(channels);
@@ -159,7 +168,8 @@ impl NexusChannel {
         let nexus = unsafe { Nexus::from_raw(device) };
         debug!("{} Destroying IO channels", nexus.bdev.name());
         let inner = NexusChannel::from_raw(ctx).inner_mut();
-        inner.ch.clear();
+        inner.write_ch.clear();
+        inner.read_ch.clear();
     }
 
     /// function called when we receive a Dynamic Reconfigure event (DR)

--- a/mayastor/src/bdev/nexus/nexus_fn_table.rs
+++ b/mayastor/src/bdev/nexus/nexus_fn_table.rs
@@ -110,9 +110,11 @@ impl NexusFnTable {
 
         // set the fields that need to be (re)set per-attempt
         if nio.io_type() == io_type::READ {
+            // set that we only need to read from one child
+            // before we complete the IO to the callee.
             nio.reset(1);
         } else {
-            nio.reset(ch.ch.len())
+            nio.reset(ch.write_ch.len())
         }
 
         let nexus = nio.nexus_as_ref();

--- a/mayastor/src/bdev/nexus/nexus_fn_table.rs
+++ b/mayastor/src/bdev/nexus/nexus_fn_table.rs
@@ -114,7 +114,7 @@ impl NexusFnTable {
             // before we complete the IO to the callee.
             nio.reset(1);
         } else {
-            nio.reset(ch.write_ch.len())
+            nio.reset(ch.writers.len())
         }
 
         let nexus = nio.nexus_as_ref();


### PR DESCRIPTION
To make the logic for controlling write-only child bdevs more straightforward.
The write-only count in the NexusChannel is removed and now we use a two separate vectors of BdevHandles,
one for read operations and one for write (or other modifying) operations.
Included new check for attempted reads when no readable channels are present.