### PR TITLE
test(e2e): run back-to-back CI runs

### DIFF
--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -22,7 +22,7 @@ EXTENDED_TESTS=""
 device=
 registry=
 tag="ci"
-#  sript state variables
+#  script state variables
 tests=""
 run_extended_tests=
 on_fail="stop"
@@ -140,9 +140,7 @@ if [ -n "$tag" ]; then
   export e2e_image_tag="$tag"
 fi
 
-if [ -n "$registry" ]; then
-  export e2e_docker_registry="$registry"
-fi
+export e2e_docker_registry="$registry" # can be empty string
 
 if [ -z "$tests" ]; then
   tests="$TESTS"


### PR DESCRIPTION
Add parameter to build to indicate a continuous test.
Continuous tests need only run E2E tests and test a specific labelled
image from dockerhub.
A successful completed run will trigger another run if
the parameter e2e_continuous is set to true and if the global
config option E2E_CONTINUOUS_ENABLE is set to "true".
A failure will send a Slack message to alert developers.
Continuous tests have their own Xray test plan target.