### PR TITLE
cas-561 Provide access to udev databse for mayastor container via additional volume mount.

### DIFF
--- a/deploy/mayastor-daemonset.yaml
+++ b/deploy/mayastor-daemonset.yaml
@@ -67,6 +67,8 @@ spec:
         volumeMounts:
         - name: device
           mountPath: /dev
+        - name: udev
+          mountPath: /run/udev
         - name: dshm
           mountPath: /dev/shm
         - name: configlocation
@@ -93,6 +95,10 @@ spec:
       - name: device
         hostPath:
           path: /dev
+          type: Directory
+      - name: udev
+        hostPath:
+          path: /run/udev
           type: Directory
       - name: dshm
         emptyDir:


### PR DESCRIPTION
mayastor requires access to the udev database that resides in /run/udev in order for the ListBlockDevices() gRPC request to function correctly. This access must be provided via an explicit volume mount when mayastor is run from within a container.
Without such access, the gRPC call returns partial and (highly misleading) incorrect information.
