### PR TITLE
test: need ability to (easily) drive IO to a nexus

### DIFF
--- a/mayastor/src/bdev/dev/nvmf.rs
+++ b/mayastor/src/bdev/dev/nvmf.rs
@@ -9,6 +9,7 @@ use std::{
 use async_trait::async_trait;
 use futures::channel::oneshot;
 use snafu::ResultExt;
+use tracing::instrument;
 use url::Url;
 
 use spdk_sys::{
@@ -137,6 +138,7 @@ impl CreateDestroy for Nvmf {
     type Error = NexusBdevError;
 
     /// Create an NVMF bdev
+    #[instrument(err)]
     async fn create(&self) -> Result<String, Self::Error> {
         if Bdev::lookup_by_name(&self.get_name()).is_some() {
             return Err(NexusBdevError::BdevExists {

--- a/mayastor/src/bdev/nexus/nexus_io.rs
+++ b/mayastor/src/bdev/nexus/nexus_io.rs
@@ -265,6 +265,10 @@ impl Bio {
     pub(crate) fn block_len(&self) -> u64 {
         self.bdev_as_ref().block_len() as u64
     }
+    #[inline]
+    pub(crate) fn status(&self) -> i8 {
+        unsafe { self.0.as_ref().internal.status }
+    }
 
     /// determine if the IO needs an indirect buffer this can happen for example
     /// when we do a 512 write to a 4k device.
@@ -289,11 +293,12 @@ impl Debug for Bio {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         writeln!(
             f,
-            "bdev: {} offset: {:?}, num_blocks: {:?}, type: {:?} {:p} ",
+            "bdev: {} offset: {:?}, num_blocks: {:?}, type: {:?} status: {:?}, {:p} ",
             self.bdev_as_ref().name(),
             self.offset(),
             self.num_blocks(),
             self.io_type(),
+            self.status(),
             self
         )
     }

--- a/mayastor/src/core/bdev.rs
+++ b/mayastor/src/core/bdev.rs
@@ -160,7 +160,7 @@ impl Bdev {
                     info!("hot remove {} from {}", b.name, b.parent);
                     b.close();
                 }
-            })
+            });
         });
     }
 
@@ -371,7 +371,6 @@ impl Bdev {
             unsafe { Box::from_raw(sender_ptr as *mut oneshot::Sender<i32>) };
         sender.send(errno).expect("stat_cb receiver is gone");
     }
-
     /// Get bdev stats or errno value in case of an error.
     pub async fn stats(&self) -> Result<BdevStats, i32> {
         let mut stat: spdk_bdev_io_stat = Default::default();

--- a/mayastor/src/core/io_driver.rs
+++ b/mayastor/src/core/io_driver.rs
@@ -1,0 +1,403 @@
+//! helper routines to drive IO to the nexus for testing purposes
+use futures::channel::oneshot;
+use rand::Rng;
+use std::{ptr::NonNull, sync::Mutex};
+
+use spdk_sys::{
+    spdk_bdev_free_io,
+    spdk_bdev_read,
+    spdk_bdev_reset,
+    spdk_bdev_write,
+};
+
+use crate::{
+    core::{Bdev, Cores, Descriptor, DmaBuf, IoChannel, Mthread},
+    ffihelper::pair,
+    nexus_uri::bdev_create,
+};
+
+#[derive(Debug)]
+pub enum IoType {
+    /// perform random read operations
+    READ,
+    /// perform random write operations
+    WRITE,
+}
+
+impl Default for IoType {
+    fn default() -> Self {
+        Self::READ
+    }
+}
+
+#[derive(Debug)]
+struct Io {
+    /// buffer we read/write from/to
+    buf: DmaBuf,
+    /// type of IO we are supposed to issue
+    iot: IoType,
+    /// current offset where we are reading or writing
+    offset: u64,
+    /// pointer to our the job we belong too
+    job: NonNull<Job>,
+}
+
+impl Io {
+    /// start submitting
+    fn run(&mut self, job: *mut Job) {
+        self.job = NonNull::new(job).unwrap();
+        match self.iot {
+            IoType::READ => self.read(0),
+            IoType::WRITE => self.write(0),
+        };
+    }
+
+    /// obtain a reference to the inner job
+    fn job(&mut self) -> &mut Job {
+        unsafe { self.job.as_mut() }
+    }
+
+    /// dispatch the next IO, this is called from within the completion callback
+    pub fn next(&mut self, offset: u64) {
+        if self.job().request_reset {
+            self.job().request_reset = false;
+            self.reset();
+            return;
+        }
+
+        match self.iot {
+            IoType::READ => self.read(offset),
+            IoType::WRITE => self.write(offset),
+        }
+    }
+
+    /// dispatch the read IO at given offset
+    fn read(&mut self, offset: u64) {
+        unsafe {
+            if spdk_bdev_read(
+                self.job.as_ref().desc.as_ptr(),
+                self.job.as_ref().ch.as_ref().unwrap().as_ptr(),
+                *self.buf,
+                offset,
+                self.buf.len(),
+                Some(Job::io_completion),
+                self as *const _ as *mut _,
+            ) == 0
+            {
+                self.job.as_mut().n_inflight += 1;
+            } else {
+                eprintln!(
+                    "failed to submit read IO to {}",
+                    self.job.as_ref().bdev.name()
+                );
+            }
+        };
+    }
+
+    /// dispatch write IO at given offset
+    fn write(&mut self, offset: u64) {
+        unsafe {
+            if spdk_bdev_write(
+                self.job.as_ref().desc.as_ptr(),
+                self.job.as_ref().ch.as_ref().unwrap().as_ptr(),
+                *self.buf,
+                offset,
+                self.buf.len(),
+                Some(Job::io_completion),
+                self as *const _ as *mut _,
+            ) == 0
+            {
+                self.job.as_mut().n_inflight += 1;
+            } else {
+                eprintln!(
+                    "failed to submit write IO to {}",
+                    self.job.as_ref().bdev.name()
+                );
+            }
+        };
+    }
+
+    /// reset the bdev under test
+    pub fn reset(&mut self) {
+        unsafe {
+            if spdk_bdev_reset(
+                self.job.as_ref().desc.as_ptr(),
+                self.job.as_ref().ch.as_ref().unwrap().as_ptr(),
+                Some(Job::io_completion),
+                self as *const _ as *mut _,
+            ) == 0
+            {
+                self.job.as_mut().n_inflight += 1;
+            } else {
+                eprintln!(
+                    "failed to submit reset IO to {}",
+                    self.job.as_ref().bdev.name()
+                );
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct Job {
+    /// that drives IO to a bdev using its own channel.
+    bdev: Bdev,
+    /// descriptor to the bdev
+    desc: Descriptor,
+    /// io channel used to submit IO
+    ch: Option<IoChannel>,
+    /// queue depth configured for this job
+    qd: u64,
+    /// io_size the io_size is the number of blocks submit per IO
+    io_size: u64,
+    /// blk_size of the underlying device
+    blk_size: u32,
+    /// num_blocks the device has
+    num_blocks: u64,
+    /// aligned set of IOs we can do
+    io_blocks: u64,
+    /// io queue
+    queue: Vec<Io>,
+    /// number of IO's completed
+    n_io: u64,
+    /// number of IO's currently inflight
+    n_inflight: u32,
+    ///generate random number between 0 and num_block
+    rng: rand::rngs::ThreadRng,
+    /// drain the job which means that we wait for all pending IO to complete
+    /// and stop the run
+    drain: bool,
+    /// channels used to signal completion
+    s: Option<oneshot::Sender<bool>>,
+    r: Option<oneshot::Receiver<bool>>,
+    /// issue a reset to the bdev
+    request_reset: bool,
+    /// core to run this job on
+    core: u32,
+    /// thread this job is run on
+    thread: Option<Mthread>,
+}
+
+impl Job {
+    extern "C" fn io_completion(
+        bdev_io: *mut spdk_sys::spdk_bdev_io,
+        success: bool,
+        arg: *mut std::ffi::c_void,
+    ) {
+        let ioq: &mut Io = unsafe { &mut *arg.cast() };
+        let job = unsafe { ioq.job.as_mut() };
+
+        if !success {
+            error!("{}: {:#?}", job.thread.as_ref().unwrap().name(), bdev_io);
+        }
+
+        assert_eq!(Cores::current(), job.core);
+        job.n_io += 1;
+        job.n_inflight -= 1;
+
+        unsafe { spdk_bdev_free_io(bdev_io) }
+
+        if job.n_inflight == 0 {
+            trace!("{} fully drained", job.thread.as_ref().unwrap().name());
+            job.s.take().unwrap().send(true).unwrap();
+            return;
+        }
+
+        if job.drain {
+            return;
+        }
+
+        let offset = (job.rng.gen::<u64>() % job.io_size) * job.io_blocks;
+        ioq.next(offset);
+    }
+
+    pub fn stop(&mut self) -> oneshot::Receiver<bool> {
+        self.drain = true;
+        self.r.take().expect("double shut down for job")
+    }
+
+    fn as_ptr(&self) -> *mut Job {
+        self as *const _ as *mut _
+    }
+    /// start the job that will dispatch an IO up to the provided queue depth
+    fn start(mut self) -> Box<Job> {
+        let thread =
+            Mthread::new(format!("job_{}", self.bdev.name()), self.core)
+                .unwrap();
+        thread.with(|| {
+            self.ch = self.desc.get_channel();
+            let mut boxed = Box::new(self);
+            let ptr = boxed.as_ptr();
+            boxed.queue.iter_mut().for_each(|q| q.run(ptr));
+            boxed.thread = Mthread::current();
+            boxed
+        })
+    }
+}
+
+#[derive(Default)]
+pub struct Builder {
+    /// bdev URI to create
+    uri: String,
+    /// queue depth
+    qd: u64,
+    /// size of each IO
+    io_size: u64,
+    /// type of workload to generate
+    iot: IoType,
+    /// existing bdev to use instead of creating one
+    bdev: Option<Bdev>,
+    /// core to start the job on, the command will crash if the core is invalid
+    core: u32,
+}
+
+impl Builder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// create a bdev using the given URI
+    pub fn uri(mut self, uri: &str) -> Self {
+        self.uri = String::from(uri);
+        self
+    }
+
+    /// set the queue depth of the job
+    pub fn qd(mut self, qd: u64) -> Self {
+        self.qd = qd;
+        self
+    }
+
+    /// io size per IO for the job
+    pub fn io_size(mut self, io_size: u64) -> Self {
+        self.io_size = io_size;
+        self
+    }
+
+    /// issue read or write requests
+    pub fn rw(mut self, iot: IoType) -> Self {
+        self.iot = iot;
+        self
+    }
+
+    /// use the given bdev instead of the URI to create the job
+    pub fn bdev(mut self, bdev: Bdev) -> Self {
+        self.bdev = Some(bdev);
+        self
+    }
+    /// set the core to run on
+    pub fn core(mut self, core: u32) -> Self {
+        self.core = core;
+        self
+    }
+
+    pub async fn build(mut self) -> Job {
+        let bdev = if self.bdev.is_some() {
+            self.bdev.take().unwrap()
+        } else {
+            let name = bdev_create(&self.uri).await.unwrap();
+            Bdev::lookup_by_name(&name).unwrap()
+        };
+
+        let desc = bdev.open(true).unwrap();
+
+        let blk_size = bdev.block_len();
+        let num_blocks = bdev.num_blocks();
+
+        let io_size = self.io_size / blk_size as u64;
+        let io_blocks = num_blocks / io_size;
+
+        let mut queue = Vec::new();
+
+        (0 .. self.qd).for_each(|offset| {
+            queue.push(Io {
+                buf: DmaBuf::new(self.io_size as u64, bdev.alignment())
+                    .unwrap(),
+                iot: IoType::READ,
+                offset,
+                job: NonNull::dangling(),
+            });
+        });
+        let (s, r) = pair::<bool>();
+        Job {
+            core: self.core,
+            bdev,
+            desc,
+            ch: None,
+            qd: self.qd,
+            io_size,
+            blk_size,
+            num_blocks,
+            queue,
+            io_blocks,
+            n_io: 0,
+            n_inflight: 0,
+            rng: Default::default(),
+            drain: false,
+            s: Some(s),
+            r: Some(r),
+            request_reset: false,
+            thread: None,
+        }
+    }
+}
+
+pub struct JobQueue {
+    #[allow(clippy::vec_box)]
+    inner: Mutex<Vec<Box<Job>>>,
+}
+
+impl Default for JobQueue {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl JobQueue {
+    pub fn new() -> Self {
+        Self {
+            inner: Mutex::new(Vec::new()),
+        }
+    }
+
+    /// look up the job by bdev name
+    fn lookup(&self, name: &str) -> Option<Box<Job>> {
+        let mut inner = self.inner.lock().unwrap();
+        if let Some(index) =
+            inner.iter().position(|job| job.bdev.name() == name)
+        {
+            Some(inner.remove(index))
+        } else {
+            None
+        }
+    }
+
+    /// start the job
+    pub fn start(&self, job: Job) {
+        self.inner.lock().unwrap().push(job.start());
+    }
+
+    /// stop the job by bdev name
+    pub async fn stop(&self, bdevname: &str) {
+        if let Some(mut job) = self.lookup(bdevname) {
+            job.stop().await.unwrap();
+            job.thread.unwrap().with(|| drop(job));
+        }
+    }
+
+    /// stop all jobs
+    pub async fn stop_all(&self) {
+        let mut inner = self.inner.lock().unwrap();
+        while let Some(mut job) = inner.pop() {
+            job.stop().await.unwrap();
+            job.thread.unwrap().with(|| drop(job));
+        }
+    }
+
+    /// reset all jobs
+    pub fn send_reset(&self) {
+        self.inner.lock().unwrap().iter_mut().for_each(|j| {
+            j.request_reset = true;
+        });
+    }
+}

--- a/mayastor/src/core/mod.rs
+++ b/mayastor/src/core/mod.rs
@@ -16,6 +16,7 @@ pub use env::{
     MayastorEnvironment,
     GLOBAL_RC,
 };
+
 pub use handle::BdevHandle;
 pub use reactor::{Reactor, ReactorState, Reactors, REACTOR_LIST};
 pub use share::{Protocol, Share};
@@ -28,6 +29,7 @@ mod descriptor;
 mod dma;
 mod env;
 mod handle;
+pub mod io_driver;
 mod reactor;
 mod share;
 pub(crate) mod thread;

--- a/mayastor/src/core/thread.rs
+++ b/mayastor/src/core/thread.rs
@@ -59,14 +59,14 @@ impl Mthread {
     /// Avoid any blocking calls as it will block the whole reactor. Also, avoid
     /// long-running functions. In general if you follow the nodejs event loop
     /// model, you should be good.
-    pub fn with<F: FnOnce()>(self, f: F) -> Self {
-        let _th = Self::current();
+    pub fn with<T, F: FnOnce() -> T>(self, f: F) -> T {
+        let th = Self::current();
         self.enter();
-        f();
-        if let Some(t) = _th {
+        let out = f();
+        if let Some(t) = th {
             t.enter();
         }
-        self
+        out
     }
 
     #[inline]

--- a/mayastor/src/nexus_uri.rs
+++ b/mayastor/src/nexus_uri.rs
@@ -1,11 +1,11 @@
 use std::{convert::TryFrom, num::ParseIntError, str::ParseBoolError};
 
+use crate::{bdev::Uri, core::Bdev};
 use futures::channel::oneshot::Canceled;
 use nix::errno::Errno;
 use snafu::Snafu;
+use tracing::instrument;
 use url::ParseError;
-
-use crate::{bdev::Uri, core::Bdev};
 
 // parse URI and bdev create/destroy errors common for all types of bdevs
 #[derive(Debug, Snafu, Clone)]
@@ -70,11 +70,13 @@ pub enum NexusBdevError {
 
 /// Parse URI and create bdev described in the URI.
 /// Return the bdev name (which can be different from URI).
+#[instrument]
 pub async fn bdev_create(uri: &str) -> Result<String, NexusBdevError> {
     Uri::parse(uri)?.create().await
 }
 
 /// Parse URI and destroy bdev described in the URI.
+#[instrument]
 pub async fn bdev_destroy(uri: &str) -> Result<(), NexusBdevError> {
     Uri::parse(uri)?.destroy().await
 }

--- a/mayastor/tests/common/compose.rs
+++ b/mayastor/tests/common/compose.rs
@@ -211,7 +211,7 @@ type ContainerName = String;
 /// container ID
 type ContainerId = String;
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct ComposeTest {
     /// used as the network name
     name: String,
@@ -566,10 +566,31 @@ impl ComposeTest {
 
         Ok(handles)
     }
+
+    pub fn down(&self) {
+        if self.clean {
+            self.containers.keys().for_each(|c| {
+                std::process::Command::new("docker")
+                    .args(&["stop", c])
+                    .output()
+                    .unwrap();
+                std::process::Command::new("docker")
+                    .args(&["rm", c])
+                    .output()
+                    .unwrap();
+            });
+
+            std::process::Command::new("docker")
+                .args(&["network", "rm", &self.name])
+                .output()
+                .unwrap();
+        }
+    }
 }
 
 /// Mayastor test structure that simplifies sending futures. Mayastor has
 /// its own reactor, which is not tokio based, so we need to handle properly
+#[derive(Debug)]
 pub struct MayastorTest<'a> {
     reactor: &'a Reactor,
     thdl: Option<std::thread::JoinHandle<()>>,

--- a/mayastor/tests/common/mod.rs
+++ b/mayastor/tests/common/mod.rs
@@ -21,10 +21,12 @@ use mayastor::{
 use spdk_sys::spdk_get_thread;
 
 pub mod bdev_io;
-mod compose;
+pub mod compose;
 pub mod error_bdev;
 pub mod ms_exec;
-pub use compose::{Builder, ComposeTest, MayastorTest, RpcHandle};
+
+pub use compose::{ComposeTest, MayastorTest, RpcHandle};
+
 /// call F cnt times, and sleep for a duration between each invocation
 pub fn retry<F, T, E>(mut cnt: u32, timeout: Duration, mut f: F) -> T
 where

--- a/mayastor/tests/io_job.rs
+++ b/mayastor/tests/io_job.rs
@@ -1,0 +1,199 @@
+use std::sync::Arc;
+
+use once_cell::sync::OnceCell;
+use tokio::time::Duration;
+
+use mayastor::{
+    bdev::{nexus_create, nexus_lookup},
+    core::{io_driver, Bdev, MayastorCliArgs},
+};
+use rpc::mayastor::{BdevShareRequest, BdevUri};
+
+pub mod common;
+use common::compose::{self, ComposeTest, MayastorTest};
+use mayastor::core::io_driver::JobQueue;
+
+static DOCKER_COMPOSE: OnceCell<ComposeTest> = OnceCell::new();
+static MAYASTOR: OnceCell<MayastorTest> = OnceCell::new();
+
+// this functions runs with in the context of the mayastorTest instance
+async fn create_work(queue: Arc<JobQueue>) {
+    // get a vector of grpc clients to all containers that are part of this test
+    let mut hdls = DOCKER_COMPOSE.get().unwrap().grpc_handles().await.unwrap();
+
+    // for each grpc client, invoke these methods.
+    for h in &mut hdls {
+        // create the bdev
+        h.bdev
+            .create(BdevUri {
+                uri: "malloc:///disk0?size_mb=100".into(),
+            })
+            .await
+            .unwrap();
+        // share it over nvmf
+        h.bdev
+            .share(BdevShareRequest {
+                name: "disk0".into(),
+                proto: "nvmf".into(),
+            })
+            .await
+            .unwrap();
+    }
+
+    // get a reference to mayastor (used later)
+    let ms = MAYASTOR.get().unwrap();
+
+    // have ms create our nexus to the targets created above to know the IPs of
+    // the mayastor instances that run in the container, the handles can be
+    // used. This avoids hardcoded IPs and having magic constants.
+    ms.spawn(async move {
+        nexus_create(
+            "nexus0",
+            1024 * 1024 * 50,
+            None,
+            &[
+                format!(
+                    "nvmf://{}:8420/nqn.2019-05.io.openebs:disk0",
+                    hdls[0].endpoint.ip()
+                ),
+                format!(
+                    "nvmf://{}:8420/nqn.2019-05.io.openebs:disk0",
+                    hdls[1].endpoint.ip()
+                ),
+            ],
+        )
+        .await
+        .unwrap();
+
+        let bdev = Bdev::lookup_by_name("nexus0").unwrap();
+
+        // create a job using the bdev we looked up, we are in the context here
+        // of the ms instance and not the containers.
+        let job = io_driver::Builder::new()
+            .core(1)
+            .bdev(bdev)
+            .qd(64)
+            .io_size(512)
+            .build()
+            .await;
+
+        // start the first job
+        queue.start(job);
+
+        // create a new job and start it. Note that the malloc bdev is created
+        // implicitly with the uri() argument
+        let job = io_driver::Builder::new()
+            .core(0)
+            .uri("malloc:///disk0?size_mb=100")
+            .qd(64)
+            .io_size(512)
+            .build()
+            .await;
+
+        queue.start(job);
+    })
+    .await
+}
+
+async fn stats() {
+    // we grab an instance to mayastor test
+    let ms = MAYASTOR.get().unwrap();
+    // and spawn a future on it
+    ms.spawn(async move {
+        let bdev = Bdev::bdev_first().unwrap().into_iter();
+        for b in bdev {
+            let result = b.stats().await.unwrap();
+            println!("{}: {:?}", b.name(), result);
+        }
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn io_driver() {
+    //
+    // We are creating 3 mayastor instances in total. Two of them will be
+    // running in side a container. Once these two instances are running, we
+    // will create a malloc bdev on each and share that over nvmf. Using
+    // these targets a 3de mayastor instance will be started. The third one
+    // however, is started by means of struct MayastorTest. This way, we can
+    // interact with it using .spawn() and .send().
+    //
+    // The spawn() method returns an awaitable handle and .send()  does a fire
+    // and forget. Using these methods we create a nexus in the mayastor
+    // test instance (ms). As part of the test, we also create a malloc bdev
+    // on that instance
+    //
+    // Finally, we create 2 jobs, one for the nexus and one for the malloc bdev
+    // and let the test run for 5 seconds.
+
+    // To make it easy to get access to the ComposeTest and MayastorTest
+    // instances they are, after creation stored in the static globals
+    //
+
+    // the queue that holds our jobs once started. As we pass this around
+    // between this thread the mayastor instance we keep a ref count. We
+    // need to keep track of the Jobs to avoid them from being dropped.
+    let queue = Arc::new(JobQueue::new());
+
+    // create the docker containers
+    let compose = compose::Builder::new()
+        .name("cargo-test")
+        .network("10.1.0.0/16")
+        .add_container("ms2")
+        .add_container("ms1")
+        .with_clean(true)
+        .build()
+        .await
+        .unwrap();
+
+    // create the mayastor test instance
+    let mayastor_test = MayastorTest::new(MayastorCliArgs {
+        log_components: vec!["all".into()],
+        reactor_mask: "0x3".to_string(),
+        no_pci: true,
+        grpc_endpoint: "0.0.0.0".to_string(),
+        ..Default::default()
+    });
+
+    // set the created instances to the globals here such that we can access
+    // them whenever we want by "getting" them. Because some code is async
+    // we cannot do this one step as the async runtime cannot be used during
+    // init.
+    DOCKER_COMPOSE.set(compose).unwrap();
+
+    // later down the road we use the ms instance (to spawn futures) so here we
+    // use get_or_init() it is a shorter way of writing:
+    // ```rust
+    // MAYASTOR.set(mayastor);
+    // let ms = MAYASTOR.get().unwrap();
+    // ```
+    let ms = MAYASTOR.get_or_init(|| mayastor_test);
+
+    // the creation of the targets -- is done by grpc handles. Subsequently, we
+    // create the nexus and the malloc bdev (using futures). To keep things
+    // a bit organised we do that in a single function notice we pass queue
+    // here as an argument. We could also make a static queue here if we wanted
+    // too to avoid passing arguments around.
+
+    create_work(queue.clone()).await;
+
+    // the devices have been created and they are pumping IO
+    tokio::time::delay_for(Duration::from_secs(5)).await;
+
+    // we must stop all jobs otherwise mayastor would never exit (unless we
+    // signal it)
+    queue.stop_all().await;
+    // grab some stats of the bdevs in the ms instance
+    stats().await;
+
+    // Both ComposeTest and MayastorTest impl Drop. However, we want to control
+    // the sequence of shut down here, so we destroy the nexus to avoid that
+    // the system destroys the containers before it destroys mayastor.
+    ms.spawn(nexus_lookup("nexus0").unwrap().destroy())
+        .await
+        .unwrap();
+    // now we manually destroy the docker containers
+    DOCKER_COMPOSE.get().unwrap().down();
+    // ms gets dropped and will call mayastor_env_stop()
+}

--- a/mayastor/tests/lvs_pool_rpc.rs
+++ b/mayastor/tests/lvs_pool_rpc.rs
@@ -8,7 +8,7 @@ use rpc::mayastor::{
 };
 
 pub mod common;
-use common::Builder;
+use common::compose::Builder;
 static DISKNAME1: &str = "/tmp/disk1.img";
 
 #[tokio::test]

--- a/mayastor/tests/mayastor_compose_basic.rs
+++ b/mayastor/tests/mayastor_compose_basic.rs
@@ -6,7 +6,7 @@ use mayastor::{
 use rpc::mayastor::{BdevShareRequest, BdevUri, Null};
 
 pub mod common;
-use common::{Builder, MayastorTest};
+use common::{compose::Builder, MayastorTest};
 
 #[tokio::test]
 async fn compose_up_down() {

--- a/mayastor/tests/nexus_child_location.rs
+++ b/mayastor/tests/nexus_child_location.rs
@@ -5,7 +5,7 @@ use mayastor::{
 use rpc::mayastor::{BdevShareRequest, BdevUri, Null};
 
 pub mod common;
-use common::{Builder, MayastorTest};
+use common::{compose::Builder, MayastorTest};
 
 static NEXUS_NAME: &str = "child_location_nexus";
 

--- a/mayastor/tests/replica_timeout.rs
+++ b/mayastor/tests/replica_timeout.rs
@@ -1,6 +1,6 @@
 #![allow(unused_assignments)]
 
-use common::{bdev_io, Builder, MayastorTest};
+use common::{bdev_io, compose::Builder, MayastorTest};
 use mayastor::{
     bdev::{nexus_create, nexus_lookup},
     core::MayastorCliArgs,

--- a/mayastor/tests/reset.rs
+++ b/mayastor/tests/reset.rs
@@ -4,10 +4,10 @@ use mayastor::core::{BdevHandle, MayastorCliArgs};
 use rpc::mayastor::{BdevShareRequest, BdevUri};
 
 pub mod common;
-
+use common::compose;
 #[tokio::test]
 async fn nexus_reset_mirror() {
-    let test = common::Builder::new()
+    let test = compose::Builder::new()
         .name("cargo-test")
         .network("10.1.0.0/16")
         .add_container("ms2")

--- a/shell.nix
+++ b/shell.nix
@@ -21,6 +21,7 @@ mkShell {
   # fortify does not work with -O0 which is used by spdk when --enable-debug
   hardeningDisable = [ "fortify" ];
   buildInputs = [
+    docker-compose
     clang
     cowsay
     e2fsprogs


### PR DESCRIPTION
This change adds the ability to create workloads within a given mayastor
instance. This is for testing -- not just during mayastor development but
also for e2e tests where we can invoke job creations form within k8s in
the near future.

An example is given `io_job.rs` where we create 2 nvmf targets through
the compose framework, and then use `struct MayastorTest` to do
some IO to it.