### PR TITLE
ci(e2e): run e2e on shared worker

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -202,7 +202,7 @@ pipeline {
               }
             }
             stage('run e2e') {
-              agent { label 'nixos-mayastor' }
+              agent { label 'nixos' }
               environment {
                 GIT_COMMIT_SHORT = sh(
                   // using printf to get rid of trailing newline


### PR DESCRIPTION
Because of new beefier worker nodes for Jenkins we can run e2e tests in parallel
with other jobs thus keeping more CI capacity for other jobs