### PR TITLE
feat(nvmx): controller shutdown/removal

### DIFF
--- a/mayastor/src/bdev/dev/nvmx/uri.rs
+++ b/mayastor/src/bdev/dev/nvmx/uri.rs
@@ -13,7 +13,7 @@ use std::{
 
 use async_trait::async_trait;
 use controller::options::NvmeControllerOpts;
-use futures::channel::oneshot;
+use futures::channel::{oneshot, oneshot::Sender};
 use nix::errno::Errno;
 use poller::Poller;
 use snafu::ResultExt;
@@ -35,13 +35,12 @@ use crate::{
         GetName,
     },
     core::poller,
-    ffihelper::ErrnoResult,
+    ffihelper::{cb_arg, done_cb, ErrnoResult},
     nexus_uri::{
         NexusBdevError,
         {self},
     },
 };
-use futures::channel::oneshot::Sender;
 
 use super::controller::transport::NvmeTransportId;
 const DEFAULT_NVMF_PORT: u16 = 8420;
@@ -286,6 +285,43 @@ impl CreateDestroy for NvmfDeviceTemplate {
 
     // nvme_bdev_ctrlr_create
     async fn destroy(self: Box<Self>) -> Result<(), Self::Error> {
+        // 1. Initiate controller shutdown, which shuts down all I/O resources
+        // of the controller.
+        let controller = NVME_CONTROLLERS
+            .lookup_by_name(self.get_name())
+            .ok_or(NexusBdevError::BdevNotFound {
+                name: self.get_name(),
+            })?;
+
+        let (s, r) = oneshot::channel::<bool>();
+        {
+            let mut controller = controller.lock().expect("lock poisoned");
+
+            fn _shutdown_callback(success: bool, ctx: *mut c_void) {
+                done_cb(ctx, success);
+            }
+
+            controller.shutdown(_shutdown_callback, cb_arg(s)).map_err(
+                |_| NexusBdevError::DestroyBdev {
+                    source: Errno::EAGAIN,
+                    name: self.get_name(),
+                },
+            )?;
+        }
+
+        if !r.await.expect("Failed awaiting at shutdown()") {
+            error!("{} failed to shutdown controller", self.get_name());
+            return Err(NexusBdevError::DestroyBdev {
+                source: Errno::EAGAIN,
+                name: self.get_name(),
+            });
+        }
+
+        // 2. Remove controller from the list so that a new controller with the
+        // same name can be inserted. Note that there may exist other
+        // references to the controller before removal, but since all
+        // controller's resources have been invalidated, that exposes no
+        // risk, as no operations will be possible on such controllers.
         let name =
             NVME_CONTROLLERS
                 .remove_by_name(self.get_name())

--- a/mayastor/src/core/block_device.rs
+++ b/mayastor/src/core/block_device.rs
@@ -72,7 +72,8 @@ pub trait BlockDeviceDescriptor {
     ) -> Result<Box<dyn BlockDeviceHandle>, CoreError>;
 }
 
-pub type IoCompletionCallback = fn(bool, *const c_void) -> ();
+pub type IoCompletionCallbackArg = *mut c_void;
+pub type IoCompletionCallback = fn(bool, IoCompletionCallbackArg) -> ();
 
 /*
  * Core trait that represents a device I/O handle.
@@ -104,7 +105,7 @@ pub trait BlockDeviceHandle {
         offset_blocks: u64,
         num_blocks: u64,
         cb: IoCompletionCallback,
-        cb_arg: *const c_void,
+        cb_arg: IoCompletionCallbackArg,
     ) -> Result<(), CoreError>;
 
     fn writev_blocks(
@@ -114,13 +115,13 @@ pub trait BlockDeviceHandle {
         offset_blocks: u64,
         num_blocks: u64,
         cb: IoCompletionCallback,
-        cb_arg: *const c_void,
+        cb_arg: IoCompletionCallbackArg,
     ) -> Result<(), CoreError>;
 
     fn reset(
         &self,
         cb: IoCompletionCallback,
-        cb_arg: *const c_void,
+        cb_arg: IoCompletionCallbackArg,
     ) -> Result<(), CoreError>;
 
     fn unmap_blocks(
@@ -128,7 +129,7 @@ pub trait BlockDeviceHandle {
         offset_blocks: u64,
         num_blocks: u64,
         cb: IoCompletionCallback,
-        cb_arg: *const c_void,
+        cb_arg: IoCompletionCallbackArg,
     ) -> Result<(), CoreError>;
 
     fn write_zeroes(
@@ -136,7 +137,7 @@ pub trait BlockDeviceHandle {
         offset_blocks: u64,
         num_blocks: u64,
         cb: IoCompletionCallback,
-        cb_arg: *const c_void,
+        cb_arg: IoCompletionCallbackArg,
     ) -> Result<(), CoreError>;
 
     // NVMe only.

--- a/mayastor/src/core/mempool.rs
+++ b/mayastor/src/core/mempool.rs
@@ -52,8 +52,8 @@ impl<T: Sized> MemoryPool<T> {
         }
 
         info!(
-            "Memory pool '{}' with {} elements successfully created",
-            name, size
+            "Memory pool '{}' with {} elements ({} bytes size) successfully created",
+            name, size, size_of::<T>()
         );
         Some(Self {
             pool: NonNull::new(pool).unwrap(),
@@ -74,7 +74,7 @@ impl<T: Sized> MemoryPool<T> {
         }
 
         unsafe {
-            *ptr = val;
+            ptr.write(val);
         }
 
         Some(ptr)

--- a/mayastor/src/core/mod.rs
+++ b/mayastor/src/core/mod.rs
@@ -12,6 +12,7 @@ pub use block_device::{
     BlockDeviceHandle,
     BlockDeviceStats,
     IoCompletionCallback,
+    IoCompletionCallbackArg,
     LbaRangeController,
 };
 pub use channel::IoChannel;

--- a/spdk-sys/build.rs
+++ b/spdk-sys/build.rs
@@ -85,6 +85,8 @@ fn main() {
         .whitelist_function("^nvme_cmd_.*")
         .whitelist_function("^nvme_status_.*")
         .whitelist_function("^nvmf_tgt_accept")
+        .whitelist_function("^nvme_qpair_.*")
+        .whitelist_function("^nvme_ctrlr_.*")
         .blacklist_type("^longfunc")
         .whitelist_var("^NVMF.*")
         .whitelist_var("^SPDK.*")

--- a/spdk-sys/nvme_helper.h
+++ b/spdk-sys/nvme_helper.h
@@ -2,6 +2,7 @@
 #include <stdint.h>
 
 #include <spdk/bdev.h>
+#include <spdk/nvme.h>
 
 struct spdk_nvme_cmd;
 struct spdk_nvme_cpl;
@@ -19,3 +20,6 @@ int
 spdk_bdev_nvme_admin_passthru_ro(struct spdk_bdev_desc *desc, struct spdk_io_channel *ch,
 			      const struct spdk_nvme_cmd *cmd, void *buf, size_t nbytes,
 			      spdk_bdev_io_completion_cb cb, void *cb_arg);
+
+void
+nvme_qpair_abort_reqs(struct spdk_nvme_qpair *qpair, uint32_t dnr);


### PR DESCRIPTION
This fix introduces shutdown logic for NVMe controllers, which kicks in
upon device removal and properly cleans up controller I/O resources.

I/O device now uses a wrapper around SPDK I/O device handle, which
allows better I/O channel iteration and hides low-level SPDK functions
inside iterator.

Implements CAS-627