### PR TITLE
fix: update CSI sidecars used with mayastor CAS-651

### DIFF
--- a/chart/templates/moac-deployment.yaml
+++ b/chart/templates/moac-deployment.yaml
@@ -16,11 +16,11 @@ spec:
       serviceAccount: moac
       containers:
         - name: csi-provisioner
-          image: quay.io/k8scsi/csi-provisioner:v1.6.0
+          image: quay.io/k8scsi/csi-provisioner:v2.1.0
           args:
             - "--v=2"
             - "--csi-address=$(ADDRESS)"
-            - "--feature-gates=Topology=true"
+            - "--feature-gates=Topology=false"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -30,7 +30,7 @@ spec:
               mountPath: /var/lib/csi/sockets/pluginproxy/
 
         - name: csi-attacher
-          image: quay.io/k8scsi/csi-attacher:v2.2.0
+          image: quay.io/k8scsi/csi-attacher:v3.1.0
           args:
             - "--v=2"
             - "--csi-address=$(ADDRESS)"

--- a/csi/moac/csi.ts
+++ b/csi/moac/csi.ts
@@ -481,13 +481,13 @@ class CsiServer {
     }
 
     // This was used in the old days for NBD protocol
-    const accessibleTopology: TopologyKeys[] = [];
+    const topologies: TopologyKeys[] = [];
 
     this._endRequest(request, null, {
       volume: {
         capacityBytes: volume.getSize(),
         volumeId: uuid,
-        accessibleTopology,
+        accessibleTopology: topologies,
         // parameters defined in the storage class are only presented
         // to the CSI driver createVolume method.
         // Propagate them to other CSI driver methods involved in

--- a/deploy/moac-deployment.yaml
+++ b/deploy/moac-deployment.yaml
@@ -18,11 +18,11 @@ spec:
       serviceAccount: moac
       containers:
         - name: csi-provisioner
-          image: quay.io/k8scsi/csi-provisioner:v1.6.0
+          image: quay.io/k8scsi/csi-provisioner:v2.1.0
           args:
             - "--v=2"
             - "--csi-address=$(ADDRESS)"
-            - "--feature-gates=Topology=true"
+            - "--feature-gates=Topology=false"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -32,7 +32,7 @@ spec:
               mountPath: /var/lib/csi/sockets/pluginproxy/
 
         - name: csi-attacher
-          image: quay.io/k8scsi/csi-attacher:v2.2.0
+          image: quay.io/k8scsi/csi-attacher:v3.1.0
           args:
             - "--v=2"
             - "--csi-address=$(ADDRESS)"

--- a/test/e2e/uninstall/uninstall_test.go
+++ b/test/e2e/uninstall/uninstall_test.go
@@ -133,11 +133,6 @@ func teardownMayastor() {
 	if cleanup {
 		// Attempt to forcefully delete mayastor pods
 		forceDeleted := common.ForceDeleteMayastorPods()
-		// FIXME: Temporarily disable this assert CAS-651 has been fixed
-		// Expect(forceDeleted).To(BeFalse())
-		if forceDeleted {
-			logf.Log.Info("WARNING: Mayastor pods were force deleted at uninstall!!!")
-		}
 		deleteNamespace()
 		// delete the namespace prior to possibly failing the uninstall
 		// to yield a reusable cluster on fail.
@@ -145,14 +140,9 @@ func teardownMayastor() {
 		Expect(podCount).To(BeZero())
 		Expect(pvcsFound).To(BeFalse())
 		Expect(pvcsDeleted).To(BeTrue())
+		Expect(forceDeleted).To(BeFalse())
 	} else {
-		// FIXME: Temporarily disable this assert CAS-651 has been fixed
-		// and force delete lingering mayastor pods.
-		// Expect(common.MayastorUndeletedPodCount()).To(Equal(0))
-		if common.MayastorUndeletedPodCount() != 0 {
-			logf.Log.Info("WARNING: Mayastor pods not deleted at uninstall, forcing deletion.")
-			common.ForceDeleteMayastorPods()
-		}
+		Expect(common.MayastorUndeletedPodCount()).To(Equal(0))
 		// More verbose here as deleting the namespace is often where this
 		// test hangs.
 		logf.Log.Info("Deleting the mayastor namespace")


### PR DESCRIPTION
Update for bug fixes
    csi-provisioner 1.6.0 -> 2.1.0
    csi-attacher 2.2.0 -> 3.1.0
E2E:
    Re-enable the checks for mayastor pods on uninstall
Turn off the topology feature gate,
 this will be addressed in the future.