### PR TITLE
Cas-561: Provide access to udev databse for mayastor container via additional volume mount.

### DIFF
--- a/chart/templates/mayastor-daemonset.yaml
+++ b/chart/templates/mayastor-daemonset.yaml
@@ -65,6 +65,8 @@ spec:
         volumeMounts:
         - name: device
           mountPath: /dev
+        - name: udev
+          mountPath: /run/udev
         - name: dshm
           mountPath: /dev/shm
         - name: configlocation
@@ -91,6 +93,10 @@ spec:
       - name: device
         hostPath:
           path: /dev
+          type: Directory
+      - name: udev
+        hostPath:
+          path: /run/udev
           type: Directory
       - name: dshm
         emptyDir:

--- a/deploy/mayastor-daemonset.yaml
+++ b/deploy/mayastor-daemonset.yaml
@@ -67,6 +67,8 @@ spec:
         volumeMounts:
         - name: device
           mountPath: /dev
+        - name: udev
+          mountPath: /run/udev
         - name: dshm
           mountPath: /dev/shm
         - name: configlocation
@@ -93,6 +95,10 @@ spec:
       - name: device
         hostPath:
           path: /dev
+          type: Directory
+      - name: udev
+        hostPath:
+          path: /run/udev
           type: Directory
       - name: dshm
         emptyDir:


### PR DESCRIPTION
Mayastor requires access to the udev database that resides in /run/udev
in order for the ListBlockDevices() gRPC request to function correctly.
This access must be provided via an explicit volume mount when Mayastor
is run from within a container. Without such access, the gRPC call
returns partial and (highly misleading) incorrect information.

@cjones1024 carried out the investigation and made the original changes.
I have moved the changes in his PR from their original place in
deploy/mayastor-daemonset.yaml to
chart/templates/mayastor-daemonset.yaml as this is now used to construct
the YAML file in the deploy directory.

For the purposes of review see https://github.com/openebs/Mayastor/pull/576 for the original PR.