### PR TITLE
ci: check for mayastor pod restarts when running e2e-tests CAS-612

### DIFF
--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -73,6 +73,10 @@ for dir in $TESTS; do
     test_failed=1
     break
   fi
+  if ! ("$SCRIPTDIR"/e2e_check_pod_restarts.sh) ; then
+      test_failed=1
+      break
+  fi
 done
 
 # must always run uninstall test in order to clean up the cluster

--- a/scripts/e2e_check_pod_restarts.sh
+++ b/scripts/e2e_check_pod_restarts.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -e
+
+# typical output for kubectl get pods -n mayastor is,
+# collect the restart values
+#NAME                    READY   STATUS    RESTARTS   AGE
+#mayastor-4xg7x          1/1     Running   0          124m
+#mayastor-csi-6746c      2/2     Running   0          124m
+#mayastor-csi-pdwjp      2/2     Running   0          124m
+#mayastor-lzr5n          1/1     Running   0          124m
+restarts=$(kubectl get pods -n mayastor | grep -e mayastor -e moac | awk '{print $4}')
+for num in $restarts
+do
+    if [ "$num" -ne "0" ]; then
+        exit 255
+    fi
+done
+exit 0


### PR DESCRIPTION
Add script which checks for mayastor pod restarts,
invoke it after every test run