### PR TITLE
feat(poller): want poller abstraction

### DIFF
--- a/mayastor/src/core/mod.rs
+++ b/mayastor/src/core/mod.rs
@@ -33,10 +33,12 @@ mod env;
 mod handle;
 pub mod io_driver;
 mod nvme;
+pub mod poller;
 mod reactor;
 mod share;
 pub(crate) mod thread;
 mod uuid;
+
 #[derive(Debug, Snafu, Clone)]
 #[snafu(visibility = "pub")]
 pub enum CoreError {

--- a/mayastor/src/core/poller.rs
+++ b/mayastor/src/core/poller.rs
@@ -1,0 +1,148 @@
+use std::{
+    ffi::{c_void, CString},
+    ptr::NonNull,
+    time::Duration,
+};
+
+use spdk_sys::{
+    spdk_poller,
+    spdk_poller_pause,
+    spdk_poller_register,
+    spdk_poller_register_named,
+    spdk_poller_resume,
+    spdk_poller_unregister,
+};
+
+/// structure holding our function and context
+struct PollCtx<'a>(Box<dyn FnMut() -> i32 + 'a>);
+
+/// indirection to avoid raw pointers at upper layers
+#[inline(always)]
+extern "C" fn _cb(ctx: *mut c_void) -> i32 {
+    let poll = unsafe { &mut *(ctx as *mut PollCtx) };
+    (poll.0)()
+}
+
+/// Poller structure that allows us to pause, stop, resume periodic tasks
+pub struct Poller<'a> {
+    inner: NonNull<spdk_poller>,
+    ctx: NonNull<PollCtx<'a>>,
+    stopped: bool,
+}
+
+impl<'a> Poller<'a> {
+    /// stop the given poller and consumes self
+    pub fn stop(mut self) {
+        unsafe {
+            spdk_poller_unregister(&mut self.inner.as_ptr());
+            Box::from_raw(self.ctx.as_ptr());
+            self.stopped = true;
+        }
+    }
+
+    /// pause the given poller
+    pub fn pause(&mut self) {
+        unsafe {
+            spdk_poller_pause(self.inner.as_ptr());
+        }
+    }
+
+    /// resume the given poller
+    pub fn resume(&mut self) {
+        unsafe {
+            spdk_poller_resume(self.inner.as_ptr());
+        }
+    }
+}
+
+impl<'a> Drop for Poller<'a> {
+    fn drop(&mut self) {
+        if !self.stopped {
+            unsafe {
+                spdk_poller_unregister(&mut self.inner.as_ptr());
+                Box::from_raw(self.ctx.as_ptr());
+            }
+        }
+    }
+}
+
+/// builder type to create a new poller
+pub struct Builder<'a> {
+    name: Option<CString>,
+    interval: std::time::Duration,
+    poll_fn: Option<Box<dyn FnMut() -> i32 + 'a>>,
+}
+
+impl<'a> Default for Builder<'a> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<'a> Builder<'a> {
+    /// create a new nameless poller that runs every time the thread the poller
+    /// is created on is polled
+    pub fn new() -> Self {
+        Self {
+            name: None,
+            interval: Duration::from_micros(0),
+            poll_fn: None,
+        }
+    }
+
+    /// create the poller with a given name
+    pub fn with_name<S: Into<Vec<u8>>>(mut self, name: S) -> Self {
+        self.name = Some(
+            CString::new(name)
+                .expect("poller name is invalid or out of memory"),
+        );
+        self
+    }
+
+    /// set the interval for the poller in usec
+    pub fn with_interval(mut self, usec: u64) -> Self {
+        self.interval = Duration::from_micros(usec);
+        self
+    }
+
+    /// set the function for this poller
+    pub fn with_poll_fn(mut self, poll_fn: impl FnMut() -> i32 + 'a) -> Self {
+        self.poll_fn = Some(Box::new(poll_fn));
+        self
+    }
+
+    /// build a  new poller object
+    pub fn build(mut self) -> Poller<'a> {
+        let poll_fn = self
+            .poll_fn
+            .take()
+            .expect("can not start poller without poll function");
+
+        let ctx = NonNull::new(Box::into_raw(Box::new(PollCtx(poll_fn))))
+            .expect("failed to allocate new poller context");
+
+        let inner = NonNull::new(unsafe {
+            if self.name.is_none() {
+                spdk_poller_register(
+                    Some(_cb),
+                    ctx.as_ptr().cast(),
+                    self.interval.as_micros() as u64,
+                )
+            } else {
+                spdk_poller_register_named(
+                    Some(_cb),
+                    ctx.as_ptr().cast(),
+                    self.interval.as_micros() as u64,
+                    self.name.as_ref().unwrap().as_ptr(),
+                )
+            }
+        })
+        .expect("failed to register poller");
+
+        Poller {
+            inner,
+            ctx,
+            stopped: false,
+        }
+    }
+}

