### PR TITLE
chore: allow Nexus::new to create and register children (WIP)

### DIFF
--- a/mayastor/src/bdev/dev/loopback.rs
+++ b/mayastor/src/bdev/dev/loopback.rs
@@ -82,7 +82,8 @@ impl CreateDestroy for Loopback {
     }
 
     async fn destroy(self: Box<Self>) -> Result<(), Self::Error> {
-        if let Some(child) = lookup_child_from_bdev(&self.name) {
+        if let Some(child) = lookup_child_from_bdev(&self.name).await {
+            let mut child = child.write().await;
             child.remove();
         }
         Ok(())

--- a/mayastor/src/bdev/nexus/mod.rs
+++ b/mayastor/src/bdev/nexus/mod.rs
@@ -54,10 +54,16 @@ pub fn instances() -> &'static mut Vec<Box<Nexus>> {
     nexus_module::NexusModule::get_instances()
 }
 
-/// function used to create a new nexus when parsing a config file
-pub fn nexus_instance_new(name: String, size: u64, children: Vec<String>) {
+/// Create a nexus in the global instance pool.
+pub async fn nexus_instance_new(
+    name: String,
+    size: u64,
+    children: Vec<String>,
+) -> Result<(), nexus_bdev::Error> {
     let list = instances();
-    list.push(Nexus::new(&name, size, None, Some(&children)));
+    let nexus = Nexus::new(&name, size, None, Some(&children)).await?;
+    list.push(nexus);
+    Ok(())
 }
 
 /// called during shutdown so that all nexus children are in Destroying state

--- a/mayastor/src/bdev/nexus/nexus_bdev_rebuild.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev_rebuild.rs
@@ -331,7 +331,8 @@ impl Nexus {
     async fn notify_rebuild(nexus: String, job: String) {
         info!("nexus {} received notify_rebuild from job {}", nexus, job);
 
-        if let Some(nexus) = nexus_lookup(&nexus) {
+        if let Some(nexus) = nexus_lookup(&nexus).await {
+            let mut nexus = nexus.write().await;
             if let Err(e) = nexus.on_rebuild_update(job).await {
                 error!(
                     "Failed to complete the rebuild with error {}",

--- a/mayastor/src/bdev/nexus/nexus_child_error_store.rs
+++ b/mayastor/src/bdev/nexus/nexus_child_error_store.rs
@@ -271,13 +271,14 @@ impl Nexus {
         io_num_blocks: u64,
         now: Instant,
     ) {
-        let nexus = match nexus_lookup(&name) {
+        let nexus = match nexus_lookup(&name).await {
             Some(nexus) => nexus,
             None => {
                 error!("Failed to find the nexus >{}<", name);
                 return;
             }
         };
+        let mut nexus = nexus.write().await;
         trace!("Adding error record {:?} bdev {:?}", io_op_type, bdev);
         for child in nexus.children.iter_mut() {
             if let Some(bdev) = child.bdev.as_ref() {

--- a/mayastor/src/bdev/nexus/nexus_child_status_config.rs
+++ b/mayastor/src/bdev/nexus/nexus_child_status_config.rs
@@ -83,7 +83,9 @@ impl ChildStatusConfig {
     pub(crate) async fn apply() {
         debug!("Applying child status");
         let store = &ChildStatusConfig::get().status;
-        for nexus in instances() {
+        let nexus_list = instances().read().await;
+        for nexus in nexus_list.iter() {
+            let mut nexus = nexus.write().await;
             nexus.children.iter_mut().for_each(|child| {
                 if let Some(status) = store.get(&child.name) {
                     info!(

--- a/mayastor/src/bdev/nexus/nexus_config.rs
+++ b/mayastor/src/bdev/nexus/nexus_config.rs
@@ -103,7 +103,12 @@ pub(crate) fn parse_ini_config_file() -> i32 {
             name, lu_size, block_size, &child_bdevs
         );
 
-        nexus_instance_new(name, lu_size, child_bdevs);
+        futures::executor::block_on(nexus_instance_new(
+            name,
+            lu_size,
+            child_bdevs,
+        ))
+        .unwrap();
         devnum += 1;
     }
     0

--- a/mayastor/src/bdev/nexus/nexus_io.rs
+++ b/mayastor/src/bdev/nexus/nexus_io.rs
@@ -318,7 +318,8 @@ impl Bio {
     async fn child_retire(nexus: String, child: Bdev) {
         error!("{:#?}", child);
 
-        if let Some(nexus) = nexus_lookup(&nexus) {
+        if let Some(nexus) = nexus_lookup(&nexus).await {
+            let nexus = nexus.write().await;
             if let Some(child) = nexus.child_lookup(&child.name()) {
                 let current_state = child.state.compare_and_swap(
                     ChildState::Open,

--- a/mayastor/src/grpc/mayastor_grpc.rs
+++ b/mayastor/src/grpc/mayastor_grpc.rs
@@ -158,11 +158,14 @@ impl mayastor_server::Mayastor for MayastorSvc {
     ) -> GrpcResult<ListNexusReply> {
         let args = request.into_inner();
         trace!("{:?}", args);
+        let nexus_list = instances().read().await;
+        let mut nexus_grpcs = vec![];
+        for nexus in nexus_list.iter() {
+            let nexus = nexus.read().await;
+            nexus_grpcs.push(nexus.to_grpc());
+        }
         let reply = ListNexusReply {
-            nexus_list: instances()
-                .iter()
-                .map(|n| n.to_grpc())
-                .collect::<Vec<_>>(),
+            nexus_list: nexus_grpcs,
         };
         trace!("{:?}", reply);
         Ok(Response::new(reply))


### PR DESCRIPTION
Moves the `bdev::nexus::nexus_bdev_children::Nexus::create_and_register` which
`bdev::nexus::nexus_bdev::nexus_create` invokes during it's execution into
`bdev::nexus::nexus_bdev::Nexus::new`.

Previously it would only call `bdev::nexus::nexus_bdev_children::Nexus::register_children`, not
`bdev::nexus::nexus_bdev_children::Nexus::create_and_register`. This created potential for misuse,
as users could pass a child which was not created, and it would be registered invalidly. :boom: 

This has progress towards https://mayadata.atlassian.net/browse/CAS-771 and possibly https://mayadata.atlassian.net/browse/CAS-677 .
