### PR TITLE
refactor(moac): drop support for NBD in CSI

### DIFF
--- a/csi/moac/.gitignore
+++ b/csi/moac/.gitignore
@@ -1,7 +1,7 @@
 /node_modules/
 /proto/
 /result
-/watcher.js
+/csi.js
 /nexus.js
 /node.js
 /node_operator.js
@@ -11,4 +11,5 @@
 /volume.js
 /volumes.js
 /volume_operator.js
+/watcher.js
 /*.js.map

--- a/csi/moac/nexus.ts
+++ b/csi/moac/nexus.ts
@@ -1,7 +1,8 @@
 // Nexus object implementation.
 
-const _ = require('lodash');
-const assert = require('assert');
+import assert from 'assert';
+import * as _ from 'lodash';
+
 const { GrpcCode, GrpcError, mayastor } = require('./grpc_client');
 const log = require('./logger').Logger('nexus');
 
@@ -10,15 +11,12 @@ import { Replica } from './replica';
 // Protocol used to export nexus (volume)
 export enum Protocol {
   Unknown = 'unknown',
-  Nbd = 'nbd',
   Iscsi = 'iscsi',
   Nvmf = 'nvmf',
 }
 
 export function protocolFromString(val: string): Protocol {
-  if (val == Protocol.Nbd) {
-    return Protocol.Nbd;
-  } else if (val == Protocol.Iscsi) {
+  if (val == Protocol.Iscsi) {
     return Protocol.Iscsi;
   } else if (val == Protocol.Nvmf) {
     return Protocol.Nvmf;

--- a/csi/moac/package.json
+++ b/csi/moac/package.json
@@ -14,8 +14,8 @@
   },
   "scripts": {
     "prepare": "./bundle_protos.sh",
-    "clean": "rm -f replica.js pool.js nexus.js",
-    "purge": "rm -rf node_modules proto node.js replica.js pool.js nexus.js watcher.js node_operator.js pool_operator.js volume.js volumes.js volume_operator.js *.js.map",
+    "clean": "rm -f csi.js node.js replica.js pool.js nexus.js watcher.js node_operator.js pool_operator.js volume.js volumes.js volume_operator.js *.js.map",
+    "purge": "rm -rf node_modules proto csi.js node.js replica.js pool.js nexus.js watcher.js node_operator.js pool_operator.js volume.js volumes.js volume_operator.js *.js.map",
     "compile": "tsc --pretty",
     "start": "./index.js",
     "test": "mocha test/index.js",

--- a/csi/moac/pool.ts
+++ b/csi/moac/pool.ts
@@ -1,7 +1,8 @@
 // Pool object implementation.
 
-const _ = require('lodash');
-const assert = require('assert');
+import assert from 'assert';
+import * as _ from 'lodash';
+
 const { GrpcCode, GrpcError } = require('./grpc_client');
 const log = require('./logger').Logger('pool');
 

--- a/csi/moac/replica.ts
+++ b/csi/moac/replica.ts
@@ -1,6 +1,8 @@
 // Replica object implementation.
 
-const assert = require('assert');
+import assert from 'assert';
+import * as _ from 'lodash';
+
 const { GrpcCode, GrpcError } = require('./grpc_client');
 const log = require('./logger').Logger('replica');
 

--- a/csi/moac/test/nexus_test.js
+++ b/csi/moac/test/nexus_test.js
@@ -94,7 +94,7 @@ module.exports = function () {
     });
 
     it('should emit event upon change of deviceUri property', () => {
-      newProps.deviceUri = 'file:///dev/nbd0';
+      newProps.deviceUri = 'nvmf://host/nqn';
       nexus.merge(newProps);
 
       // First event is new nexus event
@@ -103,7 +103,7 @@ module.exports = function () {
         eventType: 'mod',
         object: nexus
       });
-      expect(nexus.deviceUri).to.equal('file:///dev/nbd0');
+      expect(nexus.deviceUri).to.equal('nvmf://host/nqn');
     });
 
     it('should emit event upon change of state property', () => {
@@ -231,18 +231,18 @@ module.exports = function () {
       });
     });
 
-    it('should publish the nexus with nbd protocol', async () => {
-      callStub.resolves({ deviceUri: 'file:///dev/nbd0' });
+    it('should publish the nexus with nvmf protocol', async () => {
+      callStub.resolves({ deviceUri: 'nvmf://host/nqn' });
 
-      await nexus.publish('nbd');
+      await nexus.publish('nvmf');
 
       sinon.assert.calledOnce(callStub);
       sinon.assert.calledWith(callStub, 'publishNexus', {
         uuid: UUID,
         key: '',
-        share: 0 // Nbd for now
+        share: 1
       });
-      expect(nexus.deviceUri).to.equal('file:///dev/nbd0');
+      expect(nexus.deviceUri).to.equal('nvmf://host/nqn');
       sinon.assert.calledOnce(eventSpy);
       sinon.assert.calledWith(eventSpy, 'nexus', {
         eventType: 'mod',

--- a/csi/moac/test/volume_operator_test.js
+++ b/csi/moac/test/volume_operator_test.js
@@ -52,7 +52,7 @@ const defaultSpec = {
   requiredNodes: ['node2'],
   requiredBytes: 100,
   limitBytes: 120,
-  protocol: 'nbd'
+  protocol: 'nvmf'
 };
 
 const defaultStatus = {
@@ -60,7 +60,7 @@ const defaultStatus = {
   targetNodes: ['node2'],
   state: 'healthy',
   nexus: {
-    deviceUri: 'file:///dev/nbd0',
+    deviceUri: 'nvmf://host/nqn',
     state: 'NEXUS_ONLINE',
     node: 'node2',
     children: [
@@ -129,7 +129,7 @@ module.exports = function () {
           node: 'node2',
           state: 'healthy',
           nexus: {
-            deviceUri: 'file:///dev/nbd0',
+            deviceUri: 'nvmf://host/nqn',
             state: 'NEXUS_ONLINE',
             node: 'node2',
             children: [
@@ -160,7 +160,7 @@ module.exports = function () {
       expect(res.spec.limitBytes).to.equal(120);
       expect(res.status.size).to.equal(110);
       expect(res.status.state).to.equal('healthy');
-      expect(res.status.nexus.deviceUri).to.equal('file:///dev/nbd0');
+      expect(res.status.nexus.deviceUri).to.equal('nvmf://host/nqn');
       expect(res.status.nexus.state).to.equal('NEXUS_ONLINE');
       expect(res.status.nexus.node).to.equal('node2');
       expect(res.status.nexus.children).to.have.length(1);
@@ -452,7 +452,7 @@ module.exports = function () {
           requiredNodes: [],
           requiredBytes: 90,
           limitBytes: 130,
-          protocol: 'nbd'
+          protocol: 'nvmf'
         },
         defaultStatus
       );
@@ -500,7 +500,7 @@ module.exports = function () {
           requiredNodes: [],
           requiredBytes: 111,
           limitBytes: 130,
-          protocol: 'nbd'
+          protocol: 'nvmf'
         },
         defaultStatus
       );
@@ -765,7 +765,7 @@ module.exports = function () {
         requiredNodes: [],
         requiredBytes: 90,
         limitBytes: 130,
-        protocol: 'nbd'
+        protocol: 'nvmf'
       };
       const volume = new Volume(UUID, registry, () => {}, newSpec);
       volumes.emit('volume', {
@@ -795,7 +795,7 @@ module.exports = function () {
         requiredNodes: [],
         requiredBytes: 90,
         limitBytes: 130,
-        protocol: 'nbd'
+        protocol: 'nvmf'
       };
       const volume = new Volume(UUID, registry, () => {}, newSpec);
       volumes.emit('volume', {

--- a/csi/moac/test/volume_test.js
+++ b/csi/moac/test/volume_test.js
@@ -91,10 +91,10 @@ module.exports = function () {
     const node = new Node('node');
     const stub = sinon.stub(node, 'call');
     stub.onCall(0).resolves({});
-    stub.onCall(1).resolves({ deviceUri: 'file:///dev/nbd0' });
+    stub.onCall(1).resolves({ deviceUri: 'nvmf://host/nqn' });
 
     shouldFailWith(GrpcCode.INTERNAL, async () => {
-      await volume.publish('nbd');
+      await volume.publish('nvmf');
     });
     sinon.assert.notCalled(stub);
   });
@@ -103,10 +103,10 @@ module.exports = function () {
     const [volume, node] = createFakeVolume('healthy');
     const stub = sinon.stub(node, 'call');
     stub.onCall(0).resolves({ uuid: UUID, size: 100, state: 'NEXUS_ONLINE', children: [{ uri: `bdev:///${UUID}`, state: 'CHILD_ONLINE' }] });
-    stub.onCall(1).resolves({ deviceUri: 'file:///dev/nbd0' });
+    stub.onCall(1).resolves({ deviceUri: 'nvmf://host/nqn' });
 
-    const uri = await volume.publish('nbd');
-    expect(uri).to.equal('file:///dev/nbd0');
+    const uri = await volume.publish('nvmf');
+    expect(uri).to.equal('nvmf://host/nqn');
     sinon.assert.calledTwice(stub);
     sinon.assert.calledWithMatch(stub.firstCall, 'createNexus', {
       uuid: UUID,
@@ -126,10 +126,10 @@ module.exports = function () {
     nexus.bind(node);
     volume.newNexus(nexus);
 
-    stub.resolves({ deviceUri: 'file:///dev/nbd0' });
-    const uri = await volume.publish('nbd');
-    expect(uri).to.equal('file:///dev/nbd0');
-    expect(nexus.deviceUri).to.equal('file:///dev/nbd0');
+    stub.resolves({ deviceUri: 'nvmf://host/nqn' });
+    const uri = await volume.publish('nvmf');
+    expect(uri).to.equal('nvmf://host/nqn');
+    expect(nexus.deviceUri).to.equal('nvmf://host/nqn');
     sinon.assert.calledOnce(stub);
     sinon.assert.calledWithMatch(stub, 'publishNexus', {
       uuid: UUID,
@@ -144,10 +144,10 @@ module.exports = function () {
     const getUriStub = sinon.stub(nexus, 'getUri');
     nexus.bind(node);
     volume.newNexus(nexus);
-    getUriStub.returns('file:///dev/nbd0');
+    getUriStub.returns('nvmf://host/nqn');
 
-    const uri = await volume.publish('nbd');
-    expect(uri).to.equal('file:///dev/nbd0');
+    const uri = await volume.publish('nvmf');
+    expect(uri).to.equal('nvmf://host/nqn');
     sinon.assert.notCalled(stub);
     sinon.assert.calledOnce(getUriStub);
   });
@@ -160,7 +160,7 @@ module.exports = function () {
     nexus.bind(node);
     volume.newNexus(nexus);
     volume.publishedOn = node.name;
-    getUriStub.returns('file:///dev/nbd0');
+    getUriStub.returns('nvmf://host/nqn');
     stub.onCall(0).resolves({});
 
     await volume.unpublish();

--- a/csi/moac/test/volumes_test.js
+++ b/csi/moac/test/volumes_test.js
@@ -121,7 +121,7 @@ module.exports = function () {
       nexus = new Nexus({
         uuid: UUID,
         size: 95,
-        deviceUri: 'file:///dev/nbd0',
+        deviceUri: 'nvmf://host/nqn',
         state: 'NEXUS_ONLINE',
         children: [
           {
@@ -151,7 +151,7 @@ module.exports = function () {
       requiredNodes: [],
       requiredBytes: 90,
       limitBytes: 110,
-      protocol: 'nbd'
+      protocol: 'nvmf'
     }, 'pending', 95, published ? 'node1' : undefined);
     volumes.volumes[UUID] = volume;
 
@@ -183,7 +183,7 @@ module.exports = function () {
           requiredNodes: ['node2', 'node3'],
           requiredBytes: 100,
           limitBytes: 110,
-          protocol: 'nbd'
+          protocol: 'nvmf'
         })
       );
       expect(volEvents).to.have.lengthOf(3);
@@ -224,7 +224,7 @@ module.exports = function () {
         requiredNodes: [],
         requiredBytes: 90,
         limitBytes: 0,
-        protocol: 'nbd'
+        protocol: 'nvmf'
       });
       await waitUntil(() => volume.state === 'healthy', 'healthy volume');
       expect(volume.size).to.equal(90);
@@ -268,7 +268,7 @@ module.exports = function () {
         requiredNodes: [],
         requiredBytes: 10,
         limitBytes: 50,
-        protocol: 'nbd'
+        protocol: 'nvmf'
       });
       await waitUntil(() => volume.state === 'healthy', 'healthy volume');
       expect(volume.size).to.equal(50);
@@ -291,7 +291,7 @@ module.exports = function () {
           requiredNodes: [],
           requiredBytes: 0,
           limitBytes: 0,
-          protocol: 'nbd'
+          protocol: 'nvmf'
         })
       );
       sinon.assert.notCalled(stub1);
@@ -330,7 +330,7 @@ module.exports = function () {
         requiredNodes: [],
         requiredBytes: 10,
         limitBytes: 50,
-        protocol: 'nbd'
+        protocol: 'nvmf'
       });
       await waitUntil(() => volume.state === 'faulted', 'faulted volume');
       sinon.assert.notCalled(stub2);
@@ -389,7 +389,7 @@ module.exports = function () {
         requiredNodes: [],
         requiredBytes: 10,
         limitBytes: 50,
-        protocol: 'nbd'
+        protocol: 'nvmf'
       });
       await waitUntil(
         () =>
@@ -568,7 +568,7 @@ module.exports = function () {
       requiredNodes: [],
       requiredBytes: 10,
       limitBytes: 50,
-      protocol: 'nbd'
+      protocol: 'nvmf'
     };
 
     it('should import a volume and fault it if there are no replicas', async () => {
@@ -674,7 +674,7 @@ module.exports = function () {
     });
 
     it('should import published volume with nexus', async () => {
-      const deviceUri = 'nbd:///dev/ndb0';
+      const deviceUri = 'nvmf://host/nqn';
       const replica = new Replica({
         uuid: UUID,
         size: 40,
@@ -756,7 +756,7 @@ module.exports = function () {
         requiredNodes: [],
         requiredBytes: 90,
         limitBytes: 110,
-        protocol: 'nbd'
+        protocol: 'nvmf'
       });
       volume.newReplica(replica);
       volumes.volumes[UUID] = volume;
@@ -781,7 +781,7 @@ module.exports = function () {
         requiredNodes: [node1.name],
         requiredBytes: 89,
         limitBytes: 111,
-        protocol: 'nbd'
+        protocol: 'nvmf'
       });
       sinon.assert.notCalled(stub1);
       sinon.assert.notCalled(stub2);
@@ -804,7 +804,7 @@ module.exports = function () {
         requiredNodes: [],
         requiredBytes: 90,
         limitBytes: 110,
-        protocol: 'nbd'
+        protocol: 'nvmf'
       });
       sinon.assert.notCalled(stub1);
       sinon.assert.notCalled(stub2);
@@ -821,7 +821,7 @@ module.exports = function () {
           requiredNodes: [],
           requiredBytes: 90,
           limitBytes: 94,
-          protocol: 'nbd'
+          protocol: 'nvmf'
         })
       );
     });
@@ -834,7 +834,7 @@ module.exports = function () {
           requiredNodes: [],
           requiredBytes: 96,
           limitBytes: 110,
-          protocol: 'nbd'
+          protocol: 'nvmf'
         })
       );
     });
@@ -846,7 +846,7 @@ module.exports = function () {
         requiredNodes: [node1.name],
         requiredBytes: 89,
         limitBytes: 111,
-        protocol: 'nvmf'
+        protocol: 'iscsi'
       }));
     });
   });
@@ -1003,7 +1003,7 @@ module.exports = function () {
           requiredNodes: [],
           requiredBytes: 90,
           limitBytes: 110,
-          protocol: 'nbd'
+          protocol: 'nvmf'
         });
 
         try {
@@ -1045,7 +1045,7 @@ module.exports = function () {
           requiredNodes: ['node2', 'node3'],
           requiredBytes: 90,
           limitBytes: 110,
-          protocol: 'nbd'
+          protocol: 'nvmf'
         });
 
         await waitUntil(
@@ -1097,7 +1097,7 @@ module.exports = function () {
           requiredNodes: [],
           requiredBytes: 90,
           limitBytes: 110,
-          protocol: 'nbd'
+          protocol: 'nvmf'
         });
         await waitUntil(() => volume.state === 'degraded', 'degraded volume');
 
@@ -1182,7 +1182,7 @@ module.exports = function () {
           requiredNodes: [],
           requiredBytes: 90,
           limitBytes: 110,
-          protocol: 'nbd'
+          protocol: 'nvmf'
         });
 
         await waitUntil(
@@ -1245,7 +1245,7 @@ module.exports = function () {
           requiredNodes: [],
           requiredBytes: 90,
           limitBytes: 110,
-          protocol: 'nbd'
+          protocol: 'nvmf'
         });
 
         // Nexus gets created and destroyed inbetween but it's difficult to
@@ -1371,7 +1371,7 @@ module.exports = function () {
         ]
       });
       stub1.onCall(1).resolves({
-        deviceUri: 'file:///dev/nbd0'
+        deviceUri: 'nvmf://host/nqn'
       });
 
       // pretend that node1 is down
@@ -1389,7 +1389,7 @@ module.exports = function () {
         object: node1
       });
       await waitUntil(() => volume.state === 'healthy', 'healthy volume');
-      expect(volume.nexus.deviceUri).to.equal('file:///dev/nbd0');
+      expect(volume.nexus.deviceUri).to.equal('nvmf://host/nqn');
       expect(volume.publishedOn).to.equal('node1');
     });
 
@@ -1542,7 +1542,7 @@ module.exports = function () {
         requiredNodes: [],
         requiredBytes: 90,
         limitBytes: 110,
-        protocol: 'nbd'
+        protocol: 'nvmf'
       });
 
       sinon.assert.calledTwice(stub1);
@@ -1612,7 +1612,7 @@ module.exports = function () {
     });
 
     it('should publish the volume', async () => {
-      const deviceUri = 'file:///dev/nbd0';
+      const deviceUri = 'nvmf://host/nqn';
       // on node 1 is created nexus
       stub1.onCall(0).resolves({
         uuid: UUID,
@@ -1638,7 +1638,7 @@ module.exports = function () {
       });
       stub1.onCall(1).resolves({ deviceUri });
 
-      const uri = await volume.publish('nbd');
+      const uri = await volume.publish('nvmf');
       expect(uri).to.equal(deviceUri);
 
       sinon.assert.calledTwice(stub1);
@@ -1650,7 +1650,7 @@ module.exports = function () {
       sinon.assert.calledWithMatch(stub1.secondCall, 'publishNexus', {
         uuid: UUID,
         key: '',
-        share: enums.NEXUS_NBD
+        share: enums.NEXUS_NVMF
       });
 
       sinon.assert.notCalled(stub2);

--- a/csi/moac/tsconfig.json
+++ b/csi/moac/tsconfig.json
@@ -61,7 +61,7 @@
     "resolveJsonModule": true /* allows for importing, extracting types from and generating .json files */
   },
   "files": [
-    "watcher.ts",
+    "csi.ts",
     "nexus.ts",
     "node.ts",
     "node_operator.ts",
@@ -71,5 +71,6 @@
     "volume.ts",
     "volumes.ts",
     "volume_operator.ts",
+    "watcher.ts",
   ]
 }

--- a/csi/moac/volume.ts
+++ b/csi/moac/volume.ts
@@ -46,13 +46,13 @@ export function volumeStateFromString(val: string): VolumeState {
 // maintaining desired redundancy.
 export class Volume {
   // volume spec properties
-  private uuid: string;
-  private replicaCount: number;
-  private preferredNodes: string[];
-  private requiredNodes: string[];
-  private requiredBytes: number;
-  private limitBytes: number;
-  private protocol: Protocol;
+  uuid: string;
+  replicaCount: number;
+  preferredNodes: string[];
+  requiredNodes: string[];
+  requiredBytes: number;
+  limitBytes: number;
+  protocol: Protocol;
   // volume status properties
   private size: number;
   private nexus: Nexus | null;


### PR DESCRIPTION
NBD does not work well with new nexus feature when nexus is created
only if it is used (mounted). For NBD we need to know which node the
nexus is located and the location must not change throughout the
lifetime of the volume. Apparently that does not work now when nexus
is created on whatever node is available and the location can change
between mounts of the volume.

And as part of that convert csi.js to typescript.

Resolves: CAS-672