### PR TITLE
refactor: rationalise e2e test structure further

### DIFF
--- a/test/e2e/basic_volume_io/basic_volume_io_test.go
+++ b/test/e2e/basic_volume_io/basic_volume_io_test.go
@@ -5,7 +5,7 @@ package basic_volume_io_test
 import (
 	"e2e-basic/common"
 	"e2e-basic/common/e2e_config"
-	rep "e2e-basic/common/reporter"
+
 	"testing"
 
 	. "github.com/onsi/ginkgo"
@@ -24,8 +24,8 @@ var podNames []string
 var volNames []volSc
 
 func TestBasicVolumeIO(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecsWithDefaultAndCustomReporters(t, "Basic volume IO tests, NVMe-oF TCP and iSCSI", rep.GetReporters("basic-volume-io"))
+	// Initialise test and set class and file names for reports
+	common.InitTesting(t, "Basic volume IO tests, NVMe-oF TCP and iSCSI", "basic-volume-io")
 }
 
 func basicVolumeIOTest(protocol common.ShareProto) {

--- a/test/e2e/common/test.go
+++ b/test/e2e/common/test.go
@@ -5,8 +5,10 @@ import (
 	"errors"
 	"fmt"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"testing"
 	"time"
 
+	"e2e-basic/common/reporter"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -34,6 +36,12 @@ type TestEnvironment struct {
 }
 
 var gTestEnv TestEnvironment
+
+// Initialise testing and setup class name + report filename.
+func InitTesting(t *testing.T, classname string, reportname string) {
+	RegisterFailHandler(Fail)
+	RunSpecsWithDefaultAndCustomReporters(t, classname, reporter.GetReporters(reportname))
+}
 
 func SetupTestEnv() {
 	logf.SetLogger(zap.New(zap.UseDevMode(true), zap.WriteTo(GinkgoWriter)))

--- a/test/e2e/install/install_test.go
+++ b/test/e2e/install/install_test.go
@@ -4,7 +4,6 @@ import (
 	"e2e-basic/common"
 	"e2e-basic/common/e2e_config"
 	"e2e-basic/common/locations"
-	rep "e2e-basic/common/reporter"
 
 	"fmt"
 	"os/exec"
@@ -138,8 +137,8 @@ func installMayastor() {
 }
 
 func TestInstallSuite(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecsWithDefaultAndCustomReporters(t, "Basic Install Suite", rep.GetReporters("install"))
+	// Initialise test and set class and file names for reports
+	common.InitTesting(t, "Basic Install Suite", "install")
 }
 
 var _ = Describe("Mayastor setup", func() {

--- a/test/e2e/io_soak/io_soak_test.go
+++ b/test/e2e/io_soak/io_soak_test.go
@@ -5,7 +5,6 @@ package io_soak
 import (
 	"e2e-basic/common"
 	"e2e-basic/common/e2e_config"
-	rep "e2e-basic/common/reporter"
 
 	"fmt"
 	"sort"
@@ -41,8 +40,8 @@ var scNames []string
 var jobs []IoSoakJob
 
 func TestIOSoak(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecsWithDefaultAndCustomReporters(t, "IO soak test, NVMe-oF TCP and iSCSI", rep.GetReporters("io-soak"))
+	// Initialise test and set class and file names for reports
+	common.InitTesting(t, "IO soak test, NVMe-oF TCP and iSCSI", "io-soak")
 }
 
 func monitor(errC chan<- error) {

--- a/test/e2e/node_disconnect/replica_pod_remove/replica_pod_remove_test.go
+++ b/test/e2e/node_disconnect/replica_pod_remove/replica_pod_remove_test.go
@@ -2,7 +2,6 @@ package replica_pod_remove_test
 
 import (
 	"e2e-basic/common"
-	rep "e2e-basic/common/reporter"
 
 	disconnect_lib "e2e-basic/node_disconnect/lib"
 
@@ -19,8 +18,8 @@ var env disconnect_lib.DisconnectEnv
 const gStorageClass = "mayastor-nvmf-pod-remove-test-sc"
 
 func TestMayastorPodLoss(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecsWithDefaultAndCustomReporters(t, "Replica pod removal tests", rep.GetReporters("replica-pod-remove"))
+	// Initialise test and set class and file names for reports
+	common.InitTesting(t, "Replica pod removal tests", "replica-pod-remove")
 }
 
 var _ = Describe("Mayastor replica pod removal test", func() {

--- a/test/e2e/pvc_stress_fio/pvc_stress_fio_test.go
+++ b/test/e2e/pvc_stress_fio/pvc_stress_fio_test.go
@@ -4,7 +4,6 @@ package pvc_stress_fio_test
 import (
 	"e2e-basic/common"
 	"e2e-basic/common/e2e_config"
-	rep "e2e-basic/common/reporter"
 
 	"fmt"
 	"testing"
@@ -206,8 +205,8 @@ func stressTestPVC(iters int, runFio bool) {
 }
 
 func TestPVCStress(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecsWithDefaultAndCustomReporters(t, "PVC Stress Test Suite", rep.GetReporters("pvc-stress"))
+	// Initialise test and set class and file names for reports
+	common.InitTesting(t, "PVC Stress Test Suite", "pvc-stress")
 }
 
 var _ = Describe("Mayastor PVC Stress test", func() {

--- a/test/e2e/rebuild/basic_rebuild_test.go
+++ b/test/e2e/rebuild/basic_rebuild_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"e2e-basic/common"
-	rep "e2e-basic/common/reporter"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -78,8 +77,8 @@ func basicRebuildTest() {
 }
 
 func TestRebuild(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecsWithDefaultAndCustomReporters(t, "Rebuild Test Suite", rep.GetReporters("rebuild"))
+	// Initialise test and set class and file names for reports
+	common.InitTesting(t, "Rebuild Test Suite", "rebuild")
 }
 
 var _ = Describe("Mayastor rebuild test", func() {

--- a/test/e2e/replica/replica_test.go
+++ b/test/e2e/replica/replica_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"e2e-basic/common"
-	rep "e2e-basic/common/reporter"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -70,8 +69,8 @@ func addUnpublishedReplicaTest() {
 }
 
 func TestReplica(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecsWithDefaultAndCustomReporters(t, "Replica Test Suite", rep.GetReporters("replica"))
+	// Initialise test and set class and file names for reports
+	common.InitTesting(t, "Replica Test Suite", "replica")
 }
 
 var _ = Describe("Mayastor replica tests", func() {

--- a/test/e2e/resource_check/resource_check_test.go
+++ b/test/e2e/resource_check/resource_check_test.go
@@ -2,7 +2,6 @@ package basic_test
 
 import (
 	"e2e-basic/common"
-	rep "e2e-basic/common/reporter"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
@@ -41,8 +40,8 @@ func resourceCheck() {
 }
 
 func TestResourceCheck(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecsWithDefaultAndCustomReporters(t, "Resource Check Suite", rep.GetReporters("resource_check"))
+	// Initialise test and set class and file names for reports
+	common.InitTesting(t, "Resource Check Suite", "resource_check")
 }
 
 var _ = Describe("Mayastor resource check", func() {

--- a/test/e2e/uninstall/uninstall_test.go
+++ b/test/e2e/uninstall/uninstall_test.go
@@ -4,8 +4,6 @@ import (
 	"e2e-basic/common"
 	"e2e-basic/common/e2e_config"
 	"e2e-basic/common/locations"
-	rep "e2e-basic/common/reporter"
-
 	"os/exec"
 	"testing"
 	"time"
@@ -131,8 +129,8 @@ func teardownMayastor() {
 }
 
 func TestTeardownSuite(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecsWithDefaultAndCustomReporters(t, "Basic Teardown Suite", rep.GetReporters("uninstall"))
+	// Initialise test and set class and file names for reports
+	common.InitTesting(t, "Basic Teardown Suite", "uninstall")
 }
 
 var _ = Describe("Mayastor setup", func() {


### PR DESCRIPTION
All tests register fail handlers and get reporters.
At the moment each test does these individually.
Replace the individual calls with a single call,
to a helper function which does both.
An added advantage is that this then is the best,
place to execute common actions, for example emit log markers.