### PR TITLE
test: add basic rebuild E2E test (CAS-285)

### DIFF
--- a/test/e2e/rebuild/README.md
+++ b/test/e2e/rebuild/README.md
@@ -1,0 +1,21 @@
+## Pre-requisites for this test
+
+* A Kubernetes cluster with at least 3 nodes, with mayastor installed.
+
+## Overview
+The tests in this folder are for testing the behaviour of the rebuild feature in a Kubernetes environment.
+
+## Test Descriptions
+
+### Basic rebuild test
+The purpose of this test is to ensure that a rebuild starts and completes successfully when the replica count in the MSV is incremented.
+
+To run:
+```bash
+go test basic_rebuild_test.go
+```
+
+To run with verbose output:
+```bash
+go test -v basic_rebuild_test.go
+```

--- a/test/e2e/rebuild/basic_rebuild_test.go
+++ b/test/e2e/rebuild/basic_rebuild_test.go
@@ -1,0 +1,93 @@
+package basic_rebuild_test
+
+import (
+	"e2e-basic/common"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+var (
+	pvcName      = "rebuild-test-pvc"
+	storageClass = "mayastor-nvmf"
+)
+
+const ApplicationPod = "fio.yaml"
+
+func basicRebuildTest() {
+	// Create a PVC
+	common.MkPVC(pvcName, storageClass)
+	pvc, err := common.GetPVC(pvcName)
+	Expect(err).To(BeNil())
+	Expect(pvc).ToNot(BeNil())
+
+	timeout := "90s"
+	pollPeriod := "1s"
+
+	// Create an application pod and wait for the PVC to be bound to it.
+	common.ApplyDeployYaml(ApplicationPod)
+	Eventually(func() bool { return common.IsPvcBound(pvcName) }, timeout, pollPeriod).Should(Equal(true))
+
+	uuid := string(pvc.ObjectMeta.UID)
+	repl, err := common.GetNumReplicas(uuid)
+	Expect(err).To(BeNil())
+	Expect(repl).Should(Equal(int64(1)))
+
+	// Wait for volume to be published before adding a child.
+	// This ensures that a nexus exists when the child is added.
+	Eventually(func() bool { return common.IsVolumePublished(uuid) }, timeout, pollPeriod).Should(Equal(true))
+
+	// Add another child which should kick off a rebuild.
+	common.UpdateNumReplicas(uuid, 2)
+	repl, err = common.GetNumReplicas(uuid)
+	Expect(err).To(BeNil())
+	Expect(repl).Should(Equal(int64(2)))
+
+	// Wait for the added child to show up.
+	Eventually(func() int { return common.GetNumChildren(uuid) }, timeout, pollPeriod).Should(BeEquivalentTo(2))
+
+	getChildrenFunc := func(uuid string) []common.NexusChild {
+		children, err := common.GetChildren(uuid)
+		if err != nil {
+			panic("Failed to get children")
+		}
+		Expect(len(children)).Should(Equal(2))
+		return children
+	}
+
+	// Check the added child and nexus are both degraded.
+	Eventually(func() string { return getChildrenFunc(uuid)[1].State }, timeout, pollPeriod).Should(BeEquivalentTo("CHILD_DEGRADED"))
+	Eventually(func() (string, error) { return common.GetNexusState(uuid) }, timeout, pollPeriod).Should(BeEquivalentTo("NEXUS_DEGRADED"))
+
+	// Check everything eventually goes healthy following a rebuild.
+	Eventually(func() string { return getChildrenFunc(uuid)[0].State }, timeout, pollPeriod).Should(BeEquivalentTo("CHILD_ONLINE"))
+	Eventually(func() string { return getChildrenFunc(uuid)[1].State }, timeout, pollPeriod).Should(BeEquivalentTo("CHILD_ONLINE"))
+	Eventually(func() (string, error) { return common.GetNexusState(uuid) }, timeout, pollPeriod).Should(BeEquivalentTo("NEXUS_ONLINE"))
+}
+
+func TestRebuild(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Rebuild Test Suite")
+}
+
+var _ = Describe("Mayastor rebuild test", func() {
+	It("should run a rebuild job to completion", func() {
+		basicRebuildTest()
+	})
+})
+
+var _ = BeforeSuite(func(done Done) {
+	logf.SetLogger(zap.LoggerTo(GinkgoWriter, true))
+	common.SetupTestEnv()
+	close(done)
+}, 60)
+
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
+	common.DeleteDeployYaml(ApplicationPod)
+	common.RmPVC(pvcName, storageClass)
+	common.TeardownTestEnv()
+})

--- a/test/e2e/rebuild/fio.yaml
+++ b/test/e2e/rebuild/fio.yaml
@@ -1,0 +1,19 @@
+kind: Pod
+apiVersion: v1
+metadata:
+  name: fio
+spec:
+  volumes:
+    - name: ms-volume
+      persistentVolumeClaim:
+       claimName: rebuild-test-pvc
+  containers:
+    - name: fio
+      image: nixery.dev/shell/fio/tini
+      command: [ "tini", "--" ]
+      args:
+        - sleep
+        - "1000000"
+      volumeMounts:
+        - mountPath: "/volume"
+          name: ms-volume


### PR DESCRIPTION
This test checks that a rebuild can be started and completes correctly.

Some helper functions have been added to the common directory and could
be used to refactor some of the existing code in the future.

I have purposely not added the test to the Jenkinsfile yet, as I want to wait for
the discussion on the E2E cleanup procedure to conclude. I will raise a separate
work item for this.