### PR TITLE
Print env vars in each test stage of jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -104,6 +104,7 @@ pipeline {
         stage('rust unit tests') {
           agent { label 'nixos-mayastor' }
           steps {
+            sh 'printenv'
             sh 'nix-shell --run "./scripts/cargo-test.sh"'
           }
           post {
@@ -116,6 +117,7 @@ pipeline {
         stage('mocha api tests') {
           agent { label 'nixos-mayastor' }
           steps {
+            sh 'printenv'
             sh 'nix-shell --run "./scripts/node-test.sh"'
           }
           post {
@@ -127,6 +129,7 @@ pipeline {
         stage('moac unit tests') {
           agent { label 'nixos-mayastor' }
           steps {
+            sh 'printenv'
             sh 'nix-shell --run "./scripts/moac-test.sh"'
           }
           post {


### PR DESCRIPTION
This helps when debugging problems. In particular it gives us a
name of the node where the tests are running which is useful when
trying to reproduce a failure.