### PR TITLE
fix(nexus): allow re-adding child removed by AEN

### DIFF
--- a/mayastor/src/bdev/nexus/mod.rs
+++ b/mayastor/src/bdev/nexus/mod.rs
@@ -59,3 +59,17 @@ pub fn nexus_instance_new(name: String, size: u64, children: Vec<String>) {
     let list = instances();
     list.push(Nexus::new(&name, size, None, Some(&children)));
 }
+
+/// called during shutdown so that the bdevs for each child is destroyed first
+pub async fn nexus_destroy_all() {
+    info!("destroying all nexuses...");
+    for nexus in instances() {
+        if let Err(e) = nexus.destroy().await {
+            error!(
+                "failed to destroy nexus {} during shutdown: {}",
+                nexus.name, e
+            );
+        }
+    }
+    info!("destroyed all nexuses");
+}

--- a/mayastor/src/bdev/nexus/nexus_child.rs
+++ b/mayastor/src/bdev/nexus/nexus_child.rs
@@ -32,6 +32,8 @@ pub enum ChildError {
     ChildNotClosed {},
     #[snafu(display("Child is faulted, it cannot be reopened"))]
     ChildFaulted {},
+    #[snafu(display("Child is being destroyed"))]
+    ChildBeingDestroyed {},
     #[snafu(display(
         "Child is smaller than parent {} vs {}",
         child_size,
@@ -99,6 +101,8 @@ pub enum ChildState {
     ConfigInvalid,
     /// the child is open for RW
     Open,
+    /// the child is being destroyed
+    Destroying,
     /// the child has been closed by the nexus
     Closed,
     /// the child is faulted
@@ -112,6 +116,7 @@ impl Display for ChildState {
             Self::Init => write!(f, "Init"),
             Self::ConfigInvalid => write!(f, "Config parameters are invalid"),
             Self::Open => write!(f, "Child is open"),
+            Self::Destroying => write!(f, "Child is being destroyed"),
             Self::Closed => write!(f, "Closed"),
         }
     }
@@ -132,9 +137,9 @@ pub struct NexusChild {
     /// current state of the child
     #[serde(skip_serializing)]
     pub state: AtomicCell<ChildState>,
-    /// destruction started, differentiates remove events
+    /// previous state of the child
     #[serde(skip_serializing)]
-    destroying: AtomicCell<bool>,
+    pub prev_state: AtomicCell<ChildState>,
     /// record of most-recent IO errors
     #[serde(skip_serializing)]
     pub(crate) err_store: Option<NexusErrStore>,
@@ -162,15 +167,15 @@ impl Display for NexusChild {
 
 impl NexusChild {
     pub(crate) fn set_state(&self, state: ChildState) {
+        let prev_state = self.state.swap(state);
+        self.prev_state.store(prev_state);
         trace!(
             "{}: child {}: state change from {} to {}",
             self.parent,
             self.name,
-            self.state.load().to_string(),
+            prev_state.to_string(),
             state.to_string(),
         );
-
-        self.state.store(state);
     }
 
     /// Open the child in RW mode and claim the device to be ours. If the child
@@ -182,6 +187,7 @@ impl NexusChild {
     /// A child can only be opened if:
     ///  - it's not faulted
     ///  - it's not already opened
+    ///  - it's not being destroyed
     pub(crate) fn open(
         &mut self,
         parent_size: u64,
@@ -203,6 +209,13 @@ impl NexusChild {
                 assert_eq!(self.desc.is_some(), true);
                 info!("called open on an already opened child");
                 return Ok(self.name.clone());
+            }
+            ChildState::Destroying => {
+                error!(
+                    "{}: cannot open child {} being destroyed",
+                    self.parent, self.name
+                );
+                return Err(ChildError::ChildBeingDestroyed {});
             }
             _ => {}
         }
@@ -232,7 +245,6 @@ impl NexusChild {
             },
         )?);
 
-        self.destroying.store(false);
         self.desc = Some(desc);
 
         let cfg = Config::get();
@@ -322,11 +334,6 @@ impl NexusChild {
         self.state.load()
     }
 
-    /// returns whether destruction has started
-    pub fn destroying(&self) -> bool {
-        self.destroying.load()
-    }
-
     pub(crate) fn rebuilding(&self) -> bool {
         match RebuildJob::lookup(&self.name) {
             Ok(_) => self.state() == ChildState::Faulted(Reason::OutOfSync),
@@ -362,7 +369,10 @@ impl NexusChild {
 
         // Only wait for bdev removal if the child has been initialised.
         // An uninitialized child won't have an underlying bdev.
-        if self.state.load() != ChildState::Init {
+        // Also check previous state as remove event may not have occurred
+        if self.state.load() != ChildState::Init
+            && self.prev_state.load() != ChildState::Init
+        {
             self.remove_channel.1.next().await;
         }
 
@@ -378,17 +388,18 @@ impl NexusChild {
     pub(crate) fn remove(&mut self) {
         info!("Removing child {}", self.name);
 
-        // Only remove the bdev if the child is being destroyed instead of a
-        // hot remove event e.g. NVMe AEN (asynchronous event notification)
-        let destroying = self.destroying();
-        info!("Destroying child: {}", destroying);
-        if destroying {
+        let mut state = self.state();
+
+        let mut destroying = false;
+        // Only remove the bdev if the child is being destroyed instead of
+        // a hot remove event
+        if state == ChildState::Destroying {
             // The bdev is being removed, so ensure we don't use it again.
             self.bdev = None;
+            destroying = true;
+
+            state = self.prev_state.load();
         }
-
-        let state = self.state();
-
         match state {
             ChildState::Open | Faulted(Reason::OutOfSync) => {
                 // Change the state of the child to ensure it is taken out of
@@ -396,7 +407,16 @@ impl NexusChild {
                 self.set_state(ChildState::Closed)
             }
             // leave the state into whatever we found it as
-            _ => {}
+            _ => {
+                if destroying {
+                    // Restore the previous state
+                    info!(
+                        "Restoring previous child state {}",
+                        state.to_string()
+                    );
+                    self.set_state(state);
+                }
+            }
         }
 
         // Remove the child from the I/O path. If we had an IO error the bdev,
@@ -415,8 +435,7 @@ impl NexusChild {
         if destroying {
             // Dropping the last descriptor results in the bdev being removed.
             // This must be performed in this function.
-            let desc = self.desc.take();
-            drop(desc);
+            self.desc.take();
         }
 
         self.remove_complete();
@@ -445,7 +464,7 @@ impl NexusChild {
             parent,
             desc: None,
             state: AtomicCell::new(ChildState::Init),
-            destroying: AtomicCell::new(false),
+            prev_state: AtomicCell::new(ChildState::Init),
             err_store: None,
             remove_channel: mpsc::channel(0),
         }
@@ -455,7 +474,7 @@ impl NexusChild {
     pub(crate) async fn destroy(&self) -> Result<(), NexusBdevError> {
         trace!("destroying child {:?}", self);
         if self.bdev.is_some() {
-            self.destroying.store(true);
+            self.set_state(ChildState::Destroying);
             bdev_destroy(&self.name).await
         } else {
             warn!("Destroy child without bdev");

--- a/mayastor/src/core/bdev.rs
+++ b/mayastor/src/core/bdev.rs
@@ -161,7 +161,7 @@ impl Bdev {
         bdev: *mut spdk_bdev,
         _ctx: *mut c_void,
     ) {
-        let bdev = Bdev(NonNull::new(bdev).unwrap());
+        let bdev = Bdev::from_ptr(bdev).unwrap();
         // Take the appropriate action for the given event type
         match event {
             spdk_sys::SPDK_BDEV_EVENT_REMOVE => {
@@ -171,9 +171,9 @@ impl Bdev {
                 }
             }
             spdk_sys::SPDK_BDEV_EVENT_RESIZE => {
-                info!("Received resize event for bdev {}", bdev.name())
+                warn!("Received resize event for bdev {}", bdev.name())
             }
-            spdk_sys::SPDK_BDEV_EVENT_MEDIA_MANAGEMENT => info!(
+            spdk_sys::SPDK_BDEV_EVENT_MEDIA_MANAGEMENT => warn!(
                 "Received media management event for bdev {}",
                 bdev.name()
             ),

--- a/mayastor/src/core/env.rs
+++ b/mayastor/src/core/env.rs
@@ -40,7 +40,7 @@ use spdk_sys::{
 };
 
 use crate::{
-    bdev::nexus::nexus_child_status_config::ChildStatusConfig,
+    bdev::{nexus, nexus::nexus_child_status_config::ChildStatusConfig},
     core::{
         reactor::{Reactor, ReactorState, Reactors},
         Cores,
@@ -279,6 +279,7 @@ async fn do_shutdown(arg: *mut c_void) {
     }
 
     iscsi::fini();
+    nexus::nexus_destroy_all().await;
     unsafe {
         spdk_rpc_finish();
         spdk_subsystem_fini(Some(reactors_stop), arg);

--- a/mayastor/src/grpc/nexus_grpc.rs
+++ b/mayastor/src/grpc/nexus_grpc.rs
@@ -21,6 +21,7 @@ impl From<ChildState> for rpc::ChildState {
             ChildState::Init => rpc::ChildState::ChildDegraded,
             ChildState::ConfigInvalid => rpc::ChildState::ChildFaulted,
             ChildState::Open => rpc::ChildState::ChildOnline,
+            ChildState::Destroying => rpc::ChildState::ChildDegraded,
             ChildState::Closed => rpc::ChildState::ChildDegraded,
             ChildState::Faulted(reason) => match reason {
                 Reason::OutOfSync => rpc::ChildState::ChildDegraded,


### PR DESCRIPTION
Add a destroying flag to NexusChild and only set it in destroy() so
a nexus child destroyed via the normal close() path actually removes
the bdev.

This allows a remove via e.g. an NVMe async event notification to only
mark the child as faulted, which does remove it from the I/O path, and
allows a subsequent normal destroy of a child to remove the bdev.
Previously it would have set NexusChild::bdev to None without
destroying the bdev, which leaks it.

This requires that the shutdown process destroys nexuses first so that
it then destroys each child and its bdev, in that order, as the remove
event from SPDK as part of shutdown would not destroy the bdev, which
would result in the process hanging.

Fixes CAS-624