### PR TITLE
fix(moac): import vols after nodes are registered

### DIFF
--- a/csi/moac/event_stream.js
+++ b/csi/moac/event_stream.js
@@ -91,18 +91,21 @@ class EventStream extends Readable {
           eventType: 'new',
           object: node
         });
+        // First we emit replica and then pool events. Otherwise volume manager
+        // could start creating new volume on imported pool although that the
+        // volume is already there.
         node.pools.forEach((obj) => {
-          self.events.push({
-            kind: 'pool',
-            eventType: 'new',
-            object: obj
-          });
           obj.replicas.forEach((obj) => {
             self.events.push({
               kind: 'replica',
               eventType: 'new',
               object: obj
             });
+          });
+          self.events.push({
+            kind: 'pool',
+            eventType: 'new',
+            object: obj
           });
         });
         node.nexus.forEach((obj) => {

--- a/csi/moac/test/event_stream_test.js
+++ b/csi/moac/test/event_stream_test.js
@@ -171,9 +171,6 @@ module.exports = function () {
       expect(events[i].kind).to.equal('node');
       expect(events[i].eventType).to.equal('new');
       expect(events[i++].object.name).to.equal('node1');
-      expect(events[i].kind).to.equal('pool');
-      expect(events[i].eventType).to.equal('new');
-      expect(events[i++].object.name).to.equal('pool1');
       expect(events[i].kind).to.equal('replica');
       expect(events[i].eventType).to.equal('new');
       expect(events[i++].object.uuid).to.equal('uuid1');
@@ -182,10 +179,13 @@ module.exports = function () {
       expect(events[i++].object.uuid).to.equal('uuid2');
       expect(events[i].kind).to.equal('pool');
       expect(events[i].eventType).to.equal('new');
-      expect(events[i++].object.name).to.equal('pool2');
+      expect(events[i++].object.name).to.equal('pool1');
       expect(events[i].kind).to.equal('replica');
       expect(events[i].eventType).to.equal('new');
       expect(events[i++].object.uuid).to.equal('uuid3');
+      expect(events[i].kind).to.equal('pool');
+      expect(events[i].eventType).to.equal('new');
+      expect(events[i++].object.name).to.equal('pool2');
       expect(events[i].kind).to.equal('nexus');
       expect(events[i].eventType).to.equal('new');
       expect(events[i++].object.uuid).to.equal('nexus1');
@@ -198,9 +198,6 @@ module.exports = function () {
       expect(events[i].kind).to.equal('node');
       expect(events[i].eventType).to.equal('new');
       expect(events[i++].object.name).to.equal('node2');
-      expect(events[i].kind).to.equal('pool');
-      expect(events[i].eventType).to.equal('new');
-      expect(events[i++].object.name).to.equal('pool3');
       expect(events[i].kind).to.equal('replica');
       expect(events[i].eventType).to.equal('new');
       expect(events[i++].object.uuid).to.equal('uuid4');
@@ -210,6 +207,9 @@ module.exports = function () {
       expect(events[i].kind).to.equal('replica');
       expect(events[i].eventType).to.equal('new');
       expect(events[i++].object.uuid).to.equal('uuid6');
+      expect(events[i].kind).to.equal('pool');
+      expect(events[i].eventType).to.equal('new');
+      expect(events[i++].object.name).to.equal('pool3');
       expect(events[i].kind).to.equal('node');
       expect(events[i].eventType).to.equal('sync');
       expect(events[i++].object.name).to.equal('node2');

--- a/csi/moac/test/index.js
+++ b/csi/moac/test/index.js
@@ -53,12 +53,14 @@ describe('moac', function () {
   it('start moac process', function (done) {
     // Starting moac, which includes loading all NPM modules from disk, takes
     // time when running in docker with FS mounted from non-linux host.
-    this.timeout(4000);
+    this.timeout(5000);
 
     const child = spawn(path.join(__dirname, '..', 'index.js'), [
       '-s',
       // NATS does not run but just to verify that the option works
-      '--message-bus=127.0.0.1'
+      '--message-bus=127.0.0.1',
+      // shorten the warm up to make the test faster
+      '--heartbeat-interval=1'
     ]);
     let stderr = '';
 

--- a/mayastor/src/subsys/mbus/registration.rs
+++ b/mayastor/src/subsys/mbus/registration.rs
@@ -14,7 +14,7 @@ use snafu::Snafu;
 use std::{env, time::Duration};
 
 /// Mayastor sends registration messages in this interval (kind of heart-beat)
-const HB_INTERVAL: Duration = Duration::from_secs(10);
+const HB_INTERVAL: Duration = Duration::from_secs(5);
 
 /// Errors for pool operations.
 ///

--- a/services/node/src/server.rs
+++ b/services/node/src/server.rs
@@ -14,8 +14,8 @@ struct CliArgs {
     #[structopt(long, short, default_value = "nats://127.0.0.1:4222")]
     nats: String,
     /// Deadline for the mayastor instance keep alive registration
-    /// Default: 20s
-    #[structopt(long, short, default_value = "20s")]
+    /// Default: 10s
+    #[structopt(long, short, default_value = "10s")]
     deadline: humantime::Duration,
 }
 


### PR DESCRIPTION
Give storage nodes a chance to register with control plane before
we start to import volumes from crds. Otherwise moac tries to fix
volumes that are ok, but it does not know about it.