### PR TITLE
fix(replica): delay adding replica (CAS-585)

### DIFF
--- a/csi/moac/volume.ts
+++ b/csi/moac/volume.ts
@@ -244,20 +244,6 @@ export class Volume {
         return;
       }
 
-      // check number of replicas for the volume
-      const newReplicaCount = this.replicaCount - Object.values(this.replicas).length;
-      if (newReplicaCount > 0) {
-        this._setState(VolumeState.Degraded);
-        try {
-          await this._createReplicas(newReplicaCount);
-        } catch (err) {
-          logError(err);
-        }
-        // New replicas will be added to the volume through events. On next fsa
-        // enter they will be there and we may continue beyound this point then.
-        return;
-      }
-
       if (!this.publishedOn) {
         // If the volume hasn't been published we can't do anything more than what
         // we have done (that is maintain required # of replicas). When we create
@@ -329,9 +315,9 @@ export class Volume {
     }
 
     // pair nexus children with replica objects to get the full picture
-    const childReplicaPairs: {ch: Child, r: Replica | undefined}[] = this.nexus.children.map((ch) => {
+    const childReplicaPairs: { ch: Child, r: Replica | undefined }[] = this.nexus.children.map((ch) => {
       const r = Object.values(this.replicas).find((r) => r.uri === ch.uri);
-      return {ch, r};
+      return { ch, r };
     });
     // add newly found replicas to the nexus (one by one)
     const newReplicas = Object.values(this.replicas).filter((r) => {
@@ -421,7 +407,7 @@ export class Volume {
         if (!rmPair && onlineCount > this.replicaCount) {
           // The replica with the lowest score must go away
           const rmReplica = this._prioritizeReplicas(
-            <Replica[]> childReplicaPairs
+            <Replica[]>childReplicaPairs
               .map((pair) => pair.r)
               .filter((r) => r !== undefined)
           ).pop();
@@ -541,7 +527,7 @@ export class Volume {
     if (pools.length < count) {
       log.error(
         `No suitable pool(s) for volume "${this}" with capacity ` +
-          `${this.requiredBytes} and replica count ${this.replicaCount}`
+        `${this.requiredBytes} and replica count ${this.replicaCount}`
       );
       throw new GrpcError(
         GrpcCode.RESOURCE_EXHAUSTED,
@@ -604,7 +590,7 @@ export class Volume {
   // @param   {object} replica  Replica object.
   // @returns {number} Score from 0 to 18.
   //
-  _scoreReplica (replica: Replica) {
+  _scoreReplica(replica: Replica) {
     let score = 0;
     const node = replica.pool!.node;
 

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -6,7 +6,8 @@ exit 0
 set -eux
 
 SCRIPTDIR=$(dirname "$(realpath "$0")")
-TESTS="install basic_volume_io node_disconnect/replica_pod_remove"
+# new tests should be added before the replica_pod_remove test
+TESTS="install basic_volume_io replica node_disconnect/replica_pod_remove"
 DEVICE=
 REGISTRY=
 TAG=

--- a/test/e2e/replica/README.md
+++ b/test/e2e/replica/README.md
@@ -1,0 +1,21 @@
+## Pre-requisites for this test
+
+* A Kubernetes cluster with at least 3 nodes, with mayastor installed.
+
+## Overview
+The tests in this folder are for testing the behaviour of the replicas in a Kubernetes environment.
+
+## Test Descriptions
+
+### replica test
+The purpose of this test is to ensure that a replica can be correctly added to an unpublished nexus.
+
+To run:
+```bash
+go test replica_test.go
+```
+
+To run with verbose output:
+```bash
+go test -v replica_test.go
+```

--- a/test/e2e/replica/replica_test.go
+++ b/test/e2e/replica/replica_test.go
@@ -1,0 +1,82 @@
+package replica_test
+
+import (
+	"e2e-basic/common"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+var (
+	pvcName      = "replica-test-pvc"
+	storageClass = "mayastor-nvmf"
+)
+
+const fioPodName = "fio"
+
+func addUnpublishedReplicaTest() {
+	// Create a PVC
+	common.MkPVC(pvcName, storageClass)
+	pvc, err := common.GetPVC(pvcName)
+	Expect(err).To(BeNil())
+	Expect(pvc).ToNot(BeNil())
+
+	timeout := "90s"
+	pollPeriod := "1s"
+
+	// Add another child before publishing the volume.
+	uuid := string(pvc.ObjectMeta.UID)
+	common.UpdateNumReplicas(uuid, 2)
+	repl, err := common.GetNumReplicas(uuid)
+	Expect(err).To(BeNil())
+	Expect(repl).Should(Equal(int64(2)))
+
+	// Use the PVC and wait for the volume to be published
+	common.CreateFioPod(fioPodName, pvcName)
+	Eventually(func() bool { return common.IsVolumePublished(uuid) }, timeout, pollPeriod).Should(Equal(true))
+
+	getChildrenFunc := func(uuid string) []common.NexusChild {
+		children, err := common.GetChildren(uuid)
+		if err != nil {
+			panic("Failed to get children")
+		}
+		Expect(len(children)).Should(Equal(2))
+		return children
+	}
+
+	// Check the added child and nexus are both degraded.
+	Eventually(func() string { return getChildrenFunc(uuid)[1].State }, timeout, pollPeriod).Should(BeEquivalentTo("CHILD_DEGRADED"))
+	Eventually(func() (string, error) { return common.GetNexusState(uuid) }, timeout, pollPeriod).Should(BeEquivalentTo("NEXUS_DEGRADED"))
+
+	// Check everything eventually goes healthy following a rebuild.
+	Eventually(func() string { return getChildrenFunc(uuid)[0].State }, timeout, pollPeriod).Should(BeEquivalentTo("CHILD_ONLINE"))
+	Eventually(func() string { return getChildrenFunc(uuid)[1].State }, timeout, pollPeriod).Should(BeEquivalentTo("CHILD_ONLINE"))
+	Eventually(func() (string, error) { return common.GetNexusState(uuid) }, timeout, pollPeriod).Should(BeEquivalentTo("NEXUS_ONLINE"))
+}
+
+func TestReplica(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Replica Test Suite")
+}
+
+var _ = Describe("Mayastor replica tests", func() {
+	It("should test the addition of a replica to an unpublished volume", func() {
+		addUnpublishedReplicaTest()
+	})
+})
+
+var _ = BeforeSuite(func(done Done) {
+	logf.SetLogger(zap.LoggerTo(GinkgoWriter, true))
+	common.SetupTestEnv()
+	close(done)
+}, 60)
+
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
+	common.DeletePod(fioPodName)
+	common.RmPVC(pvcName, storageClass)
+	common.TeardownTestEnv()
+})


### PR DESCRIPTION
Adding a replica to an unpublished nexus was causing the child to be
added as online rather than degraded when the volume was subsequently
published. Because of this a rebuild was not run and data corruption
could occur when reading from the newly added child.

This change delays the addition of a replica until a volume is
published; ensuring the child is added as degraded and rebuilt
accordingly.

Also added a new "replica_test" E2E test.