### PR TITLE
CAS-582: Set nexus state to degraded when adding replica

### DIFF
--- a/csi/moac/nexus.ts
+++ b/csi/moac/nexus.ts
@@ -262,6 +262,7 @@ export class Nexus {
     // confirmation back from the nexus, set it as pending
     this.children.push(new Child(childInfo.uri, childInfo.state));
     this.children.sort(compareChildren);
+    this.state = "NEXUS_DEGRADED"
     log.info(`Replica uri "${uri}" added to the nexus "${this}"`);
     this._emitMod();
   }


### PR DESCRIPTION
When adding a replica to a nexus, ensure that the nexus state in the MSV
is set to degraded.