### PR TITLE
feat: support multiple client output formats

### DIFF
--- a/doc/mayastor-client.md
+++ b/doc/mayastor-client.md
@@ -81,7 +81,7 @@ a URI to the resource and we can start using it.
 
 ```bash
 > mayastor-client nexus create `uuidgen -r` 1GiB aio:///dev/sdb
-Nexus 4db90841-5ee8-4b7d-a4e9-13be1043bcb3 created
+4db90841-5ee8-4b7d-a4e9-13be1043bcb3
 ```
 Tip: To find out what the arguments are, simply append the `-h` flag to any command.
 
@@ -101,7 +101,7 @@ fine writing to it as it were a local disk.
 ```bash
 > fallocate -l 2GiB /data/file.img
 > mayastor-client nexus create `uuidgen -r` 1GiB 'aio:///data/file.img?blk_size=512 aio:///dev/sdb'
-Nexus d0c47a07-d104-48e6-8f36-bfdb47e8e766 created
+d0c47a07-d104-48e6-8f36-bfdb47e8e766
 ```
 
 Notice the added query parameter `blk_size`, required as files do not have block sizes.
@@ -117,7 +117,7 @@ yourself by running fio on top of the NBD device.
 
 ```bash
 > mayastor-client nexus remove d0c47a07-d104-48e6-8f36-bfdb47e8e766 'aio:///data/file.img?blk_size=512'
-Removed aio:///data/file.img?blk_size=512 from children of d0c47a07-d104-48e6-8f36-bfdb47e8e766
+aio:///data/file.img?blk_size=512
 ```
 
 In the logs of mayastor you will see something like:
@@ -134,7 +134,7 @@ Now we can add the device again:
 
 ```bash
 > mayastor-client nexus add d0c47a07-d104-48e6-8f36-bfdb47e8e766 'aio:///data/file.img?blk_size=512'
-Added aio:///data/file.img?blk_size=512 to children of d0c47a07-d104-48e6-8f36-bfdb47e8e766
+aio:///data/file.img?blk_size=512
 ```
 
 Both the nexus and the newly added children are now degraded. The child is degraded because it needs to be rebuilt
@@ -280,9 +280,8 @@ We are maxing out at roughly 90MB, as this a 1 GbE network that is to be expecte
 Now, let's disconnect it and create a Nexus that that consumes one of the NVMe targets and rerun the test:
 
 ```bash
-    nvme disconnect -d {/dev/nvme1,/dev/nvme2}
-    mayastor-client nexus create `uuidgen -r` 64MiB 'nvmf://192.168.1.2/nqn.2019-05.io.openebs:cnode2
-        nvmf://192.168.1.2/nqn.2019-05.io.openebs:cnode1'
+nvme disconnect -d {/dev/nvme1,/dev/nvme2}
+mayastor-client nexus create `uuidgen -r` 64MiB 'nvmf://192.168.1.2/nqn.2019-05.io.openebs:cnode2 nvmf://192.168.1.2/nqn.2019-05.io.openebs:cnode1'
 ```
 
 Ok we now have created a nexus that consists out of 2 replica's:
@@ -300,7 +299,7 @@ and NVMF
 
 ```bash
 > mayastor-client nexus publish 787f82e7-e7d8-4ae1-8a25-5d48ead4f4cd
-Nexus published at file:///dev/nbd0
+file:///dev/nbd0
 ```
 
 And the results:

--- a/mayastor/src/bin/mayastor-client/device_cli.rs
+++ b/mayastor/src/bin/mayastor-client/device_cli.rs
@@ -2,27 +2,23 @@
 //! methods to obtain information about block devices on the current host
 
 use super::context::Context;
+use crate::{context::OutputFormat, GrpcStatus};
 use ::rpc::mayastor as rpc;
 use clap::{App, AppSettings, Arg, ArgMatches, SubCommand};
 use colored_json::ToColoredJson;
