### PR TITLE
feat(control plane): allow images to be built

### DIFF
--- a/doc/build.md
+++ b/doc/build.md
@@ -217,7 +217,7 @@ short commit hash of the top-most commit or a tag name of the commit if
 present. Example of building a moac package:
 
 ```bash
-nix-build -A images.moac-image
+nix-build -A images.moac
 ```
 
 At the end of the build is printed path to docker image tar archive. Load the
@@ -229,9 +229,9 @@ docker run --rm -it image-hash /bin/bash
 ```
 
 Mayastor and csi plugin images can have multiple flavours. Production image
-name does not contain the flavour name (i.e. `mayastor-image`). Debug image
-contains the `dev` in its name (i.e. `mayastor-dev-image`). Mayastor package
-has additional flavour called `adhoc` (`mayastor-adhoc-image`), that is handy
+name does not contain the flavour name (i.e. `mayastor`). Debug image
+contains the `dev` in its name (i.e. `mayastor-dev`). Mayastor package
+has additional flavour called `adhoc` (`mayastor-adhoc`), that is handy
 for testing because it is not based on mayastor package but rather on whatever
 binaries are present in `target/debug` directory.
 

--- a/nix/pkgs/images/default.nix
+++ b/nix/pkgs/images/default.nix
@@ -51,7 +51,7 @@ let
       mkdir -p var/tmp
     '';
   };
-  servicesImageProps = {
+  clientImageProps = {
     tag = version;
     created = "now";
     config = {
@@ -62,35 +62,48 @@ let
       mkdir -p var/tmp
     '';
   };
-in
-rec {
-  mayastor-image = dockerTools.buildImage (mayastorImageProps // {
-    name = "mayadata/mayastor";
-    contents = [ busybox mayastor ];
-  });
-
-  mayastor-dev-image = dockerTools.buildImage (mayastorImageProps // {
-    name = "mayadata/mayastor-dev";
-    contents = [ busybox mayastor-dev ];
-  });
-
-  mayastor-adhoc-image = dockerTools.buildImage (mayastorImageProps // {
-    name = "mayadata/mayastor-adhoc";
-    contents = [ busybox mayastor-adhoc ];
-  });
-
+  operatorImageProps = {
+    tag = version;
+    created = "now";
+    config = {
+      Env = [ "PATH=${env}" ];
+    };
+  };
+  serviceImageProps = {
+    tag = version;
+    created = "now";
+    config = {
+      Env = [ "PATH=${env}" ];
+    };
+  };
   mayastorIscsiadm = writeScriptBin "mayastor-iscsiadm" ''
     #!${stdenv.shell}
     chroot /host /usr/bin/env -i PATH="/sbin:/bin:/usr/bin" iscsiadm "$@"
   '';
+in
+{
+  mayastor = dockerTools.buildImage (mayastorImageProps // {
+    name = "mayadata/mayastor";
+    contents = [ busybox mayastor ];
+  });
 
-  mayastor-csi-image = dockerTools.buildLayeredImage (mayastorCsiImageProps // {
+  mayastor-dev = dockerTools.buildImage (mayastorImageProps // {
+    name = "mayadata/mayastor-dev";
+    contents = [ busybox mayastor-dev ];
+  });
+
+  mayastor-adhoc = dockerTools.buildImage (mayastorImageProps // {
+    name = "mayadata/mayastor-adhoc";
+    contents = [ busybox mayastor-adhoc ];
+  });
+
+  mayastor-csi = dockerTools.buildLayeredImage (mayastorCsiImageProps // {
     name = "mayadata/mayastor-csi";
     contents = [ busybox mayastor mayastorIscsiadm ];
     maxLayers = 42;
   });
 
-  mayastor-csi-dev-image = dockerTools.buildImage (mayastorCsiImageProps // {
+  mayastor-csi-dev = dockerTools.buildImage (mayastorCsiImageProps // {
     name = "mayadata/mayastor-csi-dev";
     contents = [ busybox mayastor-dev mayastorIscsiadm ];
   });
@@ -98,7 +111,7 @@ rec {
   # The algorithm for placing packages into the layers is not optimal.
   # There are a couple of layers with negligable size and then there is one
   # big layer with everything else. That defeats the purpose of layering.
-  moac-image = dockerTools.buildLayeredImage {
+  moac = dockerTools.buildLayeredImage {
     name = "mayadata/moac";
     tag = version;
     created = "now";
@@ -122,23 +135,99 @@ rec {
     maxLayers = 42;
   };
 
-  services-kiiss-image = dockerTools.buildLayeredImage (servicesImageProps // {
-    name = "mayadata/services-kiiss";
-    contents = [ busybox mayastor ];
-    config = { Entrypoint = [ "/bin/kiiss" ]; };
-    maxLayers = 42;
-  });
-
-  services-kiiss-dev-image = dockerTools.buildImage (servicesImageProps // {
-    name = "mayadata/services-kiiss-dev";
-    contents = [ busybox mayastor ];
-    config = { Entrypoint = [ "/bin/kiiss" ]; };
-  });
-
-  mayastor-client-image = dockerTools.buildImage (servicesImageProps // {
+  mayastor-client = dockerTools.buildImage (clientImageProps // {
     name = "mayadata/mayastor-client";
     contents = [ busybox mayastor ];
     config = { Entrypoint = [ "/bin/mayastor-client" ]; };
   });
 
+  # Release image of kiiss service.
+  kiiss-service = dockerTools.buildLayeredImage (serviceImageProps // {
+    name = "mayadata/kiiss-service";
+    contents = [ busybox mayastor ];
+    config = { Entrypoint = [ "/bin/kiiss" ]; };
+    maxLayers = 42;
+  });
+
+  # Development image of kiiss service.
+  kiiss-service-dev = dockerTools.buildImage (serviceImageProps // {
+    name = "mayadata/kiiss-service-dev";
+    contents = [ busybox mayastor ];
+    config = { Entrypoint = [ "/bin/kiiss" ]; };
+  });
+
+  # Release image of node service.
+  node-service = dockerTools.buildLayeredImage (serviceImageProps // {
+    name = "mayadata/node-service";
+    contents = [ busybox mayastor ];
+    config = { Entrypoint = [ "/bin/node" ]; };
+    maxLayers = 42;
+  });
+
+  # Development image of node service.
+  node-service-dev = dockerTools.buildImage (serviceImageProps // {
+    name = "mayadata/node-service-dev";
+    contents = [ busybox mayastor-dev ];
+    config = { Entrypoint = [ "/bin/node" ]; };
+  });
+
+  # Release image of volume service.
+  volume-service = dockerTools.buildLayeredImage (serviceImageProps // {
+    name = "mayadata/volume-service";
+    contents = [ busybox mayastor ];
+    config = { Entrypoint = [ "/bin/volume" ]; };
+    maxLayers = 42;
+  });
+
+  # Development image of volume service.
+  volume-service-dev = dockerTools.buildImage (serviceImageProps // {
+    name = "mayadata/volume-service-dev";
+    contents = [ busybox mayastor-dev ];
+    config = { Entrypoint = [ "/bin/volume" ]; };
+  });
+
+  # Release image of pool service.
+  pool-service = dockerTools.buildLayeredImage (serviceImageProps // {
+    name = "mayadata/pool-service";
+    contents = [ busybox mayastor ];
+    config = { Entrypoint = [ "/bin/pool" ]; };
+    maxLayers = 42;
+  });
+
+  # Development image of pool service.
+  pool-service-dev = dockerTools.buildImage (serviceImageProps // {
+    name = "mayadata/pool-service-dev";
+    contents = [ busybox mayastor-dev ];
+    config = { Entrypoint = [ "/bin/pool" ]; };
+  });
+
+  # Release image of rest service.
+  rest-service = dockerTools.buildLayeredImage (serviceImageProps // {
+    name = "mayadata/rest-service";
+    contents = [ busybox mayastor ];
+    config = { Entrypoint = [ "/bin/rest" ]; };
+    maxLayers = 42;
+  });
+
+  # Development image of rest service.
+  rest-service-dev = dockerTools.buildImage (serviceImageProps // {
+    name = "mayadata/rest-service-dev";
+    contents = [ busybox mayastor-dev ];
+    config = { Entrypoint = [ "/bin/rest" ]; };
+  });
+
+  # Release image of node operator.
+  node-operator = dockerTools.buildLayeredImage (operatorImageProps // {
+    name = "mayadata/node-operator";
+    contents = [ busybox mayastor ];
+    config = { Entrypoint = [ "/bin/node-op" ]; };
+    maxLayers = 42;
+  });
+
+  # Development image of node operator.
+  node-operator-dev = dockerTools.buildImage (operatorImageProps // {
+    name = "mayadata/node-operator-dev";
+    contents = [ busybox mayastor-dev ];
+    config = { Entrypoint = [ "/bin/node-op" ]; };
+  });
 }

--- a/nix/pkgs/mayastor/default.nix
+++ b/nix/pkgs/mayastor/default.nix
@@ -107,6 +107,10 @@ in
       ../../../target/debug/mayastor-client
       ../../../target/debug/jsonrpc
       ../../../target/debug/kiiss
+      ../../../target/debug/node
+      ../../../target/debug/volume
+      ../../../target/debug/pool
+      ../../../target/debug/rest
     ];
 
     buildInputs = [

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -134,15 +134,15 @@ for name in $IMAGES; do
   # If we're skipping the build, then we just want to upload
   # the images we already have locally.
   if [ -z $SKIP_BUILD ]; then
-    archive=${name}-image
+    archive=${name}
     if [ -z "$REGISTRY" ] && dockerhub_tag_exists $image $TAG; then
       echo "Skipping $image:$TAG that already exists"
       continue
     fi
     echo "Building $image:$TAG ..."
-    $NIX_BUILD --out-link $archive -A images.$archive
-    $DOCKER load -i $archive
-    $RM $archive
+    $NIX_BUILD --out-link $archive-image -A images.$archive
+    $DOCKER load -i $archive-image
+    $RM $archive-image
     if [ "$image" != "$image_basename" ]; then
       echo "Renaming $image_basename:$TAG to $image:$TAG"
       $DOCKER tag "${image_basename}:$TAG" "$image:$TAG"

--- a/terraform/README.adoc
+++ b/terraform/README.adoc
@@ -272,7 +272,7 @@ mayastor-csi images. Replace "hostname" by the name of your registry host.
 
 [source,bash]
 ----
-nix-build '<nixpkgs>' -A images.moac-image
+nix-build '<nixpkgs>' -A images.moac
 docker load <result
 docker tag mayadata/moac hostname:5000/moac:latest
 docker push hostname:5000/moac:latest
@@ -280,7 +280,7 @@ docker push hostname:5000/moac:latest
 
 [source,bash]
 ----
-nix-build '<nixpkgs>' -A images.moac-image
+nix-build '<nixpkgs>' -A images.moac
 skopeo copy --dest-tls-verify=false docker-archive:result docker://hostname:5000/mayadata/moac:latest
 ----
 


### PR DESCRIPTION
Provide the ability to build container images for the control plane
services and operators.
    
To build the node service, for example:
    nix-build -A images.node-service
or to build a debug version, add the suffix "-dev":
    nix-build -A images.node-service-dev
    
To build the node operator, for example:
    nix-build -A images.node-operator
or to build a debug version, add the suffix "-dev":
    nix-build -A images.node-operator-dev
    
Additional change:
    
Changed the existing image names to remove the "-image" suffix. So the
command to build the mayastor image now looks like:
    nix-build -A images.mayastor
rather than:
    nix-build -A images.mayastor-image