### PR TITLE
Integrate install & uninstall e2e tests to jenkins

### DIFF
--- a/mayastor-test/e2e/install/README.md
+++ b/mayastor-test/e2e/install/README.md
@@ -33,5 +33,5 @@ go test
 Or
 ```sh
 cd Maystor/e2e/install
-e2e_docker_registry='192.168.122.1:5000' e2e_pool_yaml_files='/e2e/pools.yaml' go test
+e2e_docker_registry='192.168.122.1:5000' e2e_pool_device='/dev/nvme1n1' go test
 ```

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env sh
+
+set -e
+
+SCRIPTDIR=$(dirname "$(realpath "$0")")
+REGISTRY=$1
+TESTS="install"
+
+# TODO: Add proper argument parser
+if [ -z "$REGISTRY" ]; then
+  echo "Missing parameter registry"
+  exit 1
+fi
+
+test_failed=
+export e2e_docker_registry="$REGISTRY"
+export e2e_pool_device=/dev/nvme1n1
+
+for dir in $TESTS; do
+  cd "$SCRIPTDIR/../mayastor-test/e2e/$dir"
+  if ! go test; then
+    test_failed=1
+    break
+  fi
+done
+
+# must always run uninstall test in order to clean up the cluster
+cd "$SCRIPTDIR/../mayastor-test/e2e/uninstall"
+go test
+
+if [ -n "$test_failed" ]; then
+  exit 1
+fi
+
+echo "All tests have passed"
+exit 0

--- a/shell.nix
+++ b/shell.nix
@@ -26,8 +26,11 @@ mkShell {
     cowsay
     e2fsprogs
     fio
+    envsubst # for e2e tests
     gdb
+    go
     gptfdisk
+    kubernetes-helm
     libaio
     libiscsi
     libiscsi.bin


### PR DESCRIPTION
It is just a starting point. There are many things to improve.
For example:

 * reworking test directory structure,
 * dynamic spawn of k8s cluster,
 * making it possible to run multiple e2e tests in parallel,
 * eliminate pool template file in install test
 * generate deployment yaml files to a different dir than deploy/
 * adding more e2e tests