### PR TITLE
fix: avoid panic with missing bdev

### DIFF
--- a/mayastor/src/bdev/nexus/nexus_io.rs
+++ b/mayastor/src/bdev/nexus/nexus_io.rs
@@ -337,7 +337,16 @@ impl Bio {
                     nexus.pause().await.unwrap();
                     nexus.reconfigure(DREvent::ChildFault).await;
                     //nexus.remove_child(&uri).await.unwrap();
-                    bdev_destroy(&uri).await.unwrap();
+
+                    // Note, an error can occur here if a separate task,
+                    // e.g. grpc request is also deleting the child,
+                    // in which case the bdev may no longer exist at
+                    // this point. To be addressed by CAS-632 to
+                    // improve synchronization.
+                    if let Err(err) = bdev_destroy(&uri).await {
+                        error!("{} destroying bdev {}", err, uri)
+                    }
+
                     nexus.resume().await.unwrap();
                     if nexus.status() == NexusStatus::Faulted {
                         error!(":{} has no children left... ", nexus);


### PR DESCRIPTION
When calling child_retire() and bdev_destroy returns
an error, log the error instead of panicking. The bdev
may be missing due to a simultaneous bdev removal via
the control plane. A further change will introduce
better synchronization to avoid this condition.