### PR TITLE
fix(csi): tackle e2e uninstall test failure

### DIFF
--- a/chart/templates/csi-daemonset.yaml
+++ b/chart/templates/csi-daemonset.yaml
@@ -71,15 +71,10 @@ spec:
             cpu: "100m"
             memory: "50Mi"
       - name: csi-driver-registrar
-        image: quay.io/k8scsi/csi-node-driver-registrar:v1.3.0
+        image: quay.io/k8scsi/csi-node-driver-registrar:v2.1.0
         args:
         - "--csi-address=/csi/csi.sock"
         - "--kubelet-registration-path=/var/lib/kubelet/plugins/mayastor.openebs.io/csi.sock"
-        lifecycle:
-          preStop:
-            exec:
-              # this is needed in order for CSI to detect that the plugin is gone
-              command: ["/bin/sh", "-c", "rm -f /registration/io.openebs.csi-mayastor-reg.sock /csi/csi.sock"]
         volumeMounts:
         - name: plugin-dir
           mountPath: /csi

--- a/deploy/csi-daemonset.yaml
+++ b/deploy/csi-daemonset.yaml
@@ -73,15 +73,10 @@ spec:
             cpu: "100m"
             memory: "50Mi"
       - name: csi-driver-registrar
-        image: quay.io/k8scsi/csi-node-driver-registrar:v1.3.0
+        image: quay.io/k8scsi/csi-node-driver-registrar:v2.1.0
         args:
         - "--csi-address=/csi/csi.sock"
         - "--kubelet-registration-path=/var/lib/kubelet/plugins/mayastor.openebs.io/csi.sock"
-        lifecycle:
-          preStop:
-            exec:
-              # this is needed in order for CSI to detect that the plugin is gone
-              command: ["/bin/sh", "-c", "rm -f /registration/io.openebs.csi-mayastor-reg.sock /csi/csi.sock"]
         volumeMounts:
         - name: plugin-dir
           mountPath: /csi

--- a/nvmeadm/src/nvmf_discovery.rs
+++ b/nvmeadm/src/nvmf_discovery.rs
@@ -529,5 +529,5 @@ pub fn disconnect(nqn: &str) -> Result<usize, NvmeError> {
             Ok(e)
         })
         .collect();
-    Ok(subsys.unwrap().len())
+    Ok(subsys?.len())
 }

--- a/nvmeadm/tests/discovery_test.rs
+++ b/nvmeadm/tests/discovery_test.rs
@@ -117,7 +117,8 @@ impl NvmfTarget {
 impl Drop for NvmfTarget {
     fn drop(&mut self) {
         // Ensure we end with no connected disk
-        let _ = disconnect(SERVED_DISK_NQN);
+        disconnect(SERVED_DISK_NQN)
+            .expect("Should disconnect from the target device");
 
         // Kill the spdk nvmf target
         self.spdk_proc.kill().expect("Failed to kill SPDK process");
@@ -156,7 +157,7 @@ fn connect_test() {
 
 #[test]
 fn disconnect_test() {
-    let _ = disconnect("mynqn");
+    disconnect("mynqn").expect("Should disconnect from the target device");
 }
 
 #[test]


### PR DESCRIPTION
The uninstall keeps failing due to an invalid prestop hook in the 
 csi-driver-registrar.
See:
https://github.com/kubernetes-csi/node-driver-registrar/pull/61/files

Also fix unwrap in nvmeadm library which caused the csi to crash