### PR TITLE
feat: make bdev share protocol argument as an option

### DIFF
--- a/mayastor/src/bin/mayastor-client/bdev_cli.rs
+++ b/mayastor/src/bin/mayastor-client/bdev_cli.rs
@@ -37,8 +37,11 @@ pub fn subcommands<'a, 'b>() -> App<'a, 'b> {
     let share = SubCommand::with_name("share")
         .about("share the given bdev")
         .arg(Arg::with_name("name").required(true).index(1))
-        .arg(Arg::from_usage("<protocol> 'the protocol to used to share the given bdev'")
+        .arg(
+            Arg::with_name("protocol")
                 .short("p")
+                .help("the protocol to used to share the given bdev")
+                .required(false)
                 .possible_values(&["nvmf", "iscsi"])
                 .default_value("nvmf"),
         );

--- a/mayastor/src/bin/mayastor-client/bdev_cli.rs
+++ b/mayastor/src/bin/mayastor-client/bdev_cli.rs
@@ -37,12 +37,10 @@ pub fn subcommands<'a, 'b>() -> App<'a, 'b> {
     let share = SubCommand::with_name("share")
         .about("share the given bdev")
         .arg(Arg::with_name("name").required(true).index(1))
-        .arg(
-            Arg::with_name("protocol")
-                .help("the protocol to used to share the given bdev")
-                .required(false)
-                .default_value("nvmf")
-                .value_names(&["nvmf", "iscsi"]),
+        .arg(Arg::from_usage("<protocol> 'the protocol to used to share the given bdev'")
+                .short("p")
+                .possible_values(&["nvmf", "iscsi"])
+                .default_value("nvmf"),
         );
 
     let unshare = SubCommand::with_name("unshare")


### PR DESCRIPTION
Resolves https://mayadata.atlassian.net/browse/CAS-718

The protocol argument of `mayastor-client bdev share` is safer and easier to document as an option
`-p nvmf` style:

```
$ ./artifacts/pkgs/mayastor/bin/mayastor-client bdev share --help
mayastor-client-bdev-share 
share the given bdev

USAGE:
    mayastor-client bdev share <name> -p <protocol>

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

OPTIONS:
    -p <protocol>        the protocol to used to share the given bdev [default: nvmf]  [possible
    values: nvmf, iscsi]

ARGS:
    <name>    

```