### PR TITLE
fix(linter): fix linter git hook

### DIFF
--- a/.github/workflows/pr-commitlint.yml
+++ b/.github/workflows/pr-commitlint.yml
@@ -18,5 +18,4 @@ jobs:
           last_commit=HEAD^2 # don't lint the merge commit
           npx commitlint --from $first_commit~1 --to $last_commit -V
       - name: Lint Pull Request
-        run: echo $'${{ github.event.pull_request.title }}\n\n${{ github.event.pull_request.body }}' | npx commitlint -V
-
+        run: echo "${{ github.event.pull_request.title }}"$'\n\n'"${{ github.event.pull_request.body }}" | npx commitlint -V

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 mayastor/local-randrw-0-verify.state
 mayastor/local-write_verify-0-verify.state
 test-yamls/*
+/package-lock.json
+/node_modules

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
         name: Commit Lint
         description: Runs commitlint against the commit message.
         language: system
-        entry: bash -c "cat $1 | npx commitlint"
+        entry: bash -c "npm install @commitlint/config-conventional @commitlint/cli; cat $1 | npx commitlint"
         args: [$1]
         stages: [commit-msg]
 


### PR DESCRIPTION
@commitlint/config-conventional is not installed by npx so we need to
install it before running @commitlint/cli.
since we're doing this, install @commitlint/cli which speeds up npx as
it no longer needs to pull it.