### PR TITLE
feat(rest-test): new rest test project 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1289,6 +1289,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctrlp-tests"
+version = "0.1.0"
+dependencies = [
+ "actix-rt",
+ "actix-web-opentelemetry",
+ "anyhow",
+ "composer",
+ "deployer",
+ "opentelemetry",
+ "opentelemetry-jaeger",
+ "rest",
+ "tracing",
+ "tracing-opentelemetry",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2668,6 +2684,7 @@ dependencies = [
  "tracing",
  "tracing-futures",
  "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,5 +20,6 @@ members = [
 	"control-plane/rest",
 	"control-plane/operators",
 	"control-plane/macros",
-	"control-plane/deployer"
+	"control-plane/deployer",
+	"control-plane/tests"
 ]

--- a/composer/src/lib.rs
+++ b/composer/src/lib.rs
@@ -113,11 +113,11 @@ impl Binary {
         let path = std::path::PathBuf::from(std::env!("CARGO_MANIFEST_DIR"));
         let srcdir = path.parent().unwrap().to_string_lossy();
 
-        Self::new(format!("{}/target/debug/{}", srcdir, name), vec![])
+        Self::new(&format!("{}/target/debug/{}", srcdir, name), vec![])
     }
     /// Setup nix shell binary from path and arguments
     pub fn from_nix(name: &str) -> Self {
-        Self::new(Self::which(name).expect("binary should exist"), vec![])
+        Self::new(name, vec![])
     }
     /// Add single argument
     /// Only one argument can be passed per use. So instead of:
@@ -171,11 +171,17 @@ impl Binary {
     }
     fn which(name: &str) -> std::io::Result<String> {
         let output = std::process::Command::new("which").arg(name).output()?;
+        if !output.status.success() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                name,
+            ));
+        }
         Ok(String::from_utf8_lossy(&output.stdout).trim().into())
     }
