### PR TITLE
chore: do profile-based yaml generation

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -1,7 +1,7 @@
 {{/* Enforce trailing slash to mayastorImagesPrefix or leave empty */}}
 {{- define "mayastorImagesPrefix" -}}
-{{- if .Values.mayastorImagesRepo }}
-{{- printf "%s/" (.Values.mayastorImagesRepo | trimSuffix "/") }}
+{{- if .Values.mayastorImagesRegistry }}
+{{- printf "%s/" (.Values.mayastorImagesRegistry | trimSuffix "/") }}
 {{- else }}
 {{- "" }}
 {{- end }}
@@ -13,6 +13,6 @@
 {{- if gt $i 0 }}
 {{- printf "," }}
 {{- end }}
-{{- printf "%d" (add $i 1) }}
+{{- printf "%d" $i }}
 {{- end }}
 {{- end }}

--- a/chart/templates/mayastor-daemonset.yaml
+++ b/chart/templates/mayastor-daemonset.yaml
@@ -45,16 +45,10 @@ spec:
         - name: IMPORT_NEXUSES
           value: "false"
         args:
-        # In order to select what cores mayastor should be running on, a mask or a list can be specified.
-        # For example: -m 0x1 will tell mayastor to only use one core which is equivalent to -l 1
-        # Using a mask of 0x3 will use the first 2 cores, which is equivalent to -l 1-2
-        #
-        # The -l argument supports ranges to be able to do the same as passing a mask for example:
-        # -l 1,2,10-20 means use core 1, 2, 10 to 20
-        #
-        # Note:
-        # 1. When both -m and -l are specified the -l argument is takes precedence.
-        # 2. Ensure that the CPU resources are updated accordingly. If you use 2 CPUs, the CPU: field should also read 2.
+        # The -l argument accepts cpu-list. Indexing starts at zero.
+        # For example -l 1,2,10-20 means use core 1, 2, 10 to 20.
+        # Note: Ensure that the CPU resources are updated accordingly.
+        #       If you use 2 CPUs, the CPU: field should also read 2.
         - "-N$(MY_NODE_NAME)"
         - "-g$(MY_POD_IP)"
         - "-nnats"

--- a/chart/templates/moac-deployment.yaml
+++ b/chart/templates/moac-deployment.yaml
@@ -49,8 +49,8 @@ spec:
             - "--csi-address=$(CSI_ENDPOINT)"
             - "--namespace=$(MY_POD_NAMESPACE)"
             - "--port=4000"
-            - "--message-bus=nats"
-            - "-v"
+            - "--message-bus=nats"{{ if .Values.moacDebug }}
+            - "-vv"{{ end }}
           env:
             - name: CSI_ENDPOINT
               value: /var/lib/csi/sockets/pluginproxy/csi.sock

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,8 +1,12 @@
-mayastorImagesTag: develop
+mayastorImagesTag: latest
 mayastorImagePullPolicy: Always
-mayastorCpuCount: "2"
+mayastorCpuCount: "1"
 mayastorHugePagesGiB: "1"
-mayastorImagesRepo: ""
+mayastorImagesRegistry: ""
 mayastorPools:
   - node: "NODE_NAME"
     device: "DEVICE"
+# This option is intended for development yamls and motivated by the problem of
+# moac that does not update status of msp resource in some cases. Feel free to
+# remove when no longer needed.
+moacDebug: false

--- a/deploy/mayastor-daemonset.yaml
+++ b/deploy/mayastor-daemonset.yaml
@@ -47,21 +47,15 @@ spec:
         - name: IMPORT_NEXUSES
           value: "false"
         args:
-        # In order to select what cores mayastor should be running on, a mask or a list can be specified.
-        # For example: -m 0x1 will tell mayastor to only use one core which is equivalent to -l 1
-        # Using a mask of 0x3 will use the first 2 cores, which is equivalent to -l 1-2
-        #
-        # The -l argument supports ranges to be able to do the same as passing a mask for example:
-        # -l 1,2,10-20 means use core 1, 2, 10 to 20
-        #
-        # Note:
-        # 1. When both -m and -l are specified the -l argument is takes precedence.
-        # 2. Ensure that the CPU resources are updated accordingly. If you use 2 CPUs, the CPU: field should also read 2.
+        # The -l argument accepts cpu-list. Indexing starts at zero.
+        # For example -l 1,2,10-20 means use core 1, 2, 10 to 20.
+        # Note: Ensure that the CPU resources are updated accordingly.
+        #       If you use 2 CPUs, the CPU: field should also read 2.
         - "-N$(MY_NODE_NAME)"
         - "-g$(MY_POD_IP)"
         - "-nnats"
         - "-y/var/local/mayastor/config.yaml"
