### PR TITLE
Add support for disconnection testing on volumes with more than 3 mayastor nodes.

### DIFF
--- a/mayastor-test/e2e/node_disconnect/iscsi_drop/node_disconnect_iscsi_drop_test.go
+++ b/mayastor-test/e2e/node_disconnect/iscsi_drop/node_disconnect_iscsi_drop_test.go
@@ -30,7 +30,7 @@ func TestNodeLoss(t *testing.T) {
 }
 
 var _ = Describe("Mayastor node loss test", func() {
-	It("should verify behaviour when a node becomes inaccessible", func() {
+	It("should verify iscsi nexus behaviour when a node becomes inaccessible (iptables DROP)", func() {
 		lossTest()
 	})
 })

--- a/mayastor-test/e2e/node_disconnect/iscsi_reject/node_disconnect_iscsi_reject_test.go
+++ b/mayastor-test/e2e/node_disconnect/iscsi_reject/node_disconnect_iscsi_reject_test.go
@@ -30,7 +30,7 @@ func TestNodeLoss(t *testing.T) {
 }
 
 var _ = Describe("Mayastor node loss test", func() {
-	It("should verify behaviour when a node becomes inaccessible", func() {
+	It("should verify iscsi nexus behaviour when a node becomes inaccessible (iptables REJECT)", func() {
 		lossTest()
 	})
 })

--- a/mayastor-test/e2e/node_disconnect/iscsi_reject_idle/node_disconnect_iscsi_reject_idle_test.go
+++ b/mayastor-test/e2e/node_disconnect/iscsi_reject_idle/node_disconnect_iscsi_reject_idle_test.go
@@ -31,7 +31,7 @@ func TestNodeLoss(t *testing.T) {
 }
 
 var _ = Describe("Mayastor node loss test", func() {
-	It("should verify behaviour when a node becomes inaccessible when no IO is received", func() {
+	It("should verify iscsi nexus behaviour when a node becomes inaccessible when no IO is received (iptables REJECT)", func() {
 		lossTest()
 	})
 })

--- a/mayastor-test/e2e/node_disconnect/nvmf_drop/node_disconnect_nvmf_drop_test.go
+++ b/mayastor-test/e2e/node_disconnect/nvmf_drop/node_disconnect_nvmf_drop_test.go
@@ -30,7 +30,7 @@ func TestNodeLoss(t *testing.T) {
 }
 
 var _ = Describe("Mayastor node loss test", func() {
-	It("should verify behaviour when a node becomes inaccessible", func() {
+	It("should verify nvmf nexus behaviour when a node becomes inaccessible (iptables DROP)", func() {
 		lossTest()
 	})
 })

--- a/mayastor-test/e2e/node_disconnect/nvmf_reject/node_disconnect_nvmf_reject_test.go
+++ b/mayastor-test/e2e/node_disconnect/nvmf_reject/node_disconnect_nvmf_reject_test.go
@@ -31,7 +31,7 @@ func TestNodeLoss(t *testing.T) {
 }
 
 var _ = Describe("Mayastor node loss test", func() {
-	It("should verify behaviour when a node becomes inaccessible", func() {
+	It("should verify nvmf nexus behaviour when a node becomes inaccessible (iptables REJECT)", func() {
 		lossTest()
 	})
 })

--- a/mayastor-test/e2e/node_disconnect/nvmf_reject_idle/node_disconnect_nvmf_reject_idle_test.go
+++ b/mayastor-test/e2e/node_disconnect/nvmf_reject_idle/node_disconnect_nvmf_reject_idle_test.go
@@ -31,7 +31,7 @@ func TestNodeLoss(t *testing.T) {
 }
 
 var _ = Describe("Mayastor node loss test", func() {
-	It("should verify behaviour when a node becomes inaccessible when no IO is received", func() {
+	It("should verify nvmf nexus behaviour when a node becomes inaccessible when no IO is received (iptables REJECT)", func() {
 		lossTest()
 	})
 })

--- a/mayastor-test/e2e/node_disconnect/setup/node_disconnect_setup_test.go
+++ b/mayastor-test/e2e/node_disconnect/setup/node_disconnect_setup_test.go
@@ -28,7 +28,7 @@ func disconnectSetupTest() {
 
 	nodeList, err := common.GetNodeLocs()
 	Expect(err).ToNot(HaveOccurred())
-	Expect(len(nodeList) >= 3)
+	Expect(len(nodeList)).To(BeNumerically(">=", 3))
 
 	// sort the nodes - that also means k8s-1 is the refuge on local clusters
 	sort.Slice(nodeList, func(i, j int) bool { return nodeList[i].NodeName < nodeList[j].NodeName })
@@ -43,7 +43,7 @@ func disconnectSetupTest() {
 			common.LabelNode(refugeNode, "openebs.io/podrefuge=true")
 		}
 	}
-	Expect(refugeNode != "")
+	Expect(refugeNode).NotTo(Equal(""))
 
 	moacOnRefugeNode := common.PodPresentOnNode(moac_regexp, namespace, refugeNode)
 

--- a/mayastor-test/e2e/node_disconnect/teardown/node_disconnect_teardown_test.go
+++ b/mayastor-test/e2e/node_disconnect/teardown/node_disconnect_teardown_test.go
@@ -23,7 +23,7 @@ func disconnectTeardownTest() {
 
 	nodeList, err := common.GetNodeLocs()
 	Expect(err).ToNot(HaveOccurred())
-	Expect(len(nodeList) >= 3)
+	Expect(len(nodeList)).To(BeNumerically(">=", 3))
 
 	// apply/remove the labels whether present or not
 	// An error will not occur if the label is already present/absent

--- a/mayastor-test/e2e/node_disconnect/test.sh
+++ b/mayastor-test/e2e/node_disconnect/test.sh
@@ -11,9 +11,9 @@ timeout=200
 (cd nvmf_reject_idle && go test -timeout "${timeout}s")
 (cd iscsi_reject_idle && go test -timeout "${timeout}s")
 
-# These tests currently fail
-# (cd nvmf_drop && go test -timeout "${timeout}s")
-# (cd iscsi_drop && go test -timeout "${timeout}s")
+# These two tests currently fail so are run with -c (compile only)
+(cd nvmf_drop && go test -c -timeout "${timeout}s")
+(cd iscsi_drop && go test -c -timeout "${timeout}s")
 
 (cd teardown && go test -timeout "${timeout}s")
 


### PR DESCRIPTION
Ensure node to isolate is one hosting a replica for the volume.
Disable tests by using "test -c" to ensure they are at least compiled.
More detailed test descriptions.