### PR TITLE
feat: make bdev create parameters strict

### DIFF
--- a/mayastor/src/bdev/dev.rs
+++ b/mayastor/src/bdev/dev.rs
@@ -20,7 +20,7 @@
 //!     bdev::Uri::parse(&uri)?.create().await?;
 //! ```
 
-use std::convert::TryFrom;
+use std::{collections::HashMap, convert::TryFrom};
 
 use snafu::ResultExt;
 use url::Url;
@@ -74,5 +74,27 @@ impl Uri {
                 scheme: scheme.to_string(),
             }),
         }
+    }
+}
+
+fn reject_unknown_parameters(
+    url: &Url,
+    parameters: HashMap<String, String>,
+) -> Result<(), NexusBdevError> {
+    if !parameters.is_empty() {
+        let invalid_parameters = parameters
+            .iter()
+            .map(|(k, v)| format!("{}={}", k, v))
+            .collect::<Vec<_>>()
+            .join(", ");
+        Err(NexusBdevError::UriInvalid {
+            uri: url.to_string(),
+            message: format!(
+                "unrecognized parameters: {}.",
+                invalid_parameters
+            ),
+        })
+    } else {
+        Ok(())
     }
 }

--- a/mayastor/src/bdev/dev/aio.rs
+++ b/mayastor/src/bdev/dev/aio.rs
@@ -8,7 +8,7 @@ use url::Url;
 use spdk_sys::{bdev_aio_delete, create_aio_bdev};
 
 use crate::{
-    bdev::{util::uri, CreateDestroy, GetName},
+    bdev::{dev::reject_unknown_parameters, util::uri, CreateDestroy, GetName},
     core::Bdev,
     ffihelper::{cb_arg, done_errno_cb, errno_result_from_i32, ErrnoResult},
     nexus_uri::{self, NexusBdevError},
@@ -55,9 +55,7 @@ impl TryFrom<&Url> for Aio {
             },
         )?;
 
