### PR TITLE
fix(nvmx): controller i/o statistics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2537,6 +2537,7 @@ dependencies = [
  "libc",
  "log",
  "mbus_api",
+ "merge",
  "nats",
  "nix 0.16.1",
  "nvmeadm",
@@ -2615,6 +2616,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "043175f069eda7b85febe4a74abbaeff828d9f8b448515d3151a14a3542811aa"
 dependencies = [
  "autocfg 1.0.1",
+]
+
+[[package]]
+name = "merge"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10bbef93abb1da61525bbc45eeaff6473a41907d19f8f9aa5168d214e10693e9"
+dependencies = [
+ "merge_derive",
+ "num-traits 0.2.14",
+]
+
+[[package]]
+name = "merge_derive"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "209d075476da2e63b4b29e72a2ef627b840589588e71400a25e3565c4f849d07"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2 1.0.24",
+ "quote 1.0.7",
+ "syn 1.0.51",
 ]
 
 [[package]]

--- a/mayastor/Cargo.toml
+++ b/mayastor/Cargo.toml
@@ -56,6 +56,7 @@ jsonrpc = { path = "../jsonrpc"}
 lazy_static = "1.4.0"
 libc = "0.2"
 log = "0.4"
+merge = "0.1.0"
 nix = "0.16"
 once_cell = "1.3.1"
 pin-utils = "0.1"

--- a/mayastor/src/core/mod.rs
+++ b/mayastor/src/core/mod.rs
@@ -10,7 +10,7 @@ pub use block_device::{
     BlockDevice,
     BlockDeviceDescriptor,
     BlockDeviceHandle,
-    BlockDeviceStats,
+    BlockDeviceIoStats,
     DeviceIoController,
     DeviceTimeoutAction,
     IoCompletionCallback,
@@ -156,5 +156,9 @@ pub enum CoreError {
     #[snafu(display("Failed to allocate DMA buffer of {} bytes", size))]
     DmaAllocationError {
         size: u64,
+    },
+    #[snafu(display("Failed to get I/O satistics for device: {}", source))]
+    DeviceStatisticsError {
+        source: Errno,
     },
 }


### PR DESCRIPTION
This fix introduces I/O statistics for read, write and unmap
operations for NVMe block devices.

Implements CAS-722