### PR TITLE
ci(moac): scale up/down test fails sometimes

### DIFF
--- a/csi/moac/test/volumes_test.js
+++ b/csi/moac/test/volumes_test.js
@@ -1045,8 +1045,10 @@ module.exports = function () {
         protocol: 'nbd'
       });
 
-      await waitUntil(() => nexus.children.length === 3, 'new replica');
-      expect(volume.state).to.equal('degraded');
+      await waitUntil(
+        () => nexus.children.length === 3 && volume.state === 'degraded',
+        'degraded volume with new replica'
+      );
 
       const newChild = volume.nexus.children.find(
         (ch) => ch.state === 'CHILD_DEGRADED'


### PR DESCRIPTION
The problem was that after we add a new replica to the volume it
does not immediately transition to degraded state (the new replica
usually starts in degraded state because it is not synced) but the
volume state change happens shortly after it. So the test code was
wrong that immediately after adding a child to nexus the state should
be degraded. It has to wait for it.