### PR TITLE
fix(composer): update separator for security options

### DIFF
--- a/composer/src/lib.rs
+++ b/composer/src/lib.rs
@@ -918,7 +918,7 @@ impl ComposeTest {
                 "IPC_LOCK".into(),
                 "SYS_NICE".into(),
             ]),
-            security_opt: Some(vec!["seccomp:unconfined".into()]),
+            security_opt: Some(vec!["seccomp=unconfined".into()]),
             init: spec.init,
             port_bindings: spec.port_map.clone(),
             ..Default::default()


### PR DESCRIPTION
Running a cargo test that uses composer results in these entries in
the system log:

dockerd[pid]: time="<time>" level=warning msg="Security options with
`:` as a separator are deprecated and will be completely unsupported
in 17.04, use `=` instead."

so update the separator to use '='.