### PR TITLE
CAS-489: limit config sync to pools

### DIFF
--- a/deploy/mayastor-daemonset.yaml
+++ b/deploy/mayastor-daemonset.yaml
@@ -46,10 +46,13 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: IMPORT_NEXUSES
+          value: "false"
         args:
         - "-N$(MY_NODE_NAME)"
         - "-g$(MY_POD_IP)"
         - "-nnats"
+        - "-y/var/local/mayastor/config.yaml"
         securityContext:
           privileged: true
         volumeMounts:
@@ -57,6 +60,10 @@ spec:
           mountPath: /dev
         - name: dshm
           mountPath: /dev/shm
+        - name: configlocation
+          mountPath: /var/local/mayastor/
+        - name: config
+          mountPath: /var/local/mayastor/config.yaml
         resources:
           limits:
             cpu: "1"
@@ -82,3 +89,11 @@ spec:
       - name: hugepage
         emptyDir:
           medium: HugePages
+      - name: configlocation
+        hostPath:
+          path: /var/local/mayastor/
+          type: DirectoryOrCreate
+      - name: config
+        hostPath:
+          path: /var/local/mayastor/config.yaml
+          type: FileOrCreate

--- a/mayastor/src/core/env.rs
+++ b/mayastor/src/core/env.rs
@@ -146,7 +146,7 @@ pub static GLOBAL_RC: Lazy<Arc<Mutex<i32>>> =
     Lazy::new(|| Arc::new(Mutex::new(-1)));
 
 /// keep track if we have received a signal already
-pub static SIG_RECIEVED: Lazy<AtomicBool> =
+pub static SIG_RECEIVED: Lazy<AtomicBool> =
     Lazy::new(|| AtomicBool::new(false));
 
 /// FFI functions that are needed to initialize the environment
@@ -299,12 +299,12 @@ unsafe extern "C" fn signal_trampoline(_: *mut c_void) {
 
 /// called on SIGINT and SIGTERM
 extern "C" fn mayastor_signal_handler(signo: i32) {
-    if SIG_RECIEVED.load(SeqCst) {
+    if SIG_RECEIVED.load(SeqCst) {
         return;
     }
 
     warn!("Received SIGNO: {}", signo);
-    SIG_RECIEVED.store(true, SeqCst);
+    SIG_RECEIVED.store(true, SeqCst);
     unsafe {
         spdk_thread_send_critical_msg(
             Mthread::get_init().0,

--- a/mayastor/src/subsys/config/mod.rs
+++ b/mayastor/src/subsys/config/mod.rs
@@ -43,7 +43,7 @@ use crate::{
     lvs::Lvs,
     nexus_uri::bdev_create,
     pool::PoolsIter,
-    replica::{self, ReplicaIter, ShareType},
+    replica::{ReplicaIter, ShareType},
     subsys::{
         config::opts::{
             BdevOpts,
@@ -156,6 +156,8 @@ pub struct Config {
     pub nexus_opts: NexusOpts,
     /// error store opts
     pub err_store_opts: ErrStoreOpts,
+    /// list of pools to create on load
+    pub pools: Option<Vec<Pool>>,
     ///
     /// The next options are intended for usage during testing
     ///
@@ -163,9 +165,7 @@ pub struct Config {
     pub base_bdevs: Option<Vec<BaseBdev>>,
     /// list of nexus bdevs that will create the base bdevs implicitly
     pub nexus_bdevs: Option<Vec<NexusBdev>>,
-    /// list of pools to create on load, the base_bdevs should be created first
-    pub pools: Option<Vec<Pool>>,
-    /// any  base bdevs created implicitly share them over nvmf
+    /// any base bdevs created implicitly are shared over nvmf
     pub implicit_share_base: bool,
     /// flag to enable or disable config sync
     pub sync_disable: bool,
@@ -311,6 +311,25 @@ impl Config {
         current.pools = Some(pools);
 
         Ok(current)
+    }
+
+    /// write the current pool configuration to disk
+    pub fn write_pools<P>(&self, file: P) -> Result<(), std::io::Error>
+    where
+        P: AsRef<Path>,
+    {
+        let pools = serde_json::json!({
+            "pools": self.pools.clone()
+        });
+
+        if let Ok(s) = serde_yaml::to_string(&pools) {
+            let mut file = File::create(file)?;
+            return file.write_all(s.as_bytes());
+        }
+        Err(std::io::Error::new(
+            std::io::ErrorKind::Other,
+            "failed to serialize the pool config",
+        ))
     }
 
     /// write the current configuration to disk
@@ -483,38 +502,6 @@ impl Config {
         failures
     }
 
-    /// Share any pool replicas defined in the config file.
-    async fn share_replicas(&self) {
-        if let Some(pools) = self.pools.as_ref() {
-            let replicas = pools
-                .iter()
-                .map(|p| {
-                    p.replicas
-                        .iter()
-                        .filter(|r| r.share.is_some())
-                        .filter_map(|replica| {
-                            ReplicaIter::new()
-                                .find(|dev| dev.get_uuid() == replica.name)
-                                .map(|dev| (dev, replica.share.unwrap()))
-                        })
-                        .collect::<Vec<(replica::Replica, ShareType)>>()
-                })
-                .flatten()
-                .collect::<Vec<(replica::Replica, ShareType)>>();
-
-            for (dev, share) in replicas {
-                if let Err(error) = dev.share(share).await {
-                    error!(
-                        "Failed to share {} over {:?}, error={}",
-                        dev.get_uuid(),
-                        share,
-                        error
-                    );
-                }
-            }
-        }
-    }
-
     pub fn import_nexuses() -> bool {
         match std::env::var_os("IMPORT_NEXUSES") {
             Some(val) => val.into_string().unwrap().parse::<bool>().unwrap(),
@@ -535,7 +522,6 @@ impl Config {
             // the nexus create will fail
 
             let mut errors = self.create_pools().await;
-            self.share_replicas().await;
 
             if Self::import_nexuses() {
                 errors += self.create_nexus_bdevs().await;
@@ -553,7 +539,7 @@ impl Config {
     pub(crate) fn export_config() -> Result<(), std::io::Error> {
         let cfg = Config::get().refresh().unwrap();
         match cfg.source.as_ref() {
-            Some(target) => cfg.write(&target),
+            Some(target) => cfg.write_pools(&target),
             // no config file to export to
             None => Ok(()),
         }
@@ -585,7 +571,7 @@ pub struct BaseBdev {
     pub uri: String,
 }
 
-#[derive(Debug, Default, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Default, PartialEq, Serialize, Deserialize, Clone)]
 /// Pools that we create. Future work will include the ability to create RAID0
 /// or RAID5.
 pub struct Pool {
@@ -593,7 +579,7 @@ pub struct Pool {
     pub name: String,
     /// bdevs to create outside of the nexus control
     pub disks: Vec<String>,
-    /// list of replicas to share on load
+    /// list of replicas (not required, informational only)
     pub replicas: Vec<Replica>,
 }
 
@@ -607,7 +593,7 @@ impl From<&Pool> for rpc::mayastor::CreatePoolRequest {
     }
 }
 
-#[derive(Debug, Default, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Default, PartialEq, Serialize, Deserialize, Clone)]
 /// Pool replicas that we share via `ShareType`
 pub struct Replica {
     /// name of the replica


### PR DESCRIPTION
The sync_config used by mayastor during configuration changes now
saves only pools into the config file.
Loading and "manually" writing of base bdev's and nexus is still
supported as it facilitates testing.
This somewhat improves the current k8s config by allowing replicas to
be revived after a crash/restart.