### PR TITLE
refactor(nvmx): more abstractions for spdk objects

### DIFF
--- a/mayastor/src/bdev/dev/nvmx/controller.rs
+++ b/mayastor/src/bdev/dev/nvmx/controller.rs
@@ -520,16 +520,28 @@ impl<'a> Drop for NvmeController<'a> {
             )
         );
 
-        let inner = self.inner.take().expect("NVMe inner already gone");
+        // Inner state might not be yes available.
+        if self.inner.is_some() {
+            let inner = self.inner.take().expect("NVMe inner already gone");
 
-        debug!("{} detaching NVMe controller", self.name);
-        let rc = unsafe { spdk_nvme_detach(inner.ctrlr.as_ptr()) };
+            debug!(
+                ?self.name,
+                "detaching NVMe controller"
+            );
+            let rc = unsafe { spdk_nvme_detach(inner.ctrlr.as_ptr()) };
 
-        debug!("{} stopping admin queue poller", self.name);
-        inner.adminq_poller.stop();
+            debug!(
+                ?self.name,
+                "stopping admin queue poller"
+            );
+            inner.adminq_poller.stop();
 
-        assert_eq!(rc, 0, "Failed to detach NVMe controller");
-        debug!("{}: NVMe controller successfully detached", self.name);
+            assert_eq!(rc, 0, "Failed to detach NVMe controller");
+            debug!(
+                ?self.name,
+                "NVMe controller successfully detached"
+            );
+        }
 
         unsafe {
             std::ptr::drop_in_place(self.timeout_config);

--- a/mayastor/src/bdev/dev/nvmx/handle.rs
+++ b/mayastor/src/bdev/dev/nvmx/handle.rs
@@ -368,7 +368,7 @@ fn check_channel_for_io(
 
     // Check against concurrent controller reset, which results in valid
     // I/O channel but deactivated I/O pair.
-    if inner.qpair.is_null() {
+    if inner.qpair.is_none() {
         errno = libc::ENODEV;
     }
 
@@ -442,7 +442,7 @@ impl BlockDeviceHandle for NvmeDeviceHandle {
         let rc = unsafe {
             spdk_nvme_ns_cmd_read(
                 self.ns.as_ptr(),
-                inner.qpair,
+                inner.qpair.as_mut().unwrap().as_ptr(),
                 **buffer,
                 offset_blocks,
                 num_blocks as u32,
@@ -507,7 +507,7 @@ impl BlockDeviceHandle for NvmeDeviceHandle {
         let rc = unsafe {
             spdk_nvme_ns_cmd_write(
                 self.ns.as_ptr(),
-                inner.qpair,
+                inner.qpair.as_mut().unwrap().as_ptr(),
                 **buffer,
                 offset_blocks,
                 num_blocks as u32,
@@ -572,7 +572,7 @@ impl BlockDeviceHandle for NvmeDeviceHandle {
             rc = unsafe {
                 spdk_nvme_ns_cmd_read(
                     self.ns.as_ptr(),
-                    inner.qpair,
+                    inner.qpair.as_mut().unwrap().as_ptr(),
                     (*iov).iov_base,
                     offset_blocks,
                     num_blocks as u32,
@@ -585,7 +585,7 @@ impl BlockDeviceHandle for NvmeDeviceHandle {
             rc = unsafe {
                 spdk_nvme_ns_cmd_readv(
                     self.ns.as_ptr(),
-                    inner.qpair,
+                    inner.qpair.as_mut().unwrap().as_ptr(),
                     offset_blocks,
                     num_blocks as u32,
                     Some(nvme_io_done),
@@ -644,7 +644,7 @@ impl BlockDeviceHandle for NvmeDeviceHandle {
             rc = unsafe {
                 spdk_nvme_ns_cmd_write(
                     self.ns.as_ptr(),
-                    inner.qpair,
+                    inner.qpair.as_mut().unwrap().as_ptr(),
                     (*iov).iov_base,
                     offset_blocks,
                     num_blocks as u32,
@@ -657,7 +657,7 @@ impl BlockDeviceHandle for NvmeDeviceHandle {
             rc = unsafe {
                 spdk_nvme_ns_cmd_writev(
                     self.ns.as_ptr(),
-                    inner.qpair,
+                    inner.qpair.as_mut().unwrap().as_ptr(),
                     offset_blocks,
                     num_blocks as u32,
                     Some(nvme_writev_done),
@@ -696,7 +696,7 @@ impl BlockDeviceHandle for NvmeDeviceHandle {
         let inner = NvmeIoChannel::inner_from_channel(self.io_channel.as_ptr());
 
         // Make sure channel allows I/O.
-        if inner.qpair.is_null() {
+        if inner.qpair.is_none() {
             return Err(CoreError::NvmeAdminDispatch {
                 source: Errno::ENODEV,
                 opcode: cmd.opc(),
@@ -826,7 +826,7 @@ impl BlockDeviceHandle for NvmeDeviceHandle {
 
             spdk_nvme_ns_cmd_dataset_management(
                 self.ns.as_ptr(),
-                inner.qpair,
+                inner.qpair.as_mut().unwrap().as_ptr(),
                 utils::NvmeDsmAttribute::Deallocate as u32,
                 dsm_ranges,
                 num_ranges as u16,


### PR DESCRIPTION
This fix introduces better API abstractions for such SPDK objects as
i/o qpair and poll group. All low-level SPDK handles are hidden
inside high-level Rust wrappers, which incapsulates low-level SPDK
library functions.
As a plus, high-level wrappers allow using Options instead of raw
pointers, which makes code look a lot better.

Implements CAS-628