### PR TITLE
test(rebuild): disable test

### DIFF
--- a/mayastor/tests/rebuild.rs
+++ b/mayastor/tests/rebuild.rs
@@ -776,6 +776,7 @@ async fn rebuild_src_disconnect() {
 /// Test rebuild when disconnecting the destination container from the
 /// network.
 #[tokio::test]
+#[ignore]
 async fn rebuild_dst_disconnect() {
     let test_name = "rebuild_dst_disconnect";
     let test = start_infrastructure(test_name).await;


### PR DESCRIPTION
Disable the rebuild_dst_disconnect test. This test is occasionally
failing on CI/CD even with a suitably high timeout time. When this
occurs an error message is output indicating that we failed to get IO
channel because we were probably low on memory.

A ticket will be raised to investigate this fully and re-enable the
test.