### PR TITLE
ci: refine ci install+uninstall tests

### DIFF
--- a/scripts/e2e-cluster-dump.sh
+++ b/scripts/e2e-cluster-dump.sh
@@ -42,6 +42,11 @@ function cluster-get {
     kubectl -n mayastor get msn --sort-by=.metadata.creationTimestamp
     echo "-- K8s Nodes -----------------------------"
     kubectl get nodes -o wide --show-labels
+    echo "-- K8s Deployments -------------------"
+    kubectl -n mayastor get deployments
+    echo "-- K8s Daemonsets --------------------"
+    kubectl -n mayastor get daemonsets
+
 }
 
 function cluster-describe {
@@ -66,8 +71,12 @@ function cluster-describe {
     kubectl -n mayastor describe msv
     echo "-- Mayastor Nodes --------------------"
     kubectl -n mayastor describe msn
-    echo "-- K8s Nodes -----------------------------"
+    echo "-- K8s Nodes -------------------------"
     kubectl describe nodes
+    echo "-- K8s Deployments -------------------"
+    kubectl -n mayastor describe deployments
+    echo "-- K8s Daemonsets --------------------"
+    kubectl -n mayastor describe daemonsets
 }
 
 function logs-csi-containers {


### PR DESCRIPTION
- Change the check for MOAC deployment readyness,
    use the condition status
    emit more diagnostics messages during the check.
- Delete pools prior to uninstall
- Make --logs option more useful in the e2e-tests script