### PR TITLE
feat(nvmx): extended nvmx i/o completion status

### DIFF
--- a/mayastor/src/bdev/dev/nvmx/controller.rs
+++ b/mayastor/src/bdev/dev/nvmx/controller.rs
@@ -50,8 +50,8 @@ use crate::{
         BlockDeviceIoStats,
         CoreError,
         DeviceEventType,
-        IoCompletionCallback,
-        IoCompletionCallbackArg,
+        OpCompletionCallback,
+        OpCompletionCallbackArg,
     },
     ffihelper::{cb_arg, done_cb},
     nexus_uri::NexusBdevError,
@@ -64,8 +64,8 @@ static RESET_CTX_POOL: OnceCell<MemoryPool<ResetCtx>> = OnceCell::new();
 
 struct ResetCtx {
     name: String,
-    cb: IoCompletionCallback,
-    cb_arg: IoCompletionCallbackArg,
+    cb: OpCompletionCallback,
+    cb_arg: OpCompletionCallbackArg,
     spdk_handle: *mut spdk_nvme_ctrlr,
     io_device: Arc<IoDevice>,
     shutdown_in_progress: bool,
@@ -73,8 +73,8 @@ struct ResetCtx {
 
 struct ShutdownCtx {
     name: String,
-    cb: IoCompletionCallback,
-    cb_arg: IoCompletionCallbackArg,
+    cb: OpCompletionCallback,
+    cb_arg: OpCompletionCallbackArg,
 }
 
 impl<'a> NvmeControllerInner<'a> {
@@ -232,8 +232,8 @@ impl<'a> NvmeController<'a> {
     /// are reinitialized.
     pub fn reset(
         &mut self,
-        cb: IoCompletionCallback,
-        cb_arg: IoCompletionCallbackArg,
+        cb: OpCompletionCallback,
+        cb_arg: OpCompletionCallbackArg,
         failover: bool,
     ) -> Result<(), CoreError> {
         match self.state_machine.current_state() {
@@ -427,8 +427,8 @@ impl<'a> NvmeController<'a> {
     /// unregisters the I/O device associated with the controller.
     pub fn shutdown(
         &mut self,
-        cb: IoCompletionCallback,
-        cb_arg: IoCompletionCallbackArg,
+        cb: OpCompletionCallback,
+        cb_arg: OpCompletionCallbackArg,
     ) -> Result<(), CoreError> {
         self.state_machine.transition(Unconfiguring).map_err(|_| {
             error!(
@@ -639,8 +639,9 @@ impl<'a> Drop for NvmeController<'a> {
         // controller).
         assert!(
             matches!(curr_state, New | Unconfigured),
-           "{} dropping active controller in {:?} state",
-                self.name, curr_state
+            "{} dropping active controller in {:?} state",
+            self.name,
+            curr_state
         );
 
         // Inner state might not be yes available.

--- a/mayastor/src/bdev/dev/nvmx/utils.rs
+++ b/mayastor/src/bdev/dev/nvmx/utils.rs
@@ -1,3 +1,5 @@
+use crate::core::NvmeCommandStatus;
+
 use spdk_sys::{self, spdk_nvme_cpl};
 
 #[derive(Debug, PartialEq)]
@@ -57,6 +59,23 @@ pub(crate) fn nvme_cpl_succeeded(cpl: *const spdk_nvme_cpl) -> bool {
     sct == NvmeStatusCodeType::Generic as u16
         && sc == NvmeGenericCommandStatusCode::Success as u16
 }
+
+/// Translates NVMe completion status into NvmeCommandStatus.
+pub(crate) fn nvme_command_status(
+    cpl: *const spdk_nvme_cpl,
+) -> NvmeCommandStatus {
+    let (sct, sc) = unsafe {
+        let cplr = &*cpl;
+
+        (
+            cplr.__bindgen_anon_1.status.sct().into(),
+            cplr.__bindgen_anon_1.status.sc().into(),
+        )
+    };
+
+    NvmeCommandStatus::from_command_status(sct, sc)
+}
+
 /* Bit set of attributes for DATASET MANAGEMENT commands. */
 #[allow(dead_code)]
 pub enum NvmeDsmAttribute {

--- a/mayastor/src/core/block_device.rs
+++ b/mayastor/src/core/block_device.rs
@@ -1,6 +1,6 @@
 use crate::{
     bdev::nexus::nexus_io::IoType,
-    core::{CoreError, DmaBuf, DmaError},
+    core::{CoreError, DmaBuf, DmaError, IoCompletionStatus},
 };
 use async_trait::async_trait;
 use merge::Merge;
@@ -91,7 +91,10 @@ pub trait BlockDeviceDescriptor {
 }
 
 pub type IoCompletionCallbackArg = *mut c_void;
-pub type IoCompletionCallback = fn(bool, IoCompletionCallbackArg) -> ();
+pub type IoCompletionCallback =
+    fn(IoCompletionStatus, IoCompletionCallbackArg) -> ();
+pub type OpCompletionCallbackArg = *mut c_void;
+pub type OpCompletionCallback = fn(bool, OpCompletionCallbackArg) -> ();
 
 /*
  * Core trait that represents a device I/O handle.
@@ -138,8 +141,8 @@ pub trait BlockDeviceHandle {
 
     fn reset(
         &self,
-        cb: IoCompletionCallback,
-        cb_arg: IoCompletionCallbackArg,
+        cb: OpCompletionCallback,
+        cb_arg: OpCompletionCallbackArg,
     ) -> Result<(), CoreError>;
 
     fn unmap_blocks(

--- a/mayastor/src/core/mod.rs
+++ b/mayastor/src/core/mod.rs
@@ -17,6 +17,8 @@ pub use block_device::{
     IoCompletionCallback,
     IoCompletionCallbackArg,
     LbaRangeController,
+    OpCompletionCallback,
+    OpCompletionCallbackArg,
 };
 pub use channel::IoChannel;
 pub use cpu_cores::{Core, Cores};
@@ -31,7 +33,7 @@ pub use env::{
 };
 
 pub use handle::BdevHandle;
-pub use nvme::{GenericStatusCode, NvmeStatus};
+pub use nvme::{GenericStatusCode, NvmeCommandStatus, NvmeStatus};
 pub use reactor::{Reactor, ReactorState, Reactors, REACTOR_LIST};
 pub use share::{Protocol, Share};
 pub use thread::Mthread;
@@ -162,4 +164,12 @@ pub enum CoreError {
     DeviceStatisticsError {
         source: Errno,
     },
+}
+
+// Generic I/O completion status for block devices, which supports per-protocol
+// error domains.
+#[derive(Debug, Copy, Clone, Eq, PartialOrd, PartialEq)]
+pub enum IoCompletionStatus {
+    Success,
+    NvmeError(NvmeCommandStatus),
 }

--- a/mayastor/src/core/nvme.rs
+++ b/mayastor/src/core/nvme.rs
@@ -36,7 +36,6 @@ impl From<i32> for StatusCodeType {
 pub enum GenericStatusCode {
     Success,
     InvalidOpcode,
-    InvalidOPCode,
     InvalidFieldInCommand,
     CommandIDConflict,
     DataTransferError,
@@ -64,6 +63,14 @@ pub enum GenericStatusCode {
     CommandAbortPreemt,
     SanitizeFailed,
     SanitizeInProgress,
+    Reserved,
+}
+#[derive(Debug, Copy, Clone, Eq, PartialOrd, PartialEq)]
+pub enum NvmeCommandStatus {
+    CommandSpecificStatus,
+    GenericCommandStatus(GenericStatusCode),
+    MediaDataIntegrityErrors,
+    VendorSpecific,
     Reserved,
 }
 
@@ -191,6 +198,20 @@ impl From<&Bio> for NvmeStatus {
             cdw0,
             sct: StatusCodeType::from(sct),
             sc: GenericStatusCode::from(sc),
+        }
+    }
+}
+
+impl NvmeCommandStatus {
+    pub fn from_command_status(sct: i32, sc: i32) -> Self {
+        match StatusCodeType::from(sct) {
+            CommandSpecificStatus => Self::CommandSpecificStatus,
+            GenericCommandStatus => {
+                Self::GenericCommandStatus(GenericStatusCode::from(sc))
+            }
+            MediaDataIntegrityErrors => Self::MediaDataIntegrityErrors,
+            VendorSpecific => Self::VendorSpecific,
+            _ => Self::Reserved,
         }
     }
 }

--- a/mayastor/tests/nvme_device_timeout.rs
+++ b/mayastor/tests/nvme_device_timeout.rs
@@ -3,7 +3,13 @@ use crossbeam::atomic::AtomicCell;
 use libc::c_void;
 use mayastor::{
     bdev::{device_create, device_destroy, device_open},
-    core::{BlockDeviceHandle, DeviceTimeoutAction, DmaBuf, MayastorCliArgs},
+    core::{
+        BlockDeviceHandle,
+        DeviceTimeoutAction,
+        DmaBuf,
+        IoCompletionStatus,
+        MayastorCliArgs,
+    },
     subsys::{Config, NvmeBdevOpts},
 };
 use once_cell::sync::Lazy;
@@ -112,8 +118,12 @@ async fn test_io_timeout(action_on_timeout: DeviceTimeoutAction) {
     }
 
     // Read completion callback.
-    fn read_completion_callback(success: bool, ctx: *mut c_void) {
-        assert_eq!(success, false, "I/O operation completed successfully");
+    fn read_completion_callback(status: IoCompletionStatus, ctx: *mut c_void) {
+        assert_ne!(
+            status,
+            IoCompletionStatus::Success,
+            "I/O operation completed successfully"
+        );
         assert_eq!(
             CALLBACK_FLAG.load(),
             false,
@@ -284,8 +294,12 @@ async fn io_timeout_ignore() {
     }
 
     // Read completion callback.
-    fn read_completion_callback(success: bool, ctx: *mut c_void) {
-        assert_eq!(success, false, "I/O operation completed successfully");
+    fn read_completion_callback(status: IoCompletionStatus, ctx: *mut c_void) {
+        assert_ne!(
+            status,
+            IoCompletionStatus::Success,
+            "I/O operation completed successfully"
+        );
         assert_eq!(
             CALLBACK_FLAG.load(),
             false,


### PR DESCRIPTION
This fix introduces a new generic enum for indicating completion status
for I/O operations, instead of a single boolean flag.
This allows better per-domain separation of I/O errors (NVMe, SCSI,
etc).

Implements CAS-736