### PR TITLE
perf(tests): set npm jobs to cpu count

### DIFF
--- a/scripts/grpc-test.sh
+++ b/scripts/grpc-test.sh
@@ -1,11 +1,12 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 set -euxo pipefail
 
-export PATH=$PATH:${HOME}/.cargo/bin
+export PATH="$PATH:${HOME}/.cargo/bin"
+export npm_config_jobs=$(nproc)
 
 cargo build --all
-cd test/grpc
+cd "$(dirname "$0")/../test/grpc"
 npm install
 
 for ts in cli replica nexus csi rebuild snapshot nats; do

--- a/scripts/moac-test.sh
+++ b/scripts/moac-test.sh
@@ -1,8 +1,9 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 set -euxo pipefail
 
-cd csi/moac
+cd "$(dirname "$0")/../csi/moac"
+export npm_config_jobs=$(nproc)
 npm install
 npm run prepare
 npm run compile


### PR DESCRIPTION
Speed up installing npm packages by utilizing all available cores on a machine. I opted to put it to script rather than jenkins so development on local machine can do that too (nixos, rust, go compilation does it by default anyway, so it should produce no surprises).

If I missed some npm install please comment.