### PR TITLE
fix(nexus): mayastor hangs when creating a nexus if there is an error creating a child

### DIFF
--- a/control-plane/tests/tests/nexus.rs
+++ b/control-plane/tests/tests/nexus.rs
@@ -1,5 +1,3 @@
-#![feature(allow_fail)]
-
 pub mod common;
 use common::*;
 
@@ -19,14 +17,11 @@ async fn create_nexus_malloc() {
         .unwrap();
 }
 
-// FIXME: CAS-737
 #[actix_rt::test]
-#[allow_fail]
 async fn create_nexus_sizes() {
     let cluster = ClusterBuilder::builder()
         .with_rest_timeout(std::time::Duration::from_secs(1))
-        // don't log whilst we have the allow_fail
-        .compose_build(|c| c.with_logs(false))
+        .compose_build(|c| c.with_logs(true))
         .await
         .unwrap();
 

--- a/mayastor/src/bdev/nexus/nexus_bdev_children.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev_children.rs
@@ -345,13 +345,13 @@ impl Nexus {
             })
         }
     }
-    /// destroy all children that are part of this nexus closes any child
-    /// that might be open first
-    pub(crate) async fn destroy_children(&mut self) {
+
+    /// Close each child that belongs to this nexus.
+    pub(crate) async fn close_children(&mut self) {
         let futures = self.children.iter_mut().map(|c| c.close());
         let results = join_all(futures).await;
         if results.iter().any(|c| c.is_err()) {
-            error!("{}: Failed to destroy child", self.name);
+            error!("{}: Failed to close children", self.name);
         }
     }
 

--- a/mayastor/tests/child_size.rs
+++ b/mayastor/tests/child_size.rs
@@ -1,0 +1,78 @@
+use tracing::error;
+
+use once_cell::sync::OnceCell;
+
+use common::MayastorTest;
+use mayastor::{
+    bdev::{nexus_create, nexus_lookup},
+    core::{Bdev, MayastorCliArgs},
+};
+
+pub mod common;
+
+async fn create_nexus(size: u64) -> bool {
+    let children = vec![
+        String::from("malloc:///m0?size_mb=32"),
+        format!("malloc:///m1?size_mb={}", size),
+    ];
+    if let Err(error) =
+        nexus_create("core_nexus", size * 1024 * 1024, None, &children).await
+    {
+        error!("nexus_create() failed: {}", error);
+        return false;
+    }
+    true
+}
+
+static MS: OnceCell<MayastorTest> = OnceCell::new();
+
+fn mayastor() -> &'static MayastorTest<'static> {
+    let ms = MS.get_or_init(|| MayastorTest::new(MayastorCliArgs::default()));
+    &ms
+}
+
+#[tokio::test]
+async fn child_size_ok() {
+    mayastor()
+        .spawn(async {
+            assert_eq!(Bdev::bdev_first().into_iter().count(), 0);
+            assert!(create_nexus(16).await);
+
+            let bdev = Bdev::lookup_by_name("core_nexus").unwrap();
+            assert_eq!(bdev.name(), "core_nexus");
+
+            let bdev =
+                Bdev::lookup_by_name("m0").expect("child bdev m0 not found");
+            assert_eq!(bdev.name(), "m0");
+
+            let bdev =
+                Bdev::lookup_by_name("m1").expect("child bdev m1 not found");
+            assert_eq!(bdev.name(), "m1");
+
+            let nexus = nexus_lookup("core_nexus").expect("nexus not found");
+            nexus.destroy().await.unwrap();
+
+            assert!(nexus_lookup("core_nexus").is_none());
+            assert!(Bdev::lookup_by_name("core_nexus").is_none());
+            assert!(Bdev::lookup_by_name("m0").is_none());
+            assert!(Bdev::lookup_by_name("m1").is_none());
+            assert_eq!(Bdev::bdev_first().into_iter().count(), 0);
+        })
+        .await;
+}
+
+#[tokio::test]
+async fn child_too_small() {
+    mayastor()
+        .spawn(async {
+            assert_eq!(Bdev::bdev_first().into_iter().count(), 0);
+            assert!(!create_nexus(4).await);
+
+            assert!(nexus_lookup("core_nexus").is_none());
+            assert!(Bdev::lookup_by_name("core_nexus").is_none());
+            assert!(Bdev::lookup_by_name("m0").is_none());
+            assert!(Bdev::lookup_by_name("m1").is_none());
+            assert_eq!(Bdev::bdev_first().into_iter().count(), 0);
+        })
+        .await;
+}


### PR DESCRIPTION
When creating a new nexus, as a final step, the newly created
nexus is added to a global list of nexus instances.

This list is required when handling bdev removal - specifically
it is used by lookup_child_from_bdev() to determine the nexus child
that is associated with a given bdev.

The problem occurs when there is an error creating a nexus,
and proper cleanup necessitates the removal of some children that may
have already been successfully created. The removal code requires the
owning nexus to be present in the global list in order to successfully
remove the children, but the nexus has not yet been added to the list,
as it has not been successfully created.

The solution is to add the (partially created) nexus to the list of global
instances as early as possible in the creation process. This means that we
also need to ensure that it is removed again if any error is encountered.

resolves CAS-757
