### PR TITLE
test(e2e): add markers to loki log stream

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,18 +50,14 @@ def lokiInstall(tag) {
   sh 'kubectl apply -f ./test/e2e/loki/promtail_namespace_e2e.yaml'
   sh 'kubectl apply -f ./test/e2e/loki/promtail_rbac_e2e.yaml'
   sh 'kubectl apply -f ./test/e2e/loki/promtail_configmap_e2e.yaml'
-  withCredentials([string(credentialsId: 'GRAFANA_API_KEY', variable: 'grafana_api_key')]) {
-    def cmd = "run=\"${env.BUILD_NUMBER}\" version=\"${tag}\" envsubst -no-unset < ./test/e2e/loki/promtail_daemonset_e2e.template.yaml | kubectl apply -f -"
-    sh "nix-shell --run '${cmd}'"
-  }
+  def cmd = "run=\"${env.BUILD_NUMBER}\" version=\"${tag}\" envsubst -no-unset < ./test/e2e/loki/promtail_daemonset_e2e.template.yaml | kubectl apply -f -"
+  sh "nix-shell --run '${cmd}'"
 }
 
 // Unnstall Loki
 def lokiUninstall(tag) {
-  withCredentials([string(credentialsId: 'GRAFANA_API_KEY', variable: 'grafana_api_key')]) {
-    def cmd = "run=\"${env.BUILD_NUMBER}\" version=\"${tag}\" envsubst -no-unset < ./test/e2e/loki/promtail_daemonset_e2e.template.yaml | kubectl delete -f -"
-    sh "nix-shell --run '${cmd}'"
-  }
+  def cmd = "run=\"${env.BUILD_NUMBER}\" version=\"${tag}\" envsubst -no-unset < ./test/e2e/loki/promtail_daemonset_e2e.template.yaml | kubectl delete -f -"
+  sh "nix-shell --run '${cmd}'"
   sh 'kubectl delete -f ./test/e2e/loki/promtail_configmap_e2e.yaml'
   sh 'kubectl delete -f ./test/e2e/loki/promtail_rbac_e2e.yaml'
   sh 'kubectl delete -f ./test/e2e/loki/promtail_namespace_e2e.yaml'
@@ -317,15 +313,19 @@ pipeline {
                   } else {
                     tag = e2e_continuous_image_tag
                   }
-                  lokiInstall(tag)
-                  def cmd = "./scripts/e2e-test.sh --device /dev/sdb --tag \"${tag}\" --logs --profile \"${e2e_test_profile}\" "
-
+                  def cmd = "./scripts/e2e-test.sh --device /dev/sdb --tag \"${tag}\" --logs --profile \"${e2e_test_profile}\" --build_number \"${env.BUILD_NUMBER}\" "
                   // building images also means using the CI registry
                   if (e2e_build_images == true) {
                     cmd = cmd + " --registry \"" + env.REGISTRY + "\""
                   }
-                  sh "nix-shell --run '${cmd}'"
-                  lokiUninstall(tag) // so that, if we keep the cluster, the next Loki instance can use different parameters
+
+                  withCredentials([
+                    usernamePassword(credentialsId: 'GRAFANA_API', usernameVariable: 'grafana_api_user', passwordVariable: 'grafana_api_pw')
+                  ]) {
+                    lokiInstall(tag)
+                    sh "nix-shell --run '${cmd}'"
+                    lokiUninstall(tag) // so that, if we keep the cluster, the next Loki instance can use different parameters
+                  }
                 }
               }
               post {

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -31,6 +31,7 @@ EXITV_FAILED_CLUSTER_OK=255
 
 # Global state variables
 #  test configuration state variables
+build_number=
 device=
 registry=
 tag="ci"
@@ -48,6 +49,7 @@ help() {
 Usage: $0 [OPTIONS]
 
 Options:
+  --build_number <number>   Build number, for use when sending Loki markers
   --device <path>           Device path to use for storage pools.
   --registry <host[:port]>  Registry to pull the mayastor images from.
   --tag <name>              Docker image tag of mayastor images (default "ci")
@@ -96,6 +98,10 @@ while [ "$#" -gt 0 ]; do
     -h|--help)
       help
       exit $EXITV_OK
+      ;;
+    --build_number)
+      shift
+      build_number="$1"
       ;;
     --logs)
       generate_logs=1
@@ -150,6 +156,8 @@ while [ "$#" -gt 0 ]; do
   esac
   shift
 done
+
+export e2e_build_number="$build_number" # can be empty string
 
 if [ -z "$device" ]; then
   echo "Device for storage pools must be specified"
@@ -240,6 +248,7 @@ contains() {
 }
 
 echo "Environment:"
+echo "    e2e_build_number=$build_number"
 echo "    e2e_top_dir=$e2e_top_dir"
 echo "    e2e_pool_device=$e2e_pool_device"
 echo "    e2e_image_tag=$e2e_image_tag"

