### PR TITLE
chore(release): Revert k8s deployment config files

### DIFF
--- a/deploy/csi-daemonset.yaml
+++ b/deploy/csi-daemonset.yaml
@@ -30,7 +30,7 @@ spec:
       # the same.
       containers:
       - name: mayastor-csi
-        image: mayadata/mayastor-csi:v0.7.1
+        image: mayadata/mayastor-csi:develop
         imagePullPolicy: Always
         # we need privileged because we mount filesystems and use mknod
         securityContext:

--- a/deploy/mayastor-daemonset.yaml
+++ b/deploy/mayastor-daemonset.yaml
@@ -33,7 +33,7 @@ spec:
         command: ['sh', '-c', 'until nc -vz nats 4222; do echo "Waiting for message bus..."; sleep 1; done;']
       containers:
       - name: mayastor
-        image: mayadata/mayastor:v0.7.1
+        image: mayadata/mayastor:develop
         imagePullPolicy: Always
         env:
         - name: MY_NODE_NAME

--- a/deploy/moac-deployment.yaml
+++ b/deploy/moac-deployment.yaml
@@ -45,7 +45,7 @@ spec:
               mountPath: /var/lib/csi/sockets/pluginproxy/
 
         - name: moac
-          image: mayadata/moac:v0.7.1
+          image: mayadata/moac:develop
           imagePullPolicy: Always
           args:
             - "--csi-address=$(CSI_ENDPOINT)"


### PR DESCRIPTION
Set mayastor image tags back to 'develop', after merging back
from master branch following GitFlow release of v0.7.1