### PR TITLE
feat(deployer): ability to deploy JsonGrpc service

### DIFF
--- a/control-plane/agents/jsongrpc/src/server.rs
+++ b/control-plane/agents/jsongrpc/src/server.rs
@@ -74,6 +74,7 @@ async fn server(cli_args: CliArgs) {
         .connect()
         .await
         .with_subscription(ServiceHandler::<JsonGrpcRequest>::default())
+        .with_default_liveness()
         .run()
         .await;
 }

--- a/control-plane/deployer/src/infra/mod.rs
+++ b/control-plane/deployer/src/infra/mod.rs
@@ -336,11 +336,12 @@ impl_component! {
     Node,       2,
     Pool,       3,
     Volume,     3,
+    JsonGrpc,   3,
     NodeOp,     4,
 }
 
 // Message Bus Control Plane Agents
-impl_ctrlp_agents!(Node, Pool, Volume);
+impl_ctrlp_agents!(Node, Pool, Volume, JsonGrpc);
 
 // Kubernetes Mayastor Low-level Operators
 impl_ctrlp_operators!(Node);


### PR DESCRIPTION
The deployer tool now has the ability to run the JsonGrpc service. To do
so, issue the following command:
	../deployer start -s JsonGrpc

The JsonGrpc agent isn't added to the list of default services to run
because in most cases it won't be necessary (it provides a way to invoke
SPDK JSON gRPC methods).