### PR TITLE
Add replica re-assignment e2e test. 

### DIFF
--- a/mayastor-test/e2e/node_disconnect/README.md
+++ b/mayastor-test/e2e/node_disconnect/README.md
@@ -2,8 +2,9 @@
 The tests in this folder are not currently deployable by the CI system
 as the test assumes a vagrant installation
 
-## Pre-requisites for this test
+## Pre-requisites for these tests
 
 * A Kubernetes cluster with at least 3 nodes, with mayastor installed.
+* The re-assignment test requires at least 4 nodes
 * The cluster is deployed using vagrant and KUBESPRAY_REPO is correctly
   defined in ./lib/io_connect_node.sh

--- a/mayastor-test/e2e/node_disconnect/nvmf_reject_reassign/nvmf_reject_reassign_test.go
+++ b/mayastor-test/e2e/node_disconnect/nvmf_reject_reassign/nvmf_reject_reassign_test.go
@@ -1,0 +1,55 @@
+package node_disconnect_nvmf_reassign_test
+
+import (
+	"e2e-basic/common"
+	disconnect_lib "e2e-basic/node_disconnect/lib"
+
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+var (
+	g_nodeToIsolate    = ""
+	g_otherNodes       []string
+	g_uuid             = ""
+	g_disconnectMethod = "REJECT"
+)
+
+func lossTest() {
+	g_nodeToIsolate, g_otherNodes = disconnect_lib.GetNodes(g_uuid)
+	disconnect_lib.ReplicaReassignTest(g_nodeToIsolate, g_otherNodes, g_disconnectMethod, g_uuid)
+}
+
+func TestNodeLoss(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Node Loss NVMF assign new replica")
+}
+
+var _ = Describe("Mayastor node loss test", func() {
+	It("should verify nvmf nexus repair of volume when a node becomes inaccessible", func() {
+		lossTest()
+	})
+})
+
+var _ = BeforeSuite(func(done Done) {
+	logf.SetLogger(zap.LoggerTo(GinkgoWriter, true))
+	common.SetupTestEnv()
+	g_uuid = disconnect_lib.Setup("loss-test-pvc-nvmf", "mayastor-nvmf-2")
+	close(done)
+}, 60)
+
+var _ = AfterSuite(func() {
+	// NB This only tears down the local structures for talking to the cluster,
+	// not the kubernetes cluster itself.
+	By("tearing down the test environment")
+
+	// ensure node is reconnected in the event of a test failure
+	disconnect_lib.ReconnectNode(g_nodeToIsolate, g_otherNodes, false, g_disconnectMethod)
+	disconnect_lib.Teardown("loss-test-pvc-nvmf", "mayastor-nvmf-2")
+	common.TeardownTestEnv()
+})

--- a/mayastor-test/e2e/node_disconnect/test.sh
+++ b/mayastor-test/e2e/node_disconnect/test.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -e
-timeout=200
+timeout=500
 
 (cd setup && go test -timeout "${timeout}s")
 
@@ -14,6 +14,8 @@ timeout=200
 # These two tests currently fail so are run with -c (compile only)
 (cd nvmf_drop && go test -c -timeout "${timeout}s")
 (cd iscsi_drop && go test -c -timeout "${timeout}s")
+
+(cd nvmf_reject_reassign && go test -timeout "${timeout}s")
 
 (cd teardown && go test -timeout "${timeout}s")
 


### PR DESCRIPTION
This test causes a replica node to be faulted by IO packet rejection, and then waits for the control plane
to provision a new replica. The test requires 4 mayastor nodes.