### PR TITLE
refactor(rest): improve rest versioning and add certificate arguments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3718,6 +3718,7 @@ name = "rest"
 version = "0.1.0"
 dependencies = [
  "actix-rt",
+ "actix-service",
  "actix-web",
  "actix-web-opentelemetry",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,6 @@
 [patch.crates-io]
 h2 = { git = "https://github.com/gila/h2", branch = "v0.2.7"}
 partition-identity = { git = "https://github.com/openebs/partition-identity.git" }
-#paperclip = { git = "https://github.com/tiagolobocastro/paperclip.git", branch = "tuple_struct_doc", features = ["actix3-nightly"] }
 
 [profile.dev]
 panic = "abort"

--- a/mbus-api/src/lib.rs
+++ b/mbus-api/src/lib.rs
@@ -146,9 +146,10 @@ impl FromStr for Channel {
     type Err = strum::ParseError;
 
     fn from_str(source: &str) -> Result<Self, Self::Err> {
-        match &source[0 ..= 2] {
-            "v0/" => {
-                let c: v0::ChannelVs = source[3 ..].parse()?;
+        match source.split('/').next() {
+            Some(v0::VERSION) => {
+                let c: v0::ChannelVs =
+                    source[v0::VERSION.len() + 1 ..].parse()?;
                 Ok(Self::v0(c))
             }
             _ => Err(strum::ParseError::VariantNotFound),
@@ -208,9 +209,10 @@ impl FromStr for MessageId {
     type Err = strum::ParseError;
 
     fn from_str(source: &str) -> Result<Self, Self::Err> {
-        match &source[0 ..= 2] {
-            "v0/" => {
-                let id: v0::MessageIdVs = source[3 ..].parse()?;
+        match source.split('/').next() {
+            Some(v0::VERSION) => {
+                let id: v0::MessageIdVs =
+                    source[v0::VERSION.len() + 1 ..].parse()?;
                 Ok(Self::v0(id))
             }
             _ => Err(strum::ParseError::VariantNotFound),
@@ -220,7 +222,7 @@ impl FromStr for MessageId {
 impl ToString for MessageId {
     fn to_string(&self) -> String {
         match self {
-            Self::v0(id) => format!("v0/{}", id.to_string()),
+            Self::v0(id) => format!("{}/{}", v0::VERSION, id.to_string()),
         }
     }
 }

--- a/mbus-api/src/message_bus/v0.rs
+++ b/mbus-api/src/message_bus/v0.rs
@@ -1,7 +1,7 @@
 // clippy warning caused by the instrument macro
 #![allow(clippy::unit_arg)]
 
-use crate::{v0::*, *};
+pub use crate::{v0::*, *};
 use async_trait::async_trait;
 
 /// Error sending/receiving
@@ -27,83 +27,6 @@ impl From<Error> for BusError {
 
 /// Result for sending/receiving
 pub type BusResult<T> = Result<T, BusError>;
-
-/// Node
-pub type Node = crate::v0::Node;
-/// Node list
-pub type Nodes = crate::v0::Nodes;
-/// Pool
-pub type Pool = crate::v0::Pool;
-/// Pool list
-pub type Pools = crate::v0::Pools;
-/// Replica
-pub type Replica = crate::v0::Replica;
-/// Replica list
-pub type Replicas = crate::v0::Replicas;
-/// Protocol
-pub type Protocol = crate::v0::Protocol;
-/// Replica Create
-pub type CreateReplica = crate::v0::CreateReplica;
-/// Pool Create
-pub type CreatePool = crate::v0::CreatePool;
-/// Replica Destroy
-pub type DestroyReplica = crate::v0::DestroyReplica;
-/// Pool Destroy
-pub type DestroyPool = crate::v0::DestroyPool;
-/// Replica Share
-pub type ShareReplica = crate::v0::ShareReplica;
-/// Replica Unshare
-pub type UnshareReplica = crate::v0::UnshareReplica;
-/// Query Filter
-pub type Filter = crate::v0::Filter;
-/// Nexus from the volume service
-pub type Nexus = crate::v0::Nexus;
-/// Vector of Nexuses from the volume service
-pub type Nexuses = crate::v0::Nexuses;
-/// State of the nexus
-pub type NexusState = crate::v0::NexusState;
-/// State of the volume
-pub type VolumeState = crate::v0::VolumeState;
-/// Child of the nexus
-pub type Child = crate::v0::Child;
-/// State of the child
-pub type ChildState = crate::v0::ChildState;
-/// Nexus Create
-pub type CreateNexus = crate::v0::CreateNexus;
-/// Nexus Destroy
-pub type DestroyNexus = crate::v0::DestroyNexus;
-/// Nexus Share
-pub type ShareNexus = crate::v0::ShareNexus;
-/// Nexus Unshare
-pub type UnshareNexus = crate::v0::UnshareNexus;
-/// Remove Nexus Child
-pub type RemoveNexusChild = crate::v0::RemoveNexusChild;
-/// Add Nexus Child
-pub type AddNexusChild = crate::v0::AddNexusChild;
-/// Volume
-pub type Volume = crate::v0::Volume;
-/// Volumes
-pub type Volumes = crate::v0::Volumes;
-/// Create Volume
-pub type CreateVolume = crate::v0::CreateVolume;
-/// Delete Volume
-pub type DestroyVolume = crate::v0::DestroyVolume;
-/// Add Volume Nexus
-pub type AddVolumeNexus = crate::v0::AddVolumeNexus;
-/// Remove Volume Nexus
-pub type RemoveVolumeNexus = crate::v0::RemoveVolumeNexus;
-/// Id of a mayastor node
-pub type NodeId = crate::v0::NodeId;
-/// Id of a mayastor pool
-pub type PoolId = crate::v0::PoolId;
-/// UUID of a mayastor pool replica
-pub type ReplicaId = crate::v0::ReplicaId;
-/// UUID of a mayastor nexus
-pub type NexusId = crate::v0::NexusId;
-/// URI of a mayastor nexus child
-pub type ChildUri = crate::v0::ChildUri;
-/// UUID of a mayastor volume
-pub type VolumeId = crate::v0::VolumeId;
 
 macro_rules! only_one {
     ($list:ident) => {

--- a/mbus-api/src/v0.rs
+++ b/mbus-api/src/v0.rs
@@ -6,6 +6,8 @@ use serde::{Deserialize, Serialize};
 use std::{cmp::Ordering, fmt::Debug};
 use strum_macros::{EnumString, ToString};
 
+pub(super) const VERSION: &str = "v0";
+
 /// Versioned Channels
 #[derive(Clone, Debug, EnumString, ToString)]
 #[strum(serialize_all = "camelCase")]

--- a/nix/pkgs/mayastor/default.nix
+++ b/nix/pkgs/mayastor/default.nix
@@ -39,7 +39,7 @@ let
   buildProps = rec {
     name = "mayastor";
     #cargoSha256 = "0000000000000000000000000000000000000000000000000000";
-    cargoSha256 = "0jxi2z78kc0knr3bscyk622rg7b5ynjiw205xl6g4v8saychxpbd";
+    cargoSha256 = "1kv66ngq371ss2ra8hpr7zxdwvqwnfg0kskl96fqmc2kbbpah2r8";
     inherit version;
     src = whitelistSource ../../../. [
       "Cargo.lock"

--- a/rest/Cargo.toml
+++ b/rest/Cargo.toml
@@ -17,6 +17,7 @@ path = "./src/lib.rs"
 [dependencies]
 rustls = "0.18"
 actix-web = { version = "3.2.0", features = ["rustls"] }
+actix-service = "1.0.6"
 mbus_api = { path = "../mbus-api" }
 async-trait = "0.1.41"
 serde_json = "1.0"

--- a/rest/service/src/main.rs
+++ b/rest/service/src/main.rs
@@ -12,7 +12,7 @@ use rustls::{
     NoClientAuth,
     ServerConfig,
 };
-use std::io::BufReader;
+use std::{fs::File, io::BufReader};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
@@ -28,6 +28,17 @@ pub(crate) struct CliArgs {
     /// Default: nats://0.0.0.0:4222
     #[structopt(long, short, default_value = "nats://0.0.0.0:4222")]
     nats: String,
+
+    /// Path to the certificate file
+    #[structopt(long, short, required_unless = "dummy-certificates")]
+    cert_file: Option<String>,
+    /// Path to the key file
+    #[structopt(long, short, required_unless = "dummy-certificates")]
+    key_file: Option<String>,
+
+    /// Use dummy HTTPS certificates (for testing)
+    #[structopt(long, short, required_unless = "cert-file")]
+    dummy_certificates: bool,
 
     /// Trace rest requests to the Jaeger endpoint agent
     #[structopt(long, short)]
@@ -90,24 +101,61 @@ where
     }
 }
 
-#[actix_web::main]
-async fn main() -> std::io::Result<()> {
-    // need to keep the jaeger pipeline tracer alive, if enabled
-    let _tracer = init_tracing();
+fn get_certificates() -> anyhow::Result<ServerConfig> {
+    if CliArgs::from_args().dummy_certificates {
+        get_dummy_certificates()
+    } else {
+        // guaranteed to be `Some` by the require_unless attribute
+        let cert_file = CliArgs::from_args()
+            .cert_file
+            .expect("cert_file is required");
+        let key_file =
+            CliArgs::from_args().key_file.expect("key_file is required");
+        let cert_file = &mut BufReader::new(File::open(cert_file)?);
+        let key_file = &mut BufReader::new(File::open(key_file)?);
+        load_certificates(cert_file, key_file)
+    }
+}
 
-    mbus_api::message_bus_init(CliArgs::from_args().nats).await;
-
-    // dummy certificates
-    let mut config = ServerConfig::new(NoClientAuth::new());
+fn get_dummy_certificates() -> anyhow::Result<ServerConfig> {
     let cert_file = &mut BufReader::new(
         &std::include_bytes!("../../certs/rsa/user.chain")[..],
     );
     let key_file = &mut BufReader::new(
         &std::include_bytes!("../../certs/rsa/user.rsa")[..],
     );
-    let cert_chain = certs(cert_file).unwrap();
-    let mut keys = rsa_private_keys(key_file).unwrap();
-    config.set_single_cert(cert_chain, keys.remove(0)).unwrap();
+
+    load_certificates(cert_file, key_file)
+}
+
+fn load_certificates<R: std::io::Read>(
+    cert_file: &mut BufReader<R>,
+    key_file: &mut BufReader<R>,
+) -> anyhow::Result<ServerConfig> {
+    let mut config = ServerConfig::new(NoClientAuth::new());
+    let cert_chain = certs(cert_file).map_err(|_| {
+        anyhow::anyhow!(
+            "Failed to retrieve certificates from the certificate file",
+        )
+    })?;
+    let mut keys = rsa_private_keys(key_file).map_err(|_| {
+        anyhow::anyhow!(
+            "Failed to retrieve the rsa private keys from the key file",
+        )
+    })?;
+    if keys.is_empty() {
+        anyhow::bail!("No keys found in the keys file");
+    }
+    config.set_single_cert(cert_chain, keys.remove(0))?;
+    Ok(config)
+}
+
+#[actix_web::main]
+async fn main() -> anyhow::Result<()> {
+    // need to keep the jaeger pipeline tracer alive, if enabled
+    let _tracer = init_tracing();
+
+    mbus_api::message_bus_init(CliArgs::from_args().nats).await;
 
     let server = HttpServer::new(move || {
         App::new()
@@ -115,12 +163,13 @@ async fn main() -> std::io::Result<()> {
             .wrap(middleware::Logger::default())
             .configure_api(&v0::configure_api)
     })
-    .bind_rustls(CliArgs::from_args().https, config)?;
+    .bind_rustls(CliArgs::from_args().https, get_certificates()?)?;
     if let Some(http) = CliArgs::from_args().http {
-        server.bind(http)?
+        server.bind(http).map_err(anyhow::Error::from)?
     } else {
         server
     }
     .run()
     .await
+    .map_err(|e| e.into())
 }

--- a/rest/service/src/v0/children.rs
+++ b/rest/service/src/v0/children.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-pub(crate) fn configure(cfg: &mut paperclip::actix::web::ServiceConfig) {
+pub(super) fn configure(cfg: &mut paperclip::actix::web::ServiceConfig) {
     cfg.service(get_nexus_children)
         .service(get_nexus_child)
         .service(get_node_nexus_children)
@@ -11,20 +11,20 @@ pub(crate) fn configure(cfg: &mut paperclip::actix::web::ServiceConfig) {
         .service(delete_node_nexus_child);
 }
 
-#[get("/v0/nexuses/{nexus_id}/children", tags(Children))]
+#[get("/v0", "/nexuses/{nexus_id}/children", tags(Children))]
 async fn get_nexus_children(
     web::Path(nexus_id): web::Path<NexusId>,
 ) -> Result<web::Json<Vec<Child>>, RestError> {
     get_children_response(Filter::Nexus(nexus_id)).await
 }
-#[get("/v0/nodes/{node_id}/nexuses/{nexus_id}/children", tags(Children))]
+#[get("/v0", "/nodes/{node_id}/nexuses/{nexus_id}/children", tags(Children))]
 async fn get_node_nexus_children(
     web::Path((node_id, nexus_id)): web::Path<(NodeId, NexusId)>,
 ) -> Result<web::Json<Vec<Child>>, RestError> {
     get_children_response(Filter::NodeNexus(node_id, nexus_id)).await
 }
 
-#[get("/v0/nexuses/{nexus_id}/children/{child_id:.*}", tags(Children))]
+#[get("/v0", "/nexuses/{nexus_id}/children/{child_id:.*}", tags(Children))]
 async fn get_nexus_child(
     web::Path((nexus_id, child_id)): web::Path<(NexusId, ChildUri)>,
     req: HttpRequest,
@@ -32,7 +32,8 @@ async fn get_nexus_child(
     get_child_response(child_id, req, Filter::Nexus(nexus_id)).await
 }
 #[get(
-    "/v0/nodes/{node_id}/nexuses/{nexus_id}/children/{child_id:.*}",
+    "/v0",
+    "/nodes/{node_id}/nexuses/{nexus_id}/children/{child_id:.*}",
     tags(Children)
 )]
 async fn get_node_nexus_child(
@@ -47,7 +48,7 @@ async fn get_node_nexus_child(
         .await
 }
 
-#[put("/v0/nexuses/{nexus_id}/children/{child_id:.*}", tags(Children))]
+#[put("/v0", "/nexuses/{nexus_id}/children/{child_id:.*}", tags(Children))]
 async fn add_nexus_child(
     web::Path((nexus_id, child_id)): web::Path<(NexusId, ChildUri)>,
     req: HttpRequest,
@@ -55,7 +56,8 @@ async fn add_nexus_child(
     add_child_filtered(child_id, req, Filter::Nexus(nexus_id)).await
 }
 #[put(
-    "/v0/nodes/{node_id}/nexuses/{nexus_id}/children/{child_id:.*}",
+    "/v0",
+    "/nodes/{node_id}/nexuses/{nexus_id}/children/{child_id:.*}",
     tags(Children)
 )]
 async fn add_node_nexus_child(
@@ -70,7 +72,7 @@ async fn add_node_nexus_child(
         .await
 }
 
-#[delete("/v0/nexuses/{nexus_id}/children/{child_id:.*}", tags(Children))]
+#[delete("/v0", "/nexuses/{nexus_id}/children/{child_id:.*}", tags(Children))]
 async fn delete_nexus_child(
     web::Path((nexus_id, child_id)): web::Path<(NexusId, ChildUri)>,
     req: HttpRequest,
@@ -78,7 +80,8 @@ async fn delete_nexus_child(
     delete_child_filtered(child_id, req, Filter::Nexus(nexus_id)).await
 }
 #[delete(
-    "/v0/nodes/{node_id}/nexuses/{nexus_id}/children/{child_id:.*}",
+    "/v0",
+    "/nodes/{node_id}/nexuses/{nexus_id}/children/{child_id:.*}",
     tags(Children)
 )]
 async fn delete_node_nexus_child(

--- a/rest/service/src/v0/mod.rs
+++ b/rest/service/src/v0/mod.rs
@@ -10,15 +10,59 @@ pub mod replicas;
 pub mod swagger_ui;
 pub mod volumes;
 
-use mbus_api::{
-    message_bus::v0::{MessageBus, *},
-    v0::Filter,
-};
 use rest_client::versions::v0::*;
 
+use actix_service::ServiceFactory;
 use actix_web::{
+    dev::{MessageBody, ServiceRequest, ServiceResponse},
     web::{self, Json},
     HttpRequest,
 };
-
 use mayastor_macros::actix::{delete, get, put};
+use paperclip::actix::OpenApiExt;
+
+fn version() -> String {
+    "v0".into()
+}
+fn base_path() -> String {
+    format!("/{}", version())
+}
+fn spec_uri() -> String {
+    format!("/{}/api/spec", version())
+}
+fn get_api() -> paperclip::v2::models::DefaultApiRaw {
+    let mut api = paperclip::v2::models::DefaultApiRaw::default();
+    api.info.version = version();
+    api.info.title = "Mayastor RESTful API".into();
+    api.base_path = Some(base_path());
+    api
+}
+
+fn configure(cfg: &mut paperclip::actix::web::ServiceConfig) {
+    nodes::configure(cfg);
+    pools::configure(cfg);
+    replicas::configure(cfg);
+    nexuses::configure(cfg);
+    children::configure(cfg);
+    volumes::configure(cfg);
+}
+
+pub(super) fn configure_api<T, B>(
+    api: actix_web::App<T, B>,
+) -> actix_web::App<T, B>
+where
+    B: MessageBody,
+    T: ServiceFactory<
+        Config = (),
+        Request = ServiceRequest,
+        Response = ServiceResponse<B>,
+        Error = actix_web::Error,
+        InitError = (),
+    >,
+{
+    api.wrap_api_with_spec(get_api())
+        .configure(configure)
+        .with_json_spec_at(&spec_uri())
+        .build()
+        .configure(swagger_ui::configure)
+}

--- a/rest/service/src/v0/nexuses.rs
+++ b/rest/service/src/v0/nexuses.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-pub(crate) fn configure(cfg: &mut paperclip::actix::web::ServiceConfig) {
+pub(super) fn configure(cfg: &mut paperclip::actix::web::ServiceConfig) {
     cfg.service(get_nexuses)
         .service(get_nexus)
         .service(get_node_nexuses)
@@ -12,24 +12,24 @@ pub(crate) fn configure(cfg: &mut paperclip::actix::web::ServiceConfig) {
         .service(del_node_nexus_share);
 }
 
-#[get("/v0/nexuses", tags(Nexuses))]
+#[get("/v0", "/nexuses", tags(Nexuses))]
 async fn get_nexuses() -> Result<Json<Vec<Nexus>>, RestError> {
     RestRespond::result(MessageBus::get_nexuses(Filter::None).await)
 }
-#[get("/v0/nexuses/{nexus_id}", tags(Nexuses))]
+#[get("/v0", "/nexuses/{nexus_id}", tags(Nexuses))]
 async fn get_nexus(
     web::Path(nexus_id): web::Path<NexusId>,
 ) -> Result<Json<Nexus>, RestError> {
     RestRespond::result(MessageBus::get_nexus(Filter::Nexus(nexus_id)).await)
 }
 
-#[get("/v0/nodes/{id}/nexuses", tags(Nexuses))]
+#[get("/v0", "/nodes/{id}/nexuses", tags(Nexuses))]
 async fn get_node_nexuses(
     web::Path(node_id): web::Path<NodeId>,
 ) -> Result<Json<Vec<Nexus>>, RestError> {
     RestRespond::result(MessageBus::get_nexuses(Filter::Node(node_id)).await)
 }
-#[get("/v0/nodes/{node_id}/nexuses/{nexus_id}", tags(Nexuses))]
+#[get("/v0", "/nodes/{node_id}/nexuses/{nexus_id}", tags(Nexuses))]
 async fn get_node_nexus(
     web::Path((node_id, nexus_id)): web::Path<(NodeId, NexusId)>,
 ) -> Result<Json<Nexus>, RestError> {
@@ -38,7 +38,7 @@ async fn get_node_nexus(
     )
 }
 
-#[put("/v0/nodes/{node_id}/nexuses/{nexus_id}", tags(Nexuses))]
+#[put("/v0", "/nodes/{node_id}/nexuses/{nexus_id}", tags(Nexuses))]
 async fn put_node_nexus(
     web::Path((node_id, nexus_id)): web::Path<(NodeId, NexusId)>,
     create: web::Json<CreateNexusBody>,
@@ -47,13 +47,13 @@ async fn put_node_nexus(
     RestRespond::result(MessageBus::create_nexus(create).await)
 }
 
-#[delete("/v0/nodes/{node_id}/nexuses/{nexus_id}", tags(Nexuses))]
+#[delete("/v0", "/nodes/{node_id}/nexuses/{nexus_id}", tags(Nexuses))]
 async fn del_node_nexus(
     web::Path((node_id, nexus_id)): web::Path<(NodeId, NexusId)>,
 ) -> Result<Json<()>, RestError> {
     destroy_nexus(Filter::NodeNexus(node_id, nexus_id)).await
 }
-#[delete("/v0/nexuses/{nexus_id}", tags(Nexuses))]
+#[delete("/v0", "/nexuses/{nexus_id}", tags(Nexuses))]
 async fn del_nexus(
     web::Path(nexus_id): web::Path<NexusId>,
 ) -> Result<Json<()>, RestError> {
@@ -61,7 +61,8 @@ async fn del_nexus(
 }
 
 #[put(
-    "/v0/nodes/{node_id}/nexuses/{nexus_id}/share/{protocol}",
+    "/v0",
+    "/nodes/{node_id}/nexuses/{nexus_id}/share/{protocol}",
     tags(Nexuses)
 )]
 async fn put_node_nexus_share(
@@ -80,7 +81,7 @@ async fn put_node_nexus_share(
     RestRespond::result(MessageBus::share_nexus(share).await)
 }
 
-#[delete("/v0/nodes/{node_id}/nexuses/{nexus_id}/share", tags(Nexuses))]
+#[delete("/v0", "/nodes/{node_id}/nexuses/{nexus_id}/share", tags(Nexuses))]
 async fn del_node_nexus_share(
     web::Path((node_id, nexus_id)): web::Path<(NodeId, NexusId)>,
 ) -> Result<Json<()>, RestError> {

--- a/rest/service/src/v0/nodes.rs
+++ b/rest/service/src/v0/nodes.rs
@@ -1,14 +1,14 @@
 use super::*;
 
-pub(crate) fn configure(cfg: &mut paperclip::actix::web::ServiceConfig) {
+pub(super) fn configure(cfg: &mut paperclip::actix::web::ServiceConfig) {
     cfg.service(get_nodes).service(get_node);
 }
 
-#[get("/v0/nodes", tags(Nodes))]
+#[get("/v0", "/nodes", tags(Nodes))]
 async fn get_nodes() -> Result<web::Json<Vec<Node>>, RestError> {
     RestRespond::result(MessageBus::get_nodes().await)
 }
-#[get("/v0/nodes/{id}", tags(Nodes))]
+#[get("/v0", "/nodes/{id}", tags(Nodes))]
 async fn get_node(
     web::Path(node_id): web::Path<NodeId>,
 ) -> Result<web::Json<Node>, RestError> {

--- a/rest/service/src/v0/pools.rs
+++ b/rest/service/src/v0/pools.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-pub(crate) fn configure(cfg: &mut paperclip::actix::web::ServiceConfig) {
+pub(super) fn configure(cfg: &mut paperclip::actix::web::ServiceConfig) {
     cfg.service(get_pools)
         .service(get_pool)
         .service(get_node_pools)
@@ -10,25 +10,25 @@ pub(crate) fn configure(cfg: &mut paperclip::actix::web::ServiceConfig) {
         .service(del_pool);
 }
 
-#[get("/v0/pools", tags(Pools))]
+#[get("/v0", "/pools", tags(Pools))]
 async fn get_pools() -> Result<Json<Vec<Pool>>, RestError> {
     RestRespond::result(MessageBus::get_pools(Filter::None).await)
 }
-#[get("/v0/pools/{id}", tags(Pools))]
+#[get("/v0", "/pools/{id}", tags(Pools))]
 async fn get_pool(
     web::Path(pool_id): web::Path<PoolId>,
 ) -> Result<Json<Pool>, RestError> {
     RestRespond::result(MessageBus::get_pool(Filter::Pool(pool_id)).await)
 }
 
-#[get("/v0/nodes/{id}/pools", tags(Pools))]
+#[get("/v0", "/nodes/{id}/pools", tags(Pools))]
 async fn get_node_pools(
     web::Path(node_id): web::Path<NodeId>,
 ) -> Result<Json<Vec<Pool>>, RestError> {
     RestRespond::result(MessageBus::get_pools(Filter::Node(node_id)).await)
 }
 
-#[get("/v0/nodes/{node_id}/pools/{pool_id}", tags(Pools))]
+#[get("/v0", "/nodes/{node_id}/pools/{pool_id}", tags(Pools))]
 async fn get_node_pool(
     web::Path((node_id, pool_id)): web::Path<(NodeId, PoolId)>,
 ) -> Result<Json<Pool>, RestError> {
@@ -37,7 +37,7 @@ async fn get_node_pool(
     )
 }
 
-#[put("/v0/nodes/{node_id}/pools/{pool_id}", tags(Pools))]
+#[put("/v0", "/nodes/{node_id}/pools/{pool_id}", tags(Pools))]
 async fn put_node_pool(
     web::Path((node_id, pool_id)): web::Path<(NodeId, PoolId)>,
     create: web::Json<CreatePoolBody>,
@@ -46,13 +46,13 @@ async fn put_node_pool(
     RestRespond::result(MessageBus::create_pool(create).await)
 }
 
-#[delete("/v0/nodes/{node_id}/pools/{pool_id}", tags(Pools))]
+#[delete("/v0", "/nodes/{node_id}/pools/{pool_id}", tags(Pools))]
 async fn del_node_pool(
     web::Path((node_id, pool_id)): web::Path<(NodeId, PoolId)>,
 ) -> Result<Json<()>, RestError> {
     destroy_pool(Filter::NodePool(node_id, pool_id)).await
 }
-#[delete("/v0/pools/{pool_id}", tags(Pools))]
+#[delete("/v0", "/pools/{pool_id}", tags(Pools))]
 async fn del_pool(
     web::Path(pool_id): web::Path<PoolId>,
 ) -> Result<Json<()>, RestError> {

--- a/rest/service/src/v0/replicas.rs
+++ b/rest/service/src/v0/replicas.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-pub(crate) fn configure(cfg: &mut paperclip::actix::web::ServiceConfig) {
+pub(super) fn configure(cfg: &mut paperclip::actix::web::ServiceConfig) {
     cfg.service(get_replicas)
         .service(get_replica)
         .service(get_node_replicas)
@@ -16,11 +16,11 @@ pub(crate) fn configure(cfg: &mut paperclip::actix::web::ServiceConfig) {
         .service(del_pool_replica_share);
 }
 
-#[get("/v0/replicas", tags(Replicas))]
+#[get("/v0", "/replicas", tags(Replicas))]
 async fn get_replicas() -> Result<Json<Vec<Replica>>, RestError> {
     RestRespond::result(MessageBus::get_replicas(Filter::None).await)
 }
-#[get("/v0/replicas/{id}", tags(Replicas))]
+#[get("/v0", "/replicas/{id}", tags(Replicas))]
 async fn get_replica(
     web::Path(replica_id): web::Path<ReplicaId>,
 ) -> Result<Json<Replica>, RestError> {
@@ -29,14 +29,14 @@ async fn get_replica(
     )
 }
 
-#[get("/v0/nodes/{id}/replicas", tags(Replicas))]
+#[get("/v0", "/nodes/{id}/replicas", tags(Replicas))]
 async fn get_node_replicas(
     web::Path(node_id): web::Path<NodeId>,
 ) -> Result<Json<Vec<Replica>>, RestError> {
     RestRespond::result(MessageBus::get_replicas(Filter::Node(node_id)).await)
 }
 
-#[get("/v0/nodes/{node_id}/pools/{pool_id}/replicas", tags(Replicas))]
+#[get("/v0", "/nodes/{node_id}/pools/{pool_id}/replicas", tags(Replicas))]
 async fn get_node_pool_replicas(
     web::Path((node_id, pool_id)): web::Path<(NodeId, PoolId)>,
 ) -> Result<Json<Vec<Replica>>, RestError> {
@@ -45,7 +45,8 @@ async fn get_node_pool_replicas(
     )
 }
 #[get(
-    "/v0/nodes/{node_id}/pools/{pool_id}/replicas/{replica_id}",
+    "/v0",
+    "/nodes/{node_id}/pools/{pool_id}/replicas/{replica_id}",
     tags(Replicas)
 )]
 async fn get_node_pool_replica(
@@ -64,7 +65,8 @@ async fn get_node_pool_replica(
 }
 
 #[put(
-    "/v0/nodes/{node_id}/pools/{pool_id}/replicas/{replica_id}",
+    "/v0",
+    "/nodes/{node_id}/pools/{pool_id}/replicas/{replica_id}",
     tags(Replicas)
 )]
 async fn put_node_pool_replica(
@@ -81,7 +83,7 @@ async fn put_node_pool_replica(
     )
     .await
 }
-#[put("/v0/pools/{pool_id}/replicas/{replica_id}", tags(Replicas))]
+#[put("/v0", "/pools/{pool_id}/replicas/{replica_id}", tags(Replicas))]
 async fn put_pool_replica(
     web::Path((pool_id, replica_id)): web::Path<(PoolId, ReplicaId)>,
     create: web::Json<CreateReplicaBody>,
@@ -94,7 +96,8 @@ async fn put_pool_replica(
 }
 
 #[delete(
-    "/v0/nodes/{node_id}/pools/{pool_id}/replicas/{replica_id}",
+    "/v0",
+    "/nodes/{node_id}/pools/{pool_id}/replicas/{replica_id}",
     tags(Replicas)
 )]
 async fn del_node_pool_replica(
@@ -106,14 +109,18 @@ async fn del_node_pool_replica(
 ) -> Result<Json<()>, RestError> {
     destroy_replica(Filter::NodePoolReplica(node_id, pool_id, replica_id)).await
 }
-#[delete("/v0/pools/{pool_id}/replicas/{replica_id}", tags(Replicas))]
+#[delete("/v0", "/pools/{pool_id}/replicas/{replica_id}", tags(Replicas))]
 async fn del_pool_replica(
     web::Path((pool_id, replica_id)): web::Path<(PoolId, ReplicaId)>,
 ) -> Result<Json<()>, RestError> {
     destroy_replica(Filter::PoolReplica(pool_id, replica_id)).await
 }
 
-#[put("/v0/nodes/{node_id}/pools/{pool_id}/replicas/{replica_id}/share/{protocol}", tags(Replicas))]
+#[put(
+    "/v0",
+    "/nodes/{node_id}/pools/{pool_id}/replicas/{replica_id}/share/{protocol}",
+    tags(Replicas)
+)]
 async fn put_node_pool_replica_share(
     web::Path((node_id, pool_id, replica_id, protocol)): web::Path<(
         NodeId,
@@ -129,7 +136,8 @@ async fn put_node_pool_replica_share(
     .await
 }
 #[put(
-    "/v0/pools/{pool_id}/replicas/{replica_id}/share/{protocol}",
+    "/v0",
+    "/pools/{pool_id}/replicas/{replica_id}/share/{protocol}",
     tags(Replicas)
 )]
 async fn put_pool_replica_share(
@@ -143,7 +151,8 @@ async fn put_pool_replica_share(
 }
 
 #[delete(
-    "/v0/nodes/{node_id}/pools/{pool_id}/replicas/{replica_id}/share",
+    "/v0",
+    "/nodes/{node_id}/pools/{pool_id}/replicas/{replica_id}/share",
     tags(Replicas)
 )]
 async fn del_node_pool_replica_share(
@@ -155,7 +164,7 @@ async fn del_node_pool_replica_share(
 ) -> Result<Json<()>, RestError> {
     unshare_replica(Filter::NodePoolReplica(node_id, pool_id, replica_id)).await
 }
-#[delete("/v0/pools/{pool_id}/replicas/{replica_id}/share", tags(Replicas))]
+#[delete("/v0", "/pools/{pool_id}/replicas/{replica_id}/share", tags(Replicas))]
 async fn del_pool_replica_share(
     web::Path((pool_id, replica_id)): web::Path<(PoolId, ReplicaId)>,
 ) -> Result<Json<()>, RestError> {

--- a/rest/service/src/v0/swagger_ui.rs
+++ b/rest/service/src/v0/swagger_ui.rs
@@ -2,10 +2,10 @@ use actix_web::{dev::Factory, web, Error, HttpResponse};
 use futures::future::{ok as fut_ok, Ready};
 use tinytemplate::TinyTemplate;
 
-pub(crate) fn configure(cfg: &mut web::ServiceConfig) {
+pub(super) fn configure(cfg: &mut web::ServiceConfig) {
     cfg.service(
-        web::resource("/v0/swagger-ui").route(
-            web::get().to(GetSwaggerUi(get_swagger_html(crate::SPEC_URI))),
+        web::resource(&format!("{}/swagger-ui", super::version())).route(
+            web::get().to(GetSwaggerUi(get_swagger_html(&super::spec_uri()))),
         ),
     );
 }

--- a/rest/service/src/v0/volumes.rs
+++ b/rest/service/src/v0/volumes.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-pub(crate) fn configure(cfg: &mut paperclip::actix::web::ServiceConfig) {
+pub(super) fn configure(cfg: &mut paperclip::actix::web::ServiceConfig) {
     cfg.service(get_volumes)
         .service(get_volume)
         .service(get_node_volumes)
@@ -9,25 +9,25 @@ pub(crate) fn configure(cfg: &mut paperclip::actix::web::ServiceConfig) {
         .service(del_volume);
 }
 
-#[get("/v0/volumes", tags(Volumes))]
+#[get("/v0", "/volumes", tags(Volumes))]
 async fn get_volumes() -> Result<Json<Vec<Volume>>, RestError> {
     RestRespond::result(MessageBus::get_volumes(Filter::None).await)
 }
 
-#[get("/v0/volumes/{volume_id}", tags(Volumes))]
+#[get("/v0", "/volumes/{volume_id}", tags(Volumes))]
 async fn get_volume(
     web::Path(volume_id): web::Path<VolumeId>,
 ) -> Result<Json<Volume>, RestError> {
     RestRespond::result(MessageBus::get_volume(Filter::Volume(volume_id)).await)
 }
 
-#[get("/v0/nodes/{node_id}/volumes", tags(Volumes))]
+#[get("/v0", "/nodes/{node_id}/volumes", tags(Volumes))]
 async fn get_node_volumes(
     web::Path(node_id): web::Path<NodeId>,
 ) -> Result<Json<Vec<Volume>>, RestError> {
     RestRespond::result(MessageBus::get_volumes(Filter::Node(node_id)).await)
 }
-#[get("/v0/nodes/{node_id}/volumes/{volume_id}", tags(Volumes))]
+#[get("/v0", "/nodes/{node_id}/volumes/{volume_id}", tags(Volumes))]
 async fn get_node_volume(
     web::Path((node_id, volume_id)): web::Path<(NodeId, VolumeId)>,
 ) -> Result<Json<Volume>, RestError> {
@@ -36,7 +36,7 @@ async fn get_node_volume(
     )
 }
 
-#[put("/v0/volumes/{volume_id}", tags(Volumes))]
+#[put("/v0", "/volumes/{volume_id}", tags(Volumes))]
 async fn put_volume(
     web::Path(volume_id): web::Path<VolumeId>,
     create: web::Json<CreateVolumeBody>,
@@ -45,7 +45,7 @@ async fn put_volume(
     RestRespond::result(MessageBus::create_volume(create).await)
 }
 
-#[delete("/v0/volumes/{volume_id}", tags(Volumes))]
+#[delete("/v0", "/volumes/{volume_id}", tags(Volumes))]
 async fn del_volume(
     web::Path(volume_id): web::Path<VolumeId>,
 ) -> Result<Json<()>, RestError> {

--- a/rest/src/versions/v0.rs
+++ b/rest/src/versions/v0.rs
@@ -8,10 +8,7 @@ use actix_web::{
     ResponseError,
 };
 use async_trait::async_trait;
-use mbus_api::{
-    message_bus::{v0, v0::BusError},
-    ErrorChain,
-};
+pub use mbus_api::message_bus::v0::*;
 use paperclip::actix::Apiv2Schema;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -20,32 +17,6 @@ use std::{
 };
 use strum_macros::{self, Display};
 
-/// Node from the node service
-pub type Node = v0::Node;
-/// Vector of Nodes from the node service
-pub type Nodes = v0::Nodes;
-/// Pool from the node service
-pub type Pool = v0::Pool;
-/// Vector of Pools from the pool service
-pub type Pools = v0::Pools;
-/// Replica
-pub type Replica = v0::Replica;
-/// Vector of Replicas from the pool service
-pub type Replicas = v0::Replicas;
-/// Replica protocol
-pub type Protocol = v0::Protocol;
-/// Create Pool request
-pub type CreatePool = v0::CreatePool;
-/// Create Replica request
-pub type CreateReplica = v0::CreateReplica;
-/// Replica Destroy
-pub type DestroyReplica = v0::DestroyReplica;
-/// Replica Share
-pub type ShareReplica = v0::ShareReplica;
-/// Replica Unshare
-pub type UnshareReplica = v0::UnshareReplica;
-/// Pool Destroy
-pub type DestroyPool = v0::DestroyPool;
 /// Create Replica Body JSON
 #[derive(Serialize, Deserialize, Default, Debug, Clone, Apiv2Schema)]
 pub struct CreateReplicaBody {
@@ -110,28 +81,6 @@ impl CreateReplicaBody {
         }
     }
 }
-/// Filter Nodes, Pools, Replicas, Nexuses
-pub type Filter = v0::Filter;
-/// Nexus from the volume service
-pub type Nexus = v0::Nexus;
-/// Vector of Nexuses from the volume service
-pub type Nexuses = v0::Nexuses;
-/// State of the nexus
-pub type NexusState = v0::NexusState;
-/// State of the nexus
-pub type VolumeState = v0::VolumeState;
-/// Child of the nexus
-pub type Child = v0::Child;
-/// State of the child
-pub type ChildState = v0::ChildState;
-/// Nexus Create
-pub type CreateNexus = v0::CreateNexus;
-/// Nexus Destroy
-pub type DestroyNexus = v0::DestroyNexus;
-/// Nexus Share
-pub type ShareNexus = v0::ShareNexus;
-/// Nexus Unshare
-pub type UnshareNexus = v0::UnshareNexus;
 
 /// Create Nexus Body JSON
 #[derive(Serialize, Deserialize, Default, Debug, Clone, Apiv2Schema)]
@@ -167,30 +116,6 @@ impl CreateNexusBody {
         }
     }
 }
-/// Remove Nexus Child
-pub type RemoveNexusChild = v0::RemoveNexusChild;
-/// Add Nexus Child
-pub type AddNexusChild = v0::AddNexusChild;
-/// Volume
-pub type Volume = v0::Volume;
-/// Volumes
-pub type Volumes = v0::Volumes;
-/// Create Volume
-pub type CreateVolume = v0::CreateVolume;
-/// Destroy Volume
-pub type DestroyVolume = v0::DestroyVolume;
-/// Id of a mayastor node
-pub type NodeId = v0::NodeId;
-/// Id of a mayastor pool
-pub type PoolId = v0::PoolId;
-/// UUID of a mayastor pool replica
-pub type ReplicaId = v0::ReplicaId;
-/// UUID of a mayastor nexus
-pub type NexusId = v0::NexusId;
-/// URI of a mayastor nexus child
-pub type ChildUri = v0::ChildUri;
-/// UUID of a mayastor volume
-pub type VolumeId = v0::VolumeId;
 
 /// Create Volume Body JSON
 #[derive(Serialize, Deserialize, Default, Debug, Clone, Apiv2Schema)]

--- a/rest/tests/v0_test.rs
+++ b/rest/tests/v0_test.rs
@@ -55,9 +55,11 @@ async fn client() {
         .add_container_spec(
             ContainerSpec::from_binary(
                 "rest",
-                Binary::from_dbg("rest")
-                    .with_nats("-n")
-                    .with_args(vec!["-j", "10.1.0.8:6831"]),
+                Binary::from_dbg("rest").with_nats("-n").with_args(vec![
+                    "-j",
+                    "10.1.0.8:6831",
+                    "--dummy-certificates",
+                ]),
             )
             .with_portmap("8080", "8080")
             .with_portmap("8081", "8081"),

--- a/services/deployer/src/infra/rest.rs
+++ b/services/deployer/src/infra/rest.rs
@@ -21,6 +21,7 @@ impl ComponentAction for Rest {
                         "rest",
                         Binary::from_dbg("rest")
                             .with_nats("-n")
+                            .with_arg("--dummy-certificates")
                             .with_args(vec!["--https", "rest:8080"])
                             .with_args(vec!["--http", "rest:8081"]),
                     )
@@ -34,6 +35,7 @@ impl ComponentAction for Rest {
                         "rest",
                         Binary::from_dbg("rest")
                             .with_nats("-n")
+                            .with_arg("--dummy-certificates")
                             .with_args(vec!["-j", &jaeger_config])
                             .with_args(vec!["--https", "rest:8080"])
                             .with_args(vec!["--http", "rest:8081"]),


### PR DESCRIPTION
refactor(rest): improve rest versions
  Part of the motivation for this is that we should not mix api versions
   on the same openapi spec.
  This change makes adding api versions easier by wrapping each version
   module with its own openapi wrapper which then generates and exposes
   versioned api specs and versioned swagger-ui's.
  
  While we're here, make use of the openapi base path to clean up the
  openapi paths and allow for easier to read auto generated code.
  Also clean up some redundant type definitions.

refactor(rest): add cmdline certificate arg
  Adds cmdline arguments to use https certificates.
  Adds argument to use dummy certificates (used by test).
