### PR TITLE
feat: unify mayastor-client address/port flags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2351,6 +2351,7 @@ dependencies = [
  "futures",
  "futures-timer",
  "git-version",
+ "http 0.1.21",
  "io-uring",
  "ioctl-gen",
  "ipnetwork",

--- a/mayastor/Cargo.toml
+++ b/mayastor/Cargo.toml
@@ -40,7 +40,7 @@ async-trait = "0.1.36"
 atty = "0.2"
 bincode = "1.2"
 byte-unit = "3.0.1"
-bytes = "0.4.12"
+bytes = "0.4"  # We are blocked on updating http until we update tonic.
 chrono = "0.4"
 clap = "2.33.0"
 colored_json = "*"
@@ -51,6 +51,7 @@ env_logger = "0.7"
 futures = "0.3"
 futures-timer = "2.0"
 git-version = "0.3"
+http = "0.1" # We are blocked on updating http until we update tonic.
 io-uring = "0.4.0"
 ioctl-gen = "0.1.1"
 jsonrpc = { path = "../jsonrpc"}

--- a/nix/pkgs/mayastor/default.nix
+++ b/nix/pkgs/mayastor/default.nix
@@ -56,7 +56,7 @@ let
   buildProps = rec {
     name = "mayastor";
     #cargoSha256 = "0000000000000000000000000000000000000000000000000000";
-    cargoSha256 = "1m0n418hp4h3j32j632l7pf2kl4pwzbzssx7h0wh5m90wsh41cy4";
+    cargoSha256 = "q2Dp9IuwxHSwZEkEiIc49M4d/BI/GyS+lnTrs4TKRs8=";
     inherit version;
     src = whitelistSource ../../../. src_list;
     LIBCLANG_PATH = "${llvmPackages.libclang}/lib";

--- a/test/grpc/test_cli.js
+++ b/test/grpc/test_cli.js
@@ -28,7 +28,7 @@ const CLIENT_CMD = path.join(
   'debug',
   'mayastor-client'
 );
-const EGRESS_CMD = CLIENT_CMD + ' -p ' + EGRESS_PORT;
+const EGRESS_CMD = CLIENT_CMD + ' --bind 127.0.0.1:' + EGRESS_PORT;
 
 let mayastorMockServer;
 


### PR DESCRIPTION
Unifies the `-a` and `-p` flags to a `-h` flag which
takes a full url (optionally) without a scheme.

Further, this makes the flag global, so it can be used
in any position:

```bash
RUST_BACKTRACE=1
RUST_LOG=mayastor=trace
cargo run -- nexus list
cargo run -- --bind 127.0.0.1 nexus list
cargo run -- -b 127.0.0.1:10124 nexus list
cargo run -- --bind http://127.0.0.1:10124 nexus list
cargo run -- --bind http://127.0.0.1 nexus list
cargo run -- nexus list --bind 127.0.0.1
cargo run -- nexus list --bind 127.0.0.1:10124
cargo run -- nexus list -b http://127.0.0.1:10124
cargo run -- nexus list --bind http://127.0.0.1
```

Closes #707.