-        - "-l1,2"
+        - "-l0"
         securityContext:
           privileged: true
         volumeMounts:
@@ -80,11 +74,11 @@ spec:
           # belong to Guaranteed QoS class, hence can never get evicted in case of
           # pressure unless they exceed those limits. limits and requests must be the same.
           limits:
-            cpu: "2"
+            cpu: "1"
             memory: "512Mi"
             hugepages-2Mi: "1Gi"
           requests:
-            cpu: "2"
+            cpu: "1"
             memory: "512Mi"
             hugepages-2Mi: "1Gi"
         ports:

--- a/deploy/moac-deployment.yaml
+++ b/deploy/moac-deployment.yaml
@@ -52,7 +52,7 @@ spec:
             - "--namespace=$(MY_POD_NAMESPACE)"
             - "--port=4000"
             - "--message-bus=nats"
-            - "-v"
+            - "-vv"
           env:
             - name: CSI_ENDPOINT
               value: /var/lib/csi/sockets/pluginproxy/csi.sock

--- a/scripts/generate-deploy-yamls.sh
+++ b/scripts/generate-deploy-yamls.sh
@@ -1,52 +1,158 @@
-#! /bin/sh
+#!/bin/sh
+
+# This is a wrapper script for helm to generate yaml files for deploying
+# mayastor. It provides reasonable defaults for helm values based on
+# selected profile. Easy to use and minimizing risk of error.
+# Keep the script as simple as possible - ad-hoc use cases can be addressed
+# by running helm directly.
 
 set -e
 
-if [ "x$1" = x ]; then
-cat <<EOF
-USAGE: $0 [-t <target_dir>] <mayastor_docker_images_tag> [<mayastor_images_repo>]
-
-Generate (some) deployment YAMLs from the helm chart and store them to deploy/
-in the repo. If -t is specified do not put them to deploy/ but rather to the
-directory given.
-EOF
-	exit 1
-fi
-
 SCRIPTDIR="$(realpath "$(dirname "$0")")"
 
-if [ "$1" = "-t" ]; then
-	TARGET_DIR="$2"
-	shift 2
-else
-	TARGET_DIR="$SCRIPTDIR/../deploy"
-fi
-if [ ! -d "$TARGET_DIR" ]; then
-	mkdir -p "$TARGET_DIR"
+# Internal variables tunable by options
+cores=
+moac_debug=false
+output_dir="$SCRIPTDIR/../deploy"
+pools=
+profile=
+pull_policy=
+registry=
+tag=
+
+help() {
+  cat <<EOF
+
+Usage: $0 [OPTIONS] <PROFILE>
+
+Common options:
+  -c <cores>       # of cpu cores for mayastor overriding the profile's default.
+  -h/--help        Display help message and exit.
+  -o <output_dir>  Directory to store the generated yaml files (default $output_dir)
+  -p <node,device> Node name and associated pool device (the option may repeat).
+  -r <registry>    Docker image registry of mayastor images (default none).
+  -t <tag>         Tag of mayastor images overriding the profile's default.
+
+Profiles:
+  develop:   Used by developers of mayastor.
+  release:   Recommended for stable releases deployed by users.
+  test:      Used by mayastor e2e tests.
+EOF
+}
+
+# Parse common options
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -c)
+      shift
+      cores=$1
+      ;;
+    -h|--help)
+      help
+      exit 0
+      ;;
+    -o)
+      shift
+      output_dir=$1
+      ;;
+    -p)
+      shift
+      pools="$pools $1"
+      ;;
+    -r)
+      shift
+      registry=$1
+      ;;
+    -t)
+      shift
+      tag=$1
+      ;;
+    -*)
+      echo "Unknown option: $1"
+      help
+      exit 1
+      ;;
+    *)
+      profile=$1
+      shift
+      break
+      ;;
+  esac
+  shift
+done
+
+# The space after profile name is reserved for profile specific options which
+# we don't have yet.
+if [ "$#" -gt 0 ]; then
+  help
+  exit 1
 fi
 
