### PR TITLE
E2e nvmf basic

### DIFF
--- a/mayastor-test/e2e/common/test.go
+++ b/mayastor-test/e2e/common/test.go
@@ -28,7 +28,9 @@ type TestEnvironment struct {
 	DynamicClient dynamic.Interface
 }
 
-func SetupTestEnv() TestEnvironment {
+var gTestEnv TestEnvironment
+
+func SetupTestEnv() {
 
 	By("bootstrapping test environment")
 	useCluster := true
@@ -70,7 +72,7 @@ func SetupTestEnv() TestEnvironment {
 	dynamicClient := dynamic.NewForConfigOrDie(restConfig)
 	Expect(dynamicClient).ToNot(BeNil())
 
-	return TestEnvironment{
+	gTestEnv = TestEnvironment{
 		Cfg:           cfg,
 		K8sClient:     k8sClient,
 		KubeInt:       kubeInt,
@@ -80,7 +82,7 @@ func SetupTestEnv() TestEnvironment {
 	}
 }
 
-func TeardownTestEnv(env *TestEnvironment) {
-	err := env.TestEnv.Stop()
+func TeardownTestEnv() {
+	err := gTestEnv.TestEnv.Stop()
 	Expect(err).ToNot(HaveOccurred())
 }

--- a/mayastor-test/e2e/common/test.go
+++ b/mayastor-test/e2e/common/test.go
@@ -1,0 +1,86 @@
+package common
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/client-go/deprecated/scheme"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+)
+
+type TestEnvironment struct {
+	Cfg           *rest.Config
+	K8sClient     client.Client
+	KubeInt       kubernetes.Interface
+	K8sManager    *ctrl.Manager
+	TestEnv       *envtest.Environment
+	DynamicClient dynamic.Interface
+}
+
+func SetupTestEnv() TestEnvironment {
+
+	By("bootstrapping test environment")
+	useCluster := true
+	testEnv := &envtest.Environment{
+		UseExistingCluster:       &useCluster,
+		AttachControlPlaneOutput: true,
+	}
+
+	var err error
+	cfg, err := testEnv.Start()
+	Expect(err).ToNot(HaveOccurred())
+	Expect(cfg).ToNot(BeNil())
+
+	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme: scheme.Scheme,
+	})
+	Expect(err).ToNot(HaveOccurred())
+
+	go func() {
+		err = k8sManager.Start(ctrl.SetupSignalHandler())
+		Expect(err).ToNot(HaveOccurred())
+	}()
+
+	mgrSyncCtx, mgrSyncCtxCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer mgrSyncCtxCancel()
+	if synced := k8sManager.GetCache().WaitForCacheSync(mgrSyncCtx.Done()); !synced {
+		fmt.Println("Failed to sync")
+	}
+
+	k8sClient := k8sManager.GetClient()
+	Expect(k8sClient).ToNot(BeNil())
+
+	restConfig := config.GetConfigOrDie()
+	Expect(restConfig).ToNot(BeNil())
+
+	kubeInt := kubernetes.NewForConfigOrDie(restConfig)
+	Expect(kubeInt).ToNot(BeNil())
+
+	dynamicClient := dynamic.NewForConfigOrDie(restConfig)
+	Expect(dynamicClient).ToNot(BeNil())
+
+	return TestEnvironment{
+		Cfg:           cfg,
+		K8sClient:     k8sClient,
+		KubeInt:       kubeInt,
+		K8sManager:    &k8sManager,
+		TestEnv:       testEnv,
+		DynamicClient: dynamicClient,
+	}
+}
+
+func TeardownTestEnv(env *TestEnvironment) {
+	err := env.TestEnv.Stop()
+	Expect(err).ToNot(HaveOccurred())
+}

--- a/mayastor-test/e2e/common/util.go
+++ b/mayastor-test/e2e/common/util.go
@@ -1,0 +1,357 @@
+package common
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	. "github.com/onsi/gomega"
+
+	"reflect"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var defTimeoutSecs = "90s"
+
+func ApplyDeployYaml(filename string) {
+	cmd := exec.Command("kubectl", "apply", "-f", filename)
+	cmd.Dir = ""
+	_, err := cmd.CombinedOutput()
+	Expect(err).ToNot(HaveOccurred())
+}
+
+func DeleteDeployYaml(filename string) {
+	cmd := exec.Command("kubectl", "delete", "-f", filename)
+	cmd.Dir = ""
+	_, err := cmd.CombinedOutput()
+	Expect(err).ToNot(HaveOccurred())
+}
+
+func LabelNode(nodename string, label string) {
+	cmd := exec.Command("kubectl", "label", "node", nodename, label)
+	cmd.Dir = ""
+	_, err := cmd.CombinedOutput()
+	Expect(err).ToNot(HaveOccurred())
+}
+
+// Status part of the mayastor volume CRD
+type mayastorVolStatus struct {
+	state  string
+	reason string
+	node   string
+}
+
+func GetMSV(uuid string, dynamicClient *dynamic.Interface) *mayastorVolStatus {
+	msvGVR := schema.GroupVersionResource{
+		Group:    "openebs.io",
+		Version:  "v1alpha1",
+		Resource: "mayastorvolumes",
+	}
+	msv, err := (*dynamicClient).Resource(msvGVR).Namespace("mayastor").Get(context.TODO(), uuid, metav1.GetOptions{})
+	if err != nil {
+		fmt.Println(err)
+		return nil
+	}
+	if msv == nil {
+		return nil
+	}
+	status, found, err := unstructured.NestedFieldCopy(msv.Object, "status")
+	if err != nil {
+		fmt.Println(err)
+		return nil
+	}
+
+	if !found {
+		return nil
+	}
+	msVol := mayastorVolStatus{}
+	v := reflect.ValueOf(status)
+	if v.Kind() == reflect.Map {
+		for _, key := range v.MapKeys() {
+			sKey := key.Interface().(string)
+			val := v.MapIndex(key)
+			switch sKey {
+			case "state":
+				msVol.state = val.Interface().(string)
+				break
+			case "reason":
+				msVol.reason = val.Interface().(string)
+				break
+			case "node":
+				msVol.node = val.Interface().(string)
+				break
+			}
+		}
+	}
+	return &msVol
+}
+
+// Check for a deleted Mayastor Volume,
+// the object does not exist if deleted
+func IsMSVDeleted(uuid string, dynamicClient *dynamic.Interface) bool {
+	msvGVR := schema.GroupVersionResource{
+		Group:    "openebs.io",
+		Version:  "v1alpha1",
+		Resource: "mayastorvolumes",
+	}
+
+	msv, err := (*dynamicClient).Resource(msvGVR).Namespace("mayastor").Get(context.TODO(), uuid, metav1.GetOptions{})
+
+	if err != nil {
+		// Unfortunately there is no associated error code so we resort to string comparison
+		if strings.HasPrefix(err.Error(), "mayastorvolumes.openebs.io") &&
+			strings.HasSuffix(err.Error(), " not found") {
+			return true
+		}
+	}
+
+	Expect(err).To(BeNil())
+	Expect(msv).ToNot(BeNil())
+	return false
+}
+
+// Check for a deleted Persistent Volume Claim,
+// either the object does not exist
+// or the status phase is invalid.
+func IsPVCDeleted(volName string, kubeInt *kubernetes.Interface) bool {
+	pvc, err := (*kubeInt).CoreV1().PersistentVolumeClaims("default").Get(context.TODO(), volName, metav1.GetOptions{})
+	if err != nil {
+		// Unfortunately there is no associated error code so we resort to string comparison
+		if strings.HasPrefix(err.Error(), "persistentvolumeclaims") &&
+			strings.HasSuffix(err.Error(), " not found") {
+			return true
+		}
+	}
+	// After the PVC has been deleted it may still accessible, but status phase will be invalid
+	Expect(err).To(BeNil())
+	Expect(pvc).ToNot(BeNil())
+	switch pvc.Status.Phase {
+	case
+		corev1.ClaimBound,
+		corev1.ClaimPending,
+		corev1.ClaimLost:
+		return false
+	default:
+		return true
+	}
+}
+
+// Check for a deleted Persistent Volume,
+// either the object does not exist
+// or the status phase is invalid.
+func IsPVDeleted(volName *string, kubeInt *kubernetes.Interface) bool {
+	vn := *volName
+	pv, err := (*kubeInt).CoreV1().PersistentVolumes().Get(context.TODO(), vn, metav1.GetOptions{})
+	if err != nil {
+		// Unfortunately there is no associated error code so we resort to string comparison
+		if strings.HasPrefix(err.Error(), "persistentvolumes") &&
+			strings.HasSuffix(err.Error(), " not found") {
+			return true
+		}
+	}
+	// After the PV has been deleted it may still accessible, but status phase will be invalid
+	Expect(err).To(BeNil())
+	Expect(pv).ToNot(BeNil())
+	switch pv.Status.Phase {
+	case
+		corev1.VolumeBound,
+		corev1.VolumeAvailable,
+		corev1.VolumeFailed,
+		corev1.VolumePending,
+		corev1.VolumeReleased:
+		return false
+	default:
+		return true
+	}
+}
+
+// Retrieve status phase of a Persistent Volume Claim
+func GetPvcStatusPhase(volname string, kubeInt *kubernetes.Interface) (phase corev1.PersistentVolumeClaimPhase) {
+	pvc, getPvcErr := (*kubeInt).CoreV1().PersistentVolumeClaims("default").Get(context.TODO(), volname, metav1.GetOptions{})
+	Expect(getPvcErr).To(BeNil())
+	Expect(pvc).ToNot(BeNil())
+	return pvc.Status.Phase
+}
+
+// Retrieve status phase of a Persistent Volume
+func GetPvStatusPhase(volname string, kubeInt *kubernetes.Interface) (phase corev1.PersistentVolumePhase) {
+	pv, getPvErr := (*kubeInt).CoreV1().PersistentVolumes().Get(context.TODO(), volname, metav1.GetOptions{})
+	Expect(getPvErr).To(BeNil())
+	Expect(pv).ToNot(BeNil())
+	return pv.Status.Phase
+}
+
+// Retrieve the state of a Mayastor Volume
+func GetMsvState(uuid string, dynamicClient *dynamic.Interface) string {
+	msv := GetMSV(uuid, dynamicClient)
+	Expect(msv).ToNot(BeNil())
+	return fmt.Sprintf("%s", msv.state)
+}
+
+// Retrieve the nexus node hosting the Mayastor Volume
+func GetMsvNode(uuid string, dynamicClient *dynamic.Interface) string {
+	msv := GetMSV(uuid, dynamicClient)
+	Expect(msv).ToNot(BeNil())
+	return fmt.Sprintf("%s", msv.node)
+}
+
+// Create a PVC and verify that
+//	1. The PVC status transitions to bound,
+//	2. The associated PV is created and its status transitions bound
+//	3. The associated MV is created and has a State "healthy"
+func MkPVC(volName string, scName string, dynamicClient *dynamic.Interface, kubeInt *kubernetes.Interface) string {
+	fmt.Printf("creating %s, %s\n", volName, scName)
+	// PVC create options
+	createOpts := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      volName,
+			Namespace: "default",
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			StorageClassName: &scName,
+			AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse("64Mi"),
+				},
+			},
+		},
+	}
+
+	// Create the PVC.
+	PVCApi := (*kubeInt).CoreV1().PersistentVolumeClaims
+	_, createErr := PVCApi("default").Create(context.TODO(), createOpts, metav1.CreateOptions{})
+	Expect(createErr).To(BeNil())
+
+	// Confirm the PVC has been created.
+	pvc, getPvcErr := PVCApi("default").Get(context.TODO(), volName, metav1.GetOptions{})
+	Expect(getPvcErr).To(BeNil())
+	Expect(pvc).ToNot(BeNil())
+
+	// Wait for the PVC to be bound.
+	Eventually(func() corev1.PersistentVolumeClaimPhase {
+		return GetPvcStatusPhase(volName, kubeInt)
+	},
+		defTimeoutSecs, // timeout
+		"1s",           // polling interval
+	).Should(Equal(corev1.ClaimBound))
+
+	// Refresh the PVC contents, so that we can get the PV name.
+	pvc, getPvcErr = PVCApi("default").Get(context.TODO(), volName, metav1.GetOptions{})
+	Expect(getPvcErr).To(BeNil())
+	Expect(pvc).ToNot(BeNil())
+
+	// Wait for the PV to be provisioned
+	Eventually(func() *corev1.PersistentVolume {
+		pv, getPvErr := (*kubeInt).CoreV1().PersistentVolumes().Get(context.TODO(), pvc.Spec.VolumeName, metav1.GetOptions{})
+		if getPvErr != nil {
+			return nil
+		}
+		return pv
+
+	},
+		defTimeoutSecs, // timeout
+		"1s",           // polling interval
+	).Should(Not(BeNil()))
+
+	// Wait for the PV to be bound.
+	Eventually(func() corev1.PersistentVolumePhase {
+		return GetPvStatusPhase(pvc.Spec.VolumeName, kubeInt)
+	},
+		defTimeoutSecs, // timeout
+		"1s",           // polling interval
+	).Should(Equal(corev1.VolumeBound))
+
+	msv := GetMSV(string(pvc.ObjectMeta.UID), dynamicClient)
+	Expect(msv).ToNot(BeNil())
+	return string(pvc.ObjectMeta.UID)
+}
+
+// Delete the PVC and verify that
+//	1. The PVC is deleted
+//	2. The associated PV is deleted
+//  3. The associated MV is deleted
+func RmPVC(volName string, scName string, dynamicClient *dynamic.Interface, kubeInt *kubernetes.Interface) {
+	fmt.Printf("removing %s, %s\n", volName, scName)
+
+	PVCApi := (*kubeInt).CoreV1().PersistentVolumeClaims
+
+	// Confirm the PVC has been created.
+	pvc, getPvcErr := PVCApi("default").Get(context.TODO(), volName, metav1.GetOptions{})
+	Expect(getPvcErr).To(BeNil())
+	Expect(pvc).ToNot(BeNil())
+
+	// Delete the PVC
+	deleteErr := PVCApi("default").Delete(context.TODO(), volName, metav1.DeleteOptions{})
+	Expect(deleteErr).To(BeNil())
+
+	// Wait for the PVC to be deleted.
+	Eventually(func() bool {
+		return IsPVCDeleted(volName, kubeInt)
+	},
+		defTimeoutSecs, // timeout
+		"1s",           // polling interval
+	).Should(Equal(true))
+
+	// Wait for the PV to be deleted.
+	Eventually(func() bool {
+		return IsPVDeleted(&(pvc.Spec.VolumeName), kubeInt)
+	},
+		defTimeoutSecs, // timeout
+		"1s",           // polling interval
+	).Should(Equal(true))
+
+	// Wait for the MSV to be deleted.
+	Eventually(func() bool {
+		return IsMSVDeleted(string(pvc.ObjectMeta.UID), dynamicClient)
+	},
+		defTimeoutSecs, // timeout
+		"1s",           // polling interval
+	).Should(Equal(true))
+}
+
+func RunFio() {
+	cmd := exec.Command(
+		"kubectl",
+		"exec",
+		"-it",
+		"fio",
+		"--",
+		"fio",
+		"--name=benchtest",
+		"--size=50m",
+		"--filename=/volume/test",
+		"--direct=1",
+		"--rw=randrw",
+		"--ioengine=libaio",
+		"--bs=4k",
+		"--iodepth=16",
+		"--numjobs=1",
+		"--time_based",
+		"--runtime=20",
+	)
+	cmd.Dir = ""
+	_, err := cmd.CombinedOutput()
+	Expect(err).ToNot(HaveOccurred())
+}
+
+func FioReadyPod(k8sClient *client.Client) bool {
+	var fioPod corev1.Pod
+	if (*k8sClient).Get(context.TODO(), types.NamespacedName{Name: "fio", Namespace: "default"}, &fioPod) != nil {
+		return false
+	}
+	return fioPod.Status.Phase == v1.PodRunning
+}

