### PR TITLE
e2e tests for a disconnected replica in a 2-replica volume

### DIFF
--- a/mayastor-test/e2e/common/io_connect_node.sh
+++ b/mayastor-test/e2e/common/io_connect_node.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Script to disconnect a node from another node using iptables
+# $1 is the node-name to isolate/restore
+# $2 is the other node-name
+# $3 is "DISCONNECT" or "RECONNECT"
+# assumes the nodes use a known fixed set of IP addresses and node names
+
+# edit the line below, if necessary, or set KUBESPRAY_REPO when calling
+KUBESPRAY_REPO="${KUBESPRAY_REPO:-$HOME/work/kubespray}"
+
+if [ $# -ne 3 ];
+    then echo "specify node-name, other node-name and action (DISCONNECT or RECONNECT)"
+    exit 1
+fi
+
+if [ "$3" = "DISCONNECT" ]; then
+	action="I"
+elif [ "$3" = "RECONNECT" ]; then
+	action="D"
+else
+    echo "specify action (DISCONNECT or RECONNECT)"
+    exit 1
+fi
+
+cd ${KUBESPRAY_REPO}
+
+nodename=$1
+other_nodename=$2
+other_node_suffix=${other_nodename: -1}
+other_ip=172.18.8.10${other_node_suffix}
+
+# apply the rule to block/unblock it
+vagrant ssh ${nodename} -c "sh -c 'sudo iptables -${action} INPUT -s ${other_ip} -j REJECT'"
+vagrant ssh ${nodename} -c "sh -c 'sudo iptables -${action} OUTPUT -s ${other_ip} -j REJECT'"
+

--- a/mayastor-test/e2e/node_disconnect/README.md
+++ b/mayastor-test/e2e/node_disconnect/README.md
@@ -1,0 +1,27 @@
+## Note
+The tests in this folder are not currently deployable by the CI system
+as the automated install does not provide the pre-requisites below.
+
+## Pre-requisites for this test
+
+* A 3-node cluster with nodes k8s-1 k8s-2 and k8s-3 located at
+  172.18.8.101-3 respectively
+* k8s-1 is the master node, does NOT have the label openebs.io/engine
+  to avoid having to disconnect the master node. and is labelled
+  openebs.io/podrefuge=true
+* moac is deployed with the following selector to keep it on k8s-1:
+
+```
+    nodeSelector:
+      openebs.io/podrefuge: "true"
+```
+
+  see deploy/moac-deployment-refuge.yaml`
+
+* k8s-2 and k8s-3 are labelled openebs.io/engine=mayastor, as usual
+* the cluster is deployed using vagrant via bringup_cluster.sh and
+  KUBESPRAY_REPO is correctly defined in ../common/io_connect_node.sh
+* mayastor is installed on the cluster, with mayastor instances on
+  k8s-2 and k8s-3 only (due to the node labels)
+* the storage classes defined in deploy/storage-class-2-repl.yaml
+  have been applied (replica count of 2).

--- a/mayastor-test/e2e/node_disconnect/deploy/fio_iscsi.yaml
+++ b/mayastor-test/e2e/node_disconnect/deploy/fio_iscsi.yaml
@@ -1,0 +1,21 @@
+kind: Pod
+apiVersion: v1
+metadata:
+  name: fio
+spec:
+  volumes:
+    - name: ms-volume
+      persistentVolumeClaim:
+       claimName: loss-test-pvc-iscsi
+  containers:
+    - name: fio
+      image: nixery.dev/shell/fio/tini
+      command: [ "tini", "--" ]
+      args:
+        - sleep
+        - "1000000"
+      volumeMounts:
+        - mountPath: "/volume"
+          name: ms-volume
+  nodeSelector:
+    openebs.io/podrefuge: "true"

--- a/mayastor-test/e2e/node_disconnect/deploy/fio_nvmf.yaml
+++ b/mayastor-test/e2e/node_disconnect/deploy/fio_nvmf.yaml
@@ -1,0 +1,21 @@
+kind: Pod
+apiVersion: v1
+metadata:
+  name: fio
+spec:
+  volumes:
+    - name: ms-volume
+      persistentVolumeClaim:
+       claimName: loss-test-pvc-nvmf
+  containers:
+    - name: fio
+      image: nixery.dev/shell/fio/tini
+      command: [ "tini", "--" ]
+      args:
+        - sleep
+        - "1000000"
+      volumeMounts:
+        - mountPath: "/volume"
+          name: ms-volume
+  nodeSelector:
+    openebs.io/podrefuge: "true"

--- a/mayastor-test/e2e/node_disconnect/deploy/moac-deployment-refuge.yaml
+++ b/mayastor-test/e2e/node_disconnect/deploy/moac-deployment-refuge.yaml
@@ -1,0 +1,72 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: moac
+  namespace: mayastor
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: moac
+  template:
+    metadata:
+      labels:
+        app: moac
+    spec:
+      nodeSelector:
+        openebs.io/podrefuge: "true"
+      serviceAccount: moac
+      containers:
+        - name: csi-provisioner
+          image: quay.io/k8scsi/csi-provisioner:v1.6.0
+          args:
+            - "--v=2"
+            - "--csi-address=$(ADDRESS)"
+            - "--feature-gates=Topology=true"
+          env:
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          imagePullPolicy: "IfNotPresent"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+
+        - name: csi-attacher
+          image: quay.io/k8scsi/csi-attacher:v2.2.0
+          args:
+            - "--v=2"
+            - "--csi-address=$(ADDRESS)"
+          env:
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          imagePullPolicy: "IfNotPresent"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+
+        - name: moac
+          image: 172.18.8.101:30291/mayadata/moac:ci
+          imagePullPolicy: Always
+          args:
+            - "--csi-address=$(CSI_ENDPOINT)"
+            - "--namespace=$(MY_POD_NAMESPACE)"
+            - "--port=4000"
+            - "--message-bus=nats"
+            - "-v"
+          env:
+            - name: CSI_ENDPOINT
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+            - name: MY_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+          ports:
+            - containerPort: 4000
+              protocol: TCP
+              name: "rest-api"
+      volumes:
+        - name: socket-dir
+          emptyDir:

--- a/mayastor-test/e2e/node_disconnect/deploy/storage-class-2-repl.yaml
+++ b/mayastor-test/e2e/node_disconnect/deploy/storage-class-2-repl.yaml
@@ -1,0 +1,17 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: mayastor-iscsi
+parameters:
+  repl: '2'
+  protocol: 'iscsi'
+provisioner: io.openebs.csi-mayastor
+---
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: mayastor-nvmf
+parameters:
+  repl: '2'
+  protocol: 'nvmf'
+provisioner: io.openebs.csi-mayastor

--- a/mayastor-test/e2e/node_disconnect/node_disconnect_iscsi/node_disconnect_iscsi_test.go
+++ b/mayastor-test/e2e/node_disconnect/node_disconnect_iscsi/node_disconnect_iscsi_test.go
@@ -1,0 +1,129 @@
+package node_disconnect_iscsi_test
+
+// TODO factor out remaining code duplicated with node_disconnect_nvmf_test
+
+import (
+	"e2e-basic/common"
+	"fmt"
+	"os/exec"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+var (
+	defTimeoutSecs = "90s"
+	g_nodeToKill   = ""
+	g_nexusNode    = ""
+	g_uuid         = ""
+)
+
+func disconnectNode(vmname string, nexusNode string) {
+	cmd := exec.Command("bash", "../../common/io_connect_node.sh", vmname, nexusNode, "DISCONNECT")
+	cmd.Dir = "./"
+	_, err := cmd.CombinedOutput()
+	Expect(err).ToNot(HaveOccurred())
+}
+
+func reconnectNode(vmname string, nexusNode string, checkError bool) {
+	cmd := exec.Command("bash", "../../common/io_connect_node.sh", vmname, nexusNode, "RECONNECT")
+	cmd.Dir = "./"
+	_, err := cmd.CombinedOutput()
+	if checkError {
+		Expect(err).ToNot(HaveOccurred())
+	}
+}
+
+func lossTest() {
+	g_nexusNode = common.GetMsvNode(g_uuid)
+	fmt.Printf("nexus node is \"%s\"\n", g_nexusNode)
+
+	if g_nexusNode == "k8s-2" {
+		g_nodeToKill = "k8s-3"
+	} else if g_nexusNode == "k8s-3" {
+		g_nodeToKill = "k8s-2"
+	} else {
+		fmt.Printf("Unexpected nexus node name\n")
+		Expect(false)
+	}
+	fmt.Printf("node to kill is \"%s\"\n", g_nodeToKill)
+
+	fmt.Printf("running spawned fio\n")
+	go common.RunFio("fio", 20)
+
+	time.Sleep(5 * time.Second)
+	fmt.Printf("disconnecting \"%s\"\n", g_nodeToKill)
+	disconnectNode(g_nodeToKill, g_nexusNode)
+	disconnectNode(g_nodeToKill, "k8s-1")
+
+	fmt.Printf("waiting 60s for disconnection to affect the nexus\n")
+	time.Sleep(60 * time.Second)
+
+	fmt.Printf("running fio while node is disconnected\n")
+	common.RunFio("fio", 20)
+
+	//volumeState = getMsvState(g_uuid)
+	//fmt.Printf("Volume state is \"%s\"\n", volumeState) ///// FIXME - this reports an incorrect value
+
+	fmt.Printf("reconnecting \"%s\"\n", g_nodeToKill)
+	reconnectNode(g_nodeToKill, g_nexusNode, true)
+	reconnectNode(g_nodeToKill, "k8s-1", true)
+
+	fmt.Printf("running fio when node is reconnected\n")
+	common.RunFio("fio", 20)
+}
+
+func TestNodeLoss(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Node Loss Test Suite")
+}
+
+var _ = Describe("Mayastor node loss test", func() {
+	It("should verify behaviour when a node becomes inaccessible", func() {
+		lossTest()
+	})
+})
+
+var _ = BeforeSuite(func(done Done) {
+	logf.SetLogger(zap.LoggerTo(GinkgoWriter, true))
+
+	common.SetupTestEnv()
+
+	g_uuid = common.MkPVC(fmt.Sprintf("loss-test-pvc-iscsi"), "mayastor-iscsi")
+
+	common.ApplyDeployYaml("../deploy/fio_iscsi.yaml")
+
+	fmt.Printf("waiting for fio\n")
+	Eventually(func() bool {
+		return common.FioReadyPod()
+	},
+		defTimeoutSecs, // timeout
+		"1s",           // polling interval
+	).Should(Equal(true))
+
+	close(done)
+}, 60)
+
+var _ = AfterSuite(func() {
+	// NB This only tears down the local structures for talking to the cluster,
+	// not the kubernetes cluster itself.
+	By("tearing down the test environment")
+
+	// ensure node is reconnected in the event of a test failure
+	fmt.Printf("reconnecting %s\n", g_nodeToKill)
+	reconnectNode(g_nodeToKill, g_nexusNode, false)
+	reconnectNode(g_nodeToKill, "k8s-1", false)
+
+	fmt.Printf("removing fio pod\n")
+	common.DeleteDeployYaml("../deploy/fio_iscsi.yaml")
+
+	fmt.Printf("removing pvc\n")
+	common.RmPVC(fmt.Sprintf("loss-test-pvc-iscsi"), "mayastor-iscsi")
+
+	common.TeardownTestEnv()
+})

--- a/mayastor-test/e2e/node_disconnect/node_disconnect_nvmf/node_disconnect_nvmf_test.go
+++ b/mayastor-test/e2e/node_disconnect/node_disconnect_nvmf/node_disconnect_nvmf_test.go
@@ -1,0 +1,129 @@
+package node_disconnect_nvmf_test
+
+// TODO factor out remaining code duplicated with node_disconnect_iscsi_test
+
+import (
+	"e2e-basic/common"
+	"fmt"
+	"os/exec"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+var (
+	defTimeoutSecs = "90s"
+	g_nodeToKill   = ""
+	g_nexusNode    = ""
+	g_uuid         = ""
+)
+
+func disconnectNode(vmname string, nexusNode string) {
+	cmd := exec.Command("bash", "../../common/io_connect_node.sh", vmname, nexusNode, "DISCONNECT")
+	cmd.Dir = "./"
+	_, err := cmd.CombinedOutput()
+	Expect(err).ToNot(HaveOccurred())
+}
+
+func reconnectNode(vmname string, nexusNode string, checkError bool) {
+	cmd := exec.Command("bash", "../../common/io_connect_node.sh", vmname, nexusNode, "RECONNECT")
+	cmd.Dir = "./"
+	_, err := cmd.CombinedOutput()
+	if checkError {
+		Expect(err).ToNot(HaveOccurred())
+	}
+}
+
+func lossTest() {
+	g_nexusNode = common.GetMsvNode(g_uuid)
+	fmt.Printf("nexus node is \"%s\"\n", g_nexusNode)
+
+	if g_nexusNode == "k8s-2" {
+		g_nodeToKill = "k8s-3"
+	} else if g_nexusNode == "k8s-3" {
+		g_nodeToKill = "k8s-2"
+	} else {
+		fmt.Printf("Unexpected nexus node name\n")
+		Expect(false)
+	}
+	fmt.Printf("node to kill is \"%s\"\n", g_nodeToKill)
+
+	fmt.Printf("running spawned fio\n")
+	go common.RunFio("fio", 20)
+
+	time.Sleep(5 * time.Second)
+	fmt.Printf("disconnecting \"%s\"\n", g_nodeToKill)
+	disconnectNode(g_nodeToKill, g_nexusNode)
+	disconnectNode(g_nodeToKill, "k8s-1")
+
+	fmt.Printf("waiting 60s for disconnection to affect the nexus\n")
+	time.Sleep(60 * time.Second)
+
+	fmt.Printf("running fio while node is disconnected\n")
+	common.RunFio("fio", 20)
+
+	//volumeState = getMsvState(g_uuid)
+	//fmt.Printf("Volume state is \"%s\"\n", volumeState) ///// FIXME - this reports an incorrect value
+
+	fmt.Printf("reconnecting \"%s\"\n", g_nodeToKill)
+	reconnectNode(g_nodeToKill, g_nexusNode, true)
+	reconnectNode(g_nodeToKill, "k8s-1", true)
+
+	fmt.Printf("running fio when node is reconnected\n")
+	common.RunFio("fio", 20)
+}
+
+func TestNodeLoss(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Node Loss Test Suite")
+}
+
+var _ = Describe("Mayastor node loss test", func() {
+	It("should verify behaviour when a node becomes inaccessible", func() {
+		lossTest()
+	})
+})
+
+var _ = BeforeSuite(func(done Done) {
+	logf.SetLogger(zap.LoggerTo(GinkgoWriter, true))
+
+	common.SetupTestEnv()
+
+	g_uuid = common.MkPVC(fmt.Sprintf("loss-test-pvc-nvmf"), "mayastor-nvmf")
+
+	common.ApplyDeployYaml("../deploy/fio_nvmf.yaml")
+
+	fmt.Printf("waiting for fio\n")
+	Eventually(func() bool {
+		return common.FioReadyPod()
+	},
+		defTimeoutSecs, // timeout
+		"1s",           // polling interval
+	).Should(Equal(true))
+
+	close(done)
+}, 60)
+
+var _ = AfterSuite(func() {
+	// NB This only tears down the local structures for talking to the cluster,
+	// not the kubernetes cluster itself.
+	By("tearing down the test environment")
+
+	// ensure node is reconnected in the event of a test failure
+	fmt.Printf("reconnecting %s\n", g_nodeToKill)
+	reconnectNode(g_nodeToKill, g_nexusNode, false)
+	reconnectNode(g_nodeToKill, "k8s-1", false)
+
+	fmt.Printf("removing fio pod\n")
+	common.DeleteDeployYaml("../deploy/fio_nvmf.yaml")
+
+	fmt.Printf("removing pvc\n")
+	common.RmPVC(fmt.Sprintf("loss-test-pvc-nvmf"), "mayastor-nvmf")
+
+	common.TeardownTestEnv()
+})


### PR DESCRIPTION
Currently tests are specific to a vagrant deployment set up according to the READMEs.
It is assumed that a cluster is running with mayastor installed with some label changes applied to k8s-1, and using the default IP addresses used by the vagrant deployment. Reducing these prerequisites is an ongoing process.
Isolation of the replica is achieved by modifying the iptables of the affected node.  
The test takes care not to isolate a node running the nexus, moac or the kubernetes master node.  
A successful fio run is used to indicate a functional volume.