### PR TITLE
Cancel all rebuild jobs on nexus destruction

### DIFF
--- a/mayastor/src/bdev/nexus/nexus_bdev.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev.rs
@@ -555,8 +555,10 @@ impl Nexus {
         // gone
         self.bdev.unshare().await.unwrap();
 
+        // wait for all rebuild jobs to be cancelled before proceeding with the
+        // destruction of the nexus
         for child in self.children.iter() {
-            self.stop_rebuild(&child.name).await.ok();
+            self.cancel_child_rebuild_jobs(&child.name).await;
         }
 
         for child in self.children.iter_mut() {

--- a/mayastor/src/bdev/nexus/nexus_bdev_rebuild.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev_rebuild.rs
@@ -171,10 +171,7 @@ impl Nexus {
 
     /// Cancels all rebuilds jobs associated with the child.
     /// Returns a list of rebuilding children whose rebuild job was cancelled.
-    pub async fn cancel_child_rebuild_jobs(
-        &mut self,
-        name: &str,
-    ) -> Vec<String> {
+    pub async fn cancel_child_rebuild_jobs(&self, name: &str) -> Vec<String> {
         let mut src_jobs = self.get_rebuild_job_src(name);
         let mut terminated_jobs = Vec::new();
         let mut rebuilding_children = Vec::new();
@@ -210,7 +207,7 @@ impl Nexus {
     /// Return rebuild job associated with the src child name.
     /// Return error if no rebuild job associated with it.
     fn get_rebuild_job_src<'a>(
-        &mut self,
+        &self,
         name: &'a str,
     ) -> Vec<&'a mut RebuildJob> {
         let jobs = RebuildJob::lookup_src(&name);

--- a/mayastor/src/bdev/nexus/nexus_child.rs
+++ b/mayastor/src/bdev/nexus/nexus_child.rs
@@ -346,6 +346,9 @@ impl NexusChild {
     pub(crate) fn remove(&mut self) {
         info!("Removing child {}", self.name);
 
+        // The bdev is being removed, so ensure we don't use it again.
+        self.bdev = None;
+
         // Remove the child from the I/O path.
         self.set_state(ChildState::Closed);
         let nexus_name = self.parent.clone();
@@ -355,9 +358,6 @@ impl NexusChild {
                 None => error!("Nexus {} not found", nexus_name),
             }
         });
-
-        // The bdev is being removed, so ensure we don't use it again.
-        self.bdev = None;
 
         // Dropping the last descriptor results in the bdev being removed.
         // This must be performed in this function.

--- a/mayastor/tests/nexus_rebuild.rs
+++ b/mayastor/tests/nexus_rebuild.rs
@@ -122,7 +122,7 @@ fn rebuild_test_add() {
             .await
             .expect("rebuild not expected to be present");
 
-        nexus_lookup(nexus_name()).unwrap().destroy().await.unwrap();
+        nexus.destroy().await.unwrap();
     });
 
     test_fini();


### PR DESCRIPTION
When destroying a nexus all rebuild jobs should be cancelled before
closing the children. This ensures that the close on the children can
complete properly as any handles held by the rebuild job will no longer
exist.

Previously, destroying the nexus resulted in the rebuild jobs being
stopped. However, this just issued a stop request but did not wait for
the rebuild job to actually stop.

Note: This change attempts to resolve the issues seen on CI where rebuild
test cases have been observed to hang.