--- a/mayastor-test/e2e/common/util.go
+++ b/mayastor-test/e2e/common/util.go
@@ -19,9 +19,6 @@ import (
 	"reflect"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/kubernetes"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var defTimeoutSecs = "90s"
@@ -54,13 +51,13 @@ type mayastorVolStatus struct {
 	node   string
 }
 
-func GetMSV(uuid string, dynamicClient *dynamic.Interface) *mayastorVolStatus {
+func GetMSV(uuid string) *mayastorVolStatus {
 	msvGVR := schema.GroupVersionResource{
 		Group:    "openebs.io",
 		Version:  "v1alpha1",
 		Resource: "mayastorvolumes",
 	}
-	msv, err := (*dynamicClient).Resource(msvGVR).Namespace("mayastor").Get(context.TODO(), uuid, metav1.GetOptions{})
+	msv, err := gTestEnv.DynamicClient.Resource(msvGVR).Namespace("mayastor").Get(context.TODO(), uuid, metav1.GetOptions{})
 	if err != nil {
 		fmt.Println(err)
 		return nil
@@ -101,14 +98,14 @@ func GetMSV(uuid string, dynamicClient *dynamic.Interface) *mayastorVolStatus {
 
 // Check for a deleted Mayastor Volume,
 // the object does not exist if deleted
-func IsMSVDeleted(uuid string, dynamicClient *dynamic.Interface) bool {
+func IsMSVDeleted(uuid string) bool {
 	msvGVR := schema.GroupVersionResource{
 		Group:    "openebs.io",
 		Version:  "v1alpha1",
 		Resource: "mayastorvolumes",
 	}
 
-	msv, err := (*dynamicClient).Resource(msvGVR).Namespace("mayastor").Get(context.TODO(), uuid, metav1.GetOptions{})
+	msv, err := gTestEnv.DynamicClient.Resource(msvGVR).Namespace("mayastor").Get(context.TODO(), uuid, metav1.GetOptions{})
 
 	if err != nil {
 		// Unfortunately there is no associated error code so we resort to string comparison
@@ -126,8 +123,8 @@ func IsMSVDeleted(uuid string, dynamicClient *dynamic.Interface) bool {
 // Check for a deleted Persistent Volume Claim,
 // either the object does not exist
 // or the status phase is invalid.
-func IsPVCDeleted(volName string, kubeInt *kubernetes.Interface) bool {
-	pvc, err := (*kubeInt).CoreV1().PersistentVolumeClaims("default").Get(context.TODO(), volName, metav1.GetOptions{})
+func IsPVCDeleted(volName string) bool {
+	pvc, err := gTestEnv.KubeInt.CoreV1().PersistentVolumeClaims("default").Get(context.TODO(), volName, metav1.GetOptions{})
 	if err != nil {
 		// Unfortunately there is no associated error code so we resort to string comparison
 		if strings.HasPrefix(err.Error(), "persistentvolumeclaims") &&
@@ -152,9 +149,9 @@ func IsPVCDeleted(volName string, kubeInt *kubernetes.Interface) bool {
 // Check for a deleted Persistent Volume,
 // either the object does not exist
 // or the status phase is invalid.
-func IsPVDeleted(volName *string, kubeInt *kubernetes.Interface) bool {
+func IsPVDeleted(volName *string) bool {
 	vn := *volName
-	pv, err := (*kubeInt).CoreV1().PersistentVolumes().Get(context.TODO(), vn, metav1.GetOptions{})
+	pv, err := gTestEnv.KubeInt.CoreV1().PersistentVolumes().Get(context.TODO(), vn, metav1.GetOptions{})
 	if err != nil {
 		// Unfortunately there is no associated error code so we resort to string comparison
 		if strings.HasPrefix(err.Error(), "persistentvolumes") &&
@@ -179,31 +176,31 @@ func IsPVDeleted(volName *string, kubeInt *kubernetes.Interface) bool {
 }
 
 // Retrieve status phase of a Persistent Volume Claim
-func GetPvcStatusPhase(volname string, kubeInt *kubernetes.Interface) (phase corev1.PersistentVolumeClaimPhase) {
-	pvc, getPvcErr := (*kubeInt).CoreV1().PersistentVolumeClaims("default").Get(context.TODO(), volname, metav1.GetOptions{})
+func GetPvcStatusPhase(volname string) (phase corev1.PersistentVolumeClaimPhase) {
+	pvc, getPvcErr := gTestEnv.KubeInt.CoreV1().PersistentVolumeClaims("default").Get(context.TODO(), volname, metav1.GetOptions{})
 	Expect(getPvcErr).To(BeNil())
 	Expect(pvc).ToNot(BeNil())
 	return pvc.Status.Phase
 }
 
 // Retrieve status phase of a Persistent Volume
-func GetPvStatusPhase(volname string, kubeInt *kubernetes.Interface) (phase corev1.PersistentVolumePhase) {
-	pv, getPvErr := (*kubeInt).CoreV1().PersistentVolumes().Get(context.TODO(), volname, metav1.GetOptions{})
+func GetPvStatusPhase(volname string) (phase corev1.PersistentVolumePhase) {
+	pv, getPvErr := gTestEnv.KubeInt.CoreV1().PersistentVolumes().Get(context.TODO(), volname, metav1.GetOptions{})
 	Expect(getPvErr).To(BeNil())
 	Expect(pv).ToNot(BeNil())
 	return pv.Status.Phase
 }
 
 // Retrieve the state of a Mayastor Volume
-func GetMsvState(uuid string, dynamicClient *dynamic.Interface) string {
-	msv := GetMSV(uuid, dynamicClient)
+func GetMsvState(uuid string) string {
+	msv := GetMSV(uuid)
 	Expect(msv).ToNot(BeNil())
 	return fmt.Sprintf("%s", msv.state)
 }
 
 // Retrieve the nexus node hosting the Mayastor Volume
-func GetMsvNode(uuid string, dynamicClient *dynamic.Interface) string {
-	msv := GetMSV(uuid, dynamicClient)
+func GetMsvNode(uuid string) string {
+	msv := GetMSV(uuid)
 	Expect(msv).ToNot(BeNil())
 	return fmt.Sprintf("%s", msv.node)
 }
@@ -212,7 +209,7 @@ func GetMsvNode(uuid string, dynamicClient *dynamic.Interface) string {
 //	1. The PVC status transitions to bound,
 //	2. The associated PV is created and its status transitions bound
 //	3. The associated MV is created and has a State "healthy"
-func MkPVC(volName string, scName string, dynamicClient *dynamic.Interface, kubeInt *kubernetes.Interface) string {
+func MkPVC(volName string, scName string) string {
 	fmt.Printf("creating %s, %s\n", volName, scName)
 	// PVC create options
 	createOpts := &corev1.PersistentVolumeClaim{
@@ -232,7 +229,7 @@ func MkPVC(volName string, scName string, dynamicClient *dynamic.Interface, kube
 	}
 
 	// Create the PVC.
-	PVCApi := (*kubeInt).CoreV1().PersistentVolumeClaims
+	PVCApi := gTestEnv.KubeInt.CoreV1().PersistentVolumeClaims
 	_, createErr := PVCApi("default").Create(context.TODO(), createOpts, metav1.CreateOptions{})
 	Expect(createErr).To(BeNil())
 
@@ -243,7 +240,7 @@ func MkPVC(volName string, scName string, dynamicClient *dynamic.Interface, kube
 
 	// Wait for the PVC to be bound.
 	Eventually(func() corev1.PersistentVolumeClaimPhase {
-		return GetPvcStatusPhase(volName, kubeInt)
+		return GetPvcStatusPhase(volName)
 	},
 		defTimeoutSecs, // timeout
 		"1s",           // polling interval
@@ -256,7 +253,7 @@ func MkPVC(volName string, scName string, dynamicClient *dynamic.Interface, kube
 
 	// Wait for the PV to be provisioned
 	Eventually(func() *corev1.PersistentVolume {
-		pv, getPvErr := (*kubeInt).CoreV1().PersistentVolumes().Get(context.TODO(), pvc.Spec.VolumeName, metav1.GetOptions{})
+		pv, getPvErr := gTestEnv.KubeInt.CoreV1().PersistentVolumes().Get(context.TODO(), pvc.Spec.VolumeName, metav1.GetOptions{})
 		if getPvErr != nil {
 			return nil
 		}
@@ -269,13 +266,13 @@ func MkPVC(volName string, scName string, dynamicClient *dynamic.Interface, kube
 
 	// Wait for the PV to be bound.
 	Eventually(func() corev1.PersistentVolumePhase {
-		return GetPvStatusPhase(pvc.Spec.VolumeName, kubeInt)
+		return GetPvStatusPhase(pvc.Spec.VolumeName)
 	},
 		defTimeoutSecs, // timeout
 		"1s",           // polling interval
 	).Should(Equal(corev1.VolumeBound))
 
-	msv := GetMSV(string(pvc.ObjectMeta.UID), dynamicClient)
+	msv := GetMSV(string(pvc.ObjectMeta.UID))
 	Expect(msv).ToNot(BeNil())
 	return string(pvc.ObjectMeta.UID)
 }
@@ -284,10 +281,10 @@ func MkPVC(volName string, scName string, dynamicClient *dynamic.Interface, kube
 //	1. The PVC is deleted
 //	2. The associated PV is deleted
 //  3. The associated MV is deleted
-func RmPVC(volName string, scName string, dynamicClient *dynamic.Interface, kubeInt *kubernetes.Interface) {
+func RmPVC(volName string, scName string) {
 	fmt.Printf("removing %s, %s\n", volName, scName)
 
-	PVCApi := (*kubeInt).CoreV1().PersistentVolumeClaims
+	PVCApi := gTestEnv.KubeInt.CoreV1().PersistentVolumeClaims
 
 	// Confirm the PVC has been created.
 	pvc, getPvcErr := PVCApi("default").Get(context.TODO(), volName, metav1.GetOptions{})
@@ -300,7 +297,7 @@ func RmPVC(volName string, scName string, dynamicClient *dynamic.Interface, kube
 
 	// Wait for the PVC to be deleted.
 	Eventually(func() bool {
-		return IsPVCDeleted(volName, kubeInt)
+		return IsPVCDeleted(volName)
 	},
 		defTimeoutSecs, // timeout
 		"1s",           // polling interval
@@ -308,7 +305,7 @@ func RmPVC(volName string, scName string, dynamicClient *dynamic.Interface, kube
 
 	// Wait for the PV to be deleted.
 	Eventually(func() bool {
-		return IsPVDeleted(&(pvc.Spec.VolumeName), kubeInt)
+		return IsPVDeleted(&(pvc.Spec.VolumeName))
 	},
 		defTimeoutSecs, // timeout
 		"1s",           // polling interval
@@ -316,7 +313,7 @@ func RmPVC(volName string, scName string, dynamicClient *dynamic.Interface, kube
 
 	// Wait for the MSV to be deleted.
 	Eventually(func() bool {
-		return IsMSVDeleted(string(pvc.ObjectMeta.UID), dynamicClient)
+		return IsMSVDeleted(string(pvc.ObjectMeta.UID))
 	},
 		defTimeoutSecs, // timeout
 		"1s",           // polling interval
@@ -348,9 +345,9 @@ func RunFio() {
 	Expect(err).ToNot(HaveOccurred())
 }
 
-func FioReadyPod(k8sClient *client.Client) bool {
+func FioReadyPod() bool {
 	var fioPod corev1.Pod
-	if (*k8sClient).Get(context.TODO(), types.NamespacedName{Name: "fio", Namespace: "default"}, &fioPod) != nil {
+	if gTestEnv.K8sClient.Get(context.TODO(), types.NamespacedName{Name: "fio", Namespace: "default"}, &fioPod) != nil {
 		return false
 	}
 	return fioPod.Status.Phase == v1.PodRunning

--- a/mayastor-test/e2e/nvmf_vol/deploy/fio_nvmf.yaml
+++ b/mayastor-test/e2e/nvmf_vol/deploy/fio_nvmf.yaml
@@ -1,0 +1,19 @@
+kind: Pod
+apiVersion: v1
+metadata:
+  name: fio
+spec:
+  volumes:
+    - name: ms-volume
+      persistentVolumeClaim:
+       claimName: vol-test-pvc-nvmf
+  containers:
+    - name: fio
+      image: nixery.dev/shell/fio/tini
+      command: [ "tini", "--" ]
+      args:
+        - sleep
+        - "1000000"
+      volumeMounts:
+        - mountPath: "/volume"
+          name: ms-volume

--- a/mayastor-test/e2e/nvmf_vol/deploy/pvc_nvmf.yaml
+++ b/mayastor-test/e2e/nvmf_vol/deploy/pvc_nvmf.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: vol-test-pvc-nvmf
+spec:
+  accessModes:
+   - ReadWriteOnce
+  resources:
+    requests:
+      storage: 64Mi
+  # storageClassName: mayastor-iscsi
+  storageClassName: mayastor-nvmf

--- a/mayastor-test/e2e/nvmf_vol/nvmf_vol_test.go
+++ b/mayastor-test/e2e/nvmf_vol/nvmf_vol_test.go
@@ -14,8 +14,6 @@ import (
 
 var defTimeoutSecs = "90s"
 
-var g_environment common.TestEnvironment
-
 func nvmfTest() {
 	fmt.Printf("running fio\n")
 	common.RunFio()
@@ -36,14 +34,14 @@ var _ = BeforeSuite(func(done Done) {
 
 	logf.SetLogger(zap.LoggerTo(GinkgoWriter, true))
 
-	g_environment = common.SetupTestEnv()
+	common.SetupTestEnv()
 
-	common.MkPVC(fmt.Sprintf("vol-test-pvc-nvmf"), "mayastor-nvmf", &g_environment.DynamicClient, &g_environment.KubeInt)
+	common.MkPVC(fmt.Sprintf("vol-test-pvc-nvmf"), "mayastor-nvmf")
 	common.ApplyDeployYaml("deploy/fio_nvmf.yaml")
 
 	fmt.Printf("waiting for fio\n")
 	Eventually(func() bool {
-		return common.FioReadyPod(&g_environment.K8sClient)
+		return common.FioReadyPod()
 	},
 		defTimeoutSecs, // timeout
 		"1s",           // polling interval
@@ -61,7 +59,7 @@ var _ = AfterSuite(func() {
 	common.DeleteDeployYaml("deploy/fio_nvmf.yaml")
 
 	fmt.Printf("removing pvc\n")
-	common.RmPVC(fmt.Sprintf("vol-test-pvc-nvmf"), "mayastor-nvmf", &g_environment.DynamicClient, &g_environment.KubeInt)
+	common.RmPVC(fmt.Sprintf("vol-test-pvc-nvmf"), "mayastor-nvmf")
 
-	common.TeardownTestEnv(&g_environment)
+	common.TeardownTestEnv()
 })

--- a/mayastor-test/e2e/nvmf_vol/nvmf_vol_test.go
+++ b/mayastor-test/e2e/nvmf_vol/nvmf_vol_test.go
@@ -1,0 +1,67 @@
+package nvmf_vol_test
+
+import (
+	"fmt"
+	"testing"
+
+	"e2e-basic/common"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+var defTimeoutSecs = "90s"
+
+var g_environment common.TestEnvironment
+
+func nvmfTest() {
+	fmt.Printf("running fio\n")
+	common.RunFio()
+}
+
+func TestNvmfVol(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Node Loss Test Suite")
+}
+
+var _ = Describe("Mayastor nvmf IO test", func() {
+	It("should verify an nvmf volume can process IO", func() {
+		nvmfTest()
+	})
+})
+
+var _ = BeforeSuite(func(done Done) {
+
+	logf.SetLogger(zap.LoggerTo(GinkgoWriter, true))
+
+	g_environment = common.SetupTestEnv()
+
+	common.MkPVC(fmt.Sprintf("vol-test-pvc-nvmf"), "mayastor-nvmf", &g_environment.DynamicClient, &g_environment.KubeInt)
+	common.ApplyDeployYaml("deploy/fio_nvmf.yaml")
+
+	fmt.Printf("waiting for fio\n")
+	Eventually(func() bool {
+		return common.FioReadyPod(&g_environment.K8sClient)
+	},
+		defTimeoutSecs, // timeout
+		"1s",           // polling interval
+	).Should(Equal(true))
+
+	close(done)
+}, 60)
+
+var _ = AfterSuite(func() {
+	// NB This only tears down the local structures for talking to the cluster,
+	// not the kubernetes cluster itself.
+	By("tearing down the test environment")
+
+	fmt.Printf("removing fio pod\n")
+	common.DeleteDeployYaml("deploy/fio_nvmf.yaml")
+
+	fmt.Printf("removing pvc\n")
+	common.RmPVC(fmt.Sprintf("vol-test-pvc-nvmf"), "mayastor-nvmf", &g_environment.DynamicClient, &g_environment.KubeInt)
+
+	common.TeardownTestEnv(&g_environment)
+})

--- a/mayastor-test/e2e/setup/bringup-cluster.sh
+++ b/mayastor-test/e2e/setup/bringup-cluster.sh
@@ -47,12 +47,12 @@ bringup_cluster() {
 
 # Runs in a timeout, so we need to pass in $MASTER_NODE_IP and $REGISTRY_PORT
 wait_for_ready() {
-  while ! kubectl get nodes; do   
+  while ! kubectl get nodes; do
     sleep 1
   done
 
   # Wait for the registry to be accessible
-  while ! nc -z $1 $2; do   
+  while ! nc -z $1 $2; do
     sleep 1
   done
 }


### PR DESCRIPTION
E2e test which creates a PVC using the mayastor-nvmf storage class, deploys a fio pod, runs fio against the volume, expects it to succeed, and then tears down the pod and the PVC. 
A module common/util.go contains functions available to other later e2e tests.
Not yet run by CI testing. Assumes an existing running cluster with a mayastor deployment.