### PR TITLE
Add back logs from test code

### DIFF
--- a/mayastor/tests/common/mod.rs
+++ b/mayastor/tests/common/mod.rs
@@ -134,7 +134,7 @@ pub fn mayastor_test_init() {
                 panic!("binary: {} not present in path", binary);
             }
         });
-    logger::init("mayastor=DEBUG");
+    logger::init("info,mayastor=DEBUG");
     mayastor::CPS_INIT!();
 }
 


### PR DESCRIPTION
Previous change set the test logs to mayastor=DEBUG to silence the h2
logs but this completely removes logs from other components including
from the test components.
Add back debug logs from all but limit h2 to info.
If this is still too much we could try info,mayastor=debug,h2=info etc