### PR TITLE
feat(rest): expose list_block_devices method

### DIFF
--- a/control-plane/agents/common/src/wrapper/v0/mod.rs
+++ b/control-plane/agents/common/src/wrapper/v0/mod.rs
@@ -143,6 +143,7 @@ macro_rules! impl_no_nexus {
     };
 }
 
+pub mod msg_translation;
 mod node_traits;
 mod pool;
 mod volume;

--- a/control-plane/agents/common/src/wrapper/v0/msg_translation.rs
+++ b/control-plane/agents/common/src/wrapper/v0/msg_translation.rs
@@ -1,0 +1,271 @@
+//! Converts rpc messages to message bus messages and vice versa.
+
+use mbus_api::{
+    v0 as mbus,
+    v0::{ChildState, NexusState, Protocol},
+};
+use rpc::mayastor as rpc;
+
+/// Trait for converting rpc messages to message bus messages.
+pub trait RpcToMessageBus {
+    /// Message bus message type.
+    type BusMessage;
+    /// Conversion of rpc message to message bus message.
+    fn to_mbus(&self) -> Self::BusMessage;
+}
+
+impl RpcToMessageBus for rpc::block_device::Partition {
+    type BusMessage = mbus::Partition;
+    fn to_mbus(&self) -> Self::BusMessage {
+        Self::BusMessage {
+            parent: self.parent.clone(),
+            number: self.number,
+            name: self.name.clone(),
+            scheme: self.scheme.clone(),
+            typeid: self.typeid.clone(),
+            uuid: self.uuid.clone(),
+        }
+    }
+}
+
+impl RpcToMessageBus for rpc::block_device::Filesystem {
+    type BusMessage = mbus::Filesystem;
+    fn to_mbus(&self) -> Self::BusMessage {
+        Self::BusMessage {
+            fstype: self.fstype.clone(),
+            label: self.label.clone(),
+            uuid: self.uuid.clone(),
+            mountpoint: self.mountpoint.clone(),
+        }
+    }
+}
+
+/// Node Agent Conversions
+
+impl RpcToMessageBus for rpc::BlockDevice {
+    type BusMessage = mbus::BlockDevice;
+    fn to_mbus(&self) -> Self::BusMessage {
+        Self::BusMessage {
+            devname: self.devname.clone(),
+            devtype: self.devtype.clone(),
+            devmajor: self.devmajor,
+            devminor: self.devminor,
+            model: self.model.clone(),
+            devpath: self.devpath.clone(),
+            devlinks: self.devlinks.clone(),
+            size: self.size,
+            partition: match &self.partition {
+                Some(partition) => partition.to_mbus(),
+                None => mbus::Partition {
+                    ..Default::default()
+                },
+            },
+            filesystem: match &self.filesystem {
+                Some(filesystem) => filesystem.to_mbus(),
+                None => mbus::Filesystem {
+                    ..Default::default()
+                },
+            },
+            available: self.available,
+        }
+    }
+}
+
+///  Pool Agent conversions
+
+impl RpcToMessageBus for rpc::Pool {
+    type BusMessage = mbus::Pool;
+    fn to_mbus(&self) -> Self::BusMessage {
+        Self::BusMessage {
+            node: Default::default(),
+            id: self.name.clone().into(),
+            disks: self.disks.clone(),
+            state: self.state.into(),
+            capacity: self.capacity,
+            used: self.used,
+        }
+    }
+}
+
+impl RpcToMessageBus for rpc::Replica {
+    type BusMessage = mbus::Replica;
+    fn to_mbus(&self) -> Self::BusMessage {
+        Self::BusMessage {
+            node: Default::default(),
+            uuid: self.uuid.clone().into(),
+            pool: self.pool.clone().into(),
+            thin: self.thin,
+            size: self.size,
+            share: self.share.into(),
+            uri: self.uri.clone(),
+        }
+    }
+}
+
+/// Volume Agent conversions
+
+impl RpcToMessageBus for rpc::Nexus {
+    type BusMessage = mbus::Nexus;
+
+    fn to_mbus(&self) -> Self::BusMessage {
+        Self::BusMessage {
+            node: Default::default(),
+            uuid: self.uuid.clone().into(),
+            size: self.size,
+            state: NexusState::from(self.state),
+            children: self.children.iter().map(|c| c.to_mbus()).collect(),
+            device_uri: self.device_uri.clone(),
+            rebuilds: self.rebuilds,
+        }
+    }
+}
+
+impl RpcToMessageBus for rpc::Child {
+    type BusMessage = mbus::Child;
+
+    fn to_mbus(&self) -> Self::BusMessage {
+        Self::BusMessage {
+            uri: self.uri.clone().into(),
+            state: ChildState::from(self.state),
+            rebuild_progress: if self.rebuild_progress >= 0 {
+                Some(self.rebuild_progress)
+            } else {
+                None
+            },
+        }
+    }
+}
+
+/// Trait for converting message bus messages to rpc messages.
+pub trait MessageBusToRpc {
+    /// RPC message type.
+    type RpcMessage;
+    /// Conversion of message bus message to rpc message.
+    fn to_rpc(&self) -> Self::RpcMessage;
+}
+
+/// Pool Agent Conversions
+
+impl MessageBusToRpc for mbus::CreateReplica {
+    type RpcMessage = rpc::CreateReplicaRequest;
+    fn to_rpc(&self) -> Self::RpcMessage {
+        Self::RpcMessage {
+            uuid: self.uuid.clone().into(),
+            pool: self.pool.clone().into(),
+            thin: self.thin,
+            size: self.size,
+            share: self.share.clone() as i32,
+        }
+    }
+}
+
+impl MessageBusToRpc for mbus::ShareReplica {
+    type RpcMessage = rpc::ShareReplicaRequest;
+    fn to_rpc(&self) -> Self::RpcMessage {
+        Self::RpcMessage {
+            uuid: self.uuid.clone().into(),
+            share: self.protocol.clone() as i32,
+        }
+    }
+}
+
+impl MessageBusToRpc for mbus::UnshareReplica {
+    type RpcMessage = rpc::ShareReplicaRequest;
+    fn to_rpc(&self) -> Self::RpcMessage {
+        Self::RpcMessage {
+            uuid: self.uuid.clone().into(),
+            share: Protocol::Off as i32,
+        }
+    }
+}
+
+impl MessageBusToRpc for mbus::CreatePool {
+    type RpcMessage = rpc::CreatePoolRequest;
+    fn to_rpc(&self) -> Self::RpcMessage {
+        Self::RpcMessage {
+            name: self.id.clone().into(),
+            disks: self.disks.clone(),
+        }
+    }
+}
+
+impl MessageBusToRpc for mbus::DestroyReplica {
+    type RpcMessage = rpc::DestroyReplicaRequest;
+    fn to_rpc(&self) -> Self::RpcMessage {
+        Self::RpcMessage {
+            uuid: self.uuid.clone().into(),
+        }
+    }
+}
+
+impl MessageBusToRpc for mbus::DestroyPool {
+    type RpcMessage = rpc::DestroyPoolRequest;
+    fn to_rpc(&self) -> Self::RpcMessage {
+        Self::RpcMessage {
+            name: self.id.clone().into(),
+        }
+    }
+}
+
+/// Volume Agent Conversions
+
+impl MessageBusToRpc for mbus::CreateNexus {
+    type RpcMessage = rpc::CreateNexusRequest;
+    fn to_rpc(&self) -> Self::RpcMessage {
+        Self::RpcMessage {
+            uuid: self.uuid.clone().into(),
+            size: self.size,
+            children: self.children.iter().map(|c| c.to_string()).collect(),
+        }
+    }
+}
+
+impl MessageBusToRpc for mbus::ShareNexus {
+    type RpcMessage = rpc::PublishNexusRequest;
+    fn to_rpc(&self) -> Self::RpcMessage {
+        Self::RpcMessage {
+            uuid: self.uuid.clone().into(),
+            key: self.key.clone().unwrap_or_default(),
+            share: self.protocol.clone() as i32,
+        }
+    }
+}
+
+impl MessageBusToRpc for mbus::UnshareNexus {
+    type RpcMessage = rpc::UnpublishNexusRequest;
+    fn to_rpc(&self) -> Self::RpcMessage {
+        Self::RpcMessage {
+            uuid: self.uuid.clone().into(),
+        }
+    }
+}
+
+impl MessageBusToRpc for mbus::DestroyNexus {
+    type RpcMessage = rpc::DestroyNexusRequest;
+    fn to_rpc(&self) -> Self::RpcMessage {
+        Self::RpcMessage {
+            uuid: self.uuid.clone().into(),
+        }
+    }
+}
+
+impl MessageBusToRpc for mbus::AddNexusChild {
+    type RpcMessage = rpc::AddChildNexusRequest;
+    fn to_rpc(&self) -> Self::RpcMessage {
+        Self::RpcMessage {
+            uuid: self.nexus.clone().into(),
+            uri: self.uri.clone().into(),
+            norebuild: !self.auto_rebuild,
+        }
+    }
+}
+
+impl MessageBusToRpc for mbus::RemoveNexusChild {
+    type RpcMessage = rpc::RemoveChildNexusRequest;
+    fn to_rpc(&self) -> Self::RpcMessage {
+        Self::RpcMessage {
+            uuid: self.nexus.clone().into(),
+            uri: self.uri.clone().into(),
+        }
+    }
+}