-    fn new(path: String, args: Vec<String>) -> Self {
+    fn new(path: &str, args: Vec<String>) -> Self {
         Self {
-            path,
+            path: Self::which(path).expect("Binary path should exist!"),
             arguments: args,
             ..Default::default()
         }
@@ -310,6 +316,10 @@ pub struct Builder {
     containers: Vec<ContainerSpec>,
     /// the network for the tests used
     network: String,
+    /// reuse existing containers
+    reuse: bool,
+    /// allow cleaning up on a panic (if clean is true)
+    allow_clean_on_panic: bool,
     /// delete the container and network when dropped
     clean: bool,
     /// destroy existing containers if any
@@ -343,6 +353,8 @@ impl Builder {
             name: TEST_NET_NAME.to_string(),
             containers: Default::default(),
             network: "10.1.0.0/16".to_string(),
+            reuse: false,
+            allow_clean_on_panic: true,
             clean: true,
             prune: true,
             autorun: true,
@@ -420,8 +432,7 @@ impl Builder {
     }
 
     /// add a generic container which runs a local binary
-    pub fn add_container_bin(self, name: &str, mut bin: Binary) -> Builder {
-        bin.setup_nats(&self.name);
+    pub fn add_container_bin(self, name: &str, bin: Binary) -> Builder {
         self.add_container_spec(ContainerSpec::from_binary(name, bin))
     }
 
@@ -430,9 +441,22 @@ impl Builder {
         self.add_container_spec(ContainerSpec::from_binary(name, image))
     }
 
+    /// attempt to reuse and restart containers instead of starting new ones
+    pub fn with_reuse(mut self, reuse: bool) -> Builder {
+        self.reuse = reuse;
+        self.prune = !reuse;
+        self
+    }
+
     /// clean on drop?
     pub fn with_clean(mut self, enable: bool) -> Builder {
         self.clean = enable;
+        self
+    }
+
+    /// allow clean on panic if clean is set
+    pub fn with_clean_on_panic(mut self, enable: bool) -> Builder {
+        self.allow_clean_on_panic = enable;
         self
     }
 
@@ -463,14 +487,16 @@ impl Builder {
     }
 
     /// setup tracing for the cargo test code with `filter`
+    /// ignore when called multiple times
     pub fn with_tracing(self, filter: &str) -> Self {
-        if let Ok(filter) =
+        let builder = if let Ok(filter) =
             tracing_subscriber::EnvFilter::try_from_default_env()
         {
-            tracing_subscriber::fmt().with_env_filter(filter).init();
+            tracing_subscriber::fmt().with_env_filter(filter)
         } else {
-            tracing_subscriber::fmt().with_env_filter(filter).init();
-        }
+            tracing_subscriber::fmt().with_env_filter(filter)
+        };
+        builder.try_init().ok();
         self
     }
 
@@ -517,6 +543,8 @@ impl Builder {
             containers: Default::default(),
             ipam,
             label_prefix: "io.mayastor.test".to_string(),
+            reuse: self.reuse,
+            allow_clean_on_panic: self.allow_clean_on_panic,
             clean: self.clean,
             prune: self.prune,
             image: self.image,
@@ -526,14 +554,37 @@ impl Builder {
         compose.network_id =
             compose.network_create().await.map_err(|e| e.to_string())?;
 
-        // containers are created where the IPs are ordinal
-        for (i, spec) in self.containers.iter().enumerate() {
-            compose
-                .create_container(
-                    spec,
-                    &net.nth((i + 2) as u32).unwrap().to_string(),
-                )
-                .await?;
+        if self.reuse {
+            let containers =
+                compose.list_network_containers(&self.name).await?;
+
+            for container in containers {
+                let networks = container
+                    .network_settings
+                    .unwrap_or_default()
+                    .networks
+                    .unwrap_or_default();
+                if let Some(n) = container.names.unwrap_or_default().first() {
+                    if let Some(endpoint) = networks.get(&self.name) {
+                        if let Some(ip) = endpoint.ip_address.clone() {
+                            compose.containers.insert(
+                                n[1 ..].into(),
+                                (container.id.unwrap_or_default(), ip.parse()?),
+                            );
+                        }
+                    }
+                }
+            }
+        } else {
+            // containers are created where the IPs are ordinal
+            for (i, spec) in self.containers.iter().enumerate() {
+                compose
+                    .create_container(
+                        spec,
+                        &net.nth((i + 2) as u32).unwrap().to_string(),
+                    )
+                    .await?;
+            }
         }
 
         Ok(compose)
@@ -569,6 +620,10 @@ pub struct ComposeTest {
     /// prefix for labels set on containers and networks
     ///   $prefix.name = $name will be created automatically
     label_prefix: String,
+    /// reuse existing containers
+    reuse: bool,
+    /// allow cleaning up on a panic (if clean is set)
+    allow_clean_on_panic: bool,
     /// automatically clean up the things we have created for this test
     clean: bool,
     /// remove existing containers upon creation
@@ -591,10 +646,10 @@ impl Drop for ComposeTest {
             });
         }
 
-        if self.clean {
+        if self.clean && (!thread::panicking() || self.allow_clean_on_panic) {
             self.containers.keys().for_each(|c| {
                 std::process::Command::new("docker")
-                    .args(&["stop", c])
+                    .args(&["kill", c])
                     .output()
                     .unwrap();
                 std::process::Command::new("docker")
@@ -723,7 +778,7 @@ impl ComposeTest {
     }
 
     /// list containers
-    pub async fn list_containers(
+    pub async fn list_cluster_containers(
         &self,
     ) -> Result<Vec<ContainerSummaryInner>, Error> {
         self.docker
@@ -974,9 +1029,11 @@ impl ComposeTest {
                 ),
             },
         )?;
-        self.docker
-            .start_container::<&str>(id.0.as_str(), None)
-            .await?;
+        if !self.reuse {
+            self.docker
+                .start_container::<&str>(id.0.as_str(), None)
+                .await?;
+        }
 
         Ok(())
     }
@@ -1010,11 +1067,16 @@ impl ComposeTest {
 
     /// restart the container
     pub async fn restart(&self, name: &str) -> Result<(), Error> {
-        let id = self.containers.get(name).unwrap();
+        let (id, _) = self.containers.get(name).unwrap();
+        self.restart_id(id.as_str()).await
+    }
+
+    /// restart the container id
+    pub async fn restart_id(&self, id: &str) -> Result<(), Error> {
         if let Err(e) = self
             .docker
             .restart_container(
-                id.0.as_str(),
+                id,
                 Some(RestartContainerOptions {
                     t: 3,
                 }),
@@ -1108,6 +1170,22 @@ impl ComposeTest {
             if let Some(id) = container.id {
                 if let Err(e) = self.stop_id(&id).await {
                     println!("Failed to stop container id {:?}", id);
+                    result = Err(e);
+                }
+            }
+        }
+        result
+    }
+
+    /// restart all the containers part of the network
+    /// returns the last error, if any or Ok
+    pub async fn restart_network_containers(&self) -> Result<(), Error> {
+        let mut result = Ok(());
+        let containers = self.list_network_containers(&self.name).await?;
+        for container in containers {
+            if let Some(id) = container.id {
+                if let Err(e) = self.restart_id(&id).await {
+                    println!("Failed to restart container id {:?}", id);
                     result = Err(e);
                 }
             }

--- a/control-plane/agents/common/src/wrapper/v0/mod.rs
+++ b/control-plane/agents/common/src/wrapper/v0/mod.rs
@@ -97,6 +97,8 @@ pub enum SvcError {
         params: String,
         error: String,
     },
+    #[snafu(display("Failed to deserialise JsonRpc response"))]
+    JsonRpcDeserialise { source: serde_json::Error },
 }
 
 impl From<NotEnough> for SvcError {

--- a/control-plane/agents/jsongrpc/src/service.rs
+++ b/control-plane/agents/jsongrpc/src/service.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::unit_arg)]
 
 use ::rpc::mayastor::{JsonRpcReply, JsonRpcRequest};
-use common::wrapper::v0::{BusGetNode, SvcError};
+use common::wrapper::v0::{BusGetNode, JsonRpcDeserialise, SvcError};
 use mbus_api::message_bus::v0::{MessageBus, *};
 use rpc::mayastor::json_rpc_client::JsonRpcClient;
 use snafu::ResultExt;
@@ -15,7 +15,7 @@ impl JsonGrpcSvc {
     /// Generic JSON gRPC call issued to Mayastor using the JsonRpcClient.
     pub(super) async fn json_grpc_call(
         request: &JsonGrpcRequest,
-    ) -> Result<String, SvcError> {
+    ) -> Result<serde_json::Value, SvcError> {
         let node =
             MessageBus::get_node(&request.node)
                 .await
@@ -39,6 +39,7 @@ impl JsonGrpcSvc {
             })?
             .into_inner();
 
-        Ok(response.result)
+        Ok(serde_json::from_str(&response.result)
+            .context(JsonRpcDeserialise)?)
     }
 }

--- a/control-plane/deployer/Cargo.toml
+++ b/control-plane/deployer/Cargo.toml
@@ -8,7 +8,11 @@ edition = "2018"
 
 [[bin]]
 name = "deployer"
-path = "src/bin.rs"
+path = "bin/src/deployer.rs"
+
+[lib]
+name = "deployer_lib"
+path = "src/lib.rs"
 
 [dependencies]
 mbus_api = { path = "../mbus-api" }

--- a/control-plane/deployer/bin/src/deployer.rs
+++ b/control-plane/deployer/bin/src/deployer.rs
@@ -6,5 +6,5 @@ async fn main() -> Result<(), Error> {
     let cli_args = CliArgs::from_args();
     println!("Using options: {:?}", &cli_args);
 
-    cli_args.act().await
+    cli_args.execute().await
 }

--- a/control-plane/deployer/bin/src/deployer.rs
+++ b/control-plane/deployer/bin/src/deployer.rs
@@ -1,0 +1,10 @@
+use deployer_lib::{infra::Error, *};
+use structopt::StructOpt;
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    let cli_args = CliArgs::from_args();
+    println!("Using options: {:?}", &cli_args);
+
+    cli_args.act().await
+}

--- a/control-plane/deployer/src/infra/mayastor.rs
+++ b/control-plane/deployer/src/infra/mayastor.rs
@@ -38,10 +38,25 @@ impl ComponentAction for Mayastor {
         }
         Ok(())
     }
+    async fn wait_on(
+        &self,
+        options: &StartOptions,
+        cfg: &ComposeTest,
+    ) -> Result<(), Error> {
+        for i in 0 .. options.mayastors {
+            let mut hdl =
+                cfg.grpc_handle(&Self::name(i, options)).await.unwrap();
+            hdl.mayastor
+                .list_nexus(rpc::mayastor::Null {})
+                .await
+                .unwrap();
+        }
+        Ok(())
+    }
 }
 
 impl Mayastor {
-    fn name(i: u32, options: &StartOptions) -> String {
+    pub fn name(i: u32, options: &StartOptions) -> String {
         if options.mayastors == 1 {
             "mayastor".into()
         } else {

--- a/control-plane/deployer/src/infra/mod.rs
+++ b/control-plane/deployer/src/infra/mod.rs
@@ -1,16 +1,9 @@
 pub mod dns;
 mod empty;
-pub mod jaeger;
-pub mod mayastor;
-pub mod nats;
-pub mod rest;
-
-pub use ::nats::*;
-pub use dns::*;
-pub use empty::*;
-pub use jaeger::*;
-pub use mayastor::*;
-pub use rest::*;
+mod jaeger;
+mod mayastor;
+mod nats;
+mod rest;
 
 use super::StartOptions;
 use async_trait::async_trait;
@@ -20,25 +13,48 @@ use mbus_api::{
     Message,
 };
 use paste::paste;
-use std::{cmp::Ordering, str::FromStr};
+use std::{cmp::Ordering, convert::TryFrom, str::FromStr};
 use structopt::StructOpt;
 use strum::VariantNames;
 use strum_macros::{EnumVariantNames, ToString};
-pub(crate) type Error = Box<dyn std::error::Error>;
+
+/// Error type used by the deployer
+pub type Error = Box<dyn std::error::Error>;
 
 #[macro_export]
 macro_rules! impl_ctrlp_agents {
     ($($name:ident,)+) => {
+        /// List of Control Plane Agents to deploy
         #[derive(Debug, Clone)]
-        pub(crate) struct ControlPlaneAgents(Vec<ControlPlaneAgent>);
+        pub struct ControlPlaneAgents(Vec<ControlPlaneAgent>);
 
+        impl ControlPlaneAgents {
+            /// Get inner vector of ControlPlaneAgent's
+            pub fn into_inner(self) -> Vec<ControlPlaneAgent> {
+                self.0
+            }
+        }
+
+        /// All the Control Plane Agents
         #[derive(Debug, Clone, StructOpt, ToString, EnumVariantNames)]
         #[structopt(about = "Control Plane Agents")]
-        pub(crate) enum ControlPlaneAgent {
+        pub enum ControlPlaneAgent {
             Empty(Empty),
             $(
                 $name($name),
             )+
+        }
+
+        impl TryFrom<Vec<&str>> for ControlPlaneAgents {
+            type Error = String;
+
+            fn try_from(src: Vec<&str>) -> Result<Self, Self::Error> {
+                let mut vec = vec![];
+                for src in src {
+                    vec.push(ControlPlaneAgent::from_str(src)?);
+                }
+                Ok(ControlPlaneAgents(vec))
+            }
         }
 
         impl From<&ControlPlaneAgent> for Component {
@@ -86,6 +102,9 @@ macro_rules! impl_ctrlp_agents {
             async fn start(&self, _options: &StartOptions, cfg: &ComposeTest) -> Result<(), Error> {
                 let name = stringify!($name).to_ascii_lowercase();
                 cfg.start(&name).await?;
+                Ok(())
+            }
+            async fn wait_on(&self, _options: &StartOptions, _cfg: &ComposeTest) -> Result<(), Error> {
                 Liveness {}.request_on(ChannelVs::$name).await?;
                 Ok(())
             }
@@ -99,12 +118,14 @@ macro_rules! impl_ctrlp_agents {
 #[macro_export]
 macro_rules! impl_ctrlp_operators {
     ($($name:ident,)+) => {
+        /// List of Control Plane Operators to deploy
         #[derive(Debug, Clone)]
-        pub(crate) struct ControlPlaneOperators(Vec<ControlPlaneOperator>);
+        pub struct ControlPlaneOperators(Vec<ControlPlaneOperator>);
 
+        /// All the Control Plane Operators
         #[derive(Debug, Clone, StructOpt, ToString, EnumVariantNames)]
         #[structopt(about = "Control Plane Operators")]
-        pub(crate) enum ControlPlaneOperator {
+        pub enum ControlPlaneOperator {
             Empty(Empty),
             $(
                 $name(paste!{[<$name Op>]}),
@@ -198,10 +219,7 @@ macro_rules! impl_ctrlp_operators {
     };
 }
 
-pub(crate) fn build_error(
-    name: &str,
-    status: Option<i32>,
-) -> Result<(), Error> {
+pub fn build_error(name: &str, status: Option<i32>) -> Result<(), Error> {
     let make_error = |extra: &str| {
         let error = format!("Failed to build {}: {}", name, extra);
         std::io::Error::new(std::io::ErrorKind::Other, error)
@@ -216,19 +234,43 @@ pub(crate) fn build_error(
     }
 }
 
+impl Components {
+    pub async fn start(&self, cfg: &ComposeTest) -> Result<(), Error> {
+        let mut last_done = None;
+        for component in &self.0 {
+            if let Some(last_done) = last_done {
+                if component.boot_order() == last_done {
+                    continue;
+                }
+            }
+            let components = self
+                .0
+                .iter()
+                .filter(|c| c.boot_order() == component.boot_order());
+            for component in components {
+                component.start(&self.1, &cfg).await?;
+            }
+            last_done = Some(component.boot_order());
+        }
+        Ok(())
+    }
+}
+
 #[macro_export]
 macro_rules! impl_component {
     ($($name:ident,$order:literal,)+) => {
+        /// All the Control Plane Components
         #[derive(Debug, Clone, StructOpt, ToString, EnumVariantNames, Eq, PartialEq)]
         #[structopt(about = "Control Plane Components")]
-        pub(crate) enum Component {
+        pub enum Component {
             $(
                 $name($name),
             )+
         }
 
+        /// List of Control Plane Components to deploy
         #[derive(Debug, Clone)]
-        pub(crate) struct Components(Vec<Component>, StartOptions);
+        pub struct Components(Vec<Component>, StartOptions);
         impl BuilderConfigure for Components {
             fn configure(&self, cfg: Builder) -> Result<Builder, Error> {
                 let mut cfg = cfg;
@@ -240,13 +282,13 @@ macro_rules! impl_component {
         }
 
         impl Components {
-            pub(crate) fn push_generic_components(&mut self, name: &str, component: Component) {
+            pub fn push_generic_components(&mut self, name: &str, component: Component) {
                 if !ControlPlaneAgent::VARIANTS.iter().any(|&s| s == name) &&
                     !ControlPlaneOperator::VARIANTS.iter().any(|&s| &format!("{}Op", s) == name) {
                     self.0.push(component);
                 }
             }
-            pub(crate) fn new(options: StartOptions) -> Components {
+            pub fn new(options: StartOptions) -> Components {
                 let agents = options.agents.clone();
                 let operators = options.operators.clone().unwrap_or_default();
                 let mut components = agents
@@ -263,18 +305,35 @@ macro_rules! impl_component {
                 components.0.sort();
                 components
             }
-            pub(crate) async fn start(&self, cfg: &ComposeTest) -> Result<(), Error> {
+            pub async fn wait_on(
+                &self,
+                cfg: &ComposeTest,
+                timeout: std::time::Duration,
+            ) -> Result<(), Error> {
+                match tokio::time::timeout(timeout, self.wait_on_inner(cfg)).await {
+                    Ok(result) => result,
+                    Err(_) => {
+                        let error = format!("Timed out of {:?} expired", timeout);
+                        Err(std::io::Error::new(std::io::ErrorKind::TimedOut, error).into())
+                    }
+                }
+            }
+            async fn wait_on_inner(&self, cfg: &ComposeTest) -> Result<(), Error> {
                 for component in &self.0 {
-                    component.start(&self.1, cfg).await?;
+                    component.wait_on(&self.1, cfg).await?;
                 }
                 Ok(())
             }
         }
 
+        /// Trait to manage a component startup sequence
         #[async_trait]
-        pub(crate) trait ComponentAction {
+        pub trait ComponentAction {
             fn configure(&self, options: &StartOptions, cfg: Builder) -> Result<Builder, Error>;
             async fn start(&self, options: &StartOptions, cfg: &ComposeTest) -> Result<(), Error>;
+            async fn wait_on(&self, _options: &StartOptions, _cfg: &ComposeTest) -> Result<(), Error> {
+                Ok(())
+            }
         }
 
         #[async_trait]
@@ -289,6 +348,11 @@ macro_rules! impl_component {
                     $(Self::$name(obj) => obj.start(options, cfg).await,)+
                 }
             }
+            async fn wait_on(&self, options: &StartOptions, cfg: &ComposeTest) -> Result<(), Error> {
+                match self {
+                    $(Self::$name(obj) => obj.wait_on(options, cfg).await,)+
+                }
+            }
         }
 
         $(impl From<$name> for Component {
@@ -297,8 +361,9 @@ macro_rules! impl_component {
             }
         })+
 
+        /// Control Plane Component
         $(#[derive(Default, Debug, Clone, StructOpt, Eq, PartialEq)]
-        pub(crate) struct $name {})+
+        pub struct $name {})+
 
         impl Component {
             fn boot_order(&self) -> u32 {
@@ -328,16 +393,18 @@ macro_rules! impl_component {
 // from lower to high
 impl_component! {
     Empty,      0,
-    Dns,        0,
-    Jaeger,     0,
+    // Note: NATS needs to be the first to support usage of this library in cargo tests
+    // to make sure that the IP does not change between tests
     Nats,       0,
-    Rest,       1,
-    Mayastor,   1,
-    Node,       2,
-    Pool,       3,
-    Volume,     3,
-    JsonGrpc,   3,
-    NodeOp,     4,
+    Dns,        1,
+    Jaeger,     1,
+    Rest,       2,
+    Node,       3,
+    Pool,       4,
+    Volume,     4,
+    JsonGrpc,   4,
+    Mayastor,   5,
+    NodeOp,     6,
 }
 
 // Message Bus Control Plane Agents

--- a/control-plane/deployer/src/lib.rs
+++ b/control-plane/deployer/src/lib.rs
@@ -150,13 +150,13 @@ impl StartOptions {
 
 impl CliArgs {
     /// Act upon the requested action
-    pub async fn act(&self) -> Result<(), Error> {
-        self.action.act().await
+    pub async fn execute(&self) -> Result<(), Error> {
+        self.action.execute().await
     }
 }
 
 impl Action {
-    async fn act(&self) -> Result<(), Error> {
+    async fn execute(&self) -> Result<(), Error> {
         match self {
             Action::Start(options) => options.start(self).await,
             Action::Stop(options) => options.stop(self).await,

--- a/control-plane/mbus-api/Cargo.toml
+++ b/control-plane/mbus-api/Cargo.toml
@@ -23,6 +23,7 @@ tracing-futures = "0.2.4"
 tracing-subscriber = "0.2.0"
 paperclip = { version = "0.5.0", features = ["actix3"] }
 percent-encoding = "2.1.0"
+uuid = { version = "0.7", features = ["v4"] }
 
 [dev-dependencies]
 composer = { path = "../../composer" }

--- a/control-plane/mbus-api/src/mbus_nats.rs
+++ b/control-plane/mbus-api/src/mbus_nats.rs
@@ -31,15 +31,16 @@ pub async fn message_bus_init(server: String) {
 }
 
 /// Initialise the Nats Message Bus with Options
+/// IGNORES all but the first initialisation of NATS_MSG_BUS
 pub async fn message_bus_init_options(
     server: String,
     timeouts: TimeoutOptions,
 ) {
-    let nc = NatsMessageBus::new(&server, BusOptions::new(), timeouts).await;
-    NATS_MSG_BUS
-        .set(nc)
-        .ok()
-        .expect("Expect to be initialised only once");
+    if NATS_MSG_BUS.get().is_none() {
+        let nc =
+            NatsMessageBus::new(&server, BusOptions::new(), timeouts).await;
+        NATS_MSG_BUS.set(nc).ok();
+    }
 }
 
 /// Get the static `NatsMessageBus` as a boxed `MessageBus`

--- a/control-plane/mbus-api/src/message_bus/v0.rs
+++ b/control-plane/mbus-api/src/message_bus/v0.rs
@@ -243,7 +243,9 @@ pub trait MessageBusTrait: Sized {
 
     /// Generic JSON gRPC call
     #[tracing::instrument(level = "debug", err)]
-    async fn json_grpc_call(request: JsonGrpcRequest) -> BusResult<String> {
+    async fn json_grpc_call(
+        request: JsonGrpcRequest,
+    ) -> BusResult<serde_json::Value> {
         Ok(request.request().await?)
     }
 }

--- a/control-plane/mbus-api/src/v0.rs
+++ b/control-plane/mbus-api/src/v0.rs
@@ -296,7 +296,7 @@ impl Default for Filter {
 macro_rules! bus_impl_string_id_inner {
     ($Name:ident, $Doc:literal) => {
         #[doc = $Doc]
-        #[derive(Serialize, Deserialize, Default, Debug, Clone, Eq, PartialEq, Hash, Apiv2Schema)]
+        #[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq, Hash, Apiv2Schema)]
         pub struct $Name(String);
 
         impl std::fmt::Display for $Name {
@@ -340,10 +340,20 @@ macro_rules! bus_impl_string_id_inner {
 macro_rules! bus_impl_string_id {
     ($Name:ident, $Doc:literal) => {
         bus_impl_string_id_inner!($Name, $Doc);
+        impl Default for $Name {
+            /// Generates new blank identifier
+            fn default() -> Self {
+                $Name(uuid::Uuid::default().to_string())
+            }
+        }
         impl $Name {
             /// Build Self from a string trait id
             pub fn from<T: Into<String>>(id: T) -> Self {
                 $Name(id.into())
+            }
+            /// Generates new random identifier
+            pub fn new() -> Self {
+                $Name(uuid::Uuid::new_v4().to_string())
             }
         }
     };
@@ -352,6 +362,11 @@ macro_rules! bus_impl_string_id {
 macro_rules! bus_impl_string_id_percent_decoding {
     ($Name:ident, $Doc:literal) => {
         bus_impl_string_id_inner!($Name, $Doc);
+        impl Default for $Name {
+            fn default() -> Self {
+                $Name("".to_string())
+            }
+        }
         impl $Name {
             /// Build Self from a string trait id
             pub fn from<T: Into<String>>(id: T) -> Self {

--- a/control-plane/mbus-api/src/v0.rs
+++ b/control-plane/mbus-api/src/v0.rs
@@ -3,6 +3,7 @@ use super::*;
 use paperclip::actix::Apiv2Schema;
 use percent_encoding::percent_decode_str;
 use serde::{Deserialize, Serialize};
+use serde_json::value::Value;
 use std::{cmp::Ordering, fmt::Debug};
 use strum_macros::{EnumString, ToString};
 
@@ -974,4 +975,5 @@ pub struct JsonGrpcRequest {
     /// parameters to be passed to the above method
     pub params: JsonGrpcParams,
 }
-bus_impl_message_all!(JsonGrpcRequest, JsonGrpc, String, JsonGrpc);
+
+bus_impl_message_all!(JsonGrpcRequest, JsonGrpc, Value, JsonGrpc);

--- a/control-plane/rest/service/src/v0/jsongrpc.rs
+++ b/control-plane/rest/service/src/v0/jsongrpc.rs
@@ -2,7 +2,6 @@
 //! These methods are typically used to control SPDK directly.
 
 use super::*;
-use mbus_api::v0::JsonGrpcRequest;
 
 /// Configure the functions that this service supports.
 pub(crate) fn configure(cfg: &mut paperclip::actix::web::ServiceConfig) {
@@ -22,8 +21,8 @@ pub(crate) fn configure(cfg: &mut paperclip::actix::web::ServiceConfig) {
 #[put("/v0", "/nodes/{node}/jsongrpc/{method}", tags(JsonGrpc))]
 async fn json_grpc_call(
     web::Path((node, method)): web::Path<(NodeId, JsonGrpcMethod)>,
-    body: web::Json<serde_json::Value>,
-) -> Result<Json<String>, RestError> {
+    body: web::Json<JsonGeneric>,
+) -> Result<web::Json<JsonGeneric>, RestError> {
     RestRespond::result(
         MessageBus::json_grpc_call(JsonGrpcRequest {
             node,
@@ -32,4 +31,5 @@ async fn json_grpc_call(
         })
         .await,
     )
+    .map(|x| web::Json(JsonGeneric::from(x.into_inner())))
 }

--- a/control-plane/rest/service/src/v0/mod.rs
+++ b/control-plane/rest/service/src/v0/mod.rs
@@ -11,7 +11,7 @@ pub mod replicas;
 pub mod swagger_ui;
 pub mod volumes;
 
-use rest_client::versions::v0::*;
+use rest_client::{versions::v0::*, JsonGeneric};
 
 use actix_service::ServiceFactory;
 use actix_web::{

--- a/control-plane/tests/Cargo.toml
+++ b/control-plane/tests/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "ctrlp-tests"
+version = "0.1.0"
+authors = ["Tiago Castro <tiago.castro@mayadata.io>"]
+edition = "2018"
+description = "Control Plane 'Compose' Tests"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+
+[dev-dependencies]
+composer = { path = "../../composer" }
+deployer = { path = "../deployer" }
+rest = { path = "../rest" }
+actix-rt = "1.1.1"
+opentelemetry-jaeger = { version = "0.10", features = ["tokio"] }
+tracing-opentelemetry = "0.10.0"
+tracing = "0.1"
+opentelemetry = "0.11.2"
+actix-web-opentelemetry = "0.9.0"
+anyhow = "1.0.32"

--- a/control-plane/tests/tests/common/mod.rs
+++ b/control-plane/tests/tests/common/mod.rs
@@ -1,0 +1,329 @@
+use composer::*;
+use deployer_lib::{
+    infra::{Components, Error, Mayastor},
+    *,
+};
+use opentelemetry::{
+    global,
+    sdk::{propagation::TraceContextPropagator, trace::Tracer},
+};
+
+use opentelemetry_jaeger::Uninstall;
+pub use rest_client::{
+    versions::v0::{self, RestClient},
+    ActixRestClient,
+};
+
+#[actix_rt::test]
+#[ignore]
+async fn smoke_test() {
+    // make sure the cluster can bootstrap properly
+    let _cluster = ClusterBuilder::builder()
+        .build()
+        .await
+        .expect("Should bootstrap the cluster!");
+}
+
+/// Default options to create a cluster
+pub fn default_options() -> StartOptions {
+    StartOptions::default()
+        .with_agents(default_agents().split(',').collect())
+        .with_jaeger(true)
+        .with_mayastors(1)
+        .with_show_info(true)
+        .with_cluster_name("rest_cluster")
+}
+
+/// Cluster with the composer, the rest client and the jaeger pipeline#
+#[allow(unused)]
+pub struct Cluster {
+    composer: ComposeTest,
+    rest_client: ActixRestClient,
+    jaeger: (Tracer, Uninstall),
+    builder: ClusterBuilder,
+}
+
+impl Cluster {
+    /// node id for `index`
+    pub fn node(&self, index: u32) -> v0::NodeId {
+        Mayastor::name(index, &self.builder.opts).into()
+    }
+
+    /// pool id for `pool` index on `node` index
+    pub fn pool(&self, node: u32, pool: u32) -> v0::PoolId {
+        format!("{}-pool-{}", self.node(node), pool + 1).into()
+    }
+
+    /// replica id with index for `pool` index and `replica` index
+    pub fn replica(pool: u32, replica: u32) -> v0::ReplicaId {
+        let mut uuid = v0::ReplicaId::default().to_string();
+        let _ = uuid.drain(27 .. uuid.len());
+        format!("{}{:01x}{:08x}", uuid, pool as u8, replica).into()
+    }
+
+    /// rest client v0
+    pub fn rest_v0(&self) -> impl RestClient {
+        self.rest_client.v0()
+    }
+
+    /// New cluster
+    async fn new(
+        trace_rest: bool,
+        components: Components,
+        composer: ComposeTest,
+        jaeger: (Tracer, Uninstall),
+    ) -> Result<Cluster, Error> {
+        let rest_client =
+            ActixRestClient::new("https://localhost:8080", trace_rest).unwrap();
+
+        components
+            .start_wait(&composer, std::time::Duration::from_secs(10))
+            .await?;
+
+        let cluster = Cluster {
+            composer,
+            rest_client,
+            jaeger,
+            builder: ClusterBuilder::builder(),
+        };
+
+        Ok(cluster)
+    }
+}
+
+fn option_str<F: ToString>(input: Option<F>) -> String {
+    match input {
+        Some(input) => input.to_string(),
+        None => "?".into(),
+    }
+}
+
+/// Run future and compare result with what's expected
+/// Expected result should be in the form Result<TestValue,TestValue>
+/// where TestValue is a useful value which will be added to the returned error
+/// string Eg, testing the replica share protocol:
+/// test_result(Ok(Nvmf), async move { ... })
+/// test_result(Err(NBD), async move { ... })
+pub async fn test_result<F, O, E, T, R>(
+    expected: &Result<O, E>,
+    future: F,
+) -> Result<(), anyhow::Error>
+where
+    F: std::future::Future<Output = Result<T, R>>,
+    R: std::fmt::Display,
+    E: std::fmt::Debug,
+    O: std::fmt::Debug,
+{
+    match future.await {
+        Ok(_) if expected.is_ok() => Ok(()),
+        Err(_) if expected.is_err() => Ok(()),
+        Err(error) => Err(anyhow::anyhow!(
+            "Expected '{:#?}' but failed with '{}'!",
+            expected,
+            error
+        )),
+        Ok(_) => {
+            Err(anyhow::anyhow!("Expected '{:#?}' but succeeded!", expected))
+        }
+    }
+}
+
+#[macro_export]
+macro_rules! result_either {
+    ($test:expr) => {
+        match $test {
+            Ok(v) => v,
+            Err(v) => v,
+        }
+    };
+}
+
+/// Builder for the Cluster
+pub struct ClusterBuilder {
+    opts: StartOptions,
+    pools: u32,
+    replicas: (u32, u64, v0::Protocol),
+    trace: bool,
+}
+
+impl ClusterBuilder {
+    /// Cluster Builder with default options
+    pub fn builder() -> Self {
+        ClusterBuilder {
+            opts: default_options(),
+            pools: 0,
+            replicas: (0, 0, v0::Protocol::Off),
+            trace: true,
+        }
+    }
+    /// Update the start options
+    pub fn with_options<F>(mut self, set: F) -> Self
+    where
+        F: Fn(StartOptions) -> StartOptions,
+    {
+        self.opts = set(self.opts);
+        self
+    }
+    /// Enable/Disable jaeger tracing
+    pub fn with_tracing(mut self, enabled: bool) -> Self {
+        self.trace = enabled;
+        self
+    }
+    /// Add `count` malloc pools (100MiB size) to each node
+    pub fn with_pools(mut self, count: u32) -> Self {
+        self.pools = count;
+        self
+    }
+    /// Add `count` replicas to each node per pool
+    pub fn with_replicas(
+        mut self,
+        count: u32,
+        size: u64,
+        share: v0::Protocol,
+    ) -> Self {
+        self.replicas = (count, size, share);
+        self
+    }
+    /// Build into the resulting Cluster using a composer closure, eg:
+    /// .compose_build(|c| c.with_logs(false))
+    pub async fn compose_build<F>(self, set: F) -> Result<Cluster, Error>
+    where
+        F: Fn(Builder) -> Builder,
+    {
+        let (components, composer) = self.build_prepare()?;
+        let composer = set(composer);
+        let mut cluster = self.new_cluster(components, composer).await?;
+        cluster.builder = self;
+        Ok(cluster)
+    }
+    /// Build into the resulting Cluster
+    pub async fn build(self) -> Result<Cluster, Error> {
+        let (components, composer) = self.build_prepare()?;
+        let mut cluster = self.new_cluster(components, composer).await?;
+        cluster.builder = self;
+        Ok(cluster)
+    }
+    fn build_prepare(&self) -> Result<(Components, Builder), Error> {
+        let components = Components::new(self.opts.clone());
+        let composer = Builder::new()
+            .name(&self.opts.cluster_name)
+            .configure(components.clone())?
+            .with_base_image(self.opts.base_image.clone())
+            .autorun(false)
+            .with_default_tracing()
+            .with_clean(true)
+            // test script will clean up containers if ran on CI/CD
+            .with_clean_on_panic(false)
+            .with_logs(true);
+        Ok((components, composer))
+    }
+    async fn new_cluster(
+        &self,
+        components: Components,
+        compose_builder: Builder,
+    ) -> Result<Cluster, Error> {
+        global::set_text_map_propagator(TraceContextPropagator::new());
+        let jaeger = opentelemetry_jaeger::new_pipeline()
+            .with_service_name("tests-client")
+            .install()
+            .unwrap();
+
+        let composer = compose_builder.build().await?;
+        let cluster =
+            Cluster::new(self.trace, components, composer, jaeger).await?;
+
+        if self.opts.show_info {
+            for container in cluster.composer.list_cluster_containers().await? {
+                let networks =
+                    container.network_settings.unwrap().networks.unwrap();
+                let ip = networks
+                    .get(&self.opts.cluster_name)
+                    .unwrap()
+                    .ip_address
+                    .clone();
+                tracing::debug!(
+                    "{:?} [{}] {}",
+                    container.names.clone().unwrap_or_default(),
+                    ip.clone().unwrap_or_default(),
+                    option_str(container.command.clone())
+                );
+            }
+        }
+        for pool in &self.pools() {
+            cluster
+                .rest_v0()
+                .create_pool(v0::CreatePool {
+                    node: pool.node.clone().into(),
+                    id: pool.id(),
+                    disks: vec![pool.disk()],
+                })
+                .await
+                .unwrap();
+            for replica in &pool.replicas {
+                cluster
+                    .rest_v0()
+                    .create_replica(replica.clone())
+                    .await
+                    .unwrap();
+            }
+        }
+
+        Ok(cluster)
+    }
+    fn pools(&self) -> Vec<Pool> {
+        let mut pools = vec![];
+        for pool_index in 0 .. self.pools {
+            for node in 0 .. self.opts.mayastors {
+                let mut pool = Pool {
+                    node: Mayastor::name(node, &self.opts),
+                    kind: PoolKind::Malloc,
+                    size_mb: 100,
+                    index: (pool_index + 1) as u32,
+                    replicas: vec![],
+                };
+                for replica_index in 0 .. self.replicas.0 {
+                    pool.replicas.push(v0::CreateReplica {
+                        node: pool.node.clone().into(),
+                        uuid: Cluster::replica(pool_index, replica_index),
+                        pool: pool.id(),
+                        size: self.replicas.1,
+                        thin: false,
+                        share: self.replicas.2.clone(),
+                    });
+                }
+                pools.push(pool);
+            }
+        }
+        pools
+    }
+}
+
+#[allow(dead_code)]
+enum PoolKind {
+    Malloc,
+    Aio,
+    Uring,
+    Nvmf,
+}
+
+struct Pool {
+    node: String,
+    kind: PoolKind,
+    size_mb: u32,
+    index: u32,
+    replicas: Vec<v0::CreateReplica>,
+}
+
+impl Pool {
+    fn id(&self) -> v0::PoolId {
+        format!("{}-pool-{}", self.node, self.index).into()
+    }
+    fn disk(&self) -> String {
+        match self.kind {
+            PoolKind::Malloc => {
+                format!("malloc:///disk{}?size_mb={}", self.index, self.size_mb)
+            }
+            _ => panic!("kind not supported!"),
+        }
+    }
+}

--- a/control-plane/tests/tests/nexus.rs
+++ b/control-plane/tests/tests/nexus.rs
@@ -1,0 +1,25 @@
+#![feature(allow_fail)]
+
+pub mod common;
+use common::*;
+
+#[actix_rt::test]
+async fn create_nexus() {
+    let cluster = ClusterBuilder::builder()
+        .with_pools(1)
+        .with_replicas(2, 5 * 1024 * 1024, v0::Protocol::Off)
+        .build()
+        .await
+        .unwrap();
+
+    cluster
+        .rest_v0()
+        .create_nexus(v0::CreateNexus {
+            node: cluster.node(0),
+            uuid: v0::NexusId::new(),
+            size: 10 * 1024 * 1024,
+            children: vec!["malloc:///disk?size_mb=100".into()],
+        })
+        .await
+        .unwrap();
+}

--- a/control-plane/tests/tests/pools.rs
+++ b/control-plane/tests/tests/pools.rs
@@ -1,0 +1,218 @@
+#![feature(allow_fail)]
+
+pub mod common;
+use common::*;
+
+#[actix_rt::test]
+async fn create_pool_malloc() {
+    let cluster = ClusterBuilder::builder().build().await.unwrap();
+    cluster
+        .rest_v0()
+        .create_pool(v0::CreatePool {
+            node: "mayastor".into(),
+            id: "pooloop".into(),
+            disks: vec!["malloc:///disk?size_mb=100".into()],
+        })
+        .await
+        .unwrap();
+}
+
+#[actix_rt::test]
+async fn create_pool_with_missing_disk() {
+    let cluster = ClusterBuilder::builder().build().await.unwrap();
+
+    cluster
+        .rest_v0()
+        .create_pool(v0::CreatePool {
+            node: "mayastor".into(),
+            id: "pooloop".into(),
+            disks: vec!["/dev/c/3po".into()],
+        })
+        .await
+        .expect_err("Device should not exist");
+}
+
+#[actix_rt::test]
+async fn create_pool_with_existing_disk() {
+    let cluster = ClusterBuilder::builder().build().await.unwrap();
+
+    cluster
+        .rest_v0()
+        .create_pool(v0::CreatePool {
+            node: "mayastor".into(),
+            id: "pooloop".into(),
+            disks: vec!["malloc:///disk?size_mb=100".into()],
+        })
+        .await
+        .unwrap();
+
+    cluster
+        .rest_v0()
+        .create_pool(v0::CreatePool {
+            node: "mayastor".into(),
+            id: "pooloop-new".into(),
+            disks: vec!["malloc:///disk?size_mb=100".into()],
+        })
+        .await
+        .expect_err("Disk should be used by another pool");
+
+    cluster
+        .rest_v0()
+        .destroy_pool(v0::DestroyPool {
+            node: "mayastor".into(),
+            id: "pooloop".into(),
+        })
+        .await
+        .unwrap();
+
+    cluster
+        .rest_v0()
+        .create_pool(v0::CreatePool {
+            node: "mayastor".into(),
+            id: "pooloop-new".into(),
+            disks: vec!["malloc:///disk?size_mb=100".into()],
+        })
+        .await
+        .expect("Should now be able to create the new pool");
+}
+
+#[actix_rt::test]
+async fn create_pool_idempotent() {
+    let cluster = ClusterBuilder::builder().build().await.unwrap();
+
+    cluster
+        .rest_v0()
+        .create_pool(v0::CreatePool {
+            node: "mayastor".into(),
+            id: "pooloop".into(),
+            disks: vec!["malloc:///disk?size_mb=100".into()],
+        })
+        .await
+        .unwrap();
+
+    cluster
+        .rest_v0()
+        .create_pool(v0::CreatePool {
+            node: "mayastor".into(),
+            id: "pooloop".into(),
+            disks: vec!["malloc:///disk?size_mb=100".into()],
+        })
+        .await
+        .unwrap();
+}
+
+/// FIXME: CAS-710
+#[actix_rt::test]
+#[allow_fail]
+async fn create_pool_idempotent_same_disk_different_query() {
+    let cluster = ClusterBuilder::builder()
+        // don't log whilst we have the allow_fail
+        .compose_build(|c| c.with_logs(false))
+        .await
+        .unwrap();
+
+    cluster
+        .rest_v0()
+        .create_pool(v0::CreatePool {
+            node: "mayastor".into(),
+            id: "pooloop".into(),
+            disks: vec!["malloc:///disk?size_mb=100&blk_size=512".into()],
+        })
+        .await
+        .unwrap();
+
+    cluster
+        .rest_v0()
+        .create_pool(v0::CreatePool {
+            node: "mayastor".into(),
+            id: "pooloop".into(),
+            disks: vec!["malloc:///disk?size_mb=200&blk_size=4096".into()],
+        })
+        .await
+        .expect_err("Different query not allowed!");
+}
+
+#[actix_rt::test]
+async fn create_pool_idempotent_different_nvmf_host() {
+    let cluster = ClusterBuilder::builder()
+        .with_options(|opts| opts.with_mayastors(3))
+        .build()
+        .await
+        .unwrap();
+
+    cluster
+        .rest_v0()
+        .create_pool(v0::CreatePool {
+            node: "mayastor-1".into(),
+            id: "pooloop-1".into(),
+            disks: vec!["malloc:///disk?size_mb=100".into()],
+        })
+        .await
+        .unwrap();
+
+    let replica1 = cluster
+        .rest_v0()
+        .create_replica(v0::CreateReplica {
+            node: "mayastor-1".into(),
+            uuid: "0aa4a830-a971-4e96-a97c-15c39dd8f162".into(),
+            pool: "pooloop-1".into(),
+            size: 10 * 1024 * 1024,
+            thin: true,
+            share: v0::Protocol::Nvmf,
+        })
+        .await
+        .unwrap();
+
+    cluster
+        .rest_v0()
+        .create_pool(v0::CreatePool {
+            node: "mayastor-2".into(),
+            id: "pooloop-2".into(),
+            disks: vec!["malloc:///disk?size_mb=100".into()],
+        })
+        .await
+        .unwrap();
+
+    let replica2 = cluster
+        .rest_v0()
+        .create_replica(v0::CreateReplica {
+            node: "mayastor-2".into(),
+            uuid: "0aa4a830-a971-4e96-a97c-15c39dd8f162".into(),
+            pool: "pooloop-2".into(),
+            size: 10 * 1024 * 1024,
+            thin: true,
+            share: v0::Protocol::Nvmf,
+        })
+        .await
+        .unwrap();
+
+    cluster
+        .rest_v0()
+        .create_pool(v0::CreatePool {
+            node: "mayastor-3".into(),
+            id: "pooloop".into(),
+            disks: vec![replica1.uri.clone()],
+        })
+        .await
+        .unwrap();
+
+    cluster
+        .rest_v0()
+        .create_pool(v0::CreatePool {
+            node: "mayastor-3".into(),
+            id: "pooloop".into(),
+            disks: vec![replica1.uri],
+        })
+        .await
+        .unwrap();
+
+    cluster
+        .rest_v0()
+        .create_pool(v0::CreatePool {
+            node: "mayastor-3".into(),
+            id: "pooloop".into(),
+            disks: vec![replica2.uri],
+        })
+        .await
+        .expect_err("Different host!");
+}

--- a/control-plane/tests/tests/replicas.rs
+++ b/control-plane/tests/tests/replicas.rs
@@ -1,0 +1,131 @@
+#![feature(allow_fail)]
+
+pub mod common;
+use common::*;
+
+// FIXME: CAS-721
+#[actix_rt::test]
+#[allow_fail]
+async fn create_replica() {
+    let cluster = ClusterBuilder::builder()
+        .with_pools(1)
+        // don't log whilst we have the allow_fail
+        .compose_build(|c| c.with_logs(false))
+        .await
+        .unwrap();
+
+    let replica = v0::CreateReplica {
+        node: cluster.node(0),
+        uuid: Default::default(),
+        pool: cluster.pool(0, 0),
+        size: 5 * 1024 * 1024,
+        thin: true,
+        share: v0::Protocol::Off,
+    };
+    let created_replica = cluster
+        .rest_v0()
+        .create_replica(replica.clone())
+        .await
+        .unwrap();
+    assert_eq!(created_replica.node, replica.node);
+    assert_eq!(created_replica.uuid, replica.uuid);
+    assert_eq!(created_replica.pool, replica.pool);
+
+    // todo: why is this not the same?
+    // assert_eq!(created_replica.size, replica.size);
+    // fixme: replicas are always created without thin provisioning
+    assert_eq!(created_replica.thin, replica.thin);
+    assert_eq!(created_replica.share, replica.share);
+}
+
+#[actix_rt::test]
+async fn create_replica_protocols() {
+    let cluster = ClusterBuilder::builder()
+        .with_pools(1)
+        .build()
+        .await
+        .unwrap();
+
+    let protocols = vec![
+        Err(v0::Protocol::Nbd),
+        Err(v0::Protocol::Iscsi),
+        Ok(v0::Protocol::Nvmf),
+        Ok(v0::Protocol::Off),
+    ];
+
+    for test in protocols {
+        let protocol = result_either!(&test);
+        test_result(
+            &test,
+            cluster.rest_v0().create_replica(v0::CreateReplica {
+                node: cluster.node(0),
+                uuid: v0::ReplicaId::new(),
+                pool: cluster.pool(0, 0),
+                size: 5 * 1024 * 1024,
+                thin: true,
+                share: protocol.clone(),
+            }),
+        )
+        .await
+        .unwrap();
+    }
+}
+
+// FIXME: CAS-731
+#[actix_rt::test]
+#[allow_fail]
+async fn create_replica_idempotent_different_sizes() {
+    let cluster = ClusterBuilder::builder()
+        .with_pools(1)
+        // don't log whilst we have the allow_fail
+        .compose_build(|c| c.with_logs(false))
+        .await
+        .unwrap();
+
+    let uuid = v0::ReplicaId::new();
+    let size = 5 * 1024 * 1024;
+    let replica = cluster
+        .rest_v0()
+        .create_replica(v0::CreateReplica {
+            node: cluster.node(0),
+            uuid: uuid.clone(),
+            pool: cluster.pool(0, 0),
+            size,
+            thin: false,
+            share: v0::Protocol::Off,
+        })
+        .await
+        .unwrap();
+    assert_eq!(&replica.uuid, &uuid);
+
+    cluster
+        .rest_v0()
+        .create_replica(v0::CreateReplica {
+            node: cluster.node(0),
+            uuid: uuid.clone(),
+            pool: cluster.pool(0, 0),
+            size,
+            thin: replica.thin,
+            share: v0::Protocol::Off,
+        })
+        .await
+        .unwrap();
+
+    let sizes = vec![Ok(size), Err(size / 2), Err(size * 2)];
+    for test in sizes {
+        let size = result_either!(test);
+        test_result(
+            &test,
+            cluster.rest_v0().create_replica(v0::CreateReplica {
+                node: cluster.node(0),
+                uuid: v0::ReplicaId::new(),
+                pool: cluster.pool(0, 0),
+                size,
+                thin: replica.thin,
+                share: v0::Protocol::Off,
+            }),
+        )
+        .await
+        .unwrap();
+    }
+}

--- a/mayastor/src/lvs/error.rs
+++ b/mayastor/src/lvs/error.rs
@@ -68,4 +68,6 @@ pub enum Error {
     SyncProperty { source: Errno, name: String },
     #[snafu(display("invalid property value: {}", name))]
     Property { source: Errno, name: String },
+    #[snafu(display("invalid replica share protocol value: {}", value))]
+    ReplicaShareProtocol { value: i32 },
 }

--- a/nix/pkgs/control-plane/cargo-project.nix
+++ b/nix/pkgs/control-plane/cargo-project.nix
@@ -29,7 +29,7 @@ let
   buildProps = rec {
     name = "control-plane";
     #cargoSha256 = "0000000000000000000000000000000000000000000000000000";
-    cargoSha256 = "02qf9pnja4cn31qnzawbrqhny88ja19sqm68zy12ly4vmg6dd3lf";
+    cargoSha256 = "1iqmrl8qm8nw1hg219kdyxd1zk9c58p1avymjis3snxnlagafx37";
     inherit version;
     src = whitelistSource ../../../. (pkgs.callPackage ../mayastor { }).src_list;
     cargoBuildFlags = [ "-p mbus_api" "-p agents" "-p rest" "-p operators" ];

--- a/nix/pkgs/mayastor/default.nix
+++ b/nix/pkgs/mayastor/default.nix
@@ -56,7 +56,7 @@ let
   buildProps = rec {
     name = "mayastor";
     #cargoSha256 = "0000000000000000000000000000000000000000000000000000";
-    cargoSha256 = "1c5zwaivwsx7gznjvsd0gfhbvjji5q1qbjacdm6vfapqv9i79yfn";
+    cargoSha256 = "1ynd6fmdr89f0g9vqsbz2rfl6ld23qv92lqcma5m4xcyhblbv5g0";
     inherit version;
     src = whitelistSource ../../../. src_list;
     LIBCLANG_PATH = "${llvmPackages.libclang}/lib";

--- a/scripts/ctrlp-cargo-test.sh
+++ b/scripts/ctrlp-cargo-test.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-SCRIPTDIR=$(dirname "$0")
-
 cleanup_handler() {
   for c in $(docker ps -a --filter "label=io.mayastor.test.name" --format '{{.ID}}') ; do
     docker kill "$c" || true
@@ -17,9 +15,8 @@ trap cleanup_handler ERR INT QUIT TERM HUP
 
 set -euxo pipefail
 export PATH=$PATH:${HOME}/.cargo/bin
-( cd jsonrpc && cargo test )
 # test dependencies
 cargo build --bins
-( cd mayastor && cargo test -- --test-threads=1 )
-( cd nvmeadm && cargo test )
-"$SCRIPTDIR/ctrlp-cargo-test.sh"
+for test in composer agents rest ctrlp-tests; do
+    cargo test -p ${test} -- --test-threads=1
+done


### PR DESCRIPTION
This is the initial bits of a new test project which leverages the new
control plane to test mayastor.
It has already revealed a few issues.

Make replica share protocol conversion from gRPC fallible as it was
causing mayastor to crash on the REST tests.

Split the deployer into a library and a binary allowing for the library
 to be used by the coming rest test project.

Allow for a JSON Value to traverse the stack allowing swagger to
 display it as JSON and with colours.
Also make sure the rest client returns the correct errors.