### PR TITLE
Change install test to use external resources CAS-541

### DIFF
--- a/mayastor-test/e2e/install/README.md
+++ b/mayastor-test/e2e/install/README.md
@@ -17,8 +17,21 @@ The test host must have the following installed:
 * kubectl (tested with v1.18)
 
 # Running the tests
-
+Environment variables
+* e2e_docker_registry
+  * The IP address:port of the registry to be used.
+  * If unspecified then the assumption is that test registry has been deployed in the cluster on port 30291, a suitable IP address is selected.
+* e2e_pool_yaml_files
+  * The list of yaml files defining pools for the cluster, comma separated, absolute paths.
+* e2e_pool_device
+  * This environment variable is used if `e2e_pool_yaml_files` is undefined.
+  * pools are created for each node running mayastor, using the template file and the specified pool device.
 ```sh
 cd Mayastor/e2e/install
 go test
+```
+Or
+```sh
+cd Maystor/e2e/install
+e2e_docker_registry='192.168.122.1:5000' e2e_pool_yaml_files='/e2e/pools.yaml' go test
 ```

--- a/mayastor-test/e2e/install/deploy/pool.yaml.template
+++ b/mayastor-test/e2e/install/deploy/pool.yaml.template
@@ -6,4 +6,4 @@ metadata:
   namespace: mayastor
 spec:
   node: ${NODE_NAME}
-  disks: ["/dev/sda"]
+  disks: ["${POOL_DEVICE}"]


### PR DESCRIPTION
Change the install test to use defined docker registry,
and yaml files for pools.

Note pool status is not checked for success.

Communication of resources to use is via environment variables.
That appears to be the way for go test.

Previous behaviour is supported, see README.md