--- a/control-plane/mbus-api/src/message_bus/v0.rs
+++ b/control-plane/mbus-api/src/message_bus/v0.rs
@@ -248,6 +248,14 @@ pub trait MessageBusTrait: Sized {
     ) -> BusResult<serde_json::Value> {
         Ok(request.request().await?)
     }
+
+    /// Get block devices on a node
+    #[tracing::instrument(level = "debug", err)]
+    async fn get_block_devices(
+        request: GetBlockDevices,
+    ) -> BusResult<BlockDevices> {
+        Ok(request.request().await?)
+    }
 }
 
 /// Implementation of the bus interface trait

--- a/control-plane/mbus-api/src/v0.rs
+++ b/control-plane/mbus-api/src/v0.rs
@@ -107,6 +107,8 @@ pub enum MessageIdVs {
     RemoveVolumeNexus,
     /// Generic JSON gRPC message
     JsonGrpc,
+    /// Get block devices
+    GetBlockDevices,
 }
 
 // Only V0 should export this macro
@@ -992,3 +994,79 @@ pub struct JsonGrpcRequest {
 }
 
 bus_impl_message_all!(JsonGrpcRequest, JsonGrpc, Value, JsonGrpc);
+
+/// Partition information
+#[derive(
+    Serialize, Deserialize, Default, Debug, Clone, Eq, PartialEq, Apiv2Schema,
+)]
+pub struct Partition {
+    /// devname of parent device to which this partition belongs
+    pub parent: String,
+    /// partition number
+    pub number: u32,
+    /// partition name
+    pub name: String,
+    /// partition scheme: gpt, dos, ...
+    pub scheme: String,
+    /// partition type identifier
+    pub typeid: String,
+    /// UUID identifying partition
+    pub uuid: String,
+}
+
+/// Filesystem information
+#[derive(
+    Serialize, Deserialize, Default, Debug, Clone, Eq, PartialEq, Apiv2Schema,
+)]
+pub struct Filesystem {
+    /// filesystem type: ext3, ntfs, ...
+    pub fstype: String,
+    /// volume label
+    pub label: String,
+    /// UUID identifying the volume (filesystem)
+    pub uuid: String,
+    /// path where filesystem is currently mounted
+    pub mountpoint: String,
+}
+
+/// Block device information
+#[derive(
+    Serialize, Deserialize, Default, Debug, Clone, Eq, PartialEq, Apiv2Schema,
+)]
+#[serde(rename_all = "camelCase")]
+pub struct BlockDevice {
+    /// entry in /dev associated with device
+    pub devname: String,
+    /// currently "disk" or "partition"
+    pub devtype: String,
+    /// major device number
+    pub devmajor: u32,
+    /// minor device number
+    pub devminor: u32,
+    /// device model - useful for identifying mayastor devices
+    pub model: String,
+    /// official device path
+    pub devpath: String,
+    /// list of udev generated symlinks by which device may be identified
+    pub devlinks: Vec<String>,
+    /// size of device in (512 byte) blocks
+    pub size: u64,
+    /// partition information in case where device represents a partition
+    pub partition: Partition,
+    /// filesystem information in case where a filesystem is present
+    pub filesystem: Filesystem,
+    /// identifies if device is available for use (ie. is not "currently" in
+    /// use)
+    pub available: bool,
+}
+/// Get block devices
+#[derive(Serialize, Deserialize, Default, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct GetBlockDevices {
+    /// id of the mayastor instance
+    pub node: NodeId,
+    /// specifies whether to get all devices or only usable devices
+    pub all: bool,
+}
+bus_impl_vector_request!(BlockDevices, BlockDevice);
+bus_impl_message_all!(GetBlockDevices, GetBlockDevices, BlockDevices, Node);

