### PR TITLE
nvme: add uri support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2049,6 +2049,7 @@ dependencies = [
  "num-traits 0.1.43",
  "once_cell",
  "snafu",
+ "url",
  "uuid",
 ]
 

--- a/csi/src/dev/nvmf.rs
+++ b/csi/src/dev/nvmf.rs
@@ -73,11 +73,9 @@ impl TryFrom<&Url> for NvmfAttach {
 #[tonic::async_trait]
 impl Attach for NvmfAttach {
     async fn attach(&self) -> Result<(), DeviceError> {
-        if let Err(error) = nvmeadm::nvmf_discovery::connect(
-            &self.host,
-            self.port as u32,
-            &self.nqn,
-        ) {
+        if let Err(error) =
+            nvmeadm::nvmf_discovery::connect(&self.host, self.port, &self.nqn)
+        {
             match (error) {
                 nvmeadm::error::NvmeError::ConnectInProgress => return Ok(()),
                 _ => {

--- a/nix/pkgs/mayastor/default.nix
+++ b/nix/pkgs/mayastor/default.nix
@@ -38,8 +38,8 @@ let
   version = builtins.readFile "${version_drv}";
   buildProps = rec {
     name = "mayastor";
-    #cargoSha256 = "0000000000000000000000000000000000000000000000000000";
-    cargoSha256 = "08raaybbxpg9vj12nmd91pd8jqxdh3rmvkyin81isbqqmawgnkq7";
+    # cargoSha256 = "0000000000000000000000000000000000000000000000000000";
+    cargoSha256 = "07d3yvl43pqw5iwjpb1rd9b34s572m8w4p89nmqd68pc0kmpq4d2";
     inherit version;
     src = whitelistSource ../../../. [
       "Cargo.lock"

--- a/nvmeadm/Cargo.toml
+++ b/nvmeadm/Cargo.toml
@@ -16,3 +16,4 @@ num-traits = "^0.1"
 once_cell = "1.3"
 snafu = "0.6"
 uuid = { version = "0.7", features = ["v4"] }
+url = "2.2.0"

--- a/nvmeadm/src/error.rs
+++ b/nvmeadm/src/error.rs
@@ -44,6 +44,10 @@ pub enum NvmeError {
         source: glob::PatternError,
         path_prefix: String,
     },
+    #[snafu(display("NVMe URI invalid: {}", source))]
+    UrlError { source: url::ParseError },
+    #[snafu(display("Transport type {} not supported", trtype))]
+    TransportError { trtype: String },
 }
 
 impl From<std::io::Error> for NvmeError {

--- a/nvmeadm/src/lib.rs
+++ b/nvmeadm/src/lib.rs
@@ -38,7 +38,9 @@ pub mod nvmf_subsystem;
 
 use error::{IoError, NvmeError};
 use snafu::ResultExt;
+mod nvme_uri;
 
+pub use nvme_uri::NvmeTarget;
 /// the device entry in /dev for issuing ioctls to the kernels nvme driver
 const NVME_FABRICS_PATH: &str = "/dev/nvme-fabrics";
 /// ioctl for passing any NVMe command to the kernel

--- a/nvmeadm/src/nvme_namespaces.rs
+++ b/nvmeadm/src/nvme_namespaces.rs
@@ -26,7 +26,7 @@ pub struct NvmeDevice {
     /// firmware revision
     fw_rev: String,
     /// the nqn of the subsystem this device instance is connected to
-    subsysnqn: String,
+    pub subsysnqn: String,
 }
 
 impl NvmeDevice {
@@ -47,11 +47,12 @@ impl NvmeDevice {
             model: parse_value(&subsys, "model")?,
             serial: parse_value(&subsys, "serial")?,
             size: parse_value(&source, "size")?,
-            // NOTE: during my testing, it seems that NON fabric devices
-            // do not have a UUID, this means that local PCIe devices will
-            // be filtered out automatically. We should not depend on this
-            // feature or, bug until we gather more data
-            uuid: parse_value(&source, "uuid")?,
+            // /* NOTE: during my testing, it seems that NON fabric devices
+            //  * do not have a UUID, this means that local PCIe devices will
+            //  * be filtered out automatically. We should not depend on this
+            //  * feature or, bug until we gather more data
+            uuid: parse_value(&source, "uuid")
+                .unwrap_or_else(|_| String::from("N/A")),
             wwid: parse_value(&source, "wwid")?,
             nsid: parse_value(&source, "nsid")?,
         })

--- a/nvmeadm/src/nvme_uri.rs
+++ b/nvmeadm/src/nvme_uri.rs
@@ -1,0 +1,128 @@
+use std::{convert::TryFrom, time::Duration};
+
+use url::{ParseError, Url};
+
+use crate::{
+    error::NvmeError,
+    nvme_namespaces::{NvmeDevice, NvmeDeviceList},
+    nvmf_discovery::disconnect,
+};
+
+use super::nvmf_discovery::connect;
+
+pub struct NvmeTarget {
+    host: String,
+    port: u16,
+    subsysnqn: String,
+    trtype: String,
+}
+
+impl TryFrom<String> for NvmeTarget {
+    type Error = NvmeError;
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        NvmeTarget::try_from(value.as_str())
+    }
+}
+
+impl TryFrom<&str> for NvmeTarget {
+    type Error = NvmeError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        let url = Url::parse(&value).map_err(|source| NvmeError::UrlError {
+            source,
+        })?;
+
+        let trtype = match url.scheme() {
+            "nvmf" | "nvmf+tcp" => Ok("tcp"),
+            _ => Err(NvmeError::UrlError {
+                source: ParseError::IdnaError,
+            }),
+        }?
+        .into();
+
+        let host = url
+            .host_str()
+            .ok_or(NvmeError::UrlError {
+                source: ParseError::EmptyHost,
+            })?
+            .into();
+
+        let subnqn = match url.path_segments() {
+            None => Err(NvmeError::UrlError {
+                source: ParseError::RelativeUrlWithCannotBeABaseBase,
+            }),
+            Some(s) => {
+                let segments = s.collect::<Vec<&str>>();
+                if segments[0].is_empty() {
+                    Err(NvmeError::UrlError {
+                        source: ParseError::RelativeUrlWithCannotBeABaseBase,
+                    })
+                } else {
+                    Ok(segments[0].to_string())
+                }
+            }
+        }?;
+
+        Ok(Self {
+            trtype,
+            host,
+            port: url.port().unwrap_or(4420),
+            subsysnqn: subnqn,
+        })
+    }
+}
+
+impl NvmeTarget {
+    pub fn connect(&self) -> Result<Vec<NvmeDevice>, NvmeError> {
+        if self.trtype != "tcp" {
+            return Err(NvmeError::TransportError {
+                trtype: self.trtype.clone(),
+            });
+        }
+
+        connect(&self.host, self.port, &self.subsysnqn)?;
+
+        let mut retries = 10;
+        let mut all_nvme_devices;
+        loop {
+            std::thread::sleep(Duration::from_millis(1000));
+
+            all_nvme_devices = NvmeDeviceList::new()
+                .filter_map(Result::ok)
+                .filter(|b| b.subsysnqn == self.subsysnqn)
+                .collect::<Vec<_>>();
+
+            retries -= 1;
+            if retries == 0 || !all_nvme_devices.is_empty() {
+                break;
+            }
+        }
+
+        Ok(all_nvme_devices)
+    }
+
+    pub fn disconnect(&self) -> Result<usize, NvmeError> {
+        disconnect(&self.subsysnqn)
+    }
+}
+
+#[test]
+fn nvme_parse_uri() {
+    let target =
+        NvmeTarget::try_from("nvmf://1.2.3.4:1234/testnqn.what-ever.foo")
+            .unwrap();
+
+    assert_eq!(target.port, 1234);
+    assert_eq!(target.host, "1.2.3.4");
+    assert_eq!(target.trtype, "tcp");
+    assert_eq!(target.subsysnqn, "testnqn.what-ever.foo");
+
+    let target =
+        NvmeTarget::try_from("nvmf+tcp://1.2.3.4:1234/testnqn.what-ever.foo")
+            .unwrap();
+
+    assert_eq!(target.port, 1234);
+    assert_eq!(target.host, "1.2.3.4");
+    assert_eq!(target.trtype, "tcp");
+    assert_eq!(target.subsysnqn, "testnqn.what-ever.foo");
+}

--- a/nvmeadm/src/nvmf_discovery.rs
+++ b/nvmeadm/src/nvmf_discovery.rs
@@ -464,7 +464,7 @@ impl DiscoveryLogEntry {
 
 pub fn connect(
     ip_addr: &str,
-    port: u32,
+    port: u16,
     nqn: &str,
 ) -> Result<String, NvmeError> {
     let mut connect_args = String::new();
@@ -488,16 +488,12 @@ pub fn connect(
         },
     )?;
     if let Err(e) = file.write_all(connect_args.as_bytes()) {
-        match e.kind() {
-            ErrorKind::AlreadyExists => {
-                return Err(NvmeError::ConnectInProgress)
-            }
-            _ => {
-                return Err(NvmeError::IoError {
-                    source: e,
-                })
-            }
-        }
+        return match e.kind() {
+            ErrorKind::AlreadyExists => Err(NvmeError::ConnectInProgress),
+            _ => Err(NvmeError::IoError {
+                source: e,
+            }),
+        };
     }
     let mut buf = String::new();
     file.read_to_string(&mut buf).context(ConnectError {


### PR DESCRIPTION
Add parsing of nvmf uri's to the admin library.

@mtzaurus will use this to move the tests that use NBD to NVMe