### PR TITLE
fix(ci): remove debug flag

### DIFF
--- a/rest/tests/v0_test.rs
+++ b/rest/tests/v0_test.rs
@@ -78,13 +78,8 @@ async fn client() {
             .with_portmap("6831/udp", "6831/udp")
             .with_portmap("6832/udp", "6832/udp"),
         )
-        // uncomment to run alpine commands within the containers
-        //.with_base_image("alpine:latest".to_string())
         .with_default_tracing()
         .autorun(false)
-        // uncomment to leave containers running allowing us access the jaeger
-        // traces at localhost:16686
-        .with_clean(false)
         .build()
         .await
         .unwrap();


### PR DESCRIPTION
Remove inadvertently checked in debug flag
Remove the commented out debug code as we now have the deployer tool
 to create control plane clusters.