### PR TITLE
feat(nvmx): set of new features for device handles

### DIFF
--- a/mayastor/src/bdev/dev/nvmx/utils.rs
+++ b/mayastor/src/bdev/dev/nvmx/utils.rs
@@ -58,10 +58,9 @@ pub(crate) fn nvme_cpl_succeeded(cpl: *const spdk_nvme_cpl) -> bool {
         && sc == NvmeGenericCommandStatusCode::Success as u16
 }
 /* Bit set of attributes for DATASET MANAGEMENT commands. */
-/*
+#[allow(dead_code)]
 pub enum NvmeDsmAttribute {
     IntegralRead = 0x1,
     IntegralWrite = 0x2,
     Deallocate = 0x4,
 }
-*/

--- a/mayastor/src/core/block_device.rs
+++ b/mayastor/src/core/block_device.rs
@@ -123,9 +123,21 @@ pub trait BlockDeviceHandle {
         cb_arg: *const c_void,
     ) -> Result<(), CoreError>;
 
-    // fn unmap_blocks(u64: offset_blocks, u64: num_blocks, cb:
-    // IoCompletionCallback, cb_arg: *const c_void) -> Result<(), CoreError>;
-    // fn write_zeroes(offset_blocks, num_blocks, cb, cb_arg);
+    fn unmap_blocks(
+        &self,
+        offset_blocks: u64,
+        num_blocks: u64,
+        cb: IoCompletionCallback,
+        cb_arg: *const c_void,
+    ) -> Result<(), CoreError>;
+
+    fn write_zeroes(
+        &self,
+        offset_blocks: u64,
+        num_blocks: u64,
+        cb: IoCompletionCallback,
+        cb_arg: *const c_void,
+    ) -> Result<(), CoreError>;
 
     // NVMe only.
     async fn nvme_admin_custom(&self, opcode: u8) -> Result<(), CoreError>;

--- a/mayastor/src/core/mod.rs
+++ b/mayastor/src/core/mod.rs
@@ -100,6 +100,16 @@ pub enum CoreError {
         source: Errno,
         opcode: u16,
     },
+    #[snafu(display(
+        "Failed to dispatch unmap at offset {} length {}",
+        offset,
+        len
+    ))]
+    NvmeUnmapDispatch {
+        source: Errno,
+        offset: u64,
+        len: u64,
+    },
     #[snafu(display("Write failed at offset {} length {}", offset, len))]
     WriteFailed {
         offset: u64,


### PR DESCRIPTION
This change adds the last remaining functionality for NVMe I/O handles
to be feature-compatible with existing generic bdev handles:
 - unmap()
 - write_zeroes()

In addition, a small refactoring in I/O channels to use poller::Poller
instead of native poller-related SPDK API.

Implements CAS-614