### PR TITLE
jenkins worker is running out of space

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -145,15 +145,25 @@ pipeline {
         )
       }
       steps {
+        // e2e tests are the most demanding step for space on the disk so we
+        // test the free space here rather than repeating the same code in all
+        // stages.
+        sh "./scripts/reclaim-space.sh 10"
         // Build images (REGISTRY is set in jenkin's global configuration).
         // Note: We might want to build and test dev images that have more
         // assertions instead but that complicates e2e tests a bit.
         sh "./scripts/release.sh --alias-tag ci --registry ${env.REGISTRY}"
-        // save space by removing docker images that are never reused
-        sh 'nix-store --delete /nix/store/*docker-image*'
         withCredentials([file(credentialsId: 'kubeconfig', variable: 'KUBECONFIG')]) {
           sh 'kubectl get nodes -o wide'
           sh "nix-shell --run './scripts/e2e-test.sh --device /dev/nvme1n1 --tag \"${env.GIT_COMMIT_SHORT}\" --registry \"${env.REGISTRY}\"'"
+        }
+      }
+      // Always remove all docker images because they are usually used just once
+      // and underlaying pkgs are already cached by nix so they can be easily
+      // recreated.
+      post {
+        always {
+          sh 'docker image prune --all --force'
         }
       }
     }

--- a/doc/jenkins.md
+++ b/doc/jenkins.md
@@ -150,14 +150,6 @@ for system configuration of nodes (as opposed to using ansible, salt, etc.).
    boot.kernelModules = [ "nbd" "xfs" "nvme_tcp" "kvm_intel" ];
    boot.extraModprobeConfig = "options kvm_intel nested=1";
 
-   nix.gc = {
-     automatic = true;
-     dates = "daily";
-   };
-   nix.extraOptions = ''
-     min-free = ${toString (10 * 1024 * 1024 * 1024)}
-   '';
-
    virtualisation.docker.enable = true;
 
    networking.firewall.enable = false;

--- a/scripts/reclaim-space.sh
+++ b/scripts/reclaim-space.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env sh
+
+#
+# The script tries to free as much space as possible by removing nix packages
+# and docker images that aren't used.
+#
+
+set -e
+
+MIN_FREE_GIB=$1
+
+get_avail_gib() {
+    echo $(( $(df --output=avail / | awk 'NR == 2 { print $1 }' ) / 1024 / 1024 ))
+}
+
+free=$(get_avail_gib)
+echo "Available space in root partition: $free GiB"
+
+if [ -n "$MIN_FREE_GIB" ]; then
+    if [ "$free" -gt "$MIN_FREE_GIB" ]; then
+        exit 0
+    fi
+fi
+
+set -x
+nix-collect-garbage
+docker prune --force --all
+set +x
+
+echo "Available space after cleanup: $(get_avail_gib) GiB"


### PR DESCRIPTION
Jenkins worker was running out of space because docker images were not
pruned. I decided to put all space reclaiming into a single script that
is run before each e2e stage. So nix GC is no longer run as a service
on worker nodes. The advantage is that we can synchronize GC with running
jobs that way.