-        if let Some(keys) = uri::keys(parameters) {
-            warn!("ignored parameters: {}", keys);
-        }
+        reject_unknown_parameters(url, parameters)?;
 
         Ok(Aio {
             name: url.path().into(),

--- a/mayastor/src/bdev/dev/iscsi.rs
+++ b/mayastor/src/bdev/dev/iscsi.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use spdk_sys::{create_iscsi_disk, delete_iscsi_disk, spdk_bdev};
 
 use crate::{
-    bdev::{util::uri, CreateDestroy, GetName},
+    bdev::{dev::reject_unknown_parameters, util::uri, CreateDestroy, GetName},
     core::Bdev,
     ffihelper::{cb_arg, done_errno_cb, errno_result_from_i32, ErrnoResult},
     nexus_uri::{self, NexusBdevError},
@@ -70,9 +70,7 @@ impl TryFrom<&Url> for Iscsi {
             },
         )?;
 
-        if let Some(keys) = uri::keys(parameters) {
-            warn!("ignored parameters: {}", keys);
-        }
+        reject_unknown_parameters(url, parameters)?;
 
         Ok(Iscsi {
             name: url[url::Position::BeforeHost .. url::Position::AfterPath]

--- a/mayastor/src/bdev/dev/loopback.rs
+++ b/mayastor/src/bdev/dev/loopback.rs
@@ -5,7 +5,13 @@ use snafu::ResultExt;
 use url::Url;
 
 use crate::{
-    bdev::{lookup_child_from_bdev, util::uri, CreateDestroy, GetName},
+    bdev::{
+        dev::reject_unknown_parameters,
+        lookup_child_from_bdev,
+        util::uri,
+        CreateDestroy,
+        GetName,
+    },
     core::Bdev,
     nexus_uri::{self, NexusBdevError},
 };
@@ -39,9 +45,7 @@ impl TryFrom<&Url> for Loopback {
             },
         )?;
 
-        if let Some(keys) = uri::keys(parameters) {
-            warn!("ignored parameters: {}", keys);
-        }
+        reject_unknown_parameters(url, parameters)?;
 
         Ok(Loopback {
             name: segments.join("/"),

--- a/mayastor/src/bdev/dev/malloc.rs
+++ b/mayastor/src/bdev/dev/malloc.rs
@@ -4,7 +4,7 @@
 //! heap. IOW, you must ensure you do not run out of huge pages while using
 //! this.
 use crate::{
-    bdev::util::uri,
+    bdev::{dev::reject_unknown_parameters, util::uri},
     nexus_uri::{
         NexusBdevError,
         {self},
@@ -103,6 +103,8 @@ impl TryFrom<&Url> for Malloc {
                 uri: uri.to_string(),
             },
         )?;
+
+        reject_unknown_parameters(uri, parameters)?;
 
         Ok(Self {
             name: uri.path()[1 ..].into(),

--- a/mayastor/src/bdev/dev/null.rs
+++ b/mayastor/src/bdev/dev/null.rs
@@ -2,7 +2,7 @@
 //! returns undefined data for reads. It's useful for benchmarking the I/O stack
 //! with minimal overhead and should *NEVER* be used with *real* data.
 use crate::{
-    bdev::util::uri,
+    bdev::{dev::reject_unknown_parameters, util::uri},
     nexus_uri::{
         NexusBdevError,
         {self},
@@ -101,6 +101,8 @@ impl TryFrom<&Url> for Null {
                 uri: uri.to_string(),
             },
         )?;
+
+        reject_unknown_parameters(uri, parameters)?;
 
         Ok(Self {
             name: uri.path()[1 ..].into(),

--- a/mayastor/src/bdev/dev/nvmf.rs
+++ b/mayastor/src/bdev/dev/nvmf.rs
@@ -21,7 +21,7 @@ use spdk_sys::{
 };
 
 use crate::{
-    bdev::{util::uri, CreateDestroy, GetName},
+    bdev::{dev::reject_unknown_parameters, util::uri, CreateDestroy, GetName},
     core::Bdev,
     ffihelper::{cb_arg, errno_result_from_i32, ErrnoResult},
     nexus_uri::{self, NexusBdevError},
@@ -108,9 +108,7 @@ impl TryFrom<&Url> for Nvmf {
             },
         )?;
 
-        if let Some(keys) = uri::keys(parameters) {
-            warn!("ignored parameters: {}", keys);
-        }
+        reject_unknown_parameters(url, parameters)?;
 
         Ok(Nvmf {
             name: url[url::Position::BeforeHost .. url::Position::AfterPath]

--- a/mayastor/src/bdev/dev/uring.rs
+++ b/mayastor/src/bdev/dev/uring.rs
@@ -8,7 +8,7 @@ use url::Url;
 use spdk_sys::{create_uring_bdev, delete_uring_bdev};
 
 use crate::{
-    bdev::{util::uri, CreateDestroy, GetName},
+    bdev::{dev::reject_unknown_parameters, util::uri, CreateDestroy, GetName},
     core::Bdev,
     ffihelper::{cb_arg, done_errno_cb, ErrnoResult},
     nexus_uri::{self, NexusBdevError},
@@ -55,9 +55,7 @@ impl TryFrom<&Url> for Uring {
             },
         )?;
 
-        if let Some(keys) = uri::keys(parameters) {
-            warn!("ignored parameters: {}", keys);
-        }
+        reject_unknown_parameters(url, parameters)?;
 
         Ok(Uring {
             name: url.path().into(),

--- a/mayastor/src/bdev/util/uri.rs
+++ b/mayastor/src/bdev/util/uri.rs
@@ -1,6 +1,6 @@
 //! Simple utility functions to help with parsing URIs.
 
-use std::{collections::HashMap, str::ParseBoolError};
+use std::str::ParseBoolError;
 
 use url::Url;
 
@@ -16,20 +16,6 @@ pub(crate) fn segments(url: &Url) -> Vec<&str> {
     }
 
     Vec::new()
-}
-
-/// Generate a comma separated list of all keys present in a HashMap as a String
-pub(crate) fn keys(map: HashMap<String, String>) -> Option<String> {
-    if map.is_empty() {
-        None
-    } else {
-        Some(
-            map.keys()
-                .map(|key| key.to_string())
-                .collect::<Vec<String>>()
-                .join(", "),
-        )
-    }
 }
 
 /// Parse a value that represents a boolean


### PR DESCRIPTION
Resolves https://mayadata.atlassian.net/browse/CAS-713 .

mayastor-client bdev create (or list) seem to no respect the configured block size, see `blk_size`:

```bash
$ mayastor-client bdev create 'malloc:///disk1?bs=4096&size_mb=10'
{
  "name": "disk1"
}

$ mayastor-client bdev list
{
  "bdevs": [
    {
      "name": "disk1",
      "uuid": "9043165c-7633-4295-abce-a2dde42b7445",
      "num_blocks": 20480,
      "blk_size": 512,
      "claimed": false,
      "claimed_by": "Orphaned",
      "aliases": "malloc:///disk1?bs=4096&size_mb=10",
      "uri": "malloc:///disk1?bs=4096&size_mb=10&uuid=9043165c-7633-4295-abce-a2dde42b7445",
      "product_name": "Malloc disk",
      "share_uri": "bdev:///disk1"
    }
  ]
}
```

Users should be guided on the correct parameters if invalid ones are passed.

Such as:

```bash
$ mayastor-client bdev create 'malloc:///disk1?bs=4096&size_mb=10'
Error: Status { code: InvalidArgument, message: "Invalid URI \"malloc:///disk1?bs=4096&size_mb=10\"
: unrecognized parameters: bs=4096." }

$ mayastor-client bdev create 'malloc:///disk1?bs=4096&size=10'
Error: Status { code: InvalidArgument, message: "Invalid URI \"malloc:///disk1?bs=4096&size=10\"
: unrecognized parameters: size=10, bs=4096." }

```