### PR TITLE
Pin io_driver targets to cores and docker cleanup wrapper for cargo-test

### DIFF
--- a/scripts/cargo-test.sh
+++ b/scripts/cargo-test.sh
@@ -1,9 +1,13 @@
 #!/usr/bin/env bash
 
 cleanup_handler() {
-  for c in $(docker ps -a --format '{{.ID}}') ; do
+  for c in $(docker ps -a --filter "label=io.mayastor.test.name" --format '{{.ID}}') ; do
     docker kill "$c" || true
     docker rm "$c" || true
+  done
+
+  for n in $(docker network ls --filter "label=io.mayastor.test.name" --format '{{.ID}}') ; do
+    docker network rm "$n" || true
   done
 }
 

--- a/scripts/cargo-test.sh
+++ b/scripts/cargo-test.sh
@@ -1,4 +1,14 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
+
+cleanup_handler() {
+  for c in $(docker ps -a --format '{{.ID}}') ; do
+    docker kill "$c" || true
+    docker rm "$c" || true
+  done
+}
+
+trap cleanup_handler ERR INT QUIT TERM HUP
+
 set -euxo pipefail
 export PATH=$PATH:${HOME}/.cargo/bin
 ( cd jsonrpc && cargo test )


### PR DESCRIPTION
I've packed two changes into one PR as they are quite small a loosely related: 

1. pins `io_driver` test target containers to improve likelihood of succeeding as suggested by @gila 
2. traps signals in the wrapper `cargo-test.sh` to allow for clean up. This is related to CAS-524, if we want to make it nice and driven by tests themselves.

~Cleanup is currently a bit brutal as it goes after all containers.~ I've done that as the other alternative would be listing names which is not very future-proof. Also our CI/CD runs on dedicated machines. Possible changes:
- explicitly list names used throughout the tests
- prefix all names in tests with a selector (e.g. `mayadata-`) and filter for it in the loop at handler
- prefix all names in tests with a selector passed as an environment variable to allow non conflicting names for parallel test runs + being able to select out containers related to this run in the handler.
- based on @tiagolobocastro 's suggestion, to use labels and mark our resources. Name of the label is `io.mayastor.test.name` and it holds value of the test which created the resource. This still means, that we can run only one mayastor on the machine, but will not kill other containers / networks.