### PR TITLE
mayastor: Build against SPDK 21.01-pre

### DIFF
--- a/mayastor/src/bdev/nexus/nexus_fn_table.rs
+++ b/mayastor/src/bdev/nexus/nexus_fn_table.rs
@@ -43,6 +43,7 @@ impl NexusFnTable {
             dump_info_json: Some(Self::dump_info_json),
             write_config_json: None,
             get_spin_time: None,
+            get_module_ctx: None,
         };
 
         NexusFnTable {

--- a/mayastor/src/target/iscsi.rs
+++ b/mayastor/src/target/iscsi.rs
@@ -358,7 +358,7 @@ fn create_portal_group(
             return Err(Error::CreatePortal {});
         }
         iscsi_portal_grp_add_portal(pg, p);
-        if iscsi_portal_grp_open(pg) != 0 {
+        if iscsi_portal_grp_open(pg, false) != 0 {
             iscsi_portal_grp_release(pg);
             return Err(Error::AddPortal {});
         }

--- a/nix/pkgs/libspdk/default.nix
+++ b/nix/pkgs/libspdk/default.nix
@@ -19,13 +19,13 @@
 let
   # Derivation attributes for production version of libspdk
   drvAttrs = rec {
-    version = "20.10";
+    version = "21.01-pre";
 
     src = fetchFromGitHub {
       owner = "openebs";
       repo = "spdk";
-      rev = "46b25360887c5d19433f575c7ad14259721abc6f";
-      sha256 = "0cjnpkqx95cgrk9kbm4drrd5piimprz7wsbiahsllm1j2avdzsfs";
+      rev = "285a96fb4bd5fb53876635ec86ebe55089b1ffde";
+      sha256 = "0bn40y28iafma19q7fh15ga651d7bcpx85ih5lyi4azvb0l0zjqv";
       #sha256 = stdenv.lib.fakeSha256;
       fetchSubmodules = true;
     };


### PR DESCRIPTION
This includes spdk/spdk@6d9d3f87 to fix #555.

Sync with upstream changes to nvme_bdev_opts (kato configuration),
spdk_bdev_fn_table and iscsi_portal_grp_open.

Remove a few members from TcpTransportOpts that are unused and should
have been removed in the 20.10 rebase.