### PR TITLE
e2e vagrant deployment usability fixes

### DIFF
--- a/mayastor-test/e2e/install/deploy/pool.yaml
+++ b/mayastor-test/e2e/install/deploy/pool.yaml
@@ -1,0 +1,9 @@
+apiVersion: "openebs.io/v1alpha1"
+kind: MayastorPool
+metadata:
+  name: pool-${NODE_NAME}
+  #generateName: pool-${NODE_NAME}
+  namespace: mayastor
+spec:
+  node: ${NODE_NAME}
+  disks: ["/dev/sda"]

--- a/mayastor-test/e2e/setup/bringup-cluster.sh
+++ b/mayastor-test/e2e/setup/bringup-cluster.sh
@@ -27,6 +27,9 @@ prepare_kubespray_repo() {
 \$vm_cpus = 4
 \$kube_node_instances_with_disks = true
 \$kube_node_instances_with_disks_size = "2G"
+\$kube_node_instances_with_disks_number = 1
+\$os = "ubuntu2004"
+\$etcd_instances = 1
 \$kube_master_instances = 1
 EOF
   popd
@@ -64,6 +67,9 @@ setup_one_node() {
 
     vagrant ssh $node_name -c "echo \"{\\\"insecure-registries\\\" : [\\\"${REGISTRY_ENDPOINT}\\\"]}\" | sudo tee /etc/docker/daemon.json"
     vagrant ssh $node_name -c "sudo service docker restart"
+    vagrant ssh $node_name -c "sudo systemctl enable iscsid"
+    vagrant ssh $node_name -c "sudo systemctl start iscsid"
+    vagrant ssh $node_name -c "sudo modprobe nvme-tcp nvmet"
 
     # Make sure everything's back after those restarts...
     export -f wait_for_ready


### PR DESCRIPTION
- Enable and start iscsi daemeon service in the nodes
- Use ubuntu2004 and load nvme kernel modules
- Add creation of pools as part of the deployment