### PR TITLE
ci: add post 3rd party test resource check CAS-691

### DIFF
--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -5,9 +5,16 @@ set -eu
 SCRIPTDIR=$(dirname "$(realpath "$0")")
 TESTDIR=$(realpath "$SCRIPTDIR/../test/e2e")
 REPORTSDIR=$(realpath "$SCRIPTDIR/..")
-# new tests should be added before the replica_pod_remove test
+
+# List and Sequence of tests.
 #tests="install basic_volume_io csi replica rebuild node_disconnect/replica_pod_remove uninstall"
-tests="install basic_volume_io csi uninstall"
+# Restrictions:
+#   1. resource_check MUST follow csi 
+#       resource_check is a follow up check for the 3rd party CSI test suite.
+#   2. replicas_pod_remove SHOULD be the last test before uninstall
+#       this is a disruptive test.
+tests="install basic_volume_io csi resource_check uninstall"
+
 device=
 registry=
 tag="ci"

--- a/test/e2e/common/util.go
+++ b/test/e2e/common/util.go
@@ -889,34 +889,34 @@ func IsVolumePublished(uuid string) bool {
 	return true
 }
 
-func CheckNoPVCs() (bool, error) {
-	logf.Log.Info("CheckNoPVCs")
+func CheckForPVCs() (bool, error) {
+	logf.Log.Info("CheckForPVCs")
 	foundResources := false
 
 	pvcs, err := gTestEnv.KubeInt.CoreV1().PersistentVolumeClaims("default").List(context.TODO(), metav1.ListOptions{})
 	if err == nil && pvcs != nil && len(pvcs.Items) != 0 {
-		logf.Log.Info("CheckNoVolumeResources: found PersistentVolumeClaims",
+		logf.Log.Info("CheckForVolumeResources: found PersistentVolumeClaims",
 			"PersistentVolumeClaims", pvcs.Items)
 		foundResources = true
 	}
 	return foundResources, err
 }
 
-func CheckNoPVs() (bool, error) {
-	logf.Log.Info("CheckNoPVs")
+func CheckForPVs() (bool, error) {
+	logf.Log.Info("CheckForPVs")
 	foundResources := false
 
 	pvs, err := gTestEnv.KubeInt.CoreV1().PersistentVolumes().List(context.TODO(), metav1.ListOptions{})
 	if err == nil && pvs != nil && len(pvs.Items) != 0 {
-		logf.Log.Info("CheckNoVolumeResources: found PersistentVolumes",
+		logf.Log.Info("CheckForVolumeResources: found PersistentVolumes",
 			"PersistentVolumes", pvs.Items)
 		foundResources = true
 	}
 	return foundResources, err
 }
 
-func CheckNoMSVs() (bool, error) {
-	logf.Log.Info("CheckNoMSVs")
+func CheckForMSVs() (bool, error) {
+	logf.Log.Info("CheckForMSVs")
 	foundResources := false
 
 	msvGVR := schema.GroupVersionResource{
@@ -927,20 +927,20 @@ func CheckNoMSVs() (bool, error) {
 
 	msvs, err := gTestEnv.DynamicClient.Resource(msvGVR).Namespace("mayastor").List(context.TODO(), metav1.ListOptions{})
 	if err == nil && msvs != nil && len(msvs.Items) != 0 {
-		logf.Log.Info("CheckNoVolumeResources: found MayastorVolumes",
+		logf.Log.Info("CheckForVolumeResources: found MayastorVolumes",
 			"MayastorVolumes", msvs.Items)
 		foundResources = true
 	}
 	return foundResources, err
 }
 
-func CheckNoTestPods() (bool, error) {
-	logf.Log.Info("CheckNoTestPods")
+func CheckForTestPods() (bool, error) {
+	logf.Log.Info("CheckForTestPods")
 	foundPods := false
 
 	pods, err := gTestEnv.KubeInt.CoreV1().Pods("default").List(context.TODO(), metav1.ListOptions{})
 	if err == nil && pods != nil && len(pods.Items) != 0 {
-		logf.Log.Info("CheckNoTestPods",
+		logf.Log.Info("CheckForTestPods",
 			"Pods", pods.Items)
 		foundPods = true
 	}

--- a/test/e2e/resource_check/resource_check_test.go
+++ b/test/e2e/resource_check/resource_check_test.go
@@ -1,0 +1,72 @@
+package basic_test
+
+import (
+	"e2e-basic/common"
+	"os"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/reporters"
+	. "github.com/onsi/gomega"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+// Check that there are no artefacts left over from
+// the previous 3rd party test.
+func resourceCheck() {
+
+	found, err := common.CheckForTestPods()
+	if err != nil {
+		logf.Log.Error(err, "Failed to check for test pods.")
+	} else {
+		Expect(found).To(BeFalse())
+	}
+
+	found, err = common.CheckForPVCs()
+	if err != nil {
+		logf.Log.Error(err, "Failed to check for PVCs")
+	}
+	Expect(found).To(BeFalse())
+
+	found, err = common.CheckForPVs()
+	if err != nil {
+		logf.Log.Error(err, "Failed to check PVs")
+	}
+	Expect(found).To(BeFalse())
+
+	found, err = common.CheckForMSVs()
+	if err != nil {
+		logf.Log.Error(err, "Failed to check MSVs")
+	}
+	Expect(found).To(BeFalse())
+}
+
+func TestResourceCheck(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	reportDir := os.Getenv("e2e_reports_dir")
+	junitReporter := reporters.NewJUnitReporter(reportDir + "/resource_check-junit.xml")
+	RunSpecsWithDefaultAndCustomReporters(t, "Resource Check Suite",
+		[]Reporter{junitReporter})
+}
+
+var _ = Describe("Mayastor resource check", func() {
+	It("should have no resources allocated", func() {
+		resourceCheck()
+	})
+})
+
+var _ = BeforeSuite(func(done Done) {
+	logf.SetLogger(zap.New(zap.UseDevMode(true), zap.WriteTo(GinkgoWriter)))
+	common.SetupTestEnv()
+
+	close(done)
+}, 60)
+
+var _ = AfterSuite(func() {
+	// NB This only tears down the local structures for talking to the cluster,
+	// not the kubernetes cluster itself.
+	By("tearing down the test environment")
+	common.TeardownTestEnv()
+})

--- a/test/e2e/uninstall/uninstall_test.go
+++ b/test/e2e/uninstall/uninstall_test.go
@@ -49,26 +49,26 @@ func teardownMayastor() {
 
 	logf.Log.Info("Settings:", "cleanup", cleanup)
 	if !cleanup {
-		found, err := common.CheckNoTestPods()
+		found, err := common.CheckForTestPods()
 		if err != nil {
 			logf.Log.Error(err, "Failed to checking for test pods.")
 		} else {
 			Expect(found).To(BeFalse())
 		}
 
-		found, err = common.CheckNoPVCs()
+		found, err = common.CheckForPVCs()
 		if err != nil {
 			logf.Log.Error(err, "Failed to check for PVCs")
 		}
 		Expect(found).To(BeFalse())
 
-		found, err = common.CheckNoPVs()
+		found, err = common.CheckForPVs()
 		if err != nil {
 			logf.Log.Error(err, "Failed to check PVs")
 		}
 		Expect(found).To(BeFalse())
 
-		found, err = common.CheckNoMSVs()
+		found, err = common.CheckForMSVs()
 		if err != nil {
 			logf.Log.Error(err, "Failed to check MSVs")
 		}


### PR DESCRIPTION
The CSI test suite is a 3rd party test suite.
We would like to apply stringent resource leakage checks for
each test.
We have test code which does this, it makes sense to reuse this.
However it is not straightforward to integrate this with the
3rd party source code.
Doing so makes it more difficult to integrate future changes in
the 3rd party source code.

Create a simple resource check test which is sequenced to run after
each 3rd party test suite.

Rename CheckNo* functions to the more apt CheckFor*