--- a/mayastor/tests/poller.rs
+++ b/mayastor/tests/poller.rs
@@ -1,0 +1,86 @@
+use crossbeam::atomic::AtomicCell;
+use once_cell::sync::Lazy;
+
+use mayastor::core::{
+    mayastor_env_stop,
+    poller,
+    MayastorCliArgs,
+    MayastorEnvironment,
+    Reactors,
+};
+
+pub mod common;
+
+static COUNT: Lazy<AtomicCell<u32>> = Lazy::new(|| AtomicCell::new(0));
+
+fn test_fn(a: u32, b: u32) -> u32 {
+    a + b
+}
+
+#[test]
+fn poller() {
+    common::mayastor_test_init();
+    MayastorEnvironment::new(MayastorCliArgs::default()).init();
+
+    let args = (1, 2);
+    let poller = poller::Builder::new()
+        .with_interval(0)
+        .with_poll_fn(move || {
+            println!("and a {} and {}", args.0, args.1);
+            let mut count = COUNT.load();
+            count += 1;
+            COUNT.store(count);
+            0
+        })
+        .build();
+
+    drop(poller);
+    Reactors::master().poll_once();
+
+    // we dropped the poller before we polled, the value should still be 0
+    assert_eq!(COUNT.load(), 0);
+
+    let args = (1, 2);
+    let mut poller = poller::Builder::new()
+        .with_interval(0)
+        .with_poll_fn(move || {
+            let count = COUNT.load();
+            println!("and a {} and {} (count: {}) ", args.0, args.1, count);
+            COUNT.store(count + 1);
+            0
+        })
+        .build();
+
+    Reactors::master().poll_times(64);
+    assert_eq!(COUNT.load(), 64);
+
+    poller.pause();
+    Reactors::master().poll_times(64);
+    assert_eq!(COUNT.load(), 64);
+
+    poller.resume();
+    Reactors::master().poll_times(64);
+    assert_eq!(COUNT.load(), 128);
+
+    // poller stop consumes self
+    poller.stop();
+
+    Reactors::master().poll_times(64);
+    assert_eq!(COUNT.load(), 128);
+
+    // demonstrate we keep state during callbacks
+    let mut ctx_state = 0;
+    let poller = poller::Builder::new()
+        .with_interval(0)
+        .with_poll_fn(move || {
+            ctx_state += test_fn(1, 2);
+            dbg!(ctx_state);
+            0
+        })
+        .build();
+
+    Reactors::master().poll_times(64);
+    drop(poller);
+
+    mayastor_env_stop(0);
+}


### PR DESCRIPTION
This change adds a safe abstraction around the poller interface. We
did not use pollers much (if not at all) but now that we need to
construct, among others our own qpairs we need to create them often
and frequently.

A small trampoline function (which is always inlined) is used to avoid
passing around raw pointers. The poller will execute a closure and allows
us to capture variables so there is no need for boxing arguments.