### PR TITLE
thread: use NonNull<>

### DIFF
--- a/mayastor/src/core/env.rs
+++ b/mayastor/src/core/env.rs
@@ -307,7 +307,7 @@ extern "C" fn mayastor_signal_handler(signo: i32) {
     SIG_RECEIVED.store(true, SeqCst);
     unsafe {
         spdk_thread_send_critical_msg(
-            Mthread::get_init().0,
+            Mthread::get_init().into_raw(),
             Some(signal_trampoline),
         );
     };

--- a/mayastor/src/core/thread.rs
+++ b/mayastor/src/core/thread.rs
@@ -15,6 +15,7 @@ use spdk_sys::{
 };
 
 use crate::core::{cpu_cores::CpuMask, Cores};
+use std::ptr::NonNull;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -27,11 +28,21 @@ pub enum Error {
 /// should not be confused with an actual thread. Consider it more to be
 /// analogous to a container to which you can submit work and poll it to drive
 /// the submitted work to completion.
-pub struct Mthread(pub(crate) *mut spdk_thread);
+pub struct Mthread(NonNull<spdk_thread>);
+
+impl From<*mut spdk_thread> for Mthread {
+    fn from(t: *mut spdk_thread) -> Self {
+        let t = NonNull::new(t).expect("thread may not be NULL");
+        Mthread(t)
+    }
+}
 
 impl Mthread {
     pub fn get_init() -> Mthread {
-        Mthread::from_null_checked(unsafe { spdk_thread_get_by_id(1) }).unwrap()
+        Mthread(
+            NonNull::new(unsafe { spdk_thread_get_by_id(1) })
+                .expect("No init thread allocated"),
+        )
     }
 
     ///
@@ -42,16 +53,20 @@ impl Mthread {
 
     pub fn new(name: String, core: u32) -> Option<Self> {
         let name = CString::new(name).unwrap();
-        let t = unsafe {
+
+        if let Some(t) = NonNull::new(unsafe {
             let mut mask = CpuMask::new();
             mask.set_cpu(core, true);
             spdk_thread_create(name.as_ptr(), mask.as_ptr())
-        };
-        Self::from_null_checked(t)
+        }) {
+            Some(Mthread(t))
+        } else {
+            None
+        }
     }
 
     pub fn id(&self) -> u64 {
-        unsafe { (*self.0).id }
+        unsafe { (self.0.as_ref()).id }
     }
     ///
     /// # Note
@@ -70,70 +85,59 @@ impl Mthread {
     }
 
     #[inline]
-    pub fn poll(self) -> Self {
-        let _ = unsafe { spdk_thread_poll(self.0, 0, 0) };
-        self
+    pub fn poll(&self) {
+        let _ = unsafe { spdk_thread_poll(self.0.as_ptr(), 0, 0) };
     }
 
     #[inline]
-    pub fn enter(self) -> Self {
+    pub fn enter(&self) {
         debug!("setting thread {:?}", self);
-        unsafe { spdk_set_thread(self.0) };
-        self
+        unsafe { spdk_set_thread(self.0.as_ptr()) };
     }
 
     #[inline]
-    pub fn exit(self) -> Self {
+    pub fn exit(&self) {
         debug!("exit thread {:?}", self);
         unsafe { spdk_set_thread(std::ptr::null_mut()) };
-        self
     }
 
     pub fn current() -> Option<Mthread> {
-        Mthread::from_null_checked(unsafe { spdk_get_thread() })
+        if let Some(t) = NonNull::new(unsafe { spdk_get_thread() }) {
+            Some(Mthread(t))
+        } else {
+            None
+        }
     }
 
     pub fn name(&self) -> &str {
         unsafe {
-            std::ffi::CStr::from_ptr(&(*self.0).name[0])
+            std::ffi::CStr::from_ptr(&self.0.as_ref().name[0])
                 .to_str()
                 .unwrap()
         }
+    }
+
+    pub fn into_raw(self) -> *mut spdk_thread {
+        self.0.as_ptr()
     }
 
     /// destroy the given thread waiting for it to become ready to destroy
     pub fn destroy(self) {
         debug!("destroying thread {}...{:p}", self.name(), self.0);
         unsafe {
-            spdk_set_thread(self.0);
+            spdk_set_thread(self.0.as_ptr());
             // set that we *want* to exit, but we have not exited yet
-            spdk_thread_exit(self.0);
+            spdk_thread_exit(self.0.as_ptr());
 
             // now wait until the thread is actually exited the internal
             // state is updated by spdk_thread_poll()
-            while !spdk_thread_is_exited(self.0) {
-                spdk_thread_poll(self.0, 0, 0);
+            while !spdk_thread_is_exited(self.0.as_ptr()) {
+                spdk_thread_poll(self.0.as_ptr(), 0, 0);
             }
-            spdk_thread_destroy(self.0);
+            spdk_thread_destroy(self.0.as_ptr());
         }
 
         debug!("thread {:p} destroyed", self.0);
-    }
-
-    pub fn inner(self) -> *const spdk_thread {
-        self.0
-    }
-
-    pub fn inner_mut(self) -> *mut spdk_thread {
-        self.0
-    }
-
-    pub fn from_null_checked(t: *mut spdk_thread) -> Option<Self> {
-        if t.is_null() {
-            None
-        } else {
-            Some(Mthread(t))
-        }
     }
 
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
@@ -142,7 +146,7 @@ impl Mthread {
         f: extern "C" fn(ctx: *mut c_void),
         arg: *mut c_void,
     ) {
-        let rc = unsafe { spdk_thread_send_msg(self.0, Some(f), arg) };
+        let rc = unsafe { spdk_thread_send_msg(self.0.as_ptr(), Some(f), arg) };
         assert_eq!(rc, 0);
     }
 
@@ -175,7 +179,7 @@ impl Mthread {
 
         let rc = unsafe {
             spdk_thread_send_msg(
-                self.0,
+                self.0.as_ptr(),
                 Some(trampoline::<F, T>),
                 Box::into_raw(ctx).cast(),
             )

--- a/mayastor/src/lvs/lvol.rs
+++ b/mayastor/src/lvs/lvol.rs
@@ -417,12 +417,10 @@ impl Lvol {
                 error!("vbdev_lvol_create_snapshot errno {}", errno);
             }
             // Must complete IO on thread IO was submitted from
-            let thread = Mthread::from_null_checked(unsafe {
+            Mthread::from(unsafe {
                 spdk_sys::spdk_bdev_io_get_thread(bio_ptr.cast())
             })
-            .expect("bio must have been submitted from an spdk_thread");
-            thread.enter();
-            Nexus::io_completion_local(errno == 0, bio_ptr);
+            .with(|| Nexus::io_completion_local(errno == 0, bio_ptr));
         }
 
         let c_snapshot_name = snapshot_name.into_cstring();

--- a/mayastor/tests/common/mod.rs
+++ b/mayastor/tests/common/mod.rs
@@ -18,7 +18,6 @@ use mayastor::{
     logger,
     rebuild::{ClientOperations, RebuildJob, RebuildState},
 };
-use spdk_sys::spdk_get_thread;
 
 pub mod bdev_io;
 pub mod compose;
@@ -320,8 +319,8 @@ pub fn clean_up_temp() {
     .unwrap();
 }
 
-pub fn thread() -> Option<Mthread> {
-    Mthread::from_null_checked(unsafe { spdk_get_thread() })
+pub fn thread() -> Mthread {
+    Mthread::get_init()
 }
 
 pub fn dd_urandom_blkdev(device: &str) -> i32 {


### PR DESCRIPTION
Use NonNull<T> to ensure pointers are not NULL when
dealing with FFI. 