### PR TITLE
fix(nexus): set children to destroying state on shutdown

### DIFF
--- a/mayastor/src/core/env.rs
+++ b/mayastor/src/core/env.rs
@@ -279,7 +279,7 @@ async fn do_shutdown(arg: *mut c_void) {
     }
 
     iscsi::fini();
-    nexus::nexus_destroy_all().await;
+    nexus::nexus_children_to_destroying_state().await;
     unsafe {
         spdk_rpc_finish();
         spdk_subsystem_fini(Some(reactors_stop), arg);


### PR DESCRIPTION
Set all children to Destroying state instead to address possible
segfault on shutdown when destroying nexuses.

Fixes CAS-697