+use snafu::ResultExt;
 use tonic::Status;
 
 pub fn subcommands<'a, 'b>() -> App<'a, 'b> {
-    let list = SubCommand::with_name("list")
-        .about("List available (ie. unused) block devices")
-        .arg(
-            Arg::with_name("all")
-                .short("a")
-                .long("all")
-                .takes_value(false)
-                .help("List all block devices (ie. also include devices currently in use)"),
-        )
-        .arg(
-            Arg::with_name("raw")
-                .long("raw")
-                .takes_value(false)
-                .help("Display output as raw JSON"),
-        );
+    let list =
+        SubCommand::with_name("list").about("List available block devices")
+            .arg(
+                Arg::with_name("all")
+                    .short("a")
+                    .long("all")
+                    .takes_value(false)
+                    .help("List all block devices (ie. also include devices currently in use)"),
+            );
 
     SubCommand::with_name("device")
         .settings(&[
@@ -37,11 +33,12 @@ pub fn subcommands<'a, 'b>() -> App<'a, 'b> {
 pub async fn handler(
     ctx: Context,
     matches: &ArgMatches<'_>,
-) -> Result<(), Status> {
+) -> crate::Result<()> {
     match matches.subcommand() {
         ("list", Some(args)) => list_block_devices(ctx, args).await,
         (cmd, _) => {
             Err(Status::not_found(format!("command {} does not exist", cmd)))
+                .context(GrpcStatus)
         }
     }
 }
@@ -57,128 +54,98 @@ fn get_partition_type(device: &rpc::BlockDevice) -> String {
 async fn list_block_devices(
     mut ctx: Context,
     matches: &ArgMatches<'_>,
-) -> Result<(), Status> {
+) -> crate::Result<()> {
     let all = matches.is_present("all");
 
-    ctx.v2(&format!(
-        "Requesting list of {} block devices",
-        if all { "all" } else { "available" }
-    ));
-
-    let reply = ctx
+    let response = ctx
         .client
         .list_block_devices(rpc::ListBlockDevicesRequest {
             all,
         })
-        .await?;
+        .await
+        .context(GrpcStatus)?;
 
-    if matches.is_present("raw") {
-        println!(
-            "{}",
-            serde_json::to_string_pretty(&reply.into_inner())
-                .unwrap()
-                .to_colored_json_auto()
-                .unwrap()
-        );
-        return Ok(());
-    }
+    match ctx.output {
+        OutputFormat::Json => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&response.into_inner())
+                    .unwrap()
+                    .to_colored_json_auto()
+                    .unwrap()
+            )
+        }
+        OutputFormat::Default => {
+            let devices: &Vec<rpc::BlockDevice> = &response.get_ref().devices;
 
-    let devices: &Vec<rpc::BlockDevice> = &reply.get_ref().devices;
+            if devices.is_empty() {
+                ctx.v1("No devices found");
+                return Ok(());
+            }
 
-    if devices.is_empty() {
-        ctx.v1("No devices found");
-        return Ok(());
-    }
+            let table = devices
+                .iter()
+                .map(|device| {
+                    let fstype: String;
+                    let uuid: String;
+                    let mountpoint: String;
 
-    if all {
-        let table = devices
-            .iter()
-            .map(|device| {
-                let fstype: String;
-                let uuid: String;
-                let mountpoint: String;
+                    if let Some(filesystem) = &device.filesystem {
+                        fstype = filesystem.fstype.clone();
+                        uuid = filesystem.uuid.clone();
+                        mountpoint = filesystem.mountpoint.clone();
+                    } else {
+                        fstype = String::from("");
+                        uuid = String::from("");
+                        mountpoint = String::from("");
+                    }
 
-                if let Some(filesystem) = &device.filesystem {
-                    fstype = filesystem.fstype.clone();
-                    uuid = filesystem.uuid.clone();
-                    mountpoint = filesystem.mountpoint.clone();
-                } else {
-                    fstype = String::from("");
-                    uuid = String::from("");
-                    mountpoint = String::from("");
-                }
+                    vec![
+                        device.devname.clone(),
+                        device.devtype.clone(),
+                        device.devmajor.to_string(),
+                        device.devminor.to_string(),
+                        device.size.to_string(),
+                        String::from(if device.available {
+                            "yes"
+                        } else {
+                            "no"
+                        }),
+                        device.model.clone(),
+                        get_partition_type(&device),
+                        fstype,
+                        uuid,
+                        mountpoint,
+                        device.devpath.clone(),
+                        device
+                            .devlinks
+                            .iter()
+                            .map(|s| format!("\"{}\"", s))
+                            .collect::<Vec<String>>()
+                            .join(" "),
+                    ]
+                })
+                .collect();
 
+            ctx.print_list(
                 vec![
-                    device.devname.clone(),
-                    device.devtype.clone(),
-                    device.devmajor.to_string(),
-                    device.devminor.to_string(),
-                    device.size.to_string(),
-                    String::from(if device.available { "yes" } else { "no" }),
-                    device.model.clone(),
-                    get_partition_type(&device),
-                    fstype,
-                    uuid,
-                    mountpoint,
-                    device.devpath.clone(),
-                    device
-                        .devlinks
-                        .iter()
-                        .map(|s| format!("\"{}\"", s))
-                        .collect::<Vec<String>>()
-                        .join(" "),
-                ]
-            })
-            .collect();
-
-        ctx.print_list(
-            vec![
-                "DEVNAME",
-                "DEVTYPE",
-                ">MAJOR",
-                "MINOR",
-                ">SIZE",
-                "AVAILABLE",
-                "MODEL",
-                "PARTTYPE",
-                "FSTYPE",
-                "FSUUID",
-                "MOUNTPOINT",
-                "DEVPATH",
-                "DEVLINKS",
-            ],
-            table,
-        );
-    } else {
-        let table = devices
-            .iter()
-            .map(|device| {
-                vec![
-                    device.devname.clone(),
-                    device.devtype.clone(),
-                    device.devmajor.to_string(),
-                    device.devminor.to_string(),
-                    device.size.to_string(),
-                    device.model.clone(),
-                    get_partition_type(&device),
-                    device.devpath.clone(),
-                    device
-                        .devlinks
-                        .iter()
-                        .map(|s| format!("\"{}\"", s))
-                        .collect::<Vec<String>>()
-                        .join(" "),
-                ]
-            })
-            .collect();
-
-        ctx.print_list(
-            vec![
-                "DEVNAME", "DEVTYPE", ">MAJOR", "MINOR", ">SIZE", "MODEL",
-                "PARTTYPE", "DEVPATH", "DEVLINKS",
-            ],
-            table,
-        );
+                    "DEVNAME",
+                    "DEVTYPE",
+                    ">MAJOR",
+                    "MINOR",
+                    ">SIZE",
+                    "AVAILABLE",
+                    "MODEL",
+                    "PARTTYPE",
+                    "FSTYPE",
+                    "FSUUID",
+                    "MOUNTPOINT",
+                    "DEVPATH",
+                    "DEVLINKS",
+                ],
+                table,
+            );
+        }
     }
 
     Ok(())

--- a/mayastor/src/bin/mayastor-client/main.rs
+++ b/mayastor/src/bin/mayastor-client/main.rs
@@ -38,6 +38,8 @@ pub enum Error {
         source: context::Error,
         backtrace: Backtrace,
     },
+    #[snafu(display("Missing value for {}", field))]
+    MissingValue { field: String },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -87,6 +89,16 @@ async fn main() -> crate::Result<()> {
                 .hide_possible_values(true)
                 .next_line_help(true)
                 .help("Output with large units: i for kiB, etc. or d for kB, etc."))
+        .arg(
+            Arg::with_name("output")
+                .short("o")
+                .long("output")
+                .value_name("FORMAT")
+                .default_value("default")
+                .possible_values(&["default", "json"])
+                .global(true)
+                .help("Output format.")
+        )
         .subcommand(pool_cli::subcommands())
         .subcommand(nexus_cli::subcommands())
         .subcommand(replica_cli::subcommands())
@@ -112,5 +124,5 @@ async fn main() -> crate::Result<()> {
         ("jsonrpc", Some(args)) => jsonrpc_cli::json_rpc_call(ctx, args).await,
         _ => panic!("Command not found"),
     };
-    status.context(GrpcStatus)
+    status
 }

--- a/mayastor/src/bin/mayastor-client/perf_cli.rs
+++ b/mayastor/src/bin/mayastor-client/perf_cli.rs
@@ -4,9 +4,14 @@
 //! At present we only have get_resource_usage() which is
 //! essentially the result of a getrusage(2) system call.
 
-use super::context::Context;
+use super::{
+    context::{Context, OutputFormat},
+    GrpcStatus,
+};
 use ::rpc::mayastor as rpc;
 use clap::{App, AppSettings, ArgMatches, SubCommand};
+use colored_json::ToColoredJson;
+use snafu::ResultExt;
 use tonic::Status;
 
 pub fn subcommands<'a, 'b>() -> App<'a, 'b> {
@@ -26,11 +31,12 @@ pub fn subcommands<'a, 'b>() -> App<'a, 'b> {
 pub async fn handler(
     ctx: Context,
     matches: &ArgMatches<'_>,
-) -> Result<(), Status> {
+) -> crate::Result<()> {
     match matches.subcommand() {
         ("resource", Some(args)) => get_resource_usage(ctx, args).await,
         (cmd, _) => {
             Err(Status::not_found(format!("command {} does not exist", cmd)))
+                .context(GrpcStatus)
         }
     }
 }
@@ -38,31 +44,48 @@ pub async fn handler(
 async fn get_resource_usage(
     mut ctx: Context,
     _matches: &ArgMatches<'_>,
-) -> Result<(), Status> {
+) -> crate::Result<()> {
     ctx.v2("Requesting resource usage statistics");
 
     let mut table: Vec<Vec<String>> = Vec::new();
 
-    let reply = ctx.client.get_resource_usage(rpc::Null {}).await?;
+    let response = ctx
+        .client
+        .get_resource_usage(rpc::Null {})
+        .await
+        .context(GrpcStatus)?;
 
-    if let Some(usage) = &reply.get_ref().usage {
-        table.push(vec![
-            usage.soft_faults.to_string(),
-            usage.hard_faults.to_string(),
-            usage.vol_csw.to_string(),
-            usage.invol_csw.to_string(),
-        ]);
-    }
+    match ctx.output {
+        OutputFormat::Json => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(response.get_ref())
+                    .unwrap()
+                    .to_colored_json_auto()
+                    .unwrap()
+            );
+        }
+        OutputFormat::Default => {
+            if let Some(usage) = &response.get_ref().usage {
+                table.push(vec![
+                    usage.soft_faults.to_string(),
+                    usage.hard_faults.to_string(),
+                    usage.vol_csw.to_string(),
+                    usage.invol_csw.to_string(),
+                ]);
+            }
 
-    ctx.print_list(
-        vec![
-            ">SOFT_FAULTS",
-            ">HARD_FAULTS",
-            ">VOLUNTARY_CSW",
-            ">INVOLUNTARY_CSW",
-        ],
-        table,
-    );
+            ctx.print_list(
+                vec![
+                    ">SOFT_FAULTS",
+                    ">HARD_FAULTS",
+                    ">VOLUNTARY_CSW",
+                    ">INVOLUNTARY_CSW",
+                ],
+                table,
+            );
+        }
+    };
 
     Ok(())
 }

--- a/nix/pkgs/mayastor/cargo-package.nix
+++ b/nix/pkgs/mayastor/cargo-package.nix
@@ -57,7 +57,7 @@ let
   buildProps = rec {
     name = "mayastor";
     #cargoSha256 = "0000000000000000000000000000000000000000000000000000";
-    cargoSha256 = "07jrhgbz7rfk1d1rwzj637afm8i1fhw143dhrz7vm9p9pyjzyj31";
+    cargoSha256 = "2FD8M5KC3LN/KK4DNgGNPQiHoqPYhwq3+yhJGcuv9wg=";
     inherit version cargoBuildFlags;
     src = whitelistSource ../../../. src_list;
     LIBCLANG_PATH = "${llvmPackages.libclang}/lib";

--- a/test/grpc/test_cli.js
+++ b/test/grpc/test_cli.js
@@ -306,7 +306,7 @@ describe('mayastor-client', function () {
           return done(err);
         }
         assert.isEmpty(stderr);
-        assert.match(stdout, /Created pool tpool/);
+        assert.match(stdout, /tpool/);
         done();
       });
     });
@@ -373,7 +373,7 @@ describe('mayastor-client', function () {
           return done(err);
         }
         assert.isEmpty(stderr);
-        assert.match(stdout, /Destroyed pool tpool/);
+        assert.match(stdout, /tpool/);
         done();
       });
     });
