### PR TITLE
CAS-512 Refactor mount_fs testcases to use NVMe protocol instead of NBD

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1742,6 +1742,7 @@ dependencies = [
  "mbus_api",
  "nats",
  "nix 0.16.1",
+ "nvmeadm",
  "once_cell",
  "pin-utils",
  "proc-mounts",

--- a/mayastor/Cargo.toml
+++ b/mayastor/Cargo.toml
@@ -81,6 +81,7 @@ dns-lookup = "1.0.4"
 ipnetwork = "0.17.0"
 bollard = "0.8.0"
 mbus_api = { path = "../mbus-api" }
+nvmeadm = {path = "../nvmeadm", version = "0.1.0"}
 
 [dependencies.rpc]
 path = "../rpc"

--- a/mayastor/tests/mount_fs.rs
+++ b/mayastor/tests/mount_fs.rs
@@ -1,15 +1,16 @@
-use crossbeam::channel::unbounded;
+use once_cell::sync::OnceCell;
+use std::convert::TryFrom;
+
+extern crate nvmeadm;
 
 use mayastor::{
     bdev::{nexus_create, nexus_lookup},
-    core::{
-        mayastor_env_stop,
-        MayastorCliArgs,
-        MayastorEnvironment,
-        Mthread,
-        Reactor,
-    },
+    core::MayastorCliArgs,
 };
+
+pub mod common;
+use common::compose::MayastorTest;
+
 use rpc::mayastor::ShareProtocolNexus;
 
 static DISKNAME1: &str = "/tmp/disk1.img";
@@ -18,175 +19,151 @@ static BDEVNAME1: &str = "aio:///tmp/disk1.img?blk_size=512";
 static DISKNAME2: &str = "/tmp/disk2.img";
 static BDEVNAME2: &str = "aio:///tmp/disk2.img?blk_size=512";
 
-pub mod common;
+static MAYASTOR: OnceCell<MayastorTest> = OnceCell::new();
 
-#[test]
-fn mount_fs() {
-    // test xfs as well as ext4
-    async fn mirror_fs_test<'a>(fstype: String) {
-        create_nexus().await;
-        let nexus = nexus_lookup("nexus").unwrap();
+macro_rules! prepare_storage {
+    () => {
+        common::delete_file(&[DISKNAME1.into(), DISKNAME2.into()]);
+        common::truncate_file(DISKNAME1, 64 * 1024);
+        common::truncate_file(DISKNAME2, 64 * 1024);
+    };
+}
 
-        //TODO: repeat this test for NVMF and ISCSI
-        let device = common::device_path_from_uri(
+fn get_ms() -> &'static MayastorTest<'static> {
+    let instance =
+        MAYASTOR.get_or_init(|| MayastorTest::new(MayastorCliArgs::default()));
+    &instance
+}
+
+async fn create_connected_nvmf_nexus(
+    ms: &'static MayastorTest<'static>,
+) -> (nvmeadm::NvmeTarget, String) {
+    let uri = ms
+        .spawn(async {
+            create_nexus().await;
+            let nexus = nexus_lookup("nexus").unwrap();
             nexus
-                .share(ShareProtocolNexus::NexusNbd, None)
+                .share(ShareProtocolNexus::NexusNvmf, None)
                 .await
-                .unwrap(),
-        );
+                .unwrap()
+        })
+        .await;
 
-        // create an XFS filesystem on the nexus device
-        {
-            let (s, r) = unbounded();
-            let mkfs_dev = device.clone();
-            Mthread::spawn_unaffinitized(move || {
-                if !common::mkfs(&mkfs_dev, &fstype) {
-                    s.send(format!(
-                        "Failed to format {} with {}",
-                        mkfs_dev, fstype
-                    ))
-                    .unwrap();
-                } else {
-                    s.send("".to_string()).unwrap();
-                }
-            });
+    // Create and connect NVMF target.
+    let target = nvmeadm::NvmeTarget::try_from(uri).unwrap();
+    let devices = target.connect().unwrap();
 
-            assert_reactor_poll!(r, "");
-        }
+    assert_eq!(devices.len(), 1);
+    (target, devices[0].path.to_string())
+}
 
-        // mount the device, create a file and return the md5 of that file
-        {
-            let (s, r) = unbounded();
-            Mthread::spawn_unaffinitized(move || {
-                s.send(match common::mount_and_write_file(&device) {
-                    Ok(_) => "".to_owned(),
-                    Err(err) => err,
-                })
-            });
+async fn mount_test(ms: &'static MayastorTest<'static>, fstype: &str) {
+    let (target, nvmf_dev) = create_connected_nvmf_nexus(ms).await;
 
-            assert_reactor_poll!(r, "");
-        }
-        // destroy the share and the nexus
+    // Create a filesystem with test file.
+    assert!(common::mkfs(&nvmf_dev, &fstype));
+    let md5sum = match common::mount_and_write_file(&nvmf_dev) {
+        Ok(r) => r,
+        Err(e) => panic!("Failed to create test file: {}", e),
+    };
+
+    // Disconnect NVMF target, then unshare and destroy nexus.
+    target.disconnect().unwrap();
+
+    ms.spawn(async {
+        let nexus = nexus_lookup("nexus").unwrap();
         nexus.unshare_nexus().await.unwrap();
         nexus.destroy().await.unwrap();
+    })
+    .await;
 
-        // create a split nexus, i.e two nexus devices which each one leg of the
-        // mirror
+    /* Create 2 single-disk nexuses for every existing disk (already)
+     * populated with test data file, and check overall data consistency
+     * by accessing each disk separately via its own nexus.
+     */
+    ms.spawn(async {
         create_nexus_splitted().await;
+    })
+    .await;
 
-        let left = nexus_lookup("left").unwrap();
-        let right = nexus_lookup("right").unwrap();
+    for n in ["left", "right"].iter() {
+        let uri = ms
+            .spawn(async move {
+                let nexus = nexus_lookup(n).unwrap();
+                nexus
+                    .share(ShareProtocolNexus::NexusNvmf, None)
+                    .await
+                    .unwrap()
+            })
+            .await;
 
-        // share both nexuses
-        // TODO: repeat this test for NVMF and ISCSI, and permutations?
-        let left_device = common::device_path_from_uri(
-            left.share(ShareProtocolNexus::NexusNbd, None)
-                .await
-                .unwrap(),
-        );
+        // Create and connect NVMF target.
+        let target = nvmeadm::NvmeTarget::try_from(uri).unwrap();
+        let devices = target.connect().unwrap();
 
-        let right_device = common::device_path_from_uri(
-            right
-                .share(ShareProtocolNexus::NexusNbd, None)
-                .await
-                .unwrap(),
-        );
+        assert_eq!(devices.len(), 1);
+        let nvmf_dev = &devices[0].path;
+        let md5 = common::mount_and_get_md5(&nvmf_dev).unwrap();
 
-        let (s, r) = unbounded();
-        let s1 = s.clone();
-        Mthread::spawn_unaffinitized(move || {
-            s1.send(common::mount_and_get_md5(&left_device))
-        });
-        let md5_left;
-        reactor_poll!(r, md5_left);
-        assert!(md5_left.is_ok());
+        assert_eq!(md5, md5sum);
 
-        left.unshare_nexus().await.unwrap();
-        left.destroy().await.unwrap();
+        // Cleanup target.
+        target.disconnect().unwrap();
+        ms.spawn(async move {
+            let nexus = nexus_lookup(n).unwrap();
+            nexus.unshare_nexus().await.unwrap();
+            nexus.destroy().await.unwrap();
+        })
+        .await;
+    }
+}
 
-        let s1 = s.clone();
-        // read the md5 of the right side of the mirror
-        Mthread::spawn_unaffinitized(move || {
-            s1.send(common::mount_and_get_md5(&right_device))
-        });
+#[tokio::test]
+async fn mount_fs_mirror() {
+    let ms = get_ms();
 
-        let md5_right;
-        reactor_poll!(r, md5_right);
-        assert!(md5_right.is_ok());
-        right.unshare_nexus().await.unwrap();
-        right.destroy().await.unwrap();
-        assert_eq!(md5_left.unwrap(), md5_right.unwrap());
+    prepare_storage!();
+
+    mount_test(ms, "xfs").await;
+    mount_test(ms, "ext4").await;
+}
+
+#[tokio::test]
+async fn mount_fs_multiple() {
+    let ms = get_ms();
+
+    prepare_storage!();
+    let (target, nvmf_dev) = create_connected_nvmf_nexus(ms).await;
+
+    for _i in 0 .. 10 {
+        common::mount_umount(&nvmf_dev).unwrap();
     }
 
-    test_init!();
-
-    common::delete_file(&[DISKNAME1.into(), DISKNAME2.into()]);
-    common::truncate_file(DISKNAME1, 64 * 1024);
-    common::truncate_file(DISKNAME2, 64 * 1024);
-
-    Reactor::block_on(async {
-        mirror_fs_test("xfs".into()).await;
-        mirror_fs_test("ext4".into()).await;
-    });
+    target.disconnect().unwrap();
+    ms.spawn(async move {
+        let nexus = nexus_lookup("nexus").unwrap();
+        nexus.unshare_nexus().await.unwrap();
+        nexus.destroy().await.unwrap();
+    })
+    .await;
 }
 
-#[test]
-fn mount_fs_1() {
-    test_init!();
-    Reactor::block_on(async {
-        let (s, r) = unbounded::<String>();
-        create_nexus().await;
+#[tokio::test]
+async fn mount_fn_fio() {
+    let ms = get_ms();
+
+    prepare_storage!();
+    let (target, nvmf_dev) = create_connected_nvmf_nexus(ms).await;
+
+    common::fio_run_verify(&nvmf_dev).unwrap();
+
+    target.disconnect().unwrap();
+    ms.spawn(async move {
         let nexus = nexus_lookup("nexus").unwrap();
-
-        //TODO: repeat this test for NVMF and ISCSI
-        let device = common::device_path_from_uri(
-            nexus
-                .share(ShareProtocolNexus::NexusNbd, None)
-                .await
-                .unwrap(),
-        );
-
-        Mthread::spawn_unaffinitized(move || {
-            for _i in 0 .. 10 {
-                if let Err(err) = common::mount_umount(&device) {
-                    return s.send(err);
-                }
-            }
-            s.send("".into())
-        });
-
-        assert_reactor_poll!(r, "");
+        nexus.unshare_nexus().await.unwrap();
         nexus.destroy().await.unwrap();
-    });
-}
-
-#[test]
-fn mount_fs_2() {
-    test_init!();
-    Reactor::block_on(async {
-        create_nexus().await;
-        let nexus = nexus_lookup("nexus").unwrap();
-
-        //TODO: repeat this test for NVMF and ISCSI
-        let device = common::device_path_from_uri(
-            nexus
-                .share(ShareProtocolNexus::NexusNbd, None)
-                .await
-                .unwrap(),
-        );
-        let (s, r) = unbounded::<String>();
-
-        Mthread::spawn_unaffinitized(move || {
-            s.send(match common::fio_run_verify(&device) {
-                Ok(_) => "".to_owned(),
-                Err(err) => err,
-            })
-        });
-        assert_reactor_poll!(r, "");
-        nexus.destroy().await.unwrap();
-    });
-
-    mayastor_env_stop(0);
+    })
+    .await;
 }
 
 async fn create_nexus() {

--- a/nix/pkgs/mayastor/default.nix
+++ b/nix/pkgs/mayastor/default.nix
@@ -39,7 +39,7 @@ let
   buildProps = rec {
     name = "mayastor";
     # cargoSha256 = "0000000000000000000000000000000000000000000000000000";
-    cargoSha256 = "07d3yvl43pqw5iwjpb1rd9b34s572m8w4p89nmqd68pc0kmpq4d2";
+    cargoSha256 = "02dfgdi1h0g4nydwg1760wqx9i7f3g5bpxj0wbq81kvmx44ic6ii";
     inherit version;
     src = whitelistSource ../../../. [
       "Cargo.lock"

--- a/nvmeadm/src/nvme_namespaces.rs
+++ b/nvmeadm/src/nvme_namespaces.rs
@@ -10,7 +10,7 @@ use std::{os::unix::fs::FileTypeExt, path::Path};
 #[derive(Debug, Default)]
 pub struct NvmeDevice {
     /// device path of the device
-    path: String,
+    pub path: String,
     /// the device model defined by the manufacturer
     model: String,
     /// serial number of the device


### PR DESCRIPTION
Existing mount tests are refactored to not use Mthreads and to use NVMF protocol for testing nexus connectivity instead of NBD.