### PR TITLE
Connect jenkins to e2e test cluster.

### DIFF
--- a/doc/jenkins.md
+++ b/doc/jenkins.md
@@ -189,7 +189,7 @@ for system configuration of nodes (as opposed to using ansible, salt, etc.).
    users.users.jenkins.openssh.authorizedKeys.keys = [ "ssh-rsa key used by Jenkins master ..." ];
 
    environment.systemPackages = with pkgs; [
-     wget curl vim git jdk openiscsi nvme-cli lsof
+     wget curl vim git jdk openiscsi nvme-cli lsof kubectl
    ];
    }
    ```
@@ -226,8 +226,13 @@ for system configuration of nodes (as opposed to using ansible, salt, etc.).
 
 3. Hardware file is the same as for the master (if needed).
 
-4. Set password for Jenkins user using passwd. You will need it when joining
-   the slave from Jenkins web UI.
+4. Create /etc/docker/daemon.json, replace private registry IP in there and restart the docker daemon:
+   ```
+   {
+     "insecure-registries" : ["192.168.1.60:5000"]
+   }
+   ```
+   This will allow the worker node to push docker images to http registry.
 
 5. You can repeat the steps and set as many slaves you want.
 

--- a/mayastor-test/e2e/example-parallel.sh
+++ b/mayastor-test/e2e/example-parallel.sh
@@ -9,14 +9,14 @@ cd "$(dirname ${BASH_SOURCE[0]})"
 pushd setup
   ./bringup-cluster.sh &
 popd
-../../scripts/release.sh --skip-publish-to-dockerhub &
+../../scripts/release.sh --skip-publish &
 
 for job in $(jobs -p); do
   wait $job
 done
 
 # Now that everything up and built, push the images...
-../../scripts/release.sh --skip-publish-to-dockerhub --skip-build --private-registry "172.18.8.101:30291"
+../../scripts/release.sh --skip-build --alias-tag "ci" --registry "172.18.8.101:30291"
 
 # ... and install mayastor.
 pushd install

--- a/mayastor-test/e2e/example-simple.sh
+++ b/mayastor-test/e2e/example-simple.sh
@@ -7,7 +7,7 @@ pushd setup
   ./bringup-cluster.sh
 popd
 
-../../scripts/release.sh --private-registry "172.18.8.101:30291" --skip-publish-to-dockerhub
+../../scripts/release.sh --registry "172.18.8.101:30291" --alias-tag "ci"
 
 pushd install
   go test

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -7,10 +7,13 @@
 
 set -euo pipefail
 
-docker_tag_exists() {
+# Test if the image already exists in dockerhub
+dockerhub_tag_exists() {
   curl --silent -f -lSL https://index.docker.io/v1/repositories/$1/tags/$2 1>/dev/null 2>&1
 }
 
+# Derives tag name from the git repo. That is git tag value or short commit
+# hash if there is no git tag on HEAD.
 get_tag() {
   vers=`git tag --points-at HEAD`
   if [ -z "$vers" ]; then
@@ -24,14 +27,17 @@ help() {
 Usage: $(basename $0) [OPTIONS]
 
 Options:
-  -d, --dry-run                 Output actions that would be taken, but don't run them.
-  -h, --help                    Display this text.
-  --private-registry <address>  Push the built images to the provided registry.
-  --skip-build                  Don't perform nix-build.
-  --skip-publish-to-dockerhub   Don't publish to Dockerhub.
+  -d, --dry-run              Output actions that would be taken, but don't run them.
+  -h, --help                 Display this text.
+  --registry <host[:port]>   Push the built images to the provided registry.
+  --debug                    Build debug version of images where possible.
+  --skip-build               Don't perform nix-build.
+  --skip-publish             Don't publish built images.
+  --image                    Specify what image to build.
+  --alias-tag                Explicit alias for short commit hash tag.
 
 Examples:
-  $(basename $0) --private-registry 127.0.0.1:5000
+  $(basename $0) --registry 127.0.0.1:5000
 EOF
 }
 
@@ -39,13 +45,15 @@ DOCKER="docker"
 NIX_BUILD="nix-build"
 RM="rm"
 SCRIPTDIR=$(dirname "$0")
-IMAGES="mayastor mayastor-csi mayastor-client moac"
 TAG=`get_tag`
 BRANCH=`git rev-parse --abbrev-ref HEAD`
+IMAGES=
 UPLOAD=
-SKIP_PUSH_TO_DOCKERHUB=
-PRIVATE_REGISTRY=
+SKIP_PUBLISH=
 SKIP_BUILD=
+REGISTRY=
+ALIAS=
+DEBUG=
 
 # Check if all needed tools are installed
 curl --version >/dev/null
@@ -73,17 +81,31 @@ while [ "$#" -gt 0 ]; do
       exit 0
       shift
       ;;
-    --private-registry)
+    --registry)
       shift
-      PRIVATE_REGISTRY=$1
+      REGISTRY=$1
+      shift
+      ;;
+    --alias-tag)
+      shift
+      ALIAS=$1
+      shift
+      ;;
+    --image)
+      shift
+      IMAGES="$IMAGES $1"
       shift
       ;;
     --skip-build)
       SKIP_BUILD="yes"
       shift
       ;;
-    --skip-publish-to-dockerhub)
-      SKIP_PUSH_TO_DOCKERHUB="yes"
+    --skip-publish)
+      SKIP_PUBLISH="yes"
+      shift
+      ;;
+    --debug)
+      DEBUG="yes"
       shift
       ;;
     *)
@@ -95,56 +117,61 @@ done
 
 cd $SCRIPTDIR/..
 
+if [ -z "$IMAGES" ]; then
+  if [ -z "$DEBUG" ]; then
+    IMAGES="mayastor mayastor-csi mayastor-client moac"
+  else
+    IMAGES="mayastor-dev mayastor-csi-dev mayastor-client moac"
+  fi
+fi
+
 for name in $IMAGES; do
-  image="mayadata/${name}"
+  image_basename="mayadata/${name}"
+  image=$image_basename
+  if [ -n "$REGISTRY" ]; then
+    image="${REGISTRY}/${image}"
+  fi
+  # If we're skipping the build, then we just want to upload
+  # the images we already have locally.
   if [ -z $SKIP_BUILD ]; then
     archive=${name}-image
-    if docker_tag_exists $image $TAG; then
+    if [ -z "$REGISTRY" ] && dockerhub_tag_exists $image $TAG; then
       echo "Skipping $image:$TAG that already exists"
-    else
-      echo "Building $image:$TAG ..."
-      $NIX_BUILD --out-link $archive -A images.$archive
-      $DOCKER load -i $archive
-      $RM $archive
-      UPLOAD="$UPLOAD $image"
+      continue
     fi
-  else
-    # If we're skipping the build, then we just want to upload
-    # the images we already have locally.
-    # We should do this for all images.
-    UPLOAD="$UPLOAD $image"
+    echo "Building $image:$TAG ..."
+    $NIX_BUILD --out-link $archive -A images.$archive
+    $DOCKER load -i $archive
+    $RM $archive
+    if [ "$image" != "$image_basename" ]; then
+      echo "Renaming $image_basename:$TAG to $image:$TAG"
+      $DOCKER tag "${image_basename}:$TAG" "$image:$TAG"
+      $DOCKER image rm "${image_basename}:$TAG"
+    fi
   fi
+  UPLOAD="$UPLOAD $image"
 done
 
-# Nothing to upload?
-[ -z "$UPLOAD" ] && exit 0
-
-if [ -z $SKIP_PUSH_TO_DOCKERHUB ]; then
+if [ -n "$UPLOAD" ] && [ -z "$SKIP_PUBLISH" ]; then
   # Upload them
   for img in $UPLOAD; do
     echo "Uploading $img:$TAG to registry ..."
     $DOCKER push $img:$TAG
   done
 
-  # Create aliases
-  if [ "$BRANCH" == "develop" ]; then
-    for img in $UPLOAD; do
-      $DOCKER tag $img:$TAG $img:develop
-      $DOCKER push $img:develop
-    done
+  # Create alias
+  alias_tag=
+  if [ -n "$ALIAS" ]; then
+    alias_tag=$ALIAS
+  elif [ "$BRANCH" == "develop" ]; then
+    alias_tag=develop
   elif [ "$BRANCH" == "master" ]; then
+    alias_tag=latest
+  fi
+  if [ -n "$alias_tag" ]; then
     for img in $UPLOAD; do
-      $DOCKER tag $img:$TAG $img:latest
-      $DOCKER push $img:latest
+      $DOCKER tag $img:$TAG $img:$alias_tag
+      $DOCKER push $img:$alias_tag
     done
   fi
-fi
-
-# If a private registry was specified (ie for ci)
-# then we push to it here.
-if [ ! -z $PRIVATE_REGISTRY ]; then
-  for img in $UPLOAD; do
-    $DOCKER tag $img:$TAG ${PRIVATE_REGISTRY}/$img:ci
-    $DOCKER push ${PRIVATE_REGISTRY}/$img:ci
-  done
 fi


### PR DESCRIPTION
Modest goal of this commit is to make jenkins aware of the e2e test
cluster without executing any e2e tests for now. A new e2e stage is
added and in that stage we build mayastor debug images, upload them to
private docker registry and run kubectl get nodes to test that
kubeconfig is set correctly.

Command line arguments of release.sh have been reworked in order to
provide greater flexibility for various use cases.