### PR TITLE
refactor(nexus): clean up label parsing code

### DIFF
--- a/mayastor/src/bdev/mod.rs
+++ b/mayastor/src/bdev/mod.rs
@@ -13,7 +13,7 @@ pub use nexus::{
     nexus_child_error_store::{ActionType, NexusErrStore, QueryType},
     nexus_child_status_config,
     nexus_io::Bio,
-    nexus_label::{GPTHeader, GptEntry},
+    nexus_label::{GptEntry, GptHeader},
     nexus_metadata_content::{
         NexusConfig,
         NexusConfigVersion1,

--- a/mayastor/src/bdev/nexus/nexus_bdev_children.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev_children.rs
@@ -23,8 +23,6 @@
 //! When reconfiguring the nexus, we traverse all our children, create new IO
 //! channels for all children that are in the open state.
 
-use std::env;
-
 use futures::future::join_all;
 use snafu::ResultExt;
 
@@ -42,12 +40,6 @@ use crate::{
             nexus_channel::DrEvent,
             nexus_child::{ChildState, NexusChild},
             nexus_child_status_config::ChildStatusConfig,
-            nexus_label::{
-                LabelError,
-                NexusChildLabel,
-                NexusLabel,
-                NexusLabelStatus,
-            },
         },
         Reason,
         VerboseError,
@@ -455,94 +447,6 @@ impl Nexus {
             })
             .for_each(drop);
         Ok(())
-    }
-
-    /// Read labels from all child devices
-    async fn get_child_labels(&self) -> Vec<NexusChildLabel<'_>> {
-        let mut futures = Vec::new();
-        self.children
-            .iter()
-            .map(|child| futures.push(child.get_label()))
-            .for_each(drop);
-        join_all(futures).await
-    }
-
-    /// Update labels of child devices as required:
-    /// (1) Update any child that does not have valid label.
-    /// (2) Upate all children with a new label if existing (valid) labels
-    ///     are not all identical.
-    ///
-    /// Return the resulting label.
-    pub async fn update_child_labels(
-        &mut self,
-    ) -> Result<NexusLabel, LabelError> {
-        // Get a list of all children and their labels
-        let list = self.get_child_labels().await;
-
-        // Search for first "valid" label
-        if let Some(target) = NexusChildLabel::find_target_label(&list) {
-            // Check that all "valid" labels are equal
-            if NexusChildLabel::compare_labels(&target, &list) {
-                let (_valid, invalid): (
-                    Vec<NexusChildLabel>,
-                    Vec<NexusChildLabel>,
-                ) = list.into_iter().partition(|label| {
-                    label.get_label_status() == NexusLabelStatus::Both
-                });
-
-                if invalid.is_empty() {
-                    info!(
-                        "{}: All child disk labels are valid and consistent",
-                        self.name
-                    );
-                } else {
-                    // Write out (only) those labels that require updating
-                    info!(
-                        "{}: Replacing missing/invalid child disk labels",
-                        self.name
-                    );
-                    self.write_labels(&target, &invalid).await?
-                }
-
-                // TODO: When the GUID does not match the given UUID.
-                // it means that the PVC has been recreated.
-                // We should consider also updating the labels in such a case.
-
-                info!("{}: existing label: {}", self.name, target.primary.guid);
-                trace!("{}: existing label:\n {}", self.name, target);
-
-                return Ok(target);
-            }
-
-            info!("{}: Child disk labels do not match, writing new label to all children", self.name);
-        } else {
-            info!("{}: Child disk labels invalid or absent, writing new label to all children", self.name);
-        }
-
-        // Either there are no valid labels or there
-        // are some valid labels that do not agree.
-        // Generate a new label ...
-        let label = self.generate_label();
-
-        // ... and write it out to ALL children.
-        let label = match self.write_all_labels(&label).await {
-            Ok(_) => Ok(label),
-            Err(LabelError::ReReadError {
-                ..
-            }) => {
-                if env::var("NEXUS_LABEL_IGNORE_ERRORS").is_ok() {
-                    warn!("ignoring label error on request");
-                    Ok(label)
-                } else {
-                    Err(LabelError::ProbeError {})
-                }
-            }
-            Err(e) => Err(e),
-        }?;
-
-        info!("{}: new label: {}", self.name, label.primary.guid);
-        trace!("{}: new label:\n{}", self.name, label);
-        Ok(label)
     }
 
     /// The nexus is allowed to be smaller then the underlying child devices

--- a/mayastor/tests/nexus_label.rs
+++ b/mayastor/tests/nexus_label.rs
@@ -6,7 +6,7 @@ use std::{
 use bincode::serialize_into;
 
 use mayastor::{
-    bdev::{nexus_create, nexus_lookup, GPTHeader, GptEntry},
+    bdev::{nexus_create, nexus_lookup, GptEntry, GptHeader},
     core::{
         mayastor_env_stop,
         DmaBuf,
@@ -74,7 +74,7 @@ fn test_known_label() {
     let mut hdr_buf: [u8; 512] = [0; 512];
     file.read_exact(&mut hdr_buf).unwrap();
 
-    let mut hdr: GPTHeader = GPTHeader::from_slice(&hdr_buf).unwrap();
+    let mut hdr: GptHeader = GptHeader::from_slice(&hdr_buf).unwrap();
     assert_eq!(hdr.self_checksum, CRC32);
     assert_eq!(hdr.guid.to_string(), HDR_GUID,);
 
@@ -91,7 +91,7 @@ fn test_known_label() {
 
     assert_eq!(hdr.checksum(), CRC32);
 
-    let array_checksum = GptEntry::checksum(&partitions);
+    let array_checksum = GptEntry::checksum(&partitions, hdr.num_entries);
 
     assert_eq!(array_checksum, hdr.table_crc);
 
@@ -105,9 +105,9 @@ fn test_known_label() {
     }
 
     let partitions =
-        GptEntry::from_slice(&buf.as_slice(), hdr.num_entries).unwrap();
+        GptEntry::from_slice(buf.as_slice(), hdr.num_entries).unwrap();
 
-    let array_checksum = GptEntry::checksum(&partitions);
+    let array_checksum = GptEntry::checksum(&partitions, hdr.num_entries);
     assert_eq!(array_checksum, hdr.table_crc);
 }
 


### PR DESCRIPTION
- dispensed with NexusChildLabel struct entirely
  (which maintained a child reference and seemed to be causing deadlocks)
- added extra sanity checking for valid labels
- create labels correctly for disks of varying size
- allow changing of disk GUID if creating nexus with different UUID

Resolves CAS-720