-if [ "x$2" = x ]; then
-	mayastor_images_repo="NONE"
+# In most of the cases the tag will be a specific version that does not change
+# so save dockerhub bandwidth and don't always pull the image.
+if [ -n "$tag" ]; then
+  pull_policy=IfNotPresent
 else
-	mayastor_images_repo="$2"
+  pull_policy=Always
 fi
+
+# Set profile defaults
+case "$profile" in
+  "develop")
+    [ -z "$cores" ] && cores=1
+    [ -z "$tag" ] && tag=develop
+    moac_debug=true
+    ;;
+  "release")
+    [ -z "$cores" ] && cores=1
+    [ -z "$tag" ] && tag=latest
+    ;;
+  "test")
+    [ -z "$cores" ] && cores=2
+    [ -z "$tag" ] && tag=ci
+    moac_debug=true
+    ;;
+  *)
+    echo "Missing or invalid profile name. Type \"$0 --help\""
+    exit 1
+    ;;
+esac
 
 set -u
 
-if ! which helm > /dev/null 2>&1; then
-	echo "Install helm to path >v3.4.1"
-	echo "https://github.com/helm/helm/releases/tag/v3.4.1"
-	exit 1
+if ! which helm >/dev/null 2>&1; then
+  echo "Install helm (>v3.4.1) to PATH"
+  exit 1
 fi
 
-tmpd=$(mktemp -d /tmp/generate-deploy.sh.XXXXXXXX)
+if [ ! -d "$output_dir" ]; then
+  mkdir -p "$output_dir"
+fi
+
+tmpd=$(mktemp -d /tmp/generate-deploy-yamls.sh.XXXXXXXX)
 # shellcheck disable=SC2064
 trap "rm -fr '$tmpd'" HUP QUIT EXIT TERM INT
 
-template_params="mayastorImagesTag=$1"
-if [ "$mayastor_images_repo" != "NONE" ]; then
-	template_params="$template_params,mayastorImagesRepo=$mayastor_images_repo"
+# A rule of thumb: # of cpu cores equals to Gigs of hugepage memory
+template_params="mayastorImagesTag=$tag"
+template_params="$template_params,mayastorImagePullPolicy=$pull_policy"
+template_params="$template_params,mayastorCpuCount=$cores"
+template_params="$template_params,mayastorHugePagesGiB=$cores"
+template_params="$template_params,moacDebug=$moac_debug"
+if [ -n "$registry" ]; then
+  template_params="$template_params,mayastorImagesRegistry=$registry"
 fi
+if [ -n "$pools" ]; then
+  i=0
+  for pool in $pools; do
+    node=$(echo "$pool" | sed 's/,.*//')
+    device=$(echo "$pool" | sed 's/.*,//')
+    template_params="$template_params,mayastorPools[$i].node=$node"
+    template_params="$template_params,mayastorPools[$i].device=$device"
+    i=$((i + 1))
+  done
+fi
+
 helm template --set "$template_params" mayastor "$SCRIPTDIR/../chart" --output-dir="$tmpd" --namespace mayastor
 
-mv "$tmpd"/mayastor/templates/*.yaml "$TARGET_DIR"
+mv "$tmpd"/mayastor/templates/*.yaml "$output_dir/"

--- a/test/e2e/install/install_test.go
+++ b/test/e2e/install/install_test.go
@@ -137,7 +137,7 @@ func getTemplateYamlDir() string {
 }
 
 func generateYamls(imageTag string, registryAddress string) {
-	bashcmd := fmt.Sprintf("../../../scripts/generate-deploy-yamls.sh -t ../../../test-yamls %s %s", imageTag, registryAddress)
+	bashcmd := fmt.Sprintf("../../../scripts/generate-deploy-yamls.sh -o ../../../test-yamls -t %s -r %s test", imageTag, registryAddress)
 	cmd := exec.Command("bash", "-c", bashcmd)
 	out, err := cmd.CombinedOutput()
 	Expect(err).ToNot(HaveOccurred(), "%s", out)


### PR DESCRIPTION
The purpose of profiles is to provide reasonable defaults for yaml
templates for each of the major use cases:

* develop: used by developers to run mayastor
* release: used for stable releases of mayastor
* test: used by mayastor e2e tests

In addition to that I have:

* increased debug level of moac when running in develop env
* fixed wrong usage of -l parameter (indexing starts at 0)
* introduced rule of thumb for cpu count and hugepage mem (1:1)

Resolves: CAS-699