### PR TITLE
chore: permit default conventional commit lengths

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,8 +1,6 @@
 module.exports = {
   extends: ['@commitlint/config-conventional'],
   rules: {
-    "header-max-length": async () => [2, "always", 50],
-    "body-max-line-length": async () => [2, "always", 72],
     'type-enum': [2, 'always', ['build', 'chore', 'ci', 'docs', 'feat', 'fix', 'perf', 'refactor', 'revert', 'style', 'test', 'example']],
   },
   defaultIgnores: false,


### PR DESCRIPTION
Previously we overrode the defaults set by
`@commitlint/config-conventional`. Now we do not.

We flagged this during a discussion on Slack about
#644 as we noted the fix still left #642 invalid
due to line length issues.

I'm not sure why we overrode this, this might cause
breakage in scripts which depend on the presumed
line length.