### PR TITLE
chore: more fine grained mayastor test permissions

### DIFF
--- a/mayastor/.cargo/config
+++ b/mayastor/.cargo/config
@@ -1,4 +1,4 @@
 # we need elevated privileges to run mayastor related tests
 # cargo will ask you nicely to type your password
 [target.x86_64-unknown-linux-gnu]
-runner = 'sudo -E'
+runner = ".cargo/runner.sh"

--- a/mayastor/.cargo/runner.sh
+++ b/mayastor/.cargo/runner.sh
@@ -1,15 +1,20 @@
 #! /usr/bin/env bash
-set -x
 
 # Grab the arguments passed to the runner.
 ARGS="${@}"
+
+if [[ $EUID -ne 0 ]]; then
+  MAYBE_SUDO='sudo -E'
+else
+  MAYBE_SUDO=''
+fi
 
 # Elevate to sudo so we can set some capabilities via `capsh`, then execute the args with the required capabilities:
 #
 # * Set `cap_setpcap` to be able to set [ambient capabilities](https://lwn.net/Articles/636533/) which can be inherited
 # by children.
 # * Set `cap_sys_admin,cap_ipc_lock,cap_sys_nice` as they are required by `mayastor`.
-sudo -E capsh \
+${MAYBE_SUDO} capsh \
   --caps="cap_setpcap+iep cap_sys_admin,cap_ipc_lock,cap_sys_nice+iep" \
   --addamb=cap_sys_admin --addamb=cap_ipc_lock --addamb=cap_sys_nice \
   -- -c "${ARGS}"

--- a/mayastor/.cargo/runner.sh
+++ b/mayastor/.cargo/runner.sh
@@ -1,0 +1,15 @@
+#! /usr/bin/env bash
+set -x
+
+# Grab the arguments passed to the runner.
+ARGS="${@}"
+
+# Elevate to sudo so we can set some capabilities via `capsh`, then execute the args with the required capabilities:
+#
+# * Set `cap_setpcap` to be able to set [ambient capabilities](https://lwn.net/Articles/636533/) which can be inherited
+# by children.
+# * Set `cap_sys_admin,cap_ipc_lock,cap_sys_nice` as they are required by `mayastor`.
+sudo -E capsh \
+  --caps="cap_setpcap+iep cap_sys_admin,cap_ipc_lock,cap_sys_nice+iep" \
+  --addamb=cap_sys_admin --addamb=cap_ipc_lock --addamb=cap_sys_nice \
+  -- -c "${ARGS}"


### PR DESCRIPTION
This reduces our usage of `sudo` in Mayastor tests.

Currently, they run as root with full privileges
(via a cargo alias), this isn't awesome.

This PR still uses `sudo`, but only uses `sudo`
long enough to gain the required capabilities
(which @gila told me, thank you). I think the
ambient capabilities are optional, but I suspect
the way it plays into inherited binaries will be
relevant to our use case.

I haven't used `capsh` much, so I'd appreciate
any pointers! :blush: 

## Testing

From `mayastor/`, as a normal user:

```bash
nix-shell ../shell.nix
> cargo test
```

From `mayastor/`, as root:

```bash
sudo nix-shell ../shell.nix
> cargo test
```