--- a/test/e2e/basic_volume_io/basic_volume_io_test.go
+++ b/test/e2e/basic_volume_io/basic_volume_io_test.go
@@ -5,6 +5,7 @@ package basic_volume_io_test
 import (
 	"e2e-basic/common"
 	"e2e-basic/common/e2e_config"
+	"e2e-basic/common/loki"
 	rep "e2e-basic/common/reporter"
 	"testing"
 
@@ -29,8 +30,11 @@ func TestBasicVolumeIO(t *testing.T) {
 }
 
 func basicVolumeIOTest(protocol common.ShareProto) {
+	err := loki.SendLokiMarker("Starting basic vol IO test")
+	Expect(err).ToNot(HaveOccurred())
+
 	scName := "basic-vol-io-test-" + string(protocol)
-	err := common.MkStorageClass(scName, e2e_config.GetConfig().BasicVolumeIO.Replicas, protocol)
+	err = common.MkStorageClass(scName, e2e_config.GetConfig().BasicVolumeIO.Replicas, protocol)
 	Expect(err).ToNot(HaveOccurred(), "Creating storage class %s", scName)
 
 	volName := "basic-vol-io-test-" + string(protocol)

--- a/test/e2e/common/loki/loki.go
+++ b/test/e2e/common/loki/loki.go
@@ -1,0 +1,72 @@
+package loki
+
+import (
+	"bytes"
+	"e2e-basic/common/e2e_config"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strconv"
+	"time"
+
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+func SendLokiMarker(text string) error {
+	logf.Log.Info("Sending Loki report", "text", text)
+
+	apiUser := os.Getenv("grafana_api_user")
+	apiPw := os.Getenv("grafana_api_pw")
+	buildNumber := os.Getenv("e2e_build_number")
+	imageTag := e2e_config.GetConfig().ImageTag
+	timestamp := strconv.FormatInt(time.Now().UnixNano(), 10)
+
+	if apiUser != "" && apiPw != "" && buildNumber != "" {
+		logentryJSON := `
+		{
+			"streams": [
+				{
+					"stream": {
+						"run": "` + buildNumber + `",
+						"version": "` + imageTag + `",
+						"app": "marker"
+					},
+					"values": [
+						["` + timestamp + `","` + text + `"]
+					]
+				}
+			]
+		}`
+		compactedBuffer := new(bytes.Buffer)
+		err := json.Compact(compactedBuffer, []byte(logentryJSON))
+		if err != nil {
+			return fmt.Errorf("Failed to compact Loki request %v", err)
+		}
+		req, err := http.NewRequest("POST", "https://logs-prod-us-central1.grafana.net/loki/api/v1/push", compactedBuffer)
+		if err != nil {
+			return fmt.Errorf("Failed to create Loki marker request %v", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.SetBasicAuth(apiUser, apiPw)
+
+		client := &http.Client{}
+		_, err = client.Do(req)
+		if err != nil {
+			return fmt.Errorf("Failed to send Loki marker %v", err)
+		}
+	} else if apiUser != "" || apiPw != "" || buildNumber != "" { // all should be defined or none
+		errorStr := "Invalid combination of environment variables"
+		if apiUser == "" {
+			errorStr += ", user is not defined"
+		}
+		if apiPw == "" {
+			errorStr += ", password is not defined"
+		}
+		if buildNumber == "" {
+			errorStr += ", build number is not defined"
+		}
+		return fmt.Errorf(errorStr)
+	}
+	return nil
+}

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -4,14 +4,14 @@ go 1.15
 
 require (
 	github.com/container-storage-interface/spec v1.2.0
-	github.com/ilyakaznacheev/cleanenv v1.2.5 // indirect
+	github.com/ilyakaznacheev/cleanenv v1.2.5
 	github.com/onsi/ginkgo v1.14.1
 	github.com/onsi/gomega v1.10.2
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/stretchr/testify v1.5.1 // indirect
 	golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae // indirect
 	google.golang.org/protobuf v1.25.0 // indirect
-	gopkg.in/yaml.v2 v2.3.0 // indirect
+	gopkg.in/yaml.v2 v2.3.0
 	k8s.io/api v0.19.2
 	k8s.io/apimachinery v0.19.2
 	k8s.io/client-go v0.19.2

--- a/test/e2e/loki/promtail_daemonset_e2e.template.yaml
+++ b/test/e2e/loki/promtail_daemonset_e2e.template.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - args:
-        - -client.url=https://${grafana_api_key}@logs-prod-us-central1.grafana.net/api/prom/push
+        - -client.url=https://${grafana_api_user}:${grafana_api_pw}@logs-prod-us-central1.grafana.net/api/prom/push
         - -config.file=/etc/promtail/promtail.yml
         - -client.external-labels=run=${run},version=${version}
         env:


### PR DESCRIPTION
Send log entries directly to Grafana/Loki from golang tests.
Change Loki credentials to username + password as this form is 
needed for the go library.
Currently just one message is generated from a go test to
verify the mechanism, with the expectation that more markers will
be added as and when needed.