### PR TITLE
feat(nvmx): i/o timeouts for nvme controller

### DIFF
--- a/mayastor/src/bdev/dev.rs
+++ b/mayastor/src/bdev/dev.rs
@@ -31,6 +31,7 @@ use crate::{
     nexus_uri::{self, NexusBdevError},
 };
 
+mod malloc;
 mod nvmx;
 
 impl Uri {
@@ -47,6 +48,7 @@ impl Uri {
         match url.scheme() {
             // backend NVMF target - fairly unstable (as of Linux 5.2)
             "nvmf" => Ok(Box::new(nvmx::NvmfDeviceTemplate::try_from(&url)?)),
+            "malloc" => Ok(Box::new(malloc::Malloc::try_from(&url)?)),
 
             scheme => Err(NexusBdevError::UriSchemeUnsupported {
                 scheme: scheme.to_string(),

--- a/mayastor/src/bdev/dev/nvmx/controller_inner.rs
+++ b/mayastor/src/bdev/dev/nvmx/controller_inner.rs
@@ -1,0 +1,328 @@
+use crossbeam::atomic::AtomicCell;
+use std::{convert::TryFrom, os::raw::c_void, ptr::NonNull};
+
+use crate::{
+    bdev::dev::nvmx::{
+        nvme_bdev_running_config,
+        utils::nvme_cpl_succeeded,
+        NvmeController,
+        NVME_CONTROLLERS,
+    },
+    core::{CoreError, DeviceIoController, DeviceTimeoutAction},
+};
+
+use spdk_sys::{
+    spdk_nvme_cmd_cb,
+    spdk_nvme_cpl,
+    spdk_nvme_ctrlr,
+    spdk_nvme_ctrlr_cmd_abort,
+    spdk_nvme_ctrlr_get_regs_csts,
+    spdk_nvme_ctrlr_register_timeout_callback,
+    spdk_nvme_qpair,
+    SPDK_BDEV_NVME_TIMEOUT_ACTION_ABORT,
+    SPDK_BDEV_NVME_TIMEOUT_ACTION_NONE,
+    SPDK_BDEV_NVME_TIMEOUT_ACTION_RESET,
+};
+
+impl TryFrom<u32> for DeviceTimeoutAction {
+    type Error = String;
+
+    fn try_from(action: u32) -> Result<Self, Self::Error> {
+        let a = match action {
+            SPDK_BDEV_NVME_TIMEOUT_ACTION_NONE => DeviceTimeoutAction::Ignore,
+            SPDK_BDEV_NVME_TIMEOUT_ACTION_RESET => DeviceTimeoutAction::Reset,
+            SPDK_BDEV_NVME_TIMEOUT_ACTION_ABORT => DeviceTimeoutAction::Abort,
+            _ => {
+                return Err(format!(
+                    "Invalid timeout action in config: {}",
+                    action
+                ));
+            }
+        };
+
+        Ok(a)
+    }
+}
+
+pub(crate) struct TimeoutConfig {
+    pub name: String,
+    timeout_action: AtomicCell<DeviceTimeoutAction>,
+    reset_in_progress: AtomicCell<bool>,
+    pub ctrlr: *mut spdk_nvme_ctrlr,
+}
+
+impl Drop for TimeoutConfig {
+    fn drop(&mut self) {
+        debug!("{} dropping TimeoutConfig", self.name);
+    }
+}
+
+/// Structure for holding I/O timeout related configuration settings and
+/// providing fast and atomic access to it.
+impl TimeoutConfig {
+    pub fn new(ctrlr: &str) -> Self {
+        Self {
+            name: String::from(ctrlr),
+            timeout_action: AtomicCell::new(DeviceTimeoutAction::Ignore),
+            reset_in_progress: AtomicCell::new(false),
+            ctrlr: std::ptr::null_mut(),
+        }
+    }
+
+    fn reset_cb(success: bool, ctx: *mut c_void) {
+        let timeout_ctx = TimeoutConfig::from_ptr(ctx as *mut TimeoutConfig);
+
+        if success {
+            info!(
+                "{} controller successfully reset in response to I/O timeout",
+                timeout_ctx.name
+            );
+        } else {
+            error!(
+                "{} failed to reset controller in response to I/O timeout",
+                timeout_ctx.name
+            );
+        }
+
+        // Clear the flag as we are the exclusive owner.
+        assert!(
+            timeout_ctx.reset_in_progress.compare_and_swap(true, false),
+            "non-exclusive access to controller reset flag"
+        );
+    }
+
+    /// Resets controller exclusively, taking into account existing active
+    /// resets related to I/O timeout.
+    pub fn reset_controller(&mut self) {
+        // Make sure no other resets are in progress.
+        if self.reset_in_progress.compare_and_swap(false, true) {
+            return;
+        }
+
+        if let Some(c) = NVME_CONTROLLERS.lookup_by_name(self.name.to_string())
+        {
+            let mut c = c.lock().expect("controller lock poisoned");
+            if let Err(e) = c.reset(
+                TimeoutConfig::reset_cb,
+                self as *mut TimeoutConfig as *mut c_void,
+                false,
+            ) {
+                error!(
+                    "{}: failed to initiate controller reset: {}",
+                    self.name, e
+                );
+            } else {
+                info!("{} controller reset initiated", self.name);
+                return;
+            }
+        } else {
+            error!(
+                "No controller instance found for {}, reset not possible",
+                self.name
+            );
+        }
+
+        // Clear the flag as we are the exclusive owner.
+        assert!(
+            self.reset_in_progress.compare_and_swap(true, false),
+            "non-exclusive access to controller reset flag"
+        );
+    }
+
+    /// Set new I/O timeout action.
+    pub fn set_timeout_action(&mut self, action: DeviceTimeoutAction) {
+        self.timeout_action.store(action);
+    }
+
+    /// Get current I/O timeout action.
+    pub fn get_timeout_action(&self) -> DeviceTimeoutAction {
+        self.timeout_action.load()
+    }
+
+    pub fn from_ptr(ptr: *mut TimeoutConfig) -> &'static mut TimeoutConfig {
+        unsafe { &mut *(ptr as *mut TimeoutConfig) }
+    }
+}
+
+pub(crate) struct SpdkNvmeController(NonNull<spdk_nvme_ctrlr>);
+
+/// Wrapper around SPDK controller object to abstract low-level library API.
+impl SpdkNvmeController {
+    /// Transform SPDK NVMe controller object into a wrapper instance.
+    pub fn from_ptr(ctrlr: *mut spdk_nvme_ctrlr) -> Option<SpdkNvmeController> {
+        NonNull::new(ctrlr).map(SpdkNvmeController)
+    }
+
+    /// Check Controller Fatal Status flag.
+    pub fn check_cfs(&self) -> bool {
+        unsafe {
+            let csts = spdk_nvme_ctrlr_get_regs_csts(self.0.as_ptr());
+            csts.bits.cfs() != 0
+        }
+    }
+
+    /// Abort command on a given I/O qpair.
+    pub fn abort_queued_command(
+        &self,
+        qpair: *mut spdk_nvme_qpair,
+        cid: u16,
+        cb: spdk_nvme_cmd_cb,
+        cb_arg: *mut c_void,
+    ) -> i32 {
+        unsafe {
+            spdk_nvme_ctrlr_cmd_abort(self.0.as_ptr(), qpair, cid, cb, cb_arg)
+        }
+    }
+}
+
+impl From<*mut spdk_nvme_ctrlr> for SpdkNvmeController {
+    fn from(ctrlr: *mut spdk_nvme_ctrlr) -> Self {
+        Self::from_ptr(ctrlr)
+            .expect("nullptr dereference while accessing NVME controller")
+    }
+}
+
+// I/O device controller API.
+impl<'a> DeviceIoController for NvmeController<'a> {
+    /// Get current I/O timeout action.
+    fn get_timeout_action(&self) -> Result<DeviceTimeoutAction, CoreError> {
+        Ok(TimeoutConfig::from_ptr(self.timeout_config).get_timeout_action())
+    }
+
+    /// Set current I/O timeout action.
+    fn set_timeout_action(
+        &mut self,
+        action: DeviceTimeoutAction,
+    ) -> Result<(), CoreError> {
+        TimeoutConfig::from_ptr(self.timeout_config).set_timeout_action(action);
+        info!("{} timeout action set to {:?}", self.name, action);
+        Ok(())
+    }
+}
+
+// I/O timeout handling for NVMe controller.
+impl<'a> NvmeController<'a> {
+    extern "C" fn command_abort_handler(
+        ctx: *mut c_void,
+        cpl: *const spdk_nvme_cpl,
+    ) {
+        let timeout_ctx = TimeoutConfig::from_ptr(ctx as *mut TimeoutConfig);
+
+        if nvme_cpl_succeeded(cpl) {
+            info!("{} CID abort succeeded for controller.", timeout_ctx.name);
+        } else {
+            error!(
+                "{} CID abort failed, resetting the controller.",
+                timeout_ctx.name
+            );
+            timeout_ctx.reset_controller();
+        }
+    }
+
+    extern "C" fn io_timeout_handler(
+        cb_arg: *mut c_void,
+        ctrlr: *mut spdk_nvme_ctrlr,
+        qpair: *mut spdk_nvme_qpair,
+        cid: u16,
+    ) {
+        let spdk_ctrlr = SpdkNvmeController::from(ctrlr);
+        let timeout_cfg = TimeoutConfig::from_ptr(cb_arg as *mut TimeoutConfig);
+        let mut timeout_action = timeout_cfg.timeout_action.load();
+
+        error!(
+            "{}: detected timeout: qpair={:p}, cid={}, action={:?}",
+            timeout_cfg.name, qpair, cid, timeout_action
+        );
+
+        // Check Controller Fatal Status for non-admin commands only to avoid
+        // endless command resubmission in case of disconnected qpair.
+        if !qpair.is_null() && spdk_ctrlr.check_cfs() {
+            error!(
+                "{}: controller Fatal Status set, reset required",
+                timeout_cfg.name
+            );
+            timeout_action = DeviceTimeoutAction::Reset;
+        }
+
+        // Handle timeout based on the action.
+        match timeout_action {
+            DeviceTimeoutAction::Abort | DeviceTimeoutAction::Reset => {
+                if timeout_action == DeviceTimeoutAction::Abort {
+                    error!("{}: aborting CID {}", timeout_cfg.name, cid);
+                    let rc = spdk_ctrlr.abort_queued_command(
+                        qpair,
+                        cid,
+                        Some(NvmeController::command_abort_handler),
+                        cb_arg,
+                    );
+                    if rc == 0 {
+                        info!(
+                            "{}: initiated abort for CID {}",
+                            timeout_cfg.name, cid
+                        );
+                        return;
+                    }
+                    error!(
+                        "{}: unable to abort CID {}, reset required",
+                        timeout_cfg.name, cid
+                    );
+                    // Fallthrough to perform controller reset in case abort
+                    // fails.
+                }
+                info!(
+                    "{} resetting controller in response to I/O timeout",
+                    timeout_cfg.name
+                );
+                timeout_cfg.reset_controller();
+            }
+            DeviceTimeoutAction::Ignore => {
+                info!(
+                    "{}: no I/O timeout action defined, timeout ignored",
+                    timeout_cfg.name
+                );
+            }
+        }
+    }
+
+    pub(crate) fn configure_timeout(&mut self) {
+        let device_defaults = nvme_bdev_running_config();
+
+        if device_defaults.timeout_us == 0 {
+            warn!(
+                "{} no timeout configured for NVMe controller, I/O timeout handling disabled.",
+                self.name
+            );
+            self.set_timeout_action(DeviceTimeoutAction::Ignore)
+                .unwrap();
+            return;
+        }
+
+        let action = match DeviceTimeoutAction::try_from(
+            device_defaults.action_on_timeout,
+        ) {
+            Ok(action) => action,
+            Err(e) => {
+                error!(
+                    "{}: can not apply requested I/O timeout action: {}, falling back to Ignore",
+                    self.name, e
+                );
+                DeviceTimeoutAction::Ignore
+            }
+        };
+
+        self.set_timeout_action(action).unwrap();
+
+        unsafe {
+            spdk_nvme_ctrlr_register_timeout_callback(
+                self.ctrlr_as_ptr(),
+                device_defaults.timeout_us,
+                Some(NvmeController::io_timeout_handler),
+                self.timeout_config as *mut c_void,
+            );
+        }
+        info!(
+            "{} I/O timeout set to {} us",
+            self.name, device_defaults.timeout_us
+        );
+    }
+}

--- a/mayastor/src/bdev/dev/nvmx/controller_state.rs
+++ b/mayastor/src/bdev/dev/nvmx/controller_state.rs
@@ -1,0 +1,209 @@
+use crossbeam::atomic::AtomicCell;
+use snafu::Snafu;
+
+#[derive(Debug, PartialEq, Copy, Clone)]
+pub enum NvmeControllerState {
+    New,
+    Initializing,
+    Running,
+    Faulted(ControllerFailureReason),
+    Unconfiguring,
+    Unconfigured,
+}
+#[derive(Debug, PartialEq, Copy, Clone)]
+pub enum ControllerFailureReason {
+    ResetFailed,
+    ShutdownFailed,
+}
+
+impl ToString for NvmeControllerState {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::New => "New",
+            Self::Initializing => "Initializing",
+            Self::Running => "Running",
+            Self::Unconfiguring => "Unconfiguring",
+            Self::Unconfigured => "Unconfigured",
+            Self::Faulted(_) => "Faulted",
+        }
+        .to_string()
+    }
+}
+
+#[derive(Eq, PartialEq, Copy, Clone, Debug)]
+pub enum ControllerFlag {
+    ResetActive,
+}
+
+impl ToString for ControllerFlag {
+    fn to_string(&self) -> String {
+        match *self {
+            ControllerFlag::ResetActive => "ResetActive",
+        }
+        .to_string()
+    }
+}
+/// Entity that manages the following components of every NVMe controller:
+/// - controller states
+/// - controller flags
+///
+/// 1. Controller state checks.
+/// Every NVMe controller passes through different states during its lifetime,
+/// which makes it important to control state transitions and disallow invalid
+/// state changes. Controller state machine enforces state checks based on the
+/// controller state diagram.
+/// 2. Controller flags.
+/// Controller flags are a set of boolean variables that carry some extra
+/// information required for the controller to operate properly.
+#[derive(Debug)]
+pub struct ControllerStateMachine {
+    name: String,
+    current_state: NvmeControllerState,
+    // TODO: As of now we have only one flag (ResetActive), so just one
+    // variable is fine. Later we need to implement array of flags in a proper
+    // way.
+    flag: AtomicCell<bool>,
+}
+
+#[derive(Debug, Snafu, Clone)]
+#[snafu(visibility = "pub")]
+pub enum ControllerStateMachineError {
+    #[snafu(display(
+        "invalid transition from {:?} to {:?}",
+        current_state,
+        new_state
+    ))]
+    ControllerStateTransitionError {
+        current_state: NvmeControllerState,
+        new_state: NvmeControllerState,
+    },
+    #[snafu(display(
+        "failed to exclusively update flag {:?} to {} from {}",
+        flag,
+        current_value,
+        new_value
+    ))]
+    ControllerFlagUpdateError {
+        flag: ControllerFlag,
+        current_value: bool,
+        new_value: bool,
+    },
+}
+
+use NvmeControllerState::*;
+
+/// Check if a transition exists between two given states.
+/// Initial state: New, final state: Unconfigured.
+fn check_transition(
+    from: NvmeControllerState,
+    to: NvmeControllerState,
+) -> bool {
+    match from {
+        New => matches!(to, Initializing),
+        Initializing => matches!(to, Running | Faulted(_)),
+        Running => matches!(to, Unconfiguring | Faulted(_)),
+        Unconfiguring => matches!(to, Unconfigured | Faulted(_)),
+        Faulted(_) => matches!(to, Running | Unconfiguring),
+        // Final state, no further transitions possible.
+        Unconfigured => false,
+    }
+}
+
+impl ControllerStateMachine {
+    pub fn new(name: &str) -> Self {
+        Self {
+            name: name.to_string(),
+            current_state: New,
+            flag: AtomicCell::new(false),
+        }
+    }
+
+    /// Unconditionally transition from the current state to a new state.
+    pub fn transition(
+        &mut self,
+        new_state: NvmeControllerState,
+    ) -> Result<(), ControllerStateMachineError> {
+        if check_transition(self.current_state, new_state) {
+            info!(
+                "{} transitioned from state {:?} to {:?}",
+                self.name, self.current_state, new_state
+            );
+            self.current_state = new_state;
+            Ok(())
+        } else {
+            Err(
+                ControllerStateMachineError::ControllerStateTransitionError {
+                    current_state: self.current_state,
+                    new_state,
+                },
+            )
+        }
+    }
+
+    /// Transition to a new state only if ID of the current state matches.
+    pub fn transition_checked(
+        &mut self,
+        current_state: NvmeControllerState,
+        new_state: NvmeControllerState,
+    ) -> Result<(), ControllerStateMachineError> {
+        if self.current_state != current_state {
+            return Err(
+                ControllerStateMachineError::ControllerStateTransitionError {
+                    current_state,
+                    new_state,
+                },
+            );
+        }
+
+        self.transition(new_state)
+    }
+
+    /// Get surrent state.
+    pub fn current_state(&self) -> NvmeControllerState {
+        self.current_state
+    }
+
+    /// Sets the flag only if it is not set.
+    pub fn set_flag_exclusively(
+        &self,
+        flag: ControllerFlag,
+    ) -> Result<(), ControllerStateMachineError> {
+        let f = self.lookup_flag(flag);
+
+        let current = f.compare_and_swap(false, true);
+        if current {
+            Err(ControllerStateMachineError::ControllerFlagUpdateError {
+                flag,
+                current_value: current,
+                new_value: true,
+            })
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Clears the flag only if it is set.
+    pub fn clear_flag_exclusively(
+        &self,
+        flag: ControllerFlag,
+    ) -> Result<(), ControllerStateMachineError> {
+        let f = self.lookup_flag(flag);
+
+        let current = f.compare_and_swap(true, false);
+        if current {
+            Ok(())
+        } else {
+            Err(ControllerStateMachineError::ControllerFlagUpdateError {
+                flag,
+                current_value: current,
+                new_value: false,
+            })
+        }
+    }
+
+    // Private functions.
+    fn lookup_flag(&self, _flag: ControllerFlag) -> &AtomicCell<bool> {
+        // TODO: Implement name-based, array-based flag lookup later.
+        &self.flag
+    }
+}

--- a/mayastor/src/bdev/dev/nvmx/handle.rs
+++ b/mayastor/src/bdev/dev/nvmx/handle.rs
@@ -158,7 +158,10 @@ extern "C" fn nvme_admin_passthru_done(
     ctx: *mut c_void,
     cpl: *const spdk_nvme_cpl,
 ) {
-    debug!("Admin passthrough completed !");
+    debug!(
+        "Admin passthrough completed, succeeded={}",
+        nvme_cpl_succeeded(cpl)
+    );
     done_cb(ctx, nvme_cpl_succeeded(cpl));
 }
 
@@ -719,6 +722,7 @@ impl BlockDeviceHandle for NvmeDeviceHandle {
         };
 
         if r.await.expect("Failed awaiting NVMe Admin command I/O") {
+            debug!("nvme_admin() done");
             Ok(())
         } else {
             Err(CoreError::NvmeAdminFailed {

--- a/mayastor/src/bdev/dev/nvmx/mod.rs
+++ b/mayastor/src/bdev/dev/nvmx/mod.rs
@@ -1,5 +1,7 @@
 mod channel;
 mod controller;
+mod controller_inner;
+mod controller_state;
 mod device;
 mod handle;
 mod namespace;
@@ -7,7 +9,8 @@ mod uri;
 mod utils;
 
 pub use channel::{NvmeControllerIoChannel, NvmeIoChannel, NvmeIoChannelInner};
-pub use controller::{NvmeController, NvmeControllerState};
+pub use controller::NvmeController;
+pub use controller_state::NvmeControllerState;
 pub use device::{lookup_by_name, open_by_name, NvmeBlockDevice};
 pub use handle::NvmeDeviceHandle;
 pub use namespace::NvmeNamespace;

--- a/mayastor/src/bdev/dev/nvmx/uri.rs
+++ b/mayastor/src/bdev/dev/nvmx/uri.rs
@@ -40,6 +40,7 @@ use crate::{
         NexusBdevError,
         {self},
     },
+    subsys::NvmeBdevOpts,
 };
 
 use super::controller::transport::NvmeTransportId;
@@ -175,8 +176,10 @@ impl<'probe> NvmeControllerContext<'probe> {
             .with_traddr(&template.host)
             .build();
 
+        let device_defaults = NvmeBdevOpts::default();
         let opts = controller::options::Builder::new()
-            .with_transport_retry_count(5)
+            .with_keep_alive_timeout_ms(device_defaults.keep_alive_timeout_ms)
+            .with_transport_retry_count(device_defaults.retry_count as u8)
             .build();
 
         let (sender, receiver) = oneshot::channel::<ErrnoResult<()>>();
@@ -274,7 +277,7 @@ impl CreateDestroy for NvmfDeviceTemplate {
         let controller = controller.lock().expect("failed to lock controller");
 
         assert_eq!(
-            controller.state,
+            controller.get_state(),
             NvmeControllerState::Running,
             "NVMe controller is not fully initialized"
         );

--- a/mayastor/src/core/mod.rs
+++ b/mayastor/src/core/mod.rs
@@ -11,6 +11,8 @@ pub use block_device::{
     BlockDeviceDescriptor,
     BlockDeviceHandle,
     BlockDeviceStats,
+    DeviceIoController,
+    DeviceTimeoutAction,
     IoCompletionCallback,
     IoCompletionCallbackArg,
     LbaRangeController,

--- a/mayastor/tests/block_device_nvmf.rs
+++ b/mayastor/tests/block_device_nvmf.rs
@@ -109,16 +109,10 @@ async fn nvmf_device_identify_controller() {
     })
     .await;
 
-    println!(
-        "Sleeping for 1 sec to let all async resource cleanup operations complete"
-    );
-    tokio::time::delay_for(std::time::Duration::from_secs(1)).await;
-    println!("Awakened.");
-
     ms.spawn(async move {
         device_destroy(&u).await.unwrap();
     })
-    .await;
+    .await
 }
 
 const GUARD_PATTERN: u8 = 0xFF;
@@ -254,12 +248,6 @@ async fn nvmf_device_read_write_at() {
     })
     .await;
 
-    println!(
-        "Sleeping for 1 sec to let all async resource cleanup operations complete"
-    );
-    tokio::time::delay_for(std::time::Duration::from_secs(1)).await;
-    println!("Awakened.");
-
     // Safely destroy the device once all handles are freed.
     ms.spawn(async move {
         device_destroy(&u).await.unwrap();
@@ -367,13 +355,6 @@ async fn nvmf_device_readv_test() {
         let _ph = unsafe { Box::from_raw(b) };
     })
     .await;
-
-    // Sleep for 1 sec to let async resource cleanup actions be processed.
-    println!(
-        "Sleeping for 1 sec to let all async resource cleanup operations complete"
-    );
-    tokio::time::delay_for(std::time::Duration::from_secs(1)).await;
-    println!("Awakened.");
 
     // Once all handles are closed, destroy the device.
     url = Arc::clone(&u);
@@ -517,12 +498,6 @@ async fn nvmf_device_writev_test() {
     })
     .await;
 
-    println!(
-        "Sleeping for 1 sec to let all async resource cleanup operations complete"
-    );
-    tokio::time::delay_for(std::time::Duration::from_secs(1)).await;
-    println!("Awakened.");
-
     // Safely destroy the device once all handles are freed.
     ms.spawn(async move {
         device_destroy(&u).await.unwrap();
@@ -654,9 +629,6 @@ async fn nvmf_device_readv_iovs_test() {
     })
     .await;
 
-    println!(
-        "Sleeping for 1 sec to let all async resource cleanup operations complete"
-    );
     tokio::time::delay_for(std::time::Duration::from_secs(1)).await;
     println!("Awakened.");
 
@@ -826,12 +798,6 @@ async fn nvmf_device_writev_iovs_test() {
     })
     .await;
 
-    println!(
-        "Sleeping for 1 sec to let all async resource cleanup operations complete"
-    );
-    tokio::time::delay_for(std::time::Duration::from_secs(1)).await;
-    println!("Awakened.");
-
     // Safely destroy the device once all handles are freed.
     ms.spawn(async move {
         device_destroy(&(*u)).await.unwrap();
@@ -855,12 +821,6 @@ async fn nvmf_device_admin_ctrl() {
         );
     })
     .await;
-
-    println!(
-        "Sleeping for 1 sec to let all async resource cleanup operations complete"
-    );
-    tokio::time::delay_for(std::time::Duration::from_secs(1)).await;
-    println!("Awakened.");
 
     // Destroy controller after all resources are freed.
     ms.spawn(async move {
@@ -940,12 +900,6 @@ async fn nvmf_device_reset() {
         println!("Controller successfully identified");
     })
     .await;
-
-    println!(
-        "Sleeping for 1 sec to let all async resource cleanup operations complete"
-    );
-    tokio::time::delay_for(std::time::Duration::from_secs(1)).await;
-    println!("Awakened.");
 
     // Destroy controller after all resources are freed.
     ms.spawn(async move {
@@ -1091,12 +1045,6 @@ async fn wipe_device_blocks(is_unmap: bool) {
                                        // zeroes.
     })
     .await;
-
-    println!(
-        "Sleeping for 1 sec to let all async resource cleanup operations complete"
-    );
-    tokio::time::delay_for(std::time::Duration::from_secs(1)).await;
-    println!("Awakened.");
 
     // Destroy controller after all resources are freed.
     ms.spawn(async move {
@@ -1289,13 +1237,6 @@ async fn nvmf_reset_abort_io() {
         let _ph = unsafe { Box::from_raw(b) };
     })
     .await;
-
-    // Sleep for 1 sec to let async resource cleanup actions be processed.
-    println!(
-        "Sleeping for 1 sec to let all async resource cleanup operations complete"
-    );
-    tokio::time::delay_for(std::time::Duration::from_secs(1)).await;
-    println!("Awakened.");
 
     // Once all handles are closed, destroy the device.
     url = Arc::clone(&u);

--- a/mayastor/tests/nvme_device_timeout.rs
+++ b/mayastor/tests/nvme_device_timeout.rs
@@ -1,0 +1,359 @@
+use common::compose::{Builder, MayastorTest};
+use crossbeam::atomic::AtomicCell;
+use libc::c_void;
+use mayastor::{
+    bdev::{device_create, device_destroy, device_open},
+    core::{BlockDeviceHandle, DeviceTimeoutAction, DmaBuf, MayastorCliArgs},
+    subsys::{Config, NvmeBdevOpts},
+};
+use once_cell::sync::Lazy;
+use rpc::mayastor::{BdevShareRequest, BdevUri, Null};
+use spdk_sys::iovec;
+use std::{slice, str, sync::atomic::AtomicPtr};
+
+pub mod common;
+
+const TEST_CTX_STRING: &str = "test context";
+
+static MAYASTOR: Lazy<MayastorTest> =
+    Lazy::new(|| MayastorTest::new(MayastorCliArgs::default()));
+
+static CALLBACK_FLAG: AtomicCell<bool> = AtomicCell::new(false);
+
+const BUF_SIZE: u64 = 32768;
+
+struct IoOpCtx {
+    iov: iovec,
+    device_url: String,
+    dma_buf: DmaBuf,
+    handle: Box<dyn BlockDeviceHandle>,
+}
+
+async fn test_io_timeout(action_on_timeout: DeviceTimeoutAction) {
+    Config::get_or_init(|| Config {
+        nvme_bdev_opts: NvmeBdevOpts {
+            timeout_us: 2_000_000,
+            keep_alive_timeout_ms: 5_000,
+            retry_count: 2,
+            ..Default::default()
+        },
+        ..Default::default()
+    })
+    .apply();
+
+    let test = Builder::new()
+        .name("cargo-test")
+        .network("10.1.0.0/16")
+        .add_container("ms1")
+        .with_clean(true)
+        .build()
+        .await
+        .unwrap();
+
+    // get the handles if needed, to invoke methods to the containers
+    let mut hdls = test.grpc_handles().await.unwrap();
+
+    // create and share a bdev on each container
+    for h in &mut hdls {
+        h.bdev.list(Null {}).await.unwrap();
+        h.bdev
+            .create(BdevUri {
+                uri: "malloc:///disk0?size_mb=128".into(),
+            })
+            .await
+            .unwrap();
+
+        h.bdev
+            .share(BdevShareRequest {
+                name: "disk0".into(),
+                proto: "nvmf".into(),
+            })
+            .await
+            .unwrap();
+    }
+
+    let bdev_url = format!(
+        "nvmf://{}:8420/nqn.2019-05.io.openebs:disk0",
+        hdls[0].endpoint.ip()
+    );
+
+    struct IoCtx {
+        handle: Box<dyn BlockDeviceHandle>,
+        device_url: String,
+    }
+
+    let cptr = MAYASTOR
+        .spawn(async move {
+            let device_name = device_create(&bdev_url).await.unwrap();
+            let descr = device_open(&device_name, false).unwrap();
+            let handle = descr.into_handle().unwrap();
+
+            // Set requested I/O timeout action.
+            let device = handle.get_device();
+            let mut io_controller = device.get_io_controller().unwrap();
+            io_controller.set_timeout_action(action_on_timeout).unwrap();
+            assert_eq!(
+                io_controller.get_timeout_action().unwrap(),
+                action_on_timeout,
+                "I/O timeout action mismatches"
+            );
+
+            AtomicPtr::new(Box::into_raw(Box::new(IoCtx {
+                handle,
+                device_url: bdev_url,
+            })))
+        })
+        .await;
+
+    test.pause("ms1").await.unwrap();
+    for i in 1 .. 6 {
+        tokio::time::delay_for(std::time::Duration::from_secs(1)).await;
+        println!("waiting for the container to be fully suspended... {}/5", i);
+    }
+
+    // Read completion callback.
+    fn read_completion_callback(success: bool, ctx: *mut c_void) {
+        assert_eq!(success, false, "I/O operation completed successfully");
+        assert_eq!(
+            CALLBACK_FLAG.load(),
+            false,
+            "Callback called multiple times"
+        );
+
+        // Make sure we were passed the same pattern string as requested.
+        let s = unsafe {
+            let slice =
+                slice::from_raw_parts(ctx as *const u8, TEST_CTX_STRING.len());
+            str::from_utf8(slice).unwrap()
+        };
+
+        assert_eq!(s, TEST_CTX_STRING);
+        CALLBACK_FLAG.store(true);
+    }
+
+    println!("Issuing I/O operation against disconnected device");
+    let io_ctx = MAYASTOR
+        .spawn(async move {
+            let ctx = unsafe { Box::from_raw(cptr.into_inner()) };
+            let device = ctx.handle.get_device();
+
+            let mut io_ctx = IoOpCtx {
+                iov: iovec::default(),
+                device_url: ctx.device_url,
+                dma_buf: DmaBuf::new(BUF_SIZE, device.alignment()).unwrap(),
+                handle: ctx.handle,
+            };
+
+            io_ctx.iov.iov_base = *io_ctx.dma_buf;
+            io_ctx.iov.iov_len = BUF_SIZE;
+
+            CALLBACK_FLAG.store(false);
+
+            io_ctx
+                .handle
+                .readv_blocks(
+                    &mut io_ctx.iov,
+                    1,
+                    (3 * 1024 * 1024) / device.block_len(),
+                    BUF_SIZE / device.block_len(),
+                    read_completion_callback,
+                    TEST_CTX_STRING.as_ptr() as *mut c_void,
+                )
+                .unwrap();
+
+            AtomicPtr::new(Box::into_raw(Box::new(io_ctx)))
+        })
+        .await;
+
+    let mut io_timedout = false;
+
+    // Wait up to 120 seconds till I/O times out.
+    for i in 1 .. 25 {
+        println!("waiting for I/O to be timed out... {}/24", i);
+        tokio::time::delay_for(std::time::Duration::from_secs(5)).await;
+        // Break the loop if the callback has been called in response to I/O
+        // cancelling.
+        if CALLBACK_FLAG.load() {
+            println!("I/O timed out");
+            io_timedout = true;
+            break;
+        }
+    }
+
+    MAYASTOR
+        .spawn(async move {
+            let ctx = unsafe { Box::from_raw(io_ctx.into_inner()) };
+
+            device_destroy(&ctx.device_url).await.unwrap();
+        })
+        .await;
+
+    // Check test result after all the resources are freed.
+    assert!(
+        io_timedout,
+        "I/O was not timed out in response to timeout action"
+    );
+}
+
+#[tokio::test]
+async fn io_timeout_reset() {
+    test_io_timeout(DeviceTimeoutAction::Reset).await;
+}
+
+#[tokio::test]
+async fn io_timeout_ignore() {
+    Config::get_or_init(|| Config {
+        nvme_bdev_opts: NvmeBdevOpts {
+            timeout_us: 2_000_000,
+            keep_alive_timeout_ms: 5_000,
+            retry_count: 2,
+            ..Default::default()
+        },
+        ..Default::default()
+    })
+    .apply();
+
+    let test = Builder::new()
+        .name("cargo-test")
+        .network("10.1.0.0/16")
+        .add_container("ms1")
+        .with_clean(true)
+        .build()
+        .await
+        .unwrap();
+
+    // get the handles if needed, to invoke methods to the containers
+    let mut hdls = test.grpc_handles().await.unwrap();
+
+    // create and share a bdev on each container
+    for h in &mut hdls {
+        h.bdev.list(Null {}).await.unwrap();
+        h.bdev
+            .create(BdevUri {
+                uri: "malloc:///disk0?size_mb=128".into(),
+            })
+            .await
+            .unwrap();
+
+        h.bdev
+            .share(BdevShareRequest {
+                name: "disk0".into(),
+                proto: "nvmf".into(),
+            })
+            .await
+            .unwrap();
+    }
+
+    let bdev_url = format!(
+        "nvmf://{}:8420/nqn.2019-05.io.openebs:disk0",
+        hdls[0].endpoint.ip()
+    );
+
+    struct IoCtx {
+        handle: Box<dyn BlockDeviceHandle>,
+        device_url: String,
+    }
+
+    let cptr = MAYASTOR
+        .spawn(async move {
+            let device_name = device_create(&bdev_url).await.unwrap();
+            let descr = device_open(&device_name, false).unwrap();
+            let handle = descr.into_handle().unwrap();
+            let device = handle.get_device();
+
+            let action_on_timeout = DeviceTimeoutAction::Ignore;
+            let mut io_controller = device.get_io_controller().unwrap();
+            io_controller.set_timeout_action(action_on_timeout).unwrap();
+            assert_eq!(
+                io_controller.get_timeout_action().unwrap(),
+                action_on_timeout,
+                "I/O timeout action mismatches"
+            );
+
+            AtomicPtr::new(Box::into_raw(Box::new(IoCtx {
+                handle,
+                device_url: bdev_url,
+            })))
+        })
+        .await;
+
+    test.pause("ms1").await.unwrap();
+    for i in 1 .. 6 {
+        tokio::time::delay_for(std::time::Duration::from_secs(1)).await;
+        println!("waiting for the container to be fully suspended... {}/5", i);
+    }
+
+    // Read completion callback.
+    fn read_completion_callback(success: bool, ctx: *mut c_void) {
+        assert_eq!(success, false, "I/O operation completed successfully");
+        assert_eq!(
+            CALLBACK_FLAG.load(),
+            false,
+            "Callback called multiple times"
+        );
+
+        // Make sure we were passed the same pattern string as requested.
+        let s = unsafe {
+            let slice =
+                slice::from_raw_parts(ctx as *const u8, TEST_CTX_STRING.len());
+            str::from_utf8(slice).unwrap()
+        };
+
+        assert_eq!(s, TEST_CTX_STRING);
+        CALLBACK_FLAG.store(true);
+    }
+
+    println!("Issuing I/O operation against disconnected device");
+    // We can't use synchronous I/O operations because all I/O timeouts are
+    // supposed to be ignored, so no possibility to interrupt active I/O
+    // operations.
+    let io_ctx = MAYASTOR
+        .spawn(async move {
+            let ctx = unsafe { Box::from_raw(cptr.into_inner()) };
+            let device = ctx.handle.get_device();
+
+            let mut io_ctx = IoOpCtx {
+                iov: iovec::default(),
+                device_url: ctx.device_url,
+                dma_buf: DmaBuf::new(BUF_SIZE, device.alignment()).unwrap(),
+                handle: ctx.handle,
+            };
+
+            io_ctx.iov.iov_base = *io_ctx.dma_buf;
+            io_ctx.iov.iov_len = BUF_SIZE;
+
+            CALLBACK_FLAG.store(false);
+
+            io_ctx
+                .handle
+                .readv_blocks(
+                    &mut io_ctx.iov,
+                    1,
+                    (3 * 1024 * 1024) / device.block_len(),
+                    BUF_SIZE / device.block_len(),
+                    read_completion_callback,
+                    TEST_CTX_STRING.as_ptr() as *mut c_void,
+                )
+                .unwrap();
+
+            AtomicPtr::new(Box::into_raw(Box::new(io_ctx)))
+        })
+        .await;
+
+    // Wait 5 times longer than timeout interval. Make sure I/O operation not
+    // interrupted.
+    for i in 1 .. 6 {
+        println!("waiting for I/O timeout to happen... {}/5", i);
+        tokio::time::delay_for(std::time::Duration::from_secs(5)).await;
+        assert_eq!(CALLBACK_FLAG.load(), false, "I/O operation interrupted");
+    }
+
+    // Destroy device.
+    MAYASTOR
+        .spawn(async move {
+            let ctx = unsafe { Box::from_raw(io_ctx.into_inner()) };
+
+            device_destroy(&ctx.device_url).await.unwrap();
+        })
+        .await
+}


### PR DESCRIPTION
This fix introduces tuneable actions for I/O timeouts for NVMe
controllers (Abort, Reset and Ignore), which are now configurable
in place for running controllers and allow setting different timeout
actions for different controllers.

State transitions for NVMe controllers are now handled by a dedicated
state machine entity, which is now part of the global state of every
controller. Such an approach provides better state encapsulation and
validation and is less error prone than direct state manipulations.

Implements CAS-659