### PR TITLE
feat(nvmx): pass device reference to i/o callbacks

### DIFF
--- a/mayastor/src/bdev/dev/nvmx/channel.rs
+++ b/mayastor/src/bdev/dev/nvmx/channel.rs
@@ -7,9 +7,10 @@ use crate::{
             NvmeControllerState,
             NVME_CONTROLLERS,
         },
+        device_lookup,
         nexus::nexus_io::IoType,
     },
-    core::{poller, BlockDeviceIoStats, CoreError},
+    core::{poller, BlockDevice, BlockDeviceIoStats, CoreError},
 };
 use std::{cmp::max, mem::size_of, os::raw::c_void, ptr::NonNull};
 
@@ -201,6 +202,8 @@ pub struct NvmeIoChannelInner<'a> {
     poller: poller::Poller<'a>,
     pub qpair: Option<IoQpair>,
     io_stats_controller: IoStatsController,
+    pub device: Box<dyn BlockDevice>,
+
     // Flag to indicate the shutdown state of the channel.
     // We need such a flag to differentiate between channel reset and shutdown.
     // Channel reset is a reversible operation, which is followed by
@@ -436,6 +439,18 @@ impl NvmeControllerIoChannel {
 
         let nvme_channel = NvmeIoChannel::from_raw(ctx);
 
+        // Get a block device that corresponds to the controller.
+        let device = match device_lookup(&cname) {
+            Some(device) => device,
+            None => {
+                error!(
+                    "{} no block device exists for controller, I/O channel creation not possible",
+                    cname,
+                );
+                return 1;
+            }
+        };
+
         // Allocate qpair.
         let mut qpair = match IoQpair::create(spdk_handle, &cname) {
             Ok(qpair) => qpair,
@@ -482,6 +497,7 @@ impl NvmeControllerIoChannel {
             poller,
             io_stats_controller: IoStatsController::new(block_size),
             is_shutdown: false,
+            device,
         });
 
         nvme_channel.inner = Box::into_raw(inner);

--- a/mayastor/src/bdev/dev/nvmx/handle.rs
+++ b/mayastor/src/bdev/dev/nvmx/handle.rs
@@ -76,7 +76,7 @@ struct NvmeIoCtx {
     iov_offset: u64,
     op: IoType,
     num_blocks: u64,
-    channel: Option<*mut spdk_io_channel>,
+    channel: *mut spdk_io_channel,
 }
 
 unsafe impl Send for NvmeIoCtx {}
@@ -107,10 +107,12 @@ pub struct NvmeDeviceHandle {
     ns: Arc<NvmeNamespace>,
     prchk_flags: u32,
 
+    // Private instance of the block device backed by the NVMe namespace.
+    block_device: Box<dyn BlockDevice>,
+
     // Static values cached for performance.
-    _num_blocks: u64,
+    num_blocks: u64,
     block_len: u64,
-    _size_in_bytes: u64,
 }
 
 impl NvmeDeviceHandle {
@@ -141,9 +143,12 @@ impl NvmeDeviceHandle {
             name: name.to_string(),
             io_channel: ManuallyDrop::new(io_channel),
             ctrlr,
-            _num_blocks: ns.num_blocks(),
+            block_device: Box::new(NvmeBlockDevice::from_ns(
+                name,
+                Arc::clone(&ns),
+            )),
+            num_blocks: ns.num_blocks(),
             block_len: ns.block_len(),
-            _size_in_bytes: ns.size_in_bytes(),
             prchk_flags,
             ns,
         })
@@ -234,22 +239,20 @@ extern "C" fn nvme_queued_next_sge(
 fn complete_nvme_command(ctx: *mut NvmeIoCtx, cpl: *const spdk_nvme_cpl) {
     let io_ctx = unsafe { &mut *ctx };
     let op_succeeded = nvme_cpl_succeeded(cpl);
+    let inner = NvmeIoChannel::inner_from_channel(io_ctx.channel);
 
     // Update I/O statistics in case the operation succeeded.
     if op_succeeded {
-        if let Some(channel) = io_ctx.channel.take() {
-            let inner = NvmeIoChannel::inner_from_channel(channel);
-            let stats_controller = inner.get_io_stats_controller();
-
-            stats_controller.account_block_io(io_ctx.op, 1, io_ctx.num_blocks);
-        }
+        let stats_controller = inner.get_io_stats_controller();
+        stats_controller.account_block_io(io_ctx.op, 1, io_ctx.num_blocks);
     }
 
     // Invoke caller's callback and free I/O context.
     if op_succeeded {
-        (io_ctx.cb)(IoCompletionStatus::Success, io_ctx.cb_arg);
+        (io_ctx.cb)(&inner.device, IoCompletionStatus::Success, io_ctx.cb_arg);
     } else {
         (io_ctx.cb)(
+            &inner.device,
             IoCompletionStatus::NvmeError(nvme_command_status(cpl)),
             io_ctx.cb_arg,
         );
@@ -406,8 +409,8 @@ fn check_channel_for_io(
 
 #[async_trait(?Send)]
 impl BlockDeviceHandle for NvmeDeviceHandle {
-    fn get_device(&self) -> Box<dyn BlockDevice> {
-        Box::new(NvmeBlockDevice::from_ns(&self.name, Arc::clone(&self.ns)))
+    fn get_device(&self) -> &Box<dyn BlockDevice> {
+        &self.block_device
     }
 
     fn dma_malloc(&self, size: u64) -> Result<DmaBuf, DmaError> {
@@ -597,7 +600,7 @@ impl BlockDeviceHandle for NvmeDeviceHandle {
                 iovcnt: iovcnt as u64,
                 iovpos: 0,
                 iov_offset: 0,
-                channel: Some(channel),
+                channel: channel,
                 op: IoType::Read,
                 num_blocks,
             },
@@ -673,7 +676,7 @@ impl BlockDeviceHandle for NvmeDeviceHandle {
                 iovcnt: iovcnt as u64,
                 iovpos: 0,
                 iov_offset: 0,
-                channel: Some(channel),
+                channel: channel,
                 op: IoType::Write,
                 num_blocks,
             },
@@ -824,7 +827,7 @@ impl BlockDeviceHandle for NvmeDeviceHandle {
                 iovcnt: 0,
                 iovpos: 0,
                 iov_offset: 0,
-                channel: Some(channel),
+                channel: channel,
                 op: IoType::Unmap,
                 num_blocks,
             },

--- a/mayastor/src/core/block_device.rs
+++ b/mayastor/src/core/block_device.rs
@@ -91,8 +91,11 @@ pub trait BlockDeviceDescriptor {
 }
 
 pub type IoCompletionCallbackArg = *mut c_void;
-pub type IoCompletionCallback =
-    fn(IoCompletionStatus, IoCompletionCallbackArg) -> ();
+pub type IoCompletionCallback = fn(
+    &Box<dyn BlockDevice>,
+    IoCompletionStatus,
+    IoCompletionCallbackArg,
+) -> ();
 pub type OpCompletionCallbackArg = *mut c_void;
 pub type OpCompletionCallback = fn(bool, OpCompletionCallbackArg) -> ();
 
@@ -103,7 +106,7 @@ pub type OpCompletionCallback = fn(bool, OpCompletionCallbackArg) -> ();
 #[async_trait(?Send)]
 pub trait BlockDeviceHandle {
     // Generic functions.
-    fn get_device(&self) -> Box<dyn BlockDevice>;
+    fn get_device(&self) -> &Box<dyn BlockDevice>;
     fn dma_malloc(&self, size: u64) -> Result<DmaBuf, DmaError>;
 
     // Futures-based I/O functions.


### PR DESCRIPTION
I/O callbacks now receive references to the device that performs I/O,
which simplifies device identification during I/O completion assessment.

Implements CAS-741