### PR TITLE
Try to fix CI nbd issues

### DIFF
--- a/nvmeadm/tests/discovery_test.rs
+++ b/nvmeadm/tests/discovery_test.rs
@@ -184,6 +184,9 @@ fn test_against_real_target() {
         .connect(SERVED_DISK_NQN)
         .expect("Problem connecting to valid target");
 
+    // allow the part scan to complete for most cases
+    std::thread::sleep(std::time::Duration::from_secs(1));
+
     // Check that we CAN disconnect from a served NQN
     let num_disconnects = disconnect(SERVED_DISK_NQN);
     assert_eq!(num_disconnects.unwrap(), 1);


### PR DESCRIPTION
Run the set timeout in another thread while we poll as it seems that
when the nbd device is open it triggers a partition scan.
Set the NBD size to 0 before disconnecting as it was observed that when
we disconnect sometimes the device gets rescanned and the kernel thinks
it should partition scan again... setting the size to 0 before the
disconnect seems to alleviate this.