### PR TITLE
test(e2e): avoid conflicts in metrics port usage

### DIFF
--- a/test/e2e/common/test.go
+++ b/test/e2e/common/test.go
@@ -46,6 +46,8 @@ func SetupTestEnv() {
 
 	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme: scheme.Scheme,
+		// We do not consume prometheus metrics.
+		MetricsBindAddress: "0",
 	})
 	Expect(err).ToNot(HaveOccurred())
 

--- a/test/e2e/install/install_test.go
+++ b/test/e2e/install/install_test.go
@@ -284,6 +284,8 @@ var _ = BeforeSuite(func(done Done) {
 
 	k8sManager, err = ctrl.NewManager(cfg, ctrl.Options{
 		Scheme: scheme.Scheme,
+		// We do not consume prometheus metrics.
+		MetricsBindAddress: "0",
 	})
 	Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
Disable metrics consumption in the agent when running e2e tests
to avoid a conflict in use of port 8080 if multiple
agents run on the same machine.