### PR TITLE
ci: i/o soak test - NVMe over TCP. MQ-25

### DIFF
--- a/test/e2e/basic_volume_io/basic_volume_io_test.go
+++ b/test/e2e/basic_volume_io/basic_volume_io_test.go
@@ -51,7 +51,9 @@ func basicVolumeIOTest(scName string) {
 	).Should(Equal(true))
 
 	// Run the fio test
-	common.RunFio(fioPodName, 20)
+	_, err = common.RunFio(fioPodName, 20, common.FioFsFilename)
+	Expect(err).ToNot(HaveOccurred())
+
 	podNames = podNames[:len(podNames)-1]
 
 	// Delete the fio pod

--- a/test/e2e/common/util_testpods.go
+++ b/test/e2e/common/util_testpods.go
@@ -3,22 +3,35 @@ package common
 // Utility functions for test pods.
 import (
 	"context"
+	"errors"
 	"fmt"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"os/exec"
-
-	. "github.com/onsi/gomega"
+	"strings"
 
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-func RunFio(podName string, duration int) {
+//  These variables match the settings used in createFioPodDef
+var FioFsMountPoint = "/volume"
+var FioBlockFilename = "/dev/sdm"
+var FioFsFilename = FioFsMountPoint + "/fiotestfile"
+
+// FIXME: this function runs fio with a bunch of parameters which are not configurable.
+func RunFio(podName string, duration int, filename string, args ...string) ([]byte, error) {
 	argRuntime := fmt.Sprintf("--runtime=%d", duration)
-	cmd := exec.Command(
-		"kubectl",
+	argFilename := fmt.Sprintf("--filename=%s", filename)
+
+	logf.Log.Info("RunFio",
+		"podName", podName,
+		"duration", duration,
+		"filename", filename,
+		"args", args)
+
+	cmdArgs := []string{
 		"exec",
 		"-it",
 		podName,
@@ -26,7 +39,7 @@ func RunFio(podName string, duration int) {
 		"fio",
 		"--name=benchtest",
 		"--size=50m",
-		"--filename=/volume/test",
+		argFilename,
 		"--direct=1",
 		"--rw=randrw",
 		"--ioengine=libaio",
@@ -35,10 +48,17 @@ func RunFio(podName string, duration int) {
 		"--numjobs=1",
 		"--time_based",
 		argRuntime,
+	}
+	if args != nil {
+		cmdArgs = append(cmdArgs, args...)
+	}
+	cmd := exec.Command(
+		"kubectl",
+		cmdArgs...,
 	)
 	cmd.Dir = ""
-	_, err := cmd.CombinedOutput()
-	Expect(err).ToNot(HaveOccurred())
+	output, err := cmd.CombinedOutput()
+	return output, err
 }
 
 func IsPodRunning(podName string) bool {
@@ -59,31 +79,33 @@ func DeletePod(podName string) error {
 	return gTestEnv.KubeInt.CoreV1().Pods("default").Delete(context.TODO(), podName, metav1.DeleteOptions{})
 }
 
-func CreateFioPod(podName string, volName string) (*corev1.Pod, error) {
-	podDef := CreateFioPodDef(podName, volName)
-	return CreatePod(podDef)
-}
-
 /// Create a test fio pod in default namespace, no options and no context
-/// mayastor volume is mounted on /volume
-func CreateFioPodDef(podName string, volName string) *corev1.Pod {
+func createFioPodDef(podName string, volName string, rawBlock bool) *corev1.Pod {
+	volMounts := []corev1.VolumeMount{
+		{
+			Name:      "ms-volume",
+			MountPath: FioFsMountPoint,
+		},
+	}
+	volDevices := []corev1.VolumeDevice{
+		{
+			Name:       "ms-volume",
+			DevicePath: FioBlockFilename,
+		},
+	}
+
 	podDef := corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      podName,
 			Namespace: "default",
 		},
 		Spec: corev1.PodSpec{
+			RestartPolicy: corev1.RestartPolicyNever,
 			Containers: []corev1.Container{
 				{
 					Name:  podName,
 					Image: "dmonakhov/alpine-fio",
 					Args:  []string{"sleep", "1000000"},
-					VolumeMounts: []corev1.VolumeMount{
-						{
-							Name:      "ms-volume",
-							MountPath: "/volume",
-						},
-					},
 				},
 			},
 			Volumes: []corev1.Volume{
@@ -98,7 +120,32 @@ func CreateFioPodDef(podName string, volName string) *corev1.Pod {
 			},
 		},
 	}
+	if rawBlock {
+		podDef.Spec.Containers[0].VolumeDevices = volDevices
+	} else {
+		podDef.Spec.Containers[0].VolumeMounts = volMounts
+	}
 	return &podDef
+}
+
+/// Create a test fio pod in default namespace, no options and no context
+/// mayastor volume is mounted on /volume
+func CreateFioPodDef(podName string, volName string) *corev1.Pod {
+	return createFioPodDef(podName, volName, false)
+}
+
+/// Create a test fio pod in default namespace, no options and no context
+/// mayastor volume is mounted on /volume
+func CreateFioPod(podName string, volName string) (*corev1.Pod, error) {
+	podDef := createFioPodDef(podName, volName, false)
+	return CreatePod(podDef)
+}
+
+/// Create a test fio pod in default namespace, no options and no context
+/// mayastor device is mounted on /dev/sdm
+func CreateRawBlockFioPod(podName string, volName string) (*corev1.Pod, error) {
+	podDef := createFioPodDef(podName, volName, true)
+	return CreatePod(podDef)
 }
 
 func CheckForTestPods() (bool, error) {
@@ -112,4 +159,33 @@ func CheckForTestPods() (bool, error) {
 		foundPods = true
 	}
 	return foundPods, err
+}
+
+// Check test pods in a namespace for restarts and failed/unknown state
+func CheckPods(namespace string) error {
+	podApi := gTestEnv.KubeInt.CoreV1().Pods
+	var errorStrings []string
+	podList, err := podApi(namespace).List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return errors.New("failed to list pods")
+	}
+
+	for _, pod := range podList.Items {
+		containerStatuses := pod.Status.ContainerStatuses
+		for _, containerStatus := range containerStatuses {
+			if containerStatus.RestartCount != 0 {
+				logf.Log.Info(pod.Name, "restarts", containerStatus.RestartCount)
+				errorStrings = append(errorStrings, fmt.Sprintf("%s restarted %d times", pod.Name, containerStatus.RestartCount))
+			}
+			if pod.Status.Phase == corev1.PodFailed || pod.Status.Phase == corev1.PodUnknown {
+				logf.Log.Info(pod.Name, "phase", pod.Status.Phase)
+				errorStrings = append(errorStrings, fmt.Sprintf("%s phase is %v", pod.Name, pod.Status.Phase))
+			}
+		}
+	}
+
+	if len(errorStrings) != 0 {
+		return errors.New(strings.Join(errorStrings[:], "; "))
+	}
+	return nil
 }

--- a/test/e2e/io_soak/README.md
+++ b/test/e2e/io_soak/README.md
@@ -1,0 +1,14 @@
+# IO Soak test
+JIRA: MQ-25
+## Abstract
+Runs fio with varying duty cycles concurrently on a number of volumes for an extended duration.
+
+## Parameters
+* `e2e_io_soak_load_factor` : Number of volumes per Mayastor node, type integer
+* `e2e_io_soak_replicas`    : Number of replicas for each volume, type integer
+* `e2e_io_soak_duration`    : Duration of fio runs, type string 
+* `e2e_io_soak_protocols`   : Share protocols to run tests with, comma separated list
+
+`e2e_io_soak_duration` is parsed using `golangs` library function `time.ParseDuration`.
+So `e2e_io_soak_duration` string is a sequence of decimal numbers, each with optional fraction and a unit suffix, such as "300ms", "-1.5h" or "2h45m".
+Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h". 

--- a/test/e2e/io_soak/filesystem_fio.go
+++ b/test/e2e/io_soak/filesystem_fio.go
@@ -1,0 +1,67 @@
+package io_soak
+
+import (
+	"e2e-basic/common"
+
+	"fmt"
+	"time"
+
+	coreV1 "k8s.io/api/core/v1"
+)
+
+// IO soak filesystem fio job
+
+type FioFsSoakJob struct {
+	volName string
+	scName  string
+	podName string
+	id      int
+}
+
+func (job FioFsSoakJob) makeVolume() {
+	common.MkPVC(job.volName, job.scName)
+}
+
+func (job FioFsSoakJob) removeVolume() {
+	common.RmPVC(job.volName, job.scName)
+}
+
+func (job FioFsSoakJob) makeTestPod() (*coreV1.Pod, error) {
+	pod, err := common.CreateFioPod(job.podName, job.volName)
+	return pod, err
+}
+
+func (job FioFsSoakJob) removeTestPod() error {
+	return common.DeletePod(job.podName)
+}
+
+func (job FioFsSoakJob) run(duration time.Duration, doneC chan<- string, errC chan<- error) {
+	ixp := job.id % len(FioDutyCycles)
+	RunIoSoakFio(
+		job.podName,
+		duration,
+		FioDutyCycles[ixp].thinkTime,
+		FioDutyCycles[ixp].thinkTimeBlocks,
+		false,
+		doneC,
+		errC,
+	)
+}
+
+func (job FioFsSoakJob) getPodName() string {
+	return job.podName
+}
+
+func (job FioFsSoakJob) getId() int {
+	return job.id
+}
+
+func MakeFioFsJob(scName string, id int) FioFsSoakJob {
+	nm := fmt.Sprintf("fio-filesystem-%s-%d", scName, id)
+	return FioFsSoakJob{
+		volName: nm,
+		scName:  scName,
+		podName: nm,
+		id:      id,
+	}
+}

--- a/test/e2e/io_soak/fio.go
+++ b/test/e2e/io_soak/fio.go
@@ -1,0 +1,88 @@
+package io_soak
+
+import (
+	"e2e-basic/common"
+
+	"fmt"
+	"io/ioutil"
+	"time"
+
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// This table of duty cycles is guesstimates and bear no relation to real loads.
+// TODO: make configurable
+var FioDutyCycles = []struct {
+	thinkTime       int
+	thinkTimeBlocks int
+}{
+	{500000, 1000},  // 0.5 second, 1000 blocks
+	{750000, 1000},  // 0.75 second, 1000 blocks
+	{1000000, 2000}, // 1 second, 2000 blocks
+	{1250000, 2000}, // 1.25 seconds, 2000 blocks
+	{1500000, 3000}, // 1.5  seconds, 3000 blocks
+	{1750000, 3000}, // 1.75  seconds, 3000 blocks
+	{2000000, 4000}, // 2  seconds, 4000 blocks
+}
+
+const fixedDuration = 60
+
+// see https://fio.readthedocs.io/en/latest/fio_doc.html#i-o-rate
+// run fio in a loop of fixed duration to fulfill a larger duration,
+// this to facilitate a relatively timely termination when an error
+// occurs elsewhere.
+// podName - name of the fio pod
+// duration - time in seconds to run fio
+// thinktime -  usecs, stall the job for the specified period of time after an I/O has completed before issuing the next
+// thinktime_blocks - how many blocks to issue, before waiting thinktime usecs.
+// rawBlock - false for filesystem volumes, true for raw block mounts.
+func RunIoSoakFio(podName string, duration time.Duration, thinkTime int, thinkTimeBlocks int, rawBlock bool, doneC chan<- string, errC chan<- error) {
+	secs := int(duration.Seconds())
+	argThinkTime := fmt.Sprintf("--thinktime=%d", thinkTime)
+	argThinkTimeBlocks := fmt.Sprintf("--thinktime_blocks=%d", thinkTimeBlocks)
+
+	logf.Log.Info("Running fio",
+		"pod", podName,
+		"duration", duration,
+		"thinktime", thinkTime,
+		"thinktime_blocks", thinkTimeBlocks,
+		"rawBlock", rawBlock,
+	)
+
+	fioFile := ""
+	if rawBlock {
+		fioFile = common.FioBlockFilename
+	} else {
+		fioFile = common.FioFsFilename
+	}
+
+	for ix := 1; secs > 0; ix++ {
+		runtime := fixedDuration
+		if runtime > secs {
+			runtime = secs
+		}
+		secs -= runtime
+
+		logf.Log.Info("run fio ",
+			"iteration", ix,
+			"pod", podName,
+			"duration", runtime,
+			"thinktime", thinkTime,
+			"thinktime_blocks", thinkTimeBlocks,
+			"rawBlock", rawBlock,
+			"fioFile", fioFile,
+		)
+		output, err := common.RunFio(podName, runtime, fioFile, argThinkTime, argThinkTimeBlocks )
+
+		//TODO: for now shove the output into /tmp
+		_ = ioutil.WriteFile("/tmp/"+podName+".out", output, 0644)
+		//logf.Log.Info(string(output))
+		if err != nil {
+			logf.Log.Info("Abort running fio", "pod", podName, "error", err)
+			errC <- err
+			return
+		}
+	}
+	logf.Log.Info("Finished running fio", "pod", podName, "duration", duration)
+	doneC <- podName
+}

--- a/test/e2e/io_soak/io_soak_test.go
+++ b/test/e2e/io_soak/io_soak_test.go
@@ -1,0 +1,228 @@
+// JIRA: MQ-25
+// JIRA: MQ-26
+package io_soak
+
+import (
+	"e2e-basic/common"
+	rep "e2e-basic/common/reporter"
+
+	"fmt"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+var defTimeoutSecs = "120s"
+
+type IoSoakJob interface {
+	makeVolume()
+	makeTestPod() (*corev1.Pod, error)
+	removeTestPod() error
+	removeVolume()
+	run(time.Duration, chan<- string, chan<- error)
+	getPodName() string
+}
+
+var scNames []string
+var jobs []IoSoakJob
+
+func TestIOSoak(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecsWithDefaultAndCustomReporters(t, "IO soak test, NVMe-oF TCP and iSCSI", rep.GetReporters("io-soak"))
+}
+
+func monitor(errC chan<- error) {
+	logf.Log.Info("IOSoakTest monitor, checking mayastor and test pods")
+	for {
+		time.Sleep(30 * time.Second)
+		err := common.CheckPods(common.NSMayastor)
+		if err != nil {
+			logf.Log.Info("IOSoakTest monitor", "namespace", common.NSMayastor, "error", err)
+			errC <- err
+			break
+		}
+		err = common.CheckPods("default")
+		if err != nil {
+			logf.Log.Info("IOSoakTest monitor", "namespace", "default", "error", err)
+			errC <- err
+			break
+		}
+	}
+}
+
+/// proto - protocol "nvmf" or "isci"
+/// replicas - number of replicas for each volume
+/// loadFactor - number of volumes for each mayastor instance
+func IOSoakTest(protocols []string, replicas int, loadFactor int, duration time.Duration) {
+	nodeList, err := common.GetNodeLocs()
+	Expect(err).ToNot(HaveOccurred())
+
+	numMayastorNodes := 0
+	jobCount := 0
+	sort.Slice(nodeList, func(i, j int) bool { return nodeList[i].NodeName < nodeList[j].NodeName })
+	for i, node := range nodeList {
+		if node.MayastorNode && !node.MasterNode {
+			logf.Log.Info("MayastorNode", "name", node.NodeName, "index", i)
+			jobCount += loadFactor
+			numMayastorNodes += 1
+		}
+	}
+
+	Expect(replicas <= numMayastorNodes).To(BeTrue())
+	logf.Log.Info("IOSoakTest", "jobs", jobCount, "volumes", jobCount, "test pods", jobCount)
+
+	for _, proto := range protocols {
+		scName := fmt.Sprintf("io-soak-%s", proto)
+		logf.Log.Info("Creating", "storage class", scName)
+		err = common.MkStorageClass(scName, replicas, proto, "io.openebs.csi-mayastor")
+		Expect(err).ToNot(HaveOccurred())
+		scNames = append(scNames, scName)
+	}
+
+	// Create the set of jobs
+	idx := 1
+	for idx <= jobCount {
+		for _, scName := range scNames {
+			if idx > jobCount {
+				break
+			}
+			logf.Log.Info("Creating", "job", "fio filesystem job", "id", idx)
+			jobs = append(jobs, MakeFioFsJob(scName, idx))
+			idx++
+
+			if idx > jobCount {
+				break
+			}
+			logf.Log.Info("Creating", "job", "fio raw block job", "id", idx)
+			jobs = append(jobs, MakeFioRawBlockJob(scName, idx))
+			idx++
+		}
+	}
+
+	logf.Log.Info("Creating volumes")
+	// Create the job volumes
+	for _, job := range jobs {
+		job.makeVolume()
+	}
+
+	logf.Log.Info("Creating test pods")
+	// Create the job test pods
+	for _, job := range jobs {
+		pod, err := job.makeTestPod()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(pod).ToNot(BeNil())
+	}
+
+	logf.Log.Info("Waiting for test pods to be ready")
+	// Wait for the test pods to be ready
+	for _, job := range jobs {
+		// Wait for the test Pod to transition to running
+		Eventually(func() bool {
+			return common.IsPodRunning(job.getPodName())
+		},
+			defTimeoutSecs,
+			"1s",
+		).Should(Equal(true))
+	}
+
+	logf.Log.Info("Starting test execution in all test pods")
+	// Run the test jobs
+	doneC, errC := make(chan string), make(chan error)
+	go monitor(errC)
+	for _, job := range jobs {
+		go job.run(duration, doneC, errC)
+	}
+
+	logf.Log.Info("Waiting for test execution to complete on all test pods")
+	// Wait and check that all test pods have executed successfully
+	for range jobs {
+		select {
+		case podName := <-doneC:
+			logf.Log.Info("Completed", "pod", podName)
+		case err := <-errC:
+			close(doneC)
+			logf.Log.Error(err, "fio run")
+			Expect(err).To(BeNil())
+		}
+	}
+
+	logf.Log.Info("All runs complete, deleting test pods")
+	for _, job := range jobs {
+		err := job.removeTestPod()
+		Expect(err).ToNot(HaveOccurred())
+	}
+
+	logf.Log.Info("All runs complete, deleting volumes")
+	for _, job := range jobs {
+		job.removeVolume()
+	}
+
+	logf.Log.Info("All runs complete, deleting storage classes")
+	for _, scName := range scNames {
+		err = common.RmStorageClass(scName)
+		Expect(err).ToNot(HaveOccurred())
+	}
+}
+
+var _ = Describe("Mayastor Volume IO test", func() {
+
+	AfterEach(func() {
+		logf.Log.Info("AfterEach")
+		// Check resource leakage.
+		err := common.AfterEachCheck()
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("should verify an NVMe-oF TCP volume can process IO on multiple volumes simultaneously", func() {
+		replicas := 1
+		loadFactor := 2
+		duration, _ := time.ParseDuration("30s")
+		protocols := []string{"nvmf"}
+		var err error
+		tmp := os.Getenv("e2e_io_soak_load_factor")
+		if tmp != "" {
+			loadFactor, err = strconv.Atoi(tmp)
+			Expect(err).ToNot(HaveOccurred())
+		}
+		tmp = os.Getenv("e2e_io_soak_duration")
+		if tmp != "" {
+			duration, err = time.ParseDuration(tmp)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(duration.Seconds() > 0).To(BeTrue())
+		}
+		tmp = os.Getenv("e2e_io_soak_replicas")
+		if tmp != "" {
+			replicas, err = strconv.Atoi(tmp)
+			Expect(err).ToNot(HaveOccurred())
+		}
+		tmp = os.Getenv("e2e_io_soak_protocols")
+		if tmp != "" {
+			protocols = strings.Split(tmp, ",")
+		}
+		logf.Log.Info("Parameters", "replicas", replicas, "loadFactor", loadFactor, "duration", duration)
+		IOSoakTest(protocols, replicas, loadFactor, duration)
+	})
+})
+
+var _ = BeforeSuite(func(done Done) {
+	logf.SetLogger(zap.New(zap.UseDevMode(true), zap.WriteTo(GinkgoWriter)))
+	common.SetupTestEnv()
+
+	close(done)
+}, 60)
+
+var _ = AfterSuite(func() {
+	// NB This only tears down the local structures for talking to the cluster,
+	// not the kubernetes cluster itself.	By("tearing down the test environment")
+	common.TeardownTestEnv()
+})

--- a/test/e2e/io_soak/rawblock_fio.go
+++ b/test/e2e/io_soak/rawblock_fio.go
@@ -1,0 +1,67 @@
+package io_soak
+
+import (
+	"e2e-basic/common"
+
+	"fmt"
+	"time"
+
+	coreV1 "k8s.io/api/core/v1"
+)
+
+// IO soak raw block fio  job
+
+type FioRawBlockSoakJob struct {
+	volName string
+	scName  string
+	podName string
+	id      int
+}
+
+func (job FioRawBlockSoakJob) makeVolume() {
+	common.MkRawBlockPVC(job.volName, job.scName)
+}
+
+func (job FioRawBlockSoakJob) removeVolume() {
+	common.RmPVC(job.volName, job.scName)
+}
+
+func (job FioRawBlockSoakJob) makeTestPod() (*coreV1.Pod, error) {
+	pod, err := common.CreateRawBlockFioPod(job.podName, job.volName)
+	return pod, err
+}
+
+func (job FioRawBlockSoakJob) removeTestPod() error {
+	return common.DeletePod(job.podName)
+}
+
+func (job FioRawBlockSoakJob) run(duration time.Duration, doneC chan<- string, errC chan<- error) {
+	ixp := job.id % len(FioDutyCycles)
+	RunIoSoakFio(
+		job.podName,
+		duration,
+		FioDutyCycles[ixp].thinkTime,
+		FioDutyCycles[ixp].thinkTimeBlocks,
+		true,
+		doneC,
+		errC,
+	)
+}
+
+func (job FioRawBlockSoakJob) getPodName() string {
+	return job.podName
+}
+
+func (job FioRawBlockSoakJob) getId() int {
+	return job.id
+}
+
+func MakeFioRawBlockJob(scName string, id int) FioRawBlockSoakJob {
+	nm := fmt.Sprintf("fio-rawblock-%s-%d", scName, id)
+	return FioRawBlockSoakJob{
+		volName: nm,
+		scName:  scName,
+		podName: nm,
+		id:      id,
+	}
+}

--- a/test/e2e/node_disconnect/lib/node_disconnect_lib.go
+++ b/test/e2e/node_disconnect/lib/node_disconnect_lib.go
@@ -104,7 +104,8 @@ func (env *DisconnectEnv) PodLossTest() {
 	logf.Log.Info("waiting for pod removal to affect the nexus", "timeout", disconnectionTimeoutSecs)
 	Eventually(func() string {
 		logf.Log.Info("running fio against the volume")
-		common.RunFio(env.fioPodName, 5)
+		_, err := common.RunFio(env.fioPodName, 5, common.FioFsFilename)
+		Expect(err).ToNot(HaveOccurred())
 		return common.GetMsvState(env.uuid)
 	},
 		disconnectionTimeoutSecs, // timeout
@@ -114,7 +115,8 @@ func (env *DisconnectEnv) PodLossTest() {
 	logf.Log.Info("volume condition", "state", common.GetMsvState(env.uuid))
 
 	logf.Log.Info("running fio against the degraded volume")
-	common.RunFio(env.fioPodName, 20)
+	_, err := common.RunFio(env.fioPodName, 20, common.FioFsFilename)
+	Expect(err).ToNot(HaveOccurred())
 
 	logf.Log.Info("enabling mayastor pod", "node", env.replicaToRemove)
 	env.UnsuppressMayastorPod()
@@ -122,7 +124,8 @@ func (env *DisconnectEnv) PodLossTest() {
 	logf.Log.Info("waiting for the volume to be repaired", "timeout", repairTimeoutSecs)
 	Eventually(func() string {
 		logf.Log.Info("running fio while volume is being repaired")
-		common.RunFio(env.fioPodName, 5)
+		_, err := common.RunFio(env.fioPodName, 5, common.FioFsFilename)
+		Expect(err).ToNot(HaveOccurred())
 		return common.GetMsvState(env.uuid)
 	},
 		repairTimeoutSecs, // timeout
@@ -132,7 +135,8 @@ func (env *DisconnectEnv) PodLossTest() {
 	logf.Log.Info("volume condition", "state", common.GetMsvState(env.uuid))
 
 	logf.Log.Info("running fio against the repaired volume")
-	common.RunFio(env.fioPodName, 20)
+	_, err = common.RunFio(env.fioPodName, 20, common.FioFsFilename)
+	Expect(err).ToNot(HaveOccurred())
 }
 
 // Common steps required when setting up the test.

--- a/test/e2e/node_disconnect/replica_pod_remove/replica_pod_remove_test.go
+++ b/test/e2e/node_disconnect/replica_pod_remove/replica_pod_remove_test.go
@@ -28,15 +28,17 @@ var _ = Describe("Mayastor replica pod removal test", func() {
 	AfterEach(func() {
 		logf.Log.Info("AfterEach")
 		env.Teardown() // removes fio pod and volume
-		common.RmStorageClass(gStorageClass)
+		err := common.RmStorageClass(gStorageClass)
+		Expect(err).ToNot(HaveOccurred())
 
 		// Check resource leakage.
-		err := common.AfterEachCheck()
+		err = common.AfterEachCheck()
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	It("should verify nvmf nexus behaviour when a mayastor pod is removed", func() {
-		common.MkStorageClass(gStorageClass, 2, "nvmf", "io.openebs.csi-mayastor")
+		err := common.MkStorageClass(gStorageClass, 2, "nvmf", "io.openebs.csi-mayastor")
+		Expect(err).ToNot(HaveOccurred())
 		env = disconnect_lib.Setup("loss-test-pvc-nvmf", gStorageClass, "fio-pod-remove-test")
 		env.PodLossTest()
 	})

--- a/test/e2e/pvc_stress_fio/pvc_stress_fio_test.go
+++ b/test/e2e/pvc_stress_fio/pvc_stress_fio_test.go
@@ -49,7 +49,7 @@ var volNames []volSc
 //	2. The associated PV is deleted
 //  3. The associated MV is deleted
 func testPVC(volName string, scName string, runFio bool) {
-	fmt.Printf("volume: %s, storageClass:%s, run FIO:%v\n", volName, scName, runFio)
+	logf.Log.Info("testPVC", "volume", volName, "storageClass", scName, "run FIO", runFio)
 	// PVC create options
 	createOpts := &coreV1.PersistentVolumeClaim{
 		ObjectMeta: metaV1.ObjectMeta{
@@ -148,7 +148,8 @@ func testPVC(volName string, scName string, runFio bool) {
 		).Should(Equal(true))
 
 		// Run the fio test
-		Cmn.RunFio(fioPodName, 5)
+		_, err = Cmn.RunFio(fioPodName, 5, Cmn.FioFsFilename)
+		Expect(err).ToNot(HaveOccurred())
 
 		// Delete the fio pod
 		err = Cmn.DeletePod(fioPodName)


### PR DESCRIPTION
Deviations from MQ-25 test configuration
- replication factor is set to 1 for now
- application pods MAY be located on the same nodes as Mayastor
    - this requires a larger test cluster and more thought

Also included is bunch of changes to ensure clusters are
rendered usable, this to faciliate ease of test development.
Re-creating clusters is time consuming in code-debug-test iteration cycle.