@@ -394,7 +394,7 @@ describe('mayastor-client', function () {
           return done(err);
         }
         assert.isEmpty(stderr);
-        assert.match(stdout, /Nexus 753b391c-9b04-4ce3-9c74-9d949152e547 created/);
+        assert.match(stdout, /753b391c-9b04-4ce3-9c74-9d949152e547/);
         done();
       });
     });
@@ -407,7 +407,7 @@ describe('mayastor-client', function () {
           return done(err);
         }
         assert.isEmpty(stderr);
-        assert.match(stdout, /Nexus published at file:\/\/\/dev\/blah/);
+        assert.match(stdout, /file:\/\/\/dev\/blah/);
         done();
       });
     });
@@ -424,7 +424,7 @@ describe('mayastor-client', function () {
           return done(err);
         }
         assert.isEmpty(stderr);
-        assert.match(stdout, /unpublished/);
+        assert.match(stdout, /753b391c-9b04-4ce3-9c74-9d949152e547/);
         done();
       });
     });
@@ -437,7 +437,7 @@ describe('mayastor-client', function () {
           return done(err);
         }
         assert.isEmpty(stderr);
-        assert.match(stdout, /Added child_a to children of 753b391c-9b04-4ce3-9c74-9d949152e547/);
+        assert.match(stdout, /753b391c-9b04-4ce3-9c74-9d949152e547/);
         done();
       });
     });
