### PR TITLE
fix(nexus): assertion failure when unpublishing a faulted nexus

### DIFF
--- a/mayastor/src/bdev/nexus/nexus_io.rs
+++ b/mayastor/src/bdev/nexus/nexus_io.rs
@@ -338,9 +338,8 @@ impl Bio {
                     nexus.reconfigure(DREvent::ChildFault).await;
                     //nexus.remove_child(&uri).await.unwrap();
                     bdev_destroy(&uri).await.unwrap();
-                    if nexus.status() != NexusStatus::Faulted {
-                        nexus.resume().await.unwrap();
-                    } else {
+                    nexus.resume().await.unwrap();
+                    if nexus.status() == NexusStatus::Faulted {
                         error!(":{} has no children left... ", nexus);
                     }
                 }


### PR DESCRIPTION
The assertion occurs due to the nvmf subsystem transitioning from a
paused to an inactive state, which is forbidden. Always resume the
nexus in child_retire so that it is usually in the active state, which
avoids the assertion when unpublishing it.

Fixes #549, CAS-549, CAS-606.