### PR TITLE
feat(control plane): allow images to be built

### DIFF
--- a/nix/mayastor-overlay.nix
+++ b/nix/mayastor-overlay.nix
@@ -8,6 +8,8 @@ self: super: {
   mayastor-adhoc = (super.callPackage ./pkgs/mayastor { }).adhoc;
   moac = (import ./../csi/moac { pkgs = super; }).package;
   images = super.callPackage ./pkgs/images { };
+  services = (super.callPackage ./pkgs/images/services { });
+  operators = (super.callPackage ./pkgs/images/operators { });
 
   ms-buildenv = super.callPackage ./pkgs/ms-buildenv { };
   mkContainerEnv = super.callPackage ./lib/mkContainerEnv.nix { };

--- a/nix/pkgs/images/default.nix
+++ b/nix/pkgs/images/default.nix
@@ -51,7 +51,7 @@ let
       mkdir -p var/tmp
     '';
   };
-  servicesImageProps = {
+  clientImageProps = {
     tag = version;
     created = "now";
     config = {
@@ -122,20 +122,7 @@ rec {
     maxLayers = 42;
   };
 
-  services-kiiss-image = dockerTools.buildLayeredImage (servicesImageProps // {
-    name = "mayadata/services-kiiss";
-    contents = [ busybox mayastor ];
-    config = { Entrypoint = [ "/bin/kiiss" ]; };
-    maxLayers = 42;
-  });
-
-  services-kiiss-dev-image = dockerTools.buildImage (servicesImageProps // {
-    name = "mayadata/services-kiiss-dev";
-    contents = [ busybox mayastor ];
-    config = { Entrypoint = [ "/bin/kiiss" ]; };
-  });
-
-  mayastor-client-image = dockerTools.buildImage (servicesImageProps // {
+  mayastor-client-image = dockerTools.buildImage (clientImageProps // {
     name = "mayadata/mayastor-client";
     contents = [ busybox mayastor ];
     config = { Entrypoint = [ "/bin/mayastor-client" ]; };

--- a/nix/pkgs/images/operators/default.nix
+++ b/nix/pkgs/images/operators/default.nix
@@ -1,0 +1,48 @@
+# It would be cool to produce OCI images instead of docker images to
+# avoid dependency on docker tool chain. Though the maturity of OCI
+# builder in nixpkgs is questionable which is why we postpone this step.
+#
+# We limit max number of image layers to 42 because there is a bug in
+# containerd triggered when there are too many layers:
+# https://github.com/containerd/containerd/issues/4684
+
+{ stdenv
+, busybox
+, dockerTools
+, e2fsprogs
+, git
+, lib
+, xfsprogs
+, utillinux
+}:
+let
+  versionDrv = import ../../../lib/version.nix { inherit lib stdenv git; };
+  version = builtins.readFile "${versionDrv}";
+  env = stdenv.lib.makeBinPath [ busybox xfsprogs e2fsprogs utillinux ];
+
+  # common props for all operator images
+  operatorImageProps = {
+    tag = version;
+    created = "now";
+    config = {
+      Env = [ "PATH=${env}" ];
+    };
+  };
+in
+{
+  # Release image of node operator.
+  node-image = dockerTools.buildLayeredImage (operatorImageProps // {
+    name = "mayadata/node-operator";
+    contents = [ busybox ];
+    config = { Entrypoint = [ "/bin/node-op" ]; };
+    maxLayers = 42;
+  });
+
+  # Development image of node operator.
+  node-image-dev = dockerTools.buildImage (operatorImageProps // {
+    name = "mayadata/node-operator-dev";
+    contents = [ busybox ];
+    config = { Entrypoint = [ "/bin/node-op" ]; };
+  });
+
+}

--- a/nix/pkgs/images/services/default.nix
+++ b/nix/pkgs/images/services/default.nix
@@ -1,0 +1,107 @@
+# It would be cool to produce OCI images instead of docker images to
+# avoid dependency on docker tool chain. Though the maturity of OCI
+# builder in nixpkgs is questionable which is why we postpone this step.
+#
+# We limit max number of image layers to 42 because there is a bug in
+# containerd triggered when there are too many layers:
+# https://github.com/containerd/containerd/issues/4684
+
+{ stdenv
+, busybox
+, dockerTools
+, e2fsprogs
+, git
+, lib
+, xfsprogs
+, utillinux
+}:
+let
+  versionDrv = import ../../../lib/version.nix { inherit lib stdenv git; };
+  version = builtins.readFile "${versionDrv}";
+  env = stdenv.lib.makeBinPath [ busybox xfsprogs e2fsprogs utillinux ];
+
+  # common props for all service images
+  serviceImageProps = {
+    tag = version;
+    created = "now";
+    config = {
+      Env = [ "PATH=${env}" ];
+    };
+  };
+in
+{
+  # Release image of kiiss service.
+  kiiss-image = dockerTools.buildLayeredImage (serviceImageProps // {
+    name = "mayadata/kiiss-service";
+    contents = [ busybox ];
+    config = { Entrypoint = [ "/bin/kiiss" ]; };
+    maxLayers = 42;
+  });
+
+  # Development image of kiiss service.
+  kiiss-image-dev = dockerTools.buildImage (serviceImageProps // {
+    name = "mayadata/kiiss-service-dev";
+    contents = [ busybox ];
+    config = { Entrypoint = [ "/bin/kiiss" ]; };
+  });
+
+  # Release image of node service.
+  node-image = dockerTools.buildLayeredImage (serviceImageProps // {
+    name = "mayadata/node-service";
+    contents = [ busybox ];
+    config = { Entrypoint = [ "/bin/node" ]; };
+    maxLayers = 42;
+  });
+
+  # Development image of node service.
+  node-image-dev = dockerTools.buildImage (serviceImageProps // {
+    name = "mayadata/node-service-dev";
+    contents = [ busybox ];
+    config = { Entrypoint = [ "/bin/node" ]; };
+  });
+
+  # Release image of volume service.
+  volume-image = dockerTools.buildLayeredImage (serviceImageProps // {
+    name = "mayadata/volume-service";
+    contents = [ busybox ];
+    config = { Entrypoint = [ "/bin/volume" ]; };
+    maxLayers = 42;
+  });
+
+  # Development image of volume service.
+  volume-image-dev = dockerTools.buildImage (serviceImageProps // {
+    name = "mayadata/volume-service-dev";
+    contents = [ busybox ];
+    config = { Entrypoint = [ "/bin/volume" ]; };
+  });
+
+  # Release image of pool service.
+  pool-image = dockerTools.buildLayeredImage (serviceImageProps // {
+    name = "mayadata/pool-service";
+    contents = [ busybox ];
+    config = { Entrypoint = [ "/bin/pool" ]; };
+    maxLayers = 42;
+  });
+
+  # Development image of pool service.
+  pool-image-dev = dockerTools.buildImage (serviceImageProps // {
+    name = "mayadata/pool-service-dev";
+    contents = [ busybox ];
+    config = { Entrypoint = [ "/bin/pool" ]; };
+  });
+
+  # Release image of rest service.
+  rest-image = dockerTools.buildLayeredImage (serviceImageProps // {
+    name = "mayadata/rest-service";
+    contents = [ busybox ];
+    config = { Entrypoint = [ "/bin/rest" ]; };
+    maxLayers = 42;
+  });
+
+  # Development image of rest service.
+  rest-image-dev = dockerTools.buildImage (serviceImageProps // {
+    name = "mayadata/rest-service-dev";
+    contents = [ busybox ];
+    config = { Entrypoint = [ "/bin/rest" ]; };
+  });
+}


### PR DESCRIPTION
Provide the ability to build container images for the various control
plane components.

Before performing a nix-build, ensure you are in the ../Mayastor
directory.

e.g.
To build a specific control plane service image such as the node
service:
        nix-build -A services.node-image

To build a development image, add the "-dev" suffix:
        nix-build -A services.node-image-dev

To build all service images:
        nix-build -A services

e.g.
To build a specific operator such as the node operator:
       nix-build -A operators.node-image

To build a development image, add the "-dev" suffix:
       nix-build -A operators.node-image-dev

To build all operator images:
       nix-build -A operators