--- a/control-plane/rest/service/src/v0/block_devices.rs
+++ b/control-plane/rest/service/src/v0/block_devices.rs
@@ -1,0 +1,36 @@
+use super::*;
+use mbus_api::v0::GetBlockDevices;
+
+pub(super) fn configure(cfg: &mut paperclip::actix::web::ServiceConfig) {
+    cfg.service(get_block_devices);
+}
+
+// Get block devices takes a query parameter 'all' which is used to determine
+// whether to return all found devices or only those that are usable.
+// Omitting the query parameter will result in all block devices being shown.
+//
+// # Examples
+// Get only usable block devices with query parameter:
+//      curl -X GET "https://localhost:8080/v0/nodes/mayastor/block_devices?all=false" \
+//      -H  "accept: application/json"
+//
+// Get all block devices with query parameter:
+//      curl -X GET "https://localhost:8080/v0/nodes/mayastor/block_devices?all=true" \
+//      -H  "accept: application/json" -k
+//
+// Get all block devices without query parameter:
+//      curl -X GET "https://localhost:8080/v0/nodes/mayastor/block_devices" \
+//      -H  "accept: application/json" -k
+//
+#[get("/v0", "/nodes/{node}/block_devices", tags(BlockDevices))]
+async fn get_block_devices(
+    web::Query(info): web::Query<GetBlockDeviceQueryParams>,
+    web::Path(node): web::Path<NodeId>,
+) -> Result<Json<Vec<BlockDevice>>, RestError> {
+    RestRespond::result(Ok(MessageBus::get_block_devices(GetBlockDevices {
+        node,
+        all: info.all.unwrap_or(true),
+    })
+    .await?
+    .into_inner()))
+}