@@ -450,7 +450,7 @@ describe('mayastor-client', function () {
           return done(err);
         }
         assert.isEmpty(stderr);
-        assert.match(stdout, /Removed child_a from children of 753b391c-9b04-4ce3-9c74-9d949152e547/);
+        assert.match(stdout, /child_a/);
         done();
       });
     });
@@ -468,10 +468,10 @@ describe('mayastor-client', function () {
           if (parts.length <= 1) { return; }
           nexus.push({
             name: parts[0],
-            path: parts[1],
-            size: parts[2],
-            state: parts[3],
-            rebuilds: parts[4],
+            size: parts[1],
+            state: parts[2],
+            rebuilds: parts[3],
+            path: parts[4],
             children: parts[5]
           });
         });
@@ -531,7 +531,7 @@ describe('mayastor-client', function () {
           return done(err);
         }
         assert.isEmpty(stderr);
-        assert.match(stdout, /destroyed/);
+        assert.match(stdout, /753b391c-9b04-4ce3-9c74-9d949152e547/);
         done();
       });
     });
@@ -692,7 +692,7 @@ describe('mayastor-client', function () {
           return done(err);
         }
         assert.isEmpty(stderr);
-        assert.isEmpty(stdout);
+        assert.match(stdout, /753b391c-9b04-4ce3-9c74-9d949152e547/);
         done();
       });
     });


### PR DESCRIPTION
Support both tables/plaintext and JSON in outputs.

Users can now specify `-o json` or `-o default` to configure their output options.
`-o default` is implied. This mimics the `nvme` tool.

Normalizes the output of commands to be similar to `docker` or `kubectl` style commands,
returning relevant URIs, names, etc.

Resolves https://github.com/openebs/Mayastor/issues/756