### PR TITLE
CAS-514: Make nexus children wait for bdev removal on close

### DIFF
--- a/mayastor/src/bdev/dev/loopback.rs
+++ b/mayastor/src/bdev/dev/loopback.rs
@@ -5,7 +5,7 @@ use snafu::ResultExt;
 use url::Url;
 
 use crate::{
-    bdev::{util::uri, CreateDestroy, GetName},
+    bdev::{lookup_child_from_bdev, util::uri, CreateDestroy, GetName},
     core::Bdev,
     nexus_uri::{self, NexusBdevError},
 };
@@ -78,6 +78,9 @@ impl CreateDestroy for Loopback {
     }
 
     async fn destroy(self: Box<Self>) -> Result<(), Self::Error> {
+        if let Some(child) = lookup_child_from_bdev(&self.name) {
+            child.remove();
+        }
         Ok(())
     }
 }

--- a/mayastor/src/bdev/mod.rs
+++ b/mayastor/src/bdev/mod.rs
@@ -9,7 +9,7 @@ pub use nexus::{
         NexusStatus,
         VerboseError,
     },
-    nexus_child::{ChildState, Reason},
+    nexus_child::{lookup_child_from_bdev, ChildState, Reason},
     nexus_child_error_store::{ActionType, NexusErrStore, QueryType},
     nexus_child_status_config,
     nexus_io::Bio,

--- a/mayastor/src/bdev/nexus/nexus_bdev.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev.rs
@@ -519,7 +519,7 @@ impl Nexus {
         let nexus_name = self.name.clone();
         Reactor::block_on(async move {
             let nexus = nexus_lookup(&nexus_name).expect("Nexus not found");
-            for child in &nexus.children {
+            for child in &mut nexus.children {
                 if child.state() == ChildState::Open {
                     if let Err(e) = child.close().await {
                         error!(
@@ -656,7 +656,7 @@ impl Nexus {
                 unsafe {
                     spdk_io_device_unregister(self.as_ptr(), None);
                 }
-                for child in &self.children {
+                for child in &mut self.children {
                     if let Err(e) = child.close().await {
                         error!(
                             "{}: child {} failed to close with error {}",


### PR DESCRIPTION
A channel is used to allow a nexus child to wait on the removal of the
underlying bdev before completing the close call.

The previous assumption had been that a call to destroy() would only
return when the bdev had actually been removed. However, in some cases,
such as for NVMf bdevs, this was not the case.

When closing a local (loopback) child, the underlying bdev must not be
destroyed. Doing so would result in the lvol and data being deleted.
Instead, the child is only removed, but the underlying bdev remains
untouched.