### PR TITLE
env: add -l option to specify cores

### DIFF
--- a/deploy/mayastor-daemonset.yaml
+++ b/deploy/mayastor-daemonset.yaml
@@ -25,10 +25,6 @@ spec:
       nodeSelector:
         openebs.io/engine: mayastor
         kubernetes.io/arch: amd64
-      # NOTE: Each container must have mem/cpu limits defined in order to
-      # belong to Guaranteed QoS class, hence can never get evicted in case of
-      # pressure unless they exceed those limits. limits and requests must be
-      # the same.
       initContainers:
       - name: message-bus-probe
         image: busybox:latest
@@ -49,10 +45,21 @@ spec:
         - name: IMPORT_NEXUSES
           value: "false"
         args:
+        # In order to select what cores mayastor should be running on, a mask or a list can be specified.
+        # For example: -m 0x1 will tell mayastor to only use one core which is equivalent to -l 1
+        # Using a mask of 0x3 will use the first 2 cores, which is equivalent to -l 1-2
+        #
+        # The -l argument supports ranges to be able to do the same as passing a mask for example:
+        # -l 1,2,10-20 means use core 1, 2, 10 to 20
+        #
+        # Note:
+        # 1. When both -m and -l are specified the -l argument is takes precedence.
+        # 2. Ensure that the CPU resources are updated accordingly. If you use 2 CPUs, the CPU: field should also read 2.
         - "-N$(MY_NODE_NAME)"
         - "-g$(MY_POD_IP)"
         - "-nnats"
         - "-y/var/local/mayastor/config.yaml"
+        - "-m0x3"
         securityContext:
           privileged: true
         volumeMounts:
@@ -65,12 +72,15 @@ spec:
         - name: config
           mountPath: /var/local/mayastor/config.yaml
         resources:
+          # NOTE: Each container must have mem/cpu limits defined in order to
+          # belong to Guaranteed QoS class, hence can never get evicted in case of
+          # pressure unless they exceed those limits. limits and requests must be the same.
           limits:
-            cpu: "1"
+            cpu: "2"
             memory: "500Mi"
             hugepages-2Mi: "1Gi"
           requests:
-            cpu: "1"
+            cpu: "2"
             memory: "500Mi"
             hugepages-2Mi: "1Gi"
         ports:

--- a/mayastor/src/subsys/config/opts.rs
+++ b/mayastor/src/subsys/config/opts.rs
@@ -133,7 +133,7 @@ pub struct TcpTransportOpts {
     max_io_size: u32,
     /// IO unit size
     io_unit_size: u32,
-    /// max admin queue depth (?)
+    /// max admin queue depth per admin queue
     max_aq_depth: u32,
     /// num of shared buffers
     num_shared_buf: u32,
@@ -147,8 +147,11 @@ pub struct TcpTransportOpts {
     ch2_success: bool,
     /// dif
     dif_insert_or_strip: bool,
-    /// no idea
+    /// The socket priority of the connection owned by this transport (TCP
+    /// only)
     sock_priority: u32,
+    /// abort execution timeout
+    abort_timeout_sec: u32,
 }
 
 impl Default for TcpTransportOpts {
@@ -160,14 +163,14 @@ impl Default for TcpTransportOpts {
             io_unit_size: 131_072,
             ch2_success: true,
             max_qpairs_per_ctrl: 128,
-            num_shared_buf: 511,
-            // reduce when we have a single target
+            num_shared_buf: 2048,
             buf_cache_size: 64,
             dif_insert_or_strip: false,
             max_aq_depth: 128,
             max_srq_depth: 0, // RDMA
             no_srq: false,    // RDMA
             sock_priority: 0,
+            abort_timeout_sec: 1,
         }
     }
 }
@@ -187,7 +190,7 @@ impl From<TcpTransportOpts> for spdk_nvmf_transport_opts {
             num_shared_buffers: o.num_shared_buf,
             buf_cache_size: o.buf_cache_size,
             dif_insert_or_strip: o.dif_insert_or_strip,
-            abort_timeout_sec: 0,
+            abort_timeout_sec: o.abort_timeout_sec,
             association_timeout: 120000,
             transport_specific: std::ptr::null(),
         }


### PR DESCRIPTION
The -l option serves the same purpose as the -m option however it accepts
a list of cores with ranges i.e 1,2,10-15.

Also two default values have been updated while here as the number of
shared buffers was to low to test this change and some notes to the YAML
file has been added.