### PR TITLE
Fix mayastorvolume.yaml file with CRD definition.

### DIFF
--- a/csi/moac/crds/mayastorvolume.yaml
+++ b/csi/moac/crds/mayastorvolume.yaml
@@ -121,14 +121,12 @@ spec:
                         type: boolean
       additionalPrinterColumns:
         - name: Targets
-          type: array
+          type: string
           description: k8s node(s) with storage targets for the volume.
           jsonPath: .status.targetNodes
-          items: string
         - name: Size
           type: integer
           format: int64
-          minimum: 0
           description: Size of the volume
           jsonPath: .status.size
         - name: State


### PR DESCRIPTION
This was a regression introduced publish nexus changes. Somehow this
part of the change did not make it to develop ...