### PR TITLE
CAS-498: Enable ANA reporting

### DIFF
--- a/mayastor/src/bdev/nexus/nexus_io.rs
+++ b/mayastor/src/bdev/nexus/nexus_io.rs
@@ -102,6 +102,11 @@ pub mod io_status {
 
 /// NVMe Admin opcode, from nvme_spec.h
 pub mod nvme_admin_opc {
+    // pub const GET_LOG_PAGE: u8 = 0x02;
+    pub const IDENTIFY: u8 = 0x06;
+    // pub const ABORT: u8 = 0x08;
+    // pub const SET_FEATURES: u8 = 0x09;
+    // pub const GET_FEATURES: u8 = 0x0a;
     // Vendor-specific
     pub const CREATE_SNAPSHOT: u8 = 0xc0;
 }

--- a/mayastor/src/core/handle.rs
+++ b/mayastor/src/core/handle.rs
@@ -206,32 +206,44 @@ impl BdevHandle {
         }
     }
 
-    /// create a snapshot on all children
+    /// create a snapshot, only works for nvme bdev
     /// returns snapshot time as u64 seconds since Unix epoch
     pub async fn create_snapshot(&self) -> Result<u64, CoreError> {
         let mut cmd = spdk_sys::spdk_nvme_cmd::default();
         cmd.set_opc(nvme_admin_opc::CREATE_SNAPSHOT.into());
         let now = subsys::set_snapshot_time(&mut cmd);
         debug!("Creating snapshot at {}", now);
-        self.nvme_admin(&cmd).await?;
+        self.nvme_admin(&cmd, None).await?;
         Ok(now as u64)
     }
 
-    /// sends an NVMe Admin command with a custom opcode to all children
-    pub async fn nvme_admin_custom(
+    /// identify controller
+    /// buffer must be at least 4096B
+    pub async fn nvme_identify_ctrlr(
         &self,
-        opcode: u8,
-    ) -> Result<usize, CoreError> {
+        mut buffer: &mut DmaBuf,
+    ) -> Result<(), CoreError> {
         let mut cmd = spdk_sys::spdk_nvme_cmd::default();
-        cmd.set_opc(opcode.into());
-        self.nvme_admin(&cmd).await
+        cmd.set_opc(nvme_admin_opc::IDENTIFY.into());
+        cmd.nsid = 0xffffffff;
+        // Controller Identifier
+        unsafe { *spdk_sys::nvme_cmd_cdw10_get(&mut cmd) = 1 };
+        self.nvme_admin(&cmd, Some(&mut buffer)).await
     }
 
-    /// sends the specified NVMe Admin command to all children
+    /// sends an NVMe Admin command, only for read commands without buffer
+    pub async fn nvme_admin_custom(&self, opcode: u8) -> Result<(), CoreError> {
+        let mut cmd = spdk_sys::spdk_nvme_cmd::default();
+        cmd.set_opc(opcode.into());
+        self.nvme_admin(&cmd, None).await
+    }
+
+    /// sends the specified NVMe Admin command, only read commands
     pub async fn nvme_admin(
         &self,
         nvme_cmd: &spdk_sys::spdk_nvme_cmd,
-    ) -> Result<usize, CoreError> {
+        buffer: Option<&mut DmaBuf>,
+    ) -> Result<(), CoreError> {
         trace!("Sending nvme_admin {}", nvme_cmd.opc());
         let (s, r) = oneshot::channel::<bool>();
         // Use the spdk-sys variant spdk_bdev_nvme_admin_passthru that
@@ -241,8 +253,14 @@ impl BdevHandle {
                 self.desc.as_ptr(),
                 self.channel.as_ptr(),
                 &*nvme_cmd,
-                std::ptr::null_mut(),
-                0,
+                match buffer {
+                    Some(ref b) => ***b,
+                    None => std::ptr::null_mut(),
+                },
+                match buffer {
+                    Some(b) => b.len(),
+                    None => 0,
+                },
                 Some(Self::io_completion_cb),
                 cb_arg(s),
             )
@@ -256,7 +274,7 @@ impl BdevHandle {
         }
 
         if r.await.expect("Failed awaiting NVMe Admin IO") {
-            Ok(0)
+            Ok(())
         } else {
             Err(CoreError::NvmeAdminFailed {
                 opcode: (*nvme_cmd).opc(),


### PR DESCRIPTION
This allows a Nexus published on nvmf to benefit from
multipath access from a supporting initiator, such as the one in the
Linux kernel. This requires multiple Nexuses published with the same
UUID which means they have the same NQN.