### PR TITLE
Run CSI e2e tests in CI/CD pipeline CAS-577

### DIFF
--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -3,10 +3,11 @@
 set -eux
 
 SCRIPTDIR=$(dirname "$(realpath "$0")")
-TESTS="install basic_volume_io"
+TESTS=${e2e_tests:-"install basic_volume_io csi uninstall"}
 DEVICE=
 REGISTRY=
 TAG=
+TESTDIR=$(realpath "$SCRIPTDIR/../test/e2e")
 
 help() {
   cat <<EOF
@@ -67,21 +68,63 @@ fi
 
 test_failed=
 
+# Run go test in directory specified as $1 (relative path)
+function runGoTest {
+    echo "Run go test in $PWD/\"$1\""
+    if [ -z "$1" ] || [ ! -d "$1" ]; then
+        return 1
+    fi
+
+    cd "$1"
+    if ! go test -v . -ginkgo.v -ginkgo.progress -timeout 0; then
+        return 1
+    fi
+
+    return 0
+}
+
 for dir in $TESTS; do
-  cd "$SCRIPTDIR/../test/e2e/$dir"
-  if ! go test -v . -ginkgo.v -ginkgo.progress -timeout 0 ; then
-    test_failed=1
-    break
-  fi
+  cd "$TESTDIR"
+  case "$dir" in
+      uninstall)
+          # defer till after all tests have been run.
+          ;;
+      csi)
+        # TODO move the csi-e2e tests to a subdirectory under e2e
+        # issues with using the same go.mod file prevents this at the moment.
+        cd "../csi-e2e/"
+        if ! ./runtest.sh ; then
+            test_failed=1
+            break
+        fi
+        ;;
+      *)
+        if ! runGoTest "$dir" ; then
+            test_failed=1
+            break
+        fi
+        ;;
+  esac
 done
 
-# must always run uninstall test in order to clean up the cluster
-cd "$SCRIPTDIR/../test/e2e/uninstall"
-go test
+for dir in $TESTS; do
+  cd "$TESTDIR"
+  case "$dir" in
+      uninstall)
+        echo "Uninstalling mayastor....."
+        if ! runGoTest "$dir" ; then
+            test_failed=1
+        fi
+        ;;
+      *)
+        ;;
+   esac
+done
 
 if [ -n "$test_failed" ]; then
+    echo "At least one test has FAILED!"
   exit 1
 fi
 
-echo "All tests have passed"
+echo "All tests have PASSED!"
 exit 0

--- a/test/csi-e2e/runtest.sh
+++ b/test/csi-e2e/runtest.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-GINKGO_FLAGS="-ginkgo.v -ginkgo.progress"
-go test -v -timeout=0 . ${GINKGO_FLAGS}
+set -eux
+cd "$(dirname "$(realpath "$0")")"
+go test -v . -ginkgo.v -ginkgo.progress -timeout 0
 
 # Required until CAS-566
 # "Mayastor volumes not destroyed when PV is destroyed if storage class reclaim policy is Retain"


### PR DESCRIPTION
Refactor scripts/e2e-test.sh to
 * Run the CSI tests
 * Be more developer friendly

1. Add csi to the set of tests run by default
2. The set of tests to be run can now be specified
   using env var e2e_tests
3. Run uninstall test only if specified,
    and always after all other tests have
    run successfully or not.