### PR TITLE
Do not overwrite versioned files in e2e tests CAS-595

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 **/*.tfstate*
 mayastor/local-randrw-0-verify.state
 mayastor/local-write_verify-0-verify.state
+test-yamls/*

--- a/scripts/generate-deploy-yamls.sh
+++ b/scripts/generate-deploy-yamls.sh
@@ -4,13 +4,27 @@ set -e
 
 if [ "x$1" = x ]; then
 cat <<EOF
-USAGE: $0 <mayastor_docker_images_tag> [<mayastor_images_repo>]
+USAGE: $0 [-t <target_dir>] <mayastor_docker_images_tag> [<mayastor_images_repo>]
 
 Generate (some) deployment YAMLs from the helm chart and store them to deploy/
-in the repo.
+in the repo. If -t is specified do not put them to deploy/ but rather to the
+directory given.
 EOF
 	exit 1
 fi
+
+SCRIPTDIR="$(realpath "$(dirname "$0")")"
+
+if [ "$1" = "-t" ]; then
+	TARGET_DIR="$2"
+	shift 2
+else
+	TARGET_DIR="$SCRIPTDIR/../deploy"
+fi
+if [ ! -d "$TARGET_DIR" ]; then
+	mkdir -p "$TARGET_DIR"
+fi
+
 if [ "x$2" = x ]; then
 	mayastor_images_repo="NONE"
 else
@@ -25,8 +39,6 @@ if ! which helm > /dev/null 2>&1; then
 	exit 1
 fi
 
-SCRIPTDIR="$(realpath "$(dirname "$0")")"
-
 tmpd=$(mktemp -d /tmp/generate-deploy.sh.XXXXXXXX)
 # shellcheck disable=SC2064
 trap "rm -fr '$tmpd'" HUP QUIT EXIT TERM INT
@@ -37,4 +49,4 @@ else
 	helm template --set "mayastorImagesTag=$1,mayastorImagesRepo=$mayastor_images_repo" mayastor "$SCRIPTDIR/../chart" --output-dir="$tmpd" --namespace mayastor
 fi
 
-mv "$tmpd"/mayastor/templates/*.yaml "$SCRIPTDIR/../deploy/"
+mv "$tmpd"/mayastor/templates/*.yaml "$TARGET_DIR"

--- a/test/e2e/install/install_test.go
+++ b/test/e2e/install/install_test.go
@@ -128,7 +128,7 @@ func makeImageName(registryAddress string, imagename string, imageversion string
 }
 
 func generateYamls(registryAddress string) {
-	bashcmd := "../../../scripts/generate-deploy-yamls.sh  ci " + registryAddress
+	bashcmd := "../../../scripts/generate-deploy-yamls.sh -t ../../../test-yamls ci " + registryAddress
 	cmd := exec.Command("bash", "-c", bashcmd)
 	out, err := cmd.CombinedOutput()
 	Expect(err).ToNot(HaveOccurred(), "%s", out)
@@ -207,15 +207,16 @@ func installMayastor() {
 
 	fmt.Printf("registry address %v, number of mayastor instances=%v\n", registryAddress, numMayastorInstances)
 
+	// FIXME use absolute paths, do not depend on CWD
 	applyDeployYaml("namespace.yaml")
 	applyDeployYaml("storage-class.yaml")
 	applyDeployYaml("moac-rbac.yaml")
 	applyDeployYaml("mayastorpoolcrd.yaml")
 	applyDeployYaml("nats-deployment.yaml")
 	generateYamls(registryAddress)
-	applyDeployYaml("csi-daemonset.yaml")
-	applyDeployYaml("moac-deployment.yaml")
-	applyDeployYaml("mayastor-daemonset.yaml")
+	applyDeployYaml("../test-yamls/csi-daemonset.yaml")
+	applyDeployYaml("../test-yamls/moac-deployment.yaml")
+	applyDeployYaml("../test-yamls/mayastor-daemonset.yaml")
 
 	// Given the yamls and the environment described in the test readme,
 	// we expect mayastor to be running on exactly 2 nodes.


### PR DESCRIPTION
Deployment yaml files are now generated to `./test-yamls` which is `.gitignore`-d to avoid polluting developer's git.