### PR TITLE
fix(lint): sanitize PR messages

### DIFF
--- a/.github/workflows/pr-commitlint.yml
+++ b/.github/workflows/pr-commitlint.yml
@@ -18,4 +18,7 @@ jobs:
           last_commit=HEAD^2 # don't lint the merge commit
           npx commitlint --from $first_commit~1 --to $last_commit -V
       - name: Lint Pull Request
-        run: echo "${{ github.event.pull_request.title }}"$'\n\n'"${{ github.event.pull_request.body }}" | npx commitlint -V
+        env:
+          TITLE: ${{ github.event.pull_request.title }}
+          BODY: ${{ github.event.pull_request.body }}
+        run: export NL=; printenv TITLE NL BODY | npx commitlint -V

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -3,6 +3,7 @@ module.exports = {
   rules: {
     "header-max-length": async () => [2, "always", 50],
     "body-max-line-length": async () => [2, "always", 72],
+    'type-enum': [2, 'always', ['build', 'chore', 'ci', 'docs', 'feat', 'fix', 'perf', 'refactor', 'revert', 'style', 'test', 'example']],
   },
-  defaultIgnores: false,    
+  defaultIgnores: false,
 }


### PR DESCRIPTION
Sanitize PR title and body when doing the lint pull request stage.
Also explicitly set type-enum values so we add "example" to the list.