--- a/control-plane/rest/service/src/v0/mod.rs
+++ b/control-plane/rest/service/src/v0/mod.rs
@@ -2,6 +2,7 @@
 //! Version 0 of the URI's
 //! Ex: /v0/nodes
 
+pub mod block_devices;
 pub mod children;
 pub mod jsongrpc;
 pub mod nexuses;
@@ -47,6 +48,7 @@ fn configure(cfg: &mut paperclip::actix::web::ServiceConfig) {
     children::configure(cfg);
     volumes::configure(cfg);
     jsongrpc::configure(cfg);
+    block_devices::configure(cfg);
 }
 
 pub(super) fn configure_api<T, B>(

--- a/control-plane/rest/src/versions/v0.rs
+++ b/control-plane/rest/src/versions/v0.rs
@@ -624,3 +624,12 @@ impl<T: Serialize> Into<HttpResponse> for RestRespond<T> {
         }
     }
 }
+
+/// Contains the query parameters that can be passed when calling
+/// get_block_devices
+#[derive(Deserialize, Apiv2Schema)]
+#[serde(rename_all = "camelCase")]
+pub struct GetBlockDeviceQueryParams {
+    /// specifies whether to list all devices or only usable ones
+    pub all: Option<bool>,
+}


### PR DESCRIPTION
Implement a REST call for listing block devices. The REST call uri can
optionally include the 'all' query parameter. This determines whether
all devices should be listed or just those that are deemed usable.
Omitting the query parameter results in all devices being listed.

Also added traits for converting messages between rpc and message bus
formats as this will be a common occurrence for control plane agents.

Resolves CAS-689