### PR TITLE
fix(moac): sync replicas more often

### DIFF
--- a/csi/moac/test/volume_test.js
+++ b/csi/moac/test/volume_test.js
@@ -166,7 +166,7 @@ module.exports = function () {
     await volume.unpublish();
     expect(volume.getNodeName()).to.be.undefined();
     sinon.assert.calledOnce(stub);
-    sinon.assert.calledWithMatch(stub, 'destroyNexus', {
+    sinon.assert.calledWithMatch(stub, 'unpublishNexus', {
       uuid: UUID
     });
   });
@@ -184,10 +184,7 @@ module.exports = function () {
 
     await volume.unpublish();
     expect(volume.getNodeName()).to.be.undefined();
-    sinon.assert.calledOnce(stub);
-    sinon.assert.calledWithMatch(stub, 'destroyNexus', {
-      uuid: UUID
-    });
+    sinon.assert.notCalled(stub);
   });
 
   it('should unpublish volume without nexus', async () => {

--- a/csi/moac/test/volumes_test.js
+++ b/csi/moac/test/volumes_test.js
@@ -33,6 +33,7 @@ module.exports = function () {
   let nexus, replica1, replica2;
   let volume;
   let volEvents;
+  let isSynced1, isSynced2, isSynced3;
 
   // Create pristine test env with 3 pools on 3 nodes
   function createTestEnv () {
@@ -41,6 +42,13 @@ module.exports = function () {
     node1 = new Node('node1');
     node2 = new Node('node2');
     node3 = new Node('node3');
+    isSynced1 = sinon.stub(node1, 'isSynced');
+    isSynced1.returns(true);
+    isSynced2 = sinon.stub(node2, 'isSynced');
+    isSynced2.returns(true);
+    isSynced3 = sinon.stub(node3, 'isSynced');
+    isSynced3.returns(true);
+
     // pools sorted from the most to the least preferred
     pool1 = new Pool({
       name: 'pool1',
@@ -196,6 +204,18 @@ module.exports = function () {
         share: 'REPLICA_NONE',
         uri: 'bdev:///' + UUID
       });
+      stub1.onCall(1).resolves({
+        uuid: UUID,
+        size: 90,
+        state: 'NEXUS_ONLINE',
+        children: [
+          {
+            uri: 'bdev:///' + UUID,
+            state: 'CHILD_ONLINE',
+            rebuildProgress: 0
+          }
+        ]
+      });
 
       volumes.start();
       volume = await volumes.createVolume(UUID, {
@@ -206,8 +226,8 @@ module.exports = function () {
         limitBytes: 0,
         protocol: 'nbd'
       });
+      await waitUntil(() => volume.state === 'healthy', 'healthy volume');
       expect(volume.size).to.equal(90);
-      expect(volume.state).to.equal('healthy');
       sinon.assert.calledWithMatch(stub1.firstCall, 'createReplica', {
         uuid: UUID,
         pool: 'pool1',
@@ -215,8 +235,7 @@ module.exports = function () {
         thin: false,
         share: 'REPLICA_NONE'
       });
-      // 1 new + 2 mods
-      expect(volEvents).to.have.lengthOf(3);
+      expect(volEvents).to.have.lengthOf(5);
     });
 
     it('should limit the size of created volume', async () => {
@@ -229,6 +248,18 @@ module.exports = function () {
         share: 'REPLICA_NONE',
         uri: 'bdev:///' + UUID
       });
+      stub1.onCall(1).resolves({
+        uuid: UUID,
+        size: 50,
+        state: 'NEXUS_ONLINE',
+        children: [
+          {
+            uri: 'bdev:///' + UUID,
+            state: 'CHILD_ONLINE',
+            rebuildProgress: 0
+          }
+        ]
+      });
 
       volumes.start();
       volume = await volumes.createVolume(UUID, {
@@ -239,8 +270,8 @@ module.exports = function () {
         limitBytes: 50,
         protocol: 'nbd'
       });
+      await waitUntil(() => volume.state === 'healthy', 'healthy volume');
       expect(volume.size).to.equal(50);
-      expect(volume.state).to.equal('healthy');
       sinon.assert.calledWithMatch(stub1.firstCall, 'createReplica', {
         uuid: UUID,
         pool: 'pool1',
@@ -248,8 +279,7 @@ module.exports = function () {
         thin: false,
         share: 'REPLICA_NONE'
       });
-      // 1 new + 2 mods
-      expect(volEvents).to.have.lengthOf(3);
+      expect(volEvents).to.have.lengthOf(5);
     });
 
     it('should fail if the size is zero', async () => {
@@ -302,16 +332,22 @@ module.exports = function () {
         limitBytes: 50,
         protocol: 'nbd'
       });
+      await waitUntil(() => volume.state === 'faulted', 'faulted volume');
       sinon.assert.notCalled(stub2);
       sinon.assert.notCalled(stub3);
-      sinon.assert.notCalled(stub1);
+      sinon.assert.calledOnce(stub1);
+      sinon.assert.calledWithMatch(stub1.firstCall, 'createNexus', {
+        uuid: UUID,
+        size: 10,
+        children: [`bdev:///${UUID}`]
+      });
       expect(Object.keys(volume.replicas)).to.have.lengthOf(1);
       expect(Object.values(volume.replicas)[0]).to.equal(replica);
-      expect(volume.state).to.equal('healthy');
-      expect(volEvents).to.have.lengthOf(3);
+      expect(volEvents).to.have.lengthOf(4);
       expect(volEvents[0].eventType).to.equal('new');
       expect(volEvents[1].eventType).to.equal('mod');
       expect(volEvents[2].eventType).to.equal('mod');
+      expect(volEvents[3].eventType).to.equal('mod');
     });
 
     it('should create the volume object and include pre-existing nexus', async () => {
@@ -336,7 +372,7 @@ module.exports = function () {
         state: 'NEXUS_ONLINE',
         children: [
           {
-            uri: `nvmf:///blabla/${UUID}`,
+            uri: `nvmf://blabla/${UUID}`,
             state: 'CHILD_ONLINE',
             rebuildProgress: 0
           }
@@ -378,7 +414,7 @@ module.exports = function () {
       });
       expect(Object.keys(volume.replicas)).to.have.lengthOf(1);
       expect(volume.nexus).to.equal(nexus);
-      expect(volEvents).to.have.lengthOf(6);
+      expect(volEvents).to.have.lengthOf(5);
     });
 
     it('should distribute nexuses evenly over available nodes', async () => {
@@ -545,6 +581,15 @@ module.exports = function () {
     });
 
     it('should import a volume without nexus', async () => {
+      // we use two replicas in this test because it uncovers some corner cases
+      const customVolumeSpec = {
+        replicaCount: 2,
+        preferredNodes: [],
+        requiredNodes: [],
+        requiredBytes: 10,
+        limitBytes: 50,
+        protocol: 'nvmf'
+      };
       const replica1 = new Replica({
         uuid: UUID,
         size: 40,
@@ -556,14 +601,31 @@ module.exports = function () {
         uuid: UUID,
         size: 40,
         share: 'REPLICA_NVMF',
-        uri: `nvmf:///${UUID}`
+        uri: `nvmf://${UUID}`
       });
       replica2.pool = { node: node2 };
       const getReplicaSetStub = sinon.stub(registry, 'getReplicaSet');
       getReplicaSetStub.returns([replica1, replica2]);
 
+      // import creates a nexus
+      stub1.onCall(0).resolves({
+        uuid: UUID,
+        deviceUri: '',
+        size: 95,
+        state: 'NEXUS_ONLINE',
+        children: [{
+          uri: `bdev:///${UUID}`,
+          state: 'CHILD_ONLINE'
+        }, {
+          uri: `nvmf://${UUID}`,
+          state: 'CHILD_ONLINE'
+        }]
+      });
+      // and then it is destroyed again
+      stub1.onCall(1).resolves({});
+
       volumes.start();
-      volume = await volumes.importVolume(UUID, volumeSpec, { size: 40 });
+      volume = await volumes.importVolume(UUID, customVolumeSpec, { size: 40 });
       expect(volume.state).to.equal('unknown');
       expect(Object.keys(volume.replicas)).to.have.lengthOf(2);
       // give FSA a chance to run
@@ -571,7 +633,7 @@ module.exports = function () {
       expect(volume.nexus).to.be.null();
       expect(volume.state).to.equal('healthy');
       expect(volume.size).to.equal(40);
-      expect(volEvents).to.have.lengthOf(4);
+      expect(volEvents).to.have.lengthOf(3);
     });
 
     it('should import unpublished volume with nexus', async () => {
@@ -604,7 +666,7 @@ module.exports = function () {
       volume = await volumes.importVolume(UUID, volumeSpec, { size: 40 });
       // give FSA a chance to run
       await sleep(EYE_BLINK_MS);
-      expect(volume.nexus.getUri()).to.be.undefined();
+      expect(volume.nexus).to.be.null();
       expect(Object.keys(volume.replicas)).to.have.lengthOf(1);
       expect(Object.values(volume.replicas)[0]).to.equal(replica);
       expect(volume.state).to.equal('healthy');
@@ -648,7 +710,7 @@ module.exports = function () {
       expect(Object.keys(volume.replicas)).to.have.lengthOf(1);
       expect(Object.values(volume.replicas)[0]).to.equal(replica);
       expect(volume.state).to.equal('healthy');
-      expect(volEvents).to.have.lengthOf(5);
+      expect(volEvents).to.have.lengthOf(4);
     });
   });
 
@@ -790,331 +852,415 @@ module.exports = function () {
   });
 
   describe('scale up/down', function () {
-    beforeEach(() => setUpReferenceEnv(true));
-    afterEach(tearDownReferenceEnv);
+    describe('with used nexus', function () {
+      beforeEach(() => setUpReferenceEnv(true));
+      afterEach(tearDownReferenceEnv);
 
-    it('should scale up if a child is faulted', async () => {
-      // on node 3 is created the new replica
-      stub3.onCall(0).resolves({
-        uuid: UUID,
-        pool: 'pool3',
-        size: 95,
-        thin: false,
-        share: 'REPLICA_NONE',
-        uri: 'bdev:///' + UUID
-      });
-      stub3.onCall(1).resolves({ uri: 'nvmf://replica3' });
-      // the faulted replica should be eventually removed
-      stub2.onCall(0).resolves({});
-      // nexus should be updated twice (add and remove a replica)
-      stub1.onCall(0).resolves({
-        uri: 'nvmf://replica3',
-        state: 'CHILD_DEGRADED',
-        rebuildProgress: 10
-      });
-      stub1.onCall(1).resolves({});
+      it('should scale up if a child is faulted', async () => {
+        // on node 3 is created the new replica
+        stub3.onCall(0).resolves({
+          uuid: UUID,
+          pool: 'pool3',
+          size: 95,
+          thin: false,
+          share: 'REPLICA_NONE',
+          uri: 'bdev:///' + UUID
+        });
+        stub3.onCall(1).resolves({ uri: 'nvmf://replica3' });
+        // the faulted replica should be eventually removed
+        stub2.onCall(0).resolves({});
+        // nexus should be updated twice (add and remove a replica)
+        stub1.onCall(0).resolves({
+          uri: 'nvmf://replica3',
+          state: 'CHILD_DEGRADED',
+          rebuildProgress: 10
+        });
+        stub1.onCall(1).resolves({});
+        // and finally the nexus should be destroyed again
+        stub1.onCall(2).resolves({});
 
-      nexus.children[1].state = 'CHILD_FAULTED';
-      registry.emit('nexus', {
-        eventType: 'mod',
-        object: nexus
-      });
+        nexus.children[1].state = 'CHILD_FAULTED';
+        registry.emit('nexus', {
+          eventType: 'mod',
+          object: nexus
+        });
 
-      await waitUntil(
-        () =>
-          nexus.children.length === 3 &&
-          nexus.children.find((ch) => ch.uri === 'nvmf://replica3'),
-        'new replica'
-      );
-
-      expect(volume.state).to.equal('degraded');
-      const child = nexus.children.find((ch) => ch.uri === 'nvmf://replica3');
-      child.state = 'CHILD_ONLINE';
-      registry.emit('nexus', {
-        eventType: 'mod',
-        object: nexus
-      });
-
-      await waitUntil(
-        () =>
-          nexus.children.length === 2 &&
-          !nexus.children.find((ch) => ch.uri === `nvmf://remote/${UUID}`) &&
-          nexus.children.find((ch) => ch.uri === 'nvmf://replica3'),
-        'faulted replica removal'
-      );
-      expect(volume.state).to.equal('healthy');
-    });
-
-    it('should scale up if replicaCount is increased', async () => {
-      // on node 3 is created the new replica
-      stub3.onCall(0).resolves({
-        uuid: UUID,
-        pool: 'pool3',
-        size: 95,
-        thin: false,
-        share: 'REPLICA_NONE',
-        uri: 'bdev:///' + UUID
-      });
-      stub3.onCall(1).resolves({ uri: 'nvmf://replica3' });
-      // nexus should be updated to add the new child
-      stub1.onCall(0).resolves({
-        uri: 'nvmf://replica3',
-        state: 'CHILD_DEGRADED',
-        rebuildProgress: 10
-      });
-
-      // update the spec
-      volumes.createVolume(UUID, {
-        replicaCount: 3,
-        preferredNodes: [],
-        requiredNodes: [],
-        requiredBytes: 90,
-        limitBytes: 110,
-        protocol: 'nbd'
-      });
-
-      await waitUntil(
-        () =>
-          nexus.children.length === 3 &&
-          nexus.children.find((ch) => ch.uri === 'nvmf://replica3'),
-        'new replica'
-      );
-      expect(volume.state).to.equal('degraded');
-    });
-
-    it('should not scale up if the replica is there but just being rebuilt', async () => {
-      // this would have been normally done but should not be the case now
-      stub3.onCall(0).resolves({
-        uuid: UUID,
-        pool: 'pool3',
-        size: 95,
-        thin: false,
-        share: 'REPLICA_NONE',
-        uri: 'bdev:///' + UUID
-      });
-      stub3.onCall(1).resolves({ uri: 'nvmf://replica3' });
-      stub1.onCall(0).resolves({
-        uri: 'nvmf://replica3',
-        state: 'CHILD_DEGRADED',
-        rebuildProgress: 10
-      });
-
-      nexus.children[0].state = 'CHILD_DEGRADED';
-      registry.emit('nexus', {
-        eventType: 'mod',
-        object: nexus
-      });
-      await waitUntil(() => volume.state === 'degraded', 'degraded volume');
-
-      try {
         await waitUntil(
-          () => nexus.children.length === 3,
-          100, // 100 ms
-          'new replica not to appear'
+          () =>
+            nexus.children.length === 3 &&
+            nexus.children.find((ch) => ch.uri === 'nvmf://replica3'),
+          'new replica'
         );
-      } catch (err) {
-        // we are fine
-        expect(volume.nexus.children).to.have.lengthOf(2);
+
         expect(volume.state).to.equal('degraded');
-        return;
-      }
-      throw new Error('well, the new replica did appear');
-    });
+        const child = nexus.children.find((ch) => ch.uri === 'nvmf://replica3');
+        child.state = 'CHILD_ONLINE';
+        registry.emit('nexus', {
+          eventType: 'mod',
+          object: nexus
+        });
 
-    it('should not scale up if replica is offline but the child is online', async () => {
-      // this would have been normally done but should not be the case now
-      stub3.onCall(0).resolves({
-        uuid: UUID,
-        pool: 'pool3',
-        size: 95,
-        thin: false,
-        share: 'REPLICA_NONE',
-        uri: 'bdev:///' + UUID
-      });
-      stub3.onCall(1).resolves({ uri: 'nvmf://replica3' });
-      stub1.onCall(0).resolves({
-        uri: 'nvmf://replica3',
-        state: 'CHILD_DEGRADED',
-        rebuildProgress: 10
-      });
-
-      replica1.offline();
-
-      try {
         await waitUntil(
-          () => nexus.children.length === 3,
-          100, // 100 ms
-          'new replica not to appear'
+          () =>
+            nexus.children.length === 2 &&
+            !nexus.children.find((ch) => ch.uri === `nvmf://remote/${UUID}`) &&
+            nexus.children.find((ch) => ch.uri === 'nvmf://replica3'),
+          'faulted replica removal'
         );
-      } catch (err) {
-        // we are fine
-        expect(volume.nexus.children).to.have.lengthOf(2);
         expect(volume.state).to.equal('healthy');
-        return;
-      }
-      throw new Error('well, the new replica did appear');
-    });
-
-    it('should scale down if replicaCount is decreased', async () => {
-      // node 1: updated nexus (remove-child)
-      stub1.onCall(0).resolves({});
-      // node 2: destroyed replica
-      stub2.onCall(1).resolves({});
-
-      // update the spec
-      volumes.createVolume(UUID, {
-        replicaCount: 1,
-        preferredNodes: [],
-        requiredNodes: [],
-        requiredBytes: 90,
-        limitBytes: 110,
-        protocol: 'nbd'
       });
 
-      await waitUntil(
-        () =>
-          nexus.children.length === 1 &&
-          !nexus.children.find((ch) => ch.uri === `nvmf://remote/${UUID}`),
-        'replica to be destroyed'
-      );
-      expect(volume.state).to.equal('healthy');
-    });
+      it('should not scale up if the replica is there but just being rebuilt', async () => {
+        // this would have been normally done but should not be the case now
+        stub3.onCall(0).resolves({
+          uuid: UUID,
+          pool: 'pool3',
+          size: 95,
+          thin: false,
+          share: 'REPLICA_NONE',
+          uri: 'bdev:///' + UUID
+        });
+        stub3.onCall(1).resolves({ uri: 'nvmf://replica3' });
+        stub1.onCall(0).resolves({
+          uri: 'nvmf://replica3',
+          state: 'CHILD_DEGRADED',
+          rebuildProgress: 10
+        });
 
-    it('should not scale down if a rebuild is in progress', async () => {
-      // node 1: updated nexus (remove-child)
-      stub1.onCall(0).resolves({});
-      // node 2: destroyed replica
-      stub2.onCall(1).resolves({});
+        nexus.children[0].state = 'CHILD_DEGRADED';
+        registry.emit('nexus', {
+          eventType: 'mod',
+          object: nexus
+        });
+        await waitUntil(() => volume.state === 'degraded', 'degraded volume');
 
-      nexus.children[0].state = 'CHILD_DEGRADED';
-      registry.emit('nexus', {
-        eventType: 'mod',
-        object: nexus
+        try {
+          await waitUntil(
+            () => nexus.children.length === 3,
+            100, // 100 ms
+            'new replica not to appear'
+          );
+        } catch (err) {
+          // we are fine
+          expect(volume.nexus.children).to.have.lengthOf(2);
+          expect(volume.state).to.equal('degraded');
+          return;
+        }
+        throw new Error('well, the new replica did appear');
       });
-      await waitUntil(() => volume.state === 'degraded', 'degraded volume');
 
-      // update the spec
-      volumes.createVolume(UUID, {
-        replicaCount: 1,
-        preferredNodes: [],
-        requiredNodes: [],
-        requiredBytes: 90,
-        limitBytes: 110,
-        protocol: 'nbd'
+      it('should not scale up if replica is offline but the child is online', async () => {
+        // this would have been normally done but should not be the case now
+        stub3.onCall(0).resolves({
+          uuid: UUID,
+          pool: 'pool3',
+          size: 95,
+          thin: false,
+          share: 'REPLICA_NONE',
+          uri: 'bdev:///' + UUID
+        });
+        stub3.onCall(1).resolves({ uri: 'nvmf://replica3' });
+        stub1.onCall(0).resolves({
+          uri: 'nvmf://replica3',
+          state: 'CHILD_DEGRADED',
+          rebuildProgress: 10
+        });
+
+        replica1.offline();
+
+        try {
+          await waitUntil(
+            () => nexus.children.length === 3,
+            100, // 100 ms
+            'new replica not to appear'
+          );
+        } catch (err) {
+          // we are fine
+          expect(volume.nexus.children).to.have.lengthOf(2);
+          expect(volume.state).to.equal('healthy');
+          return;
+        }
+        throw new Error('well, the new replica did appear');
       });
 
-      try {
+      it('should not scale down if a rebuild is in progress', async () => {
+        // node 1: updated nexus (remove-child)
+        stub1.onCall(0).resolves({});
+        // node 2: destroyed replica
+        stub2.onCall(1).resolves({});
+
+        nexus.children[0].state = 'CHILD_DEGRADED';
+        registry.emit('nexus', {
+          eventType: 'mod',
+          object: nexus
+        });
+        await waitUntil(() => volume.state === 'degraded', 'degraded volume');
+
+        // update the spec
+        await volumes.createVolume(UUID, {
+          replicaCount: 1,
+          preferredNodes: [],
+          requiredNodes: [],
+          requiredBytes: 90,
+          limitBytes: 110,
+          protocol: 'nbd'
+        });
+
+        try {
+          await waitUntil(
+            () => nexus.children.length === 1,
+            100,
+            'replica to be destroyed'
+          );
+        } catch (err) {
+          expect(volume.state).to.equal('degraded');
+          return;
+        }
+        throw new Error('The replica was removed even if in rebuild state');
+      });
+
+      it('should scale up and then scale down when a volume is moved', async () => {
+        // on node 3 is created the new replica
+        stub3.onCall(0).resolves({
+          uuid: UUID,
+          pool: 'pool3',
+          size: 95,
+          thin: false,
+          share: 'REPLICA_NONE',
+          uri: 'bdev:///' + UUID
+        });
+        stub3.onCall(1).resolves({ uri: 'nvmf://replica3' });
+        // nexus should be updated to add the new child
+        stub1.onCall(0).resolves({
+          uri: 'nvmf://replica3',
+          state: 'CHILD_DEGRADED',
+          rebuildProgress: 10
+        });
+
+        // update the spec: node2 remains but the first replica should move
+        // from node1 to node3
+        volume = await volumes.createVolume(UUID, {
+          replicaCount: 2,
+          preferredNodes: [],
+          requiredNodes: ['node2', 'node3'],
+          requiredBytes: 90,
+          limitBytes: 110,
+          protocol: 'nbd'
+        });
+
         await waitUntil(
-          () => nexus.children.length === 1,
-          100,
+          () => nexus.children.length === 3 && volume.state === 'degraded',
+          'new replica'
+        );
+
+        const newChild = volume.nexus.children.find(
+          (ch) => ch.state === 'CHILD_DEGRADED'
+        );
+        expect(newChild.uri).to.equal('nvmf://replica3');
+        newChild.state = 'CHILD_ONLINE';
+        registry.emit('nexus', {
+          eventType: 'mod',
+          object: nexus
+        });
+
+        await waitUntil(() => nexus.children.length === 2, 'replica removal');
+        expect(volume.state).to.equal('healthy');
+        expect(Object.keys(volume.replicas)).to.deep.equal(['node2', 'node3']);
+      });
+
+      it('should scale up if a new pool is created', async () => {
+        // on node 3 we destroy (and create) the pool and create the new replica
+        stub3.onCall(0).resolves({});
+        stub3.onCall(1).resolves({
+          uuid: UUID,
+          pool: 'pool3',
+          size: 95,
+          thin: false,
+          share: 'REPLICA_NONE',
+          uri: 'bdev:///' + UUID
+        });
+        stub3.onCall(2).resolves({ uri: 'nvmf://replica3' });
+        // nexus should be updated to add the new child
+        stub1.onCall(0).resolves({
+          uri: 'nvmf://replica3',
+          state: 'CHILD_DEGRADED',
+          rebuildProgress: 10
+        });
+
+        // delete the third pool to pretend we ran out of pools
+        await pool3.destroy();
+
+        // now we cannot create the new replica (this is the update op in fact)
+        await volumes.createVolume(UUID, {
+          replicaCount: 3,
+          preferredNodes: [],
+          requiredNodes: [],
+          requiredBytes: 90,
+          limitBytes: 110,
+          protocol: 'nbd'
+        });
+        await waitUntil(() => volume.state === 'degraded', 'degraded volume');
+
+        // now create the pool and see if it gets used for the new replica
+        pool3 = new Pool({
+          name: 'pool3',
+          disks: [],
+          capacity: 100,
+          used: 4,
+          state: 'POOL_DEGRADED'
+        });
+        node3._registerPool(pool3);
+
+        await waitUntil(
+          () => nexus.children.length === 3 && volume.state === 'degraded',
+          'degraded volume with new replica'
+        );
+
+        const newChild = volume.nexus.children.find(
+          (ch) => ch.state === 'CHILD_DEGRADED'
+        );
+        expect(newChild.uri).to.equal('nvmf://replica3');
+        newChild.state = 'CHILD_ONLINE';
+        registry.emit('nexus', {
+          eventType: 'mod',
+          object: nexus
+        });
+
+        await waitUntil(
+          () => nexus.children.length === 3 && volume.state === 'healthy',
+          'healthy volume'
+        );
+      });
+    });
+
+    describe('without nexus', function () {
+      beforeEach(() => setUpReferenceEnv(false));
+      afterEach(tearDownReferenceEnv);
+
+      it('should scale up if replicaCount is increased', async () => {
+        // scale up involves nexus creation
+        stub1.onCall(0).resolves({
+          uuid: UUID,
+          size: 95,
+          state: 'NEXUS_ONLINE',
+          children: [
+            {
+              uri: `bdev:///${UUID}`,
+              state: 'CHILD_ONLINE',
+              rebuildProgress: 0
+            },
+            {
+              uri: `nvmf://remote/${UUID}`,
+              state: 'CHILD_ONLINE',
+              rebuildProgress: 0
+            }
+          ]
+        });
+        // on node 3 is created the new replica
+        stub3.onCall(0).resolves({
+          uuid: UUID,
+          pool: 'pool3',
+          size: 95,
+          thin: false,
+          share: 'REPLICA_NONE',
+          uri: 'bdev:///' + UUID
+        });
+        stub3.onCall(1).resolves({ uri: 'nvmf://replica3' });
+        // nexus should be updated to add the new child
+        stub1.onCall(1).resolves({
+          uri: 'nvmf://replica3',
+          state: 'CHILD_DEGRADED',
+          rebuildProgress: 10
+        });
+        // nexus will be destroyed at the end
+        stub1.onCall(2).resolves({});
+
+        // update the spec
+        volume = await volumes.createVolume(UUID, {
+          replicaCount: 3,
+          preferredNodes: [],
+          requiredNodes: [],
+          requiredBytes: 90,
+          limitBytes: 110,
+          protocol: 'nbd'
+        });
+
+        await waitUntil(
+          () =>
+            volume.state === 'degraded' &&
+            Object.keys(volume.replicas).length === 3 &&
+            volume.nexus.children.length === 3,
+          'new replica'
+        );
+        const newReplica = Object.values(volume.replicas).find((r) => r.uri === 'nvmf://replica3');
+        const nexus = volume.nexus;
+        const child = nexus.children[2];
+        expect(nexus).not.to.be.null();
+        expect(newReplica.pool.name).to.equal('pool3');
+        expect(child.state).to.equal('CHILD_DEGRADED');
+
+        // simulate rebuild finish - the nexus should go away
+        child.state = 'CHILD_ONLINE';
+        registry.emit('nexus', {
+          eventType: 'mod',
+          object: nexus
+        });
+        await waitUntil(
+          () => volume.state === 'healthy' && volume.nexus === null,
+          'healthy volume'
+        );
+        expect(Object.keys(volume.replicas)).has.lengthOf(3);
+      });
+
+      it('should scale down if replicaCount is decreased', async () => {
+        // scale down involves nexus creation
+        stub1.onCall(0).resolves({
+          uuid: UUID,
+          size: 95,
+          state: 'NEXUS_ONLINE',
+          children: [
+            {
+              uri: `bdev:///${UUID}`,
+              state: 'CHILD_ONLINE',
+              rebuildProgress: 0
+            },
+            {
+              uri: `nvmf://remote/${UUID}`,
+              state: 'CHILD_ONLINE',
+              rebuildProgress: 0
+            }
+          ]
+        });
+        // node 1: updated nexus (remove-child)
+        stub1.onCall(1).resolves({});
+        // node 2: destroyed replica
+        stub2.onCall(0).resolves({});
+        // nexus will be destroyed at the end
+        stub1.onCall(2).resolves({});
+
+        // update the spec
+        await volumes.createVolume(UUID, {
+          replicaCount: 1,
+          preferredNodes: [],
+          requiredNodes: [],
+          requiredBytes: 90,
+          limitBytes: 110,
+          protocol: 'nbd'
+        });
+
+        // Nexus gets created and destroyed inbetween but it's difficult to
+        // capture that moment in the tests because we don't know the precise
+        // timing.
+        await waitUntil(
+          () =>
+            Object.keys(volume.replicas).length === 1 &&
+            volume.nexus === null,
           'replica to be destroyed'
         );
-      } catch (err) {
-        expect(volume.state).to.equal('degraded');
-        return;
-      }
-      throw new Error('The replica was removed even if in rebuild state');
-    });
-
-    it('should scale up and then scale down when a volume is moved', async () => {
-      // on node 3 is created the new replica
-      stub3.onCall(0).resolves({
-        uuid: UUID,
-        pool: 'pool3',
-        size: 95,
-        thin: false,
-        share: 'REPLICA_NONE',
-        uri: 'bdev:///' + UUID
+        expect(volume.state).to.equal('healthy');
+        const oldReplica = Object.values(volume.replicas).find((r) => r.uri === `nvmf://remote/${UUID}`);
+        expect(oldReplica).to.be.undefined();
       });
-      stub3.onCall(1).resolves({ uri: 'nvmf://replica3' });
-      // nexus should be updated to add the new child
-      stub1.onCall(0).resolves({
-        uri: 'nvmf://replica3',
-        state: 'CHILD_DEGRADED',
-        rebuildProgress: 10
-      });
-
-      // update the spec: node2 remains but the first replica should move
-      // from node1 to node3
-      volumes.createVolume(UUID, {
-        replicaCount: 2,
-        preferredNodes: [],
-        requiredNodes: ['node2', 'node3'],
-        requiredBytes: 90,
-        limitBytes: 110,
-        protocol: 'nbd'
-      });
-
-      await waitUntil(
-        () => nexus.children.length === 3 && volume.state === 'degraded',
-        'degraded volume with new replica'
-      );
-
-      const newChild = volume.nexus.children.find(
-        (ch) => ch.state === 'CHILD_DEGRADED'
-      );
-      expect(newChild.uri).to.equal('nvmf://replica3');
-      newChild.state = 'CHILD_ONLINE';
-      registry.emit('nexus', {
-        eventType: 'mod',
-        object: nexus
-      });
-
-      await waitUntil(() => nexus.children.length === 2, 'replica removal');
-      expect(volume.state).to.equal('healthy');
-      expect(Object.keys(volume.replicas)).to.deep.equal(['node2', 'node3']);
-    });
-
-    it('should scale up if a new pool is created', async () => {
-      // on node 3 we destroy (and create) the pool and create the new replica
-      stub3.onCall(0).resolves({});
-      stub3.onCall(1).resolves({
-        uuid: UUID,
-        pool: 'pool3',
-        size: 95,
-        thin: false,
-        share: 'REPLICA_NONE',
-        uri: 'bdev:///' + UUID
-      });
-      stub3.onCall(2).resolves({ uri: 'nvmf://replica3' });
-      // nexus should be updated to add the new child
-      stub1.onCall(0).resolves({
-        uri: 'nvmf://replica3',
-        state: 'CHILD_DEGRADED',
-        rebuildProgress: 10
-      });
-
-      // delete the third pool to pretend we ran out of pools
-      await pool3.destroy();
-
-      // now we cannot create the new replica
-      volumes.createVolume(UUID, {
-        replicaCount: 3,
-        preferredNodes: [],
-        requiredNodes: [],
-        requiredBytes: 90,
-        limitBytes: 110,
-        protocol: 'nbd'
-      });
-      await waitUntil(() => volume.state === 'degraded', 'degraded volume');
-
-      // now create the pool and see if it gets used for the new replica
-      pool3 = new Pool({
-        name: 'pool3',
-        disks: [],
-        capacity: 100,
-        used: 4,
-        state: 'POOL_DEGRADED'
-      });
-      node3._registerPool(pool3);
-
-      await waitUntil(
-        () =>
-          nexus.children.length === 3 &&
-          nexus.children.find((ch) => ch.uri === 'nvmf://replica3'),
-        'new replica'
-      );
-      expect(volume.state).to.equal('degraded');
     });
   });
 
@@ -1170,14 +1316,16 @@ module.exports = function () {
       await waitUntil(() => volume.state === 'faulted', 'offline volume');
     });
 
-    it('should move to "healthy" when volume is unpublished', async () => {
-      nexus.state = 'NEXUS_OFFLINE';
+    it('should remain what it was when volume is unpublished', async () => {
+      nexus.children[0].state = 'CHILD_DEGRADED';
       registry.emit('nexus', {
-        eventType: 'del',
+        eventType: 'mod',
         object: nexus
       });
+      await waitUntil(() => volume.state === 'degraded', 'degraded volume');
       await volume.unpublish();
-      await waitUntil(() => volume.state === 'healthy', 'healthy volume');
+      await sleep(EYE_BLINK_MS);
+      await waitUntil(() => volume.state === 'degraded', 'degraded volume');
     });
 
     it('should not move to any state when in "destroyed" state', async () => {
@@ -1226,6 +1374,8 @@ module.exports = function () {
         deviceUri: 'file:///dev/nbd0'
       });
 
+      // pretend that node1 is down
+      isSynced1.returns(false);
       // we unbind the nexus - that happens when node goes down
       nexus.unbind();
       await waitUntil(() => volume.state === 'faulted', 'volume faulted');
@@ -1233,8 +1383,7 @@ module.exports = function () {
       expect(volume.publishedOn).to.equal('node1');
 
       // this simulates node that has been just successfully sync'd
-      const isSyncedStub = sinon.stub(node1, 'isSynced');
-      isSyncedStub.returns(true);
+      isSynced1.returns(true);
       node1.emit('node', {
         eventType: 'mod',
         object: node1
@@ -1334,7 +1483,7 @@ module.exports = function () {
 
     // this creates a volume used in subsequent cases
     it('should create a new volume', async () => {
-      // on node 1 is created replica
+      // on node 1 is created replica and nexus
       stub1.onCall(0).resolves({
         uuid: UUID,
         pool: 'pool1',
@@ -1342,6 +1491,28 @@ module.exports = function () {
         thin: false,
         share: 'REPLICA_NONE',
         uri: 'bdev:///' + UUID
+      });
+      stub1.onCall(1).resolves({
+        uuid: UUID,
+        size: 96,
+        state: 'NEXUS_ONLINE',
+        children: [
+          {
+            uri: 'bdev:///' + UUID,
+            state: 'CHILD_ONLINE',
+            rebuildProgress: 0
+          },
+          {
+            uri: 'nvmf://replica2',
+            state: 'CHILD_ONLINE',
+            rebuildProgress: 0
+          },
+          {
+            uri: 'nvmf://replica3',
+            state: 'CHILD_ONLINE',
+            rebuildProgress: 0
+          }
+        ]
       });
       // on node 2 is created replica and it is shared
       stub2.onCall(0).resolves({
@@ -1374,7 +1545,7 @@ module.exports = function () {
         protocol: 'nbd'
       });
 
-      sinon.assert.calledOnce(stub1);
+      sinon.assert.calledTwice(stub1);
       sinon.assert.calledWithMatch(stub1.firstCall, 'createReplica', {
         uuid: UUID,
         pool: 'pool1',
@@ -1382,8 +1553,13 @@ module.exports = function () {
         thin: false,
         share: 'REPLICA_NONE'
       });
+      sinon.assert.calledWithMatch(stub1.secondCall, 'createNexus', {
+        uuid: UUID,
+        size: 96,
+        children: ['bdev:///' + UUID, 'nvmf://replica2', 'nvmf://replica3']
+      });
 
-      sinon.assert.calledOnce(stub2);
+      sinon.assert.calledTwice(stub2);
       sinon.assert.calledWithMatch(stub2.firstCall, 'createReplica', {
         uuid: UUID,
         pool: 'pool2',
@@ -1391,14 +1567,29 @@ module.exports = function () {
         thin: false,
         share: 'REPLICA_NONE'
       });
+      sinon.assert.calledWithMatch(stub2.secondCall, 'shareReplica', {
+        uuid: UUID,
+        share: 'REPLICA_NVMF'
+      });
 
-      sinon.assert.calledOnce(stub3);
+      sinon.assert.calledTwice(stub3);
       sinon.assert.calledWithMatch(stub3.firstCall, 'createReplica', {
         uuid: UUID,
         pool: 'pool3',
         size: 96,
         thin: false,
         share: 'REPLICA_NONE'
+      });
+      sinon.assert.calledWithMatch(stub2.secondCall, 'shareReplica', {
+        uuid: UUID,
+        share: 'REPLICA_NVMF'
+      });
+
+      // wait for the nexus to be destroyed after creation
+      await sleep(EYE_BLINK_MS);
+      sinon.assert.calledThrice(stub1);
+      sinon.assert.calledWithMatch(stub1.thirdCall, 'destroyNexus', {
+        uuid: UUID
       });
 
       expect(volumes.get(UUID)).to.equal(volume);
@@ -1417,8 +1608,7 @@ module.exports = function () {
       expect(volume.replicas.node3.uuid).to.equal(UUID);
       expect(volume.state).to.equal('healthy');
 
-      // 1 new + 3 new replicas + state change
-      expect(volEvents).to.have.lengthOf(5);
+      expect(volEvents).to.have.lengthOf(9);
     });
 
     it('should publish the volume', async () => {
@@ -1447,10 +1637,6 @@ module.exports = function () {
         ]
       });
       stub1.onCall(1).resolves({ deviceUri });
-      // on node 2 is shared replica
-      stub2.onCall(0).resolves({ uri: 'nvmf://replica2' });
-      // on node 3 is shared replica
-      stub3.onCall(0).resolves({ uri: 'nvmf://replica3' });
 
       const uri = await volume.publish('nbd');
       expect(uri).to.equal(deviceUri);
@@ -1467,17 +1653,8 @@ module.exports = function () {
         share: enums.NEXUS_NBD
       });
 
-      sinon.assert.calledOnce(stub2);
-      sinon.assert.calledWithMatch(stub2.firstCall, 'shareReplica', {
-        uuid: UUID,
-        share: 'REPLICA_NVMF'
-      });
-
-      sinon.assert.calledOnce(stub3);
-      sinon.assert.calledWithMatch(stub3.firstCall, 'shareReplica', {
-        uuid: UUID,
-        share: 'REPLICA_NVMF'
-      });
+      sinon.assert.notCalled(stub2);
+      sinon.assert.notCalled(stub3);
 
       expect(volume.getNodeName()).to.equal('node1');
       expect(volume.getSize()).to.equal(96);
@@ -1486,15 +1663,21 @@ module.exports = function () {
       expect(Object.keys(volume.replicas)).to.have.lengthOf(3);
       expect(volume.state).to.equal('healthy');
 
-      // 5 mods (2 set share, 1 new nexus, 1 publish nexus, state change)
-      expect(volEvents).to.have.lengthOf(5);
+      // 3 mods (1 new nexus, 1 publish nexus, state change)
+      expect(volEvents).to.have.lengthOf(3);
     });
 
     it('should unpublish the volume', async () => {
       stub1.onCall(0).resolves({});
+      stub1.onCall(1).resolves({});
       await volume.unpublish();
-      sinon.assert.calledOnce(stub1);
-      sinon.assert.calledWithMatch(stub1, 'destroyNexus', {
+      // wait for the nexus to be destroyed after unpublish
+      await sleep(EYE_BLINK_MS);
+      sinon.assert.calledTwice(stub1);
+      sinon.assert.calledWithMatch(stub1.firstCall, 'unpublishNexus', {
+        uuid: UUID
+      });
+      sinon.assert.calledWithMatch(stub1.secondCall, 'destroyNexus', {
         uuid: UUID
       });
       expect(volume.getNodeName()).to.be.undefined();
@@ -1502,8 +1685,8 @@ module.exports = function () {
       expect(volume.nexus).is.null();
       expect(volume.state).to.equal('healthy');
       expect(Object.keys(volume.replicas)).to.have.length(3);
-      // 2 nexus events
-      expect(volEvents).to.have.lengthOf(2);
+      // 3 nexus events
+      expect(volEvents).to.have.lengthOf(3);
     });
 
     it('should destroy the volume', async () => {

--- a/csi/moac/volumes.ts
+++ b/csi/moac/volumes.ts
@@ -127,12 +127,6 @@ export class Volumes extends EventEmitter {
         eventType: 'new',
         object: volume
       });
-      // check for components that already exist and assign them to the volume
-      this.registry.getReplicaSet(uuid).forEach((r: Replica) => volume.newReplica(r));
-      const nexus: Nexus = this.registry.getNexus(uuid);
-      if (nexus) {
-        volume.newNexus(nexus);
-      }
 
       try {
         await volume.create();
@@ -199,16 +193,9 @@ export class Volumes extends EventEmitter {
           object: volume
         });
       }, spec, status.state, status.size, publishedOn);
+      volume.attach();
+      volume.state = VolumeState.Unknown;
       this.volumes[uuid] = volume;
-
-      // attach any associated replicas to the volume
-      this.registry.getReplicaSet(uuid).forEach((r: Replica) => volume.newReplica(r));
-
-      const nexus = this.registry.getNexus(uuid);
-      if (nexus) {
-        volume.newNexus(nexus);
-      }
-      volume._setState(VolumeState.Unknown);
       volume.fsa();
     }
     return volume;


### PR DESCRIPTION
fix(moac): sync replicas more often

One of the previous fixes for moac introduced a significant change to
lifecycle of the volumes and that was that a nexus for a volume was
created only if the volume was used (published in k8s speak). That
creates a number of occasions when we don't attempt to synchronize
data on replicas although we should. To solve that we create a nexus
each time we think that data need to be synchronized. We don't publish
it so that no one can access the volume. The new cases are:

* when volume is created: nexus writes labels to replicas and goes
  away again.
* when volume is imported: nexus checks replicas and sets their
  status (not implemented in data plane yet).
* when replicas are scaled up: new replica gets added to the new
  nexus and when the synchronization is finished, the nexus is
  removed again.
* when replicas are scaled down: replica gets removed from the new
  nexus, replica is destroyed and nexus is removed again.

By performing these type of operations while nexus is there we improve
the stability of the data throughout volume's lifecycle. There are
number of cases that aren't still solved and that require other
changes in data and control plane (i.e. persisten generation numbers
stored on replicas, storing gen numbers in control plane), though
this is a step forward.