### PR TITLE
feat(changelog): convco changelog and conventionality 

### DIFF
--- a/.github/workflows/pr-commitlint.yml
+++ b/.github/workflows/pr-commitlint.yml
@@ -12,13 +12,10 @@ jobs:
           fetch-depth: 0
       - name: Install CommitLint and Dependencies
         run: npm install @commitlint/config-conventional @commitlint/cli
-      - name: Lint Commits
-        run: |
-          first_commit=$(curl ${{ github.event.pull_request.commits_url }} 2>/dev/null | jq '.[0].sha' | sed 's/"//g')
-          last_commit=HEAD^2 # don't lint the merge commit
-          npx commitlint --from $first_commit~1 --to $last_commit -V
-      - name: Lint Pull Request
-        env:
-          TITLE: ${{ github.event.pull_request.title }}
-          BODY: ${{ github.event.pull_request.body }}
-        run: export NL=; printenv TITLE NL BODY | npx commitlint -V
+      - name: Ensure follows conventional commits
+        run:
+            TEMP=$(mktemp)
+            nix-shell default.nix -A convco --run "convco changelog > ${TEMP}"
+            diff CHANGELOG.md ${TEMP}
+            rm ${TEMP}
+

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,11 +30,16 @@ repos:
         pass_filenames: true
         types: [file, javascript]
         language: system
-    -   id: commit-lint
-        name: Commit Lint
-        description: Runs commitlint against the commit message.
+    -   id: conventional
+        name: Conventional Commits
+        description: Ensures commits are conventional.
         language: system
-        entry: bash -c "npm install @commitlint/config-conventional @commitlint/cli; cat $1 | npx commitlint"
-        args: [$1]
-        stages: [commit-msg]
+        pass_filenames: false
+        entry: nix-shell default.nix -A convco --run "convco check || true"
+    -   id: changelog
+        name: Updated Changelog
+        description: Updates the changelog (to include up to before this commit -- including this commit is not possible).
+        language: system
+        pass_filenames: false
+        entry: nix-shell default.nix -A convco --run 'convco changelog > CHANGELOG.md'
 

--- a/.versionrc
+++ b/.versionrc
@@ -1,0 +1,3 @@
+# See defaults at https://convco.github.io/configuration/#default-configuration
+---
+header: "# Mayastor Changelog\n\n"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,44 @@
+# Mayastor Changelog
+
+## [Unreleased](https://github.com/openebs/Mayastor/compare/v0.5.0...HEAD) (2021-01-20)
+
+### Features
+
+* **moac:** k8s client - pull fixes from upstream dfdc2c9
+* **jaeger:** add tracing for the rest calls 73a0fce
+* add initial volume service and the rest da5282b
+* add initial pool service, extended the a3644b5
+* **composer:** add docker image capabilities 2087967
+* **js:** use new version of grpc-uds with cached binary 8148909
+* configure for direnv via envrc ab0a0ca
+* **poller:** want poller abstraction c573632
+
+### Fixes
+
+* **lint:** sanitize PR messages 8a62a42
+* **moac:** distribute nexuses more evenly f9eb305
+* avoid panic with missing bdev 8510fb5
+* **moac:** import vols after nodes are registered ba84570
+* **nexus:** segfault connecting to 0 ns nvmf tgt 11f5551
+* **moac:** need more info about watcher objects 68fb155
+* **linter:** fix linter git hook db4ea18
+* fix composer container restart and cd64417
+* **replica:** delay adding replica dcfae9d
+* **nexus:** assertion failure when unpublishing a faulted nexus 957e119
+
+
+## [v0.5.0](https://github.com/openebs/Mayastor/compare/v0.4.0...v0.5.0) (2020-10-13)
+
+
+## [v0.4.0](https://github.com/openebs/Mayastor/compare/v0.3.0...v0.4.0) (2020-09-17)
+
+
+## [v0.3.0](https://github.com/openebs/Mayastor/compare/v0.2.0...v0.3.0) (2020-08-12)
+
+
+## [v0.2.0](https://github.com/openebs/Mayastor/compare/v0.1.0...v0.2.0) (2020-06-15)
+
+
+## v0.1.0 (2020-05-15)
+
+

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,9 +1,0 @@
-module.exports = {
-  extends: ['@commitlint/config-conventional'],
-  rules: {
-    "header-max-length": async () => [2, "always", 50],
-    "body-max-line-length": async () => [2, "always", 72],
-    'type-enum': [2, 'always', ['build', 'chore', 'ci', 'docs', 'feat', 'fix', 'perf', 'refactor', 'revert', 'style', 'test', 'example']],
-  },
-  defaultIgnores: false,
-}

--- a/nix/mayastor-overlay.nix
+++ b/nix/mayastor-overlay.nix
@@ -4,6 +4,7 @@ self: super: {
   libspdk = (super.callPackage ./pkgs/libspdk { }).release;
   libspdk-dev = (super.callPackage ./pkgs/libspdk { }).debug;
   mayastor = (super.callPackage ./pkgs/mayastor { }).release;
+  convco = (super.callPackage ./pkgs/convco { });
   mayastor-dev = (super.callPackage ./pkgs/mayastor { }).debug;
   mayastor-adhoc = (super.callPackage ./pkgs/mayastor { }).adhoc;
   moac = (import ./../csi/moac { pkgs = super; }).package;

--- a/nix/pkgs/convco/default.nix
+++ b/nix/pkgs/convco/default.nix
@@ -1,0 +1,33 @@
+# Please delete me when https://github.com/NixOS/nixpkgs/pull/110375 is merged.
+{ stdenv, lib, fetchFromGitHub, openssl, perl, pkg-config, rustPlatform
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "convco";
+  version = "0.3.2";
+
+  src = fetchFromGitHub {
+    owner = "convco";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0fqq6irbq1aikhhw08gc9kp0vbk2aminfbvwdlm58cvywyq91bn4";
+  };
+
+  cargoSha256 = "073sfv42fbl8rjm3dih1ghs9vq75mjshp66zdzdan2dmmrnw5m9z";
+
+  nativeBuildInputs = [ openssl perl pkg-config ];
+
+  meta = with lib; {
+    description = "A Conventional commit cli";
+    homepage = "https://github.com/convco/convco";
+    license = with licenses; [ mit ];
+    maintainers = [
+        {
+            email = "operator+nix@hoverbear.org";
+            github = "hoverbear";
+            githubId = 130903;
+            name = "Ana Hobden";
+        }
+    ];
+  };
+}


### PR DESCRIPTION
Tries out using convco for changelog generation and workflow.

I suggest you `nix-env --file default.nix --install convco` to try out the tool, but pre-commit lint should do it all for you.


I would prefer an ability to pass messages like the `-m` param of `git`, but it's still quite nice.

Refs: #650

## Testing

To build a changelog:

```bash
nix-env --file default.nix --install convco
convco changelog > CHANGELOG.md
# or
nix-shell default.nix -A convco --run 'convco changelog > CHANGELOG.md'
```

You should try altering the `CHANGELOG.md` and make a commit, notice how the changelog is checked and it has been modified, and the commit failed. Re-commit with the correct changelog. :tada: 

To try committing with the tool (totally optional):

```bash
nix-env --file default.nix --install convco
convco commit --chore # follow the interactive prompts
# or
nix-shell default.nix -A convco --run 'convco commit --feat'
```

## Follow ups

We'll want a followup chore to use official when it merges: https://github.com/NixOS/nixpkgs/pull/110375