### PR TITLE
ci(moac): fix timing issues in moac watcher tests

### DIFF
--- a/csi/moac/test/watcher_test.js
+++ b/csi/moac/test/watcher_test.js
@@ -13,6 +13,10 @@ const RESTART_DELAY_MS = 300;
 const EVENT_TIMEOUT_MS = 200;
 const EVENT_DELAY_MS = 100;
 const EYE_BLINK_MS = 30;
+// Believe it or not but it is possible that timeout callback triggers a bit
+// earlier than it should (although that nodejs documentation says that it is
+// not possible). Accomodate this weird behaviour.
+const TOLERATE_MS = 2;
 
 const fakeConfig = {
   clusters: [
@@ -219,7 +223,7 @@ module.exports = function () {
       timeout = setTimeout(() => watcher.emitKubeEvent('add', apple), EVENT_DELAY_MS);
       await watcher.create(apple);
       const delta = new Date() - startTime;
-      expect(delta).to.be.within(EVENT_DELAY_MS - 2, EVENT_DELAY_MS + EYE_BLINK_MS);
+      expect(delta).to.be.within(EVENT_DELAY_MS - TOLERATE_MS, EVENT_DELAY_MS + EYE_BLINK_MS);
       sinon.assert.calledOnce(createStub);
     });
 
@@ -230,7 +234,7 @@ module.exports = function () {
       const startTime = new Date();
       await watcher.create(apple);
       const delta = new Date() - startTime;
-      expect(delta).to.be.within(EVENT_TIMEOUT_MS, EVENT_TIMEOUT_MS + EYE_BLINK_MS);
+      expect(delta).to.be.within(EVENT_TIMEOUT_MS - TOLERATE_MS, EVENT_TIMEOUT_MS + EYE_BLINK_MS);
       sinon.assert.calledOnce(createStub);
     });
 
@@ -247,7 +251,7 @@ module.exports = function () {
         return createApple(orig.metadata.name, [], 'also valid');
       });
       const delta = new Date() - startTime;
-      expect(delta).to.be.within(EVENT_DELAY_MS - 2, EVENT_DELAY_MS + EYE_BLINK_MS);
+      expect(delta).to.be.within(EVENT_DELAY_MS - TOLERATE_MS, EVENT_DELAY_MS + EYE_BLINK_MS);
       assertReplaceCalledWith(replaceStub, 'name1', apple, {
         spec: 'also valid'
       });
@@ -275,7 +279,7 @@ module.exports = function () {
         return createApple(orig.metadata.name, [], 'also valid');
       });
       const delta = new Date() - startTime;
-      expect(delta).to.be.within(EVENT_TIMEOUT_MS, EVENT_TIMEOUT_MS + EYE_BLINK_MS);
+      expect(delta).to.be.within(EVENT_TIMEOUT_MS - TOLERATE_MS, EVENT_TIMEOUT_MS + EYE_BLINK_MS);
       sinon.assert.calledOnce(replaceStub);
     });
 
@@ -335,7 +339,7 @@ module.exports = function () {
         });
       });
       const delta = new Date() - startTime;
-      expect(delta).to.be.within(EVENT_TIMEOUT_MS, EVENT_TIMEOUT_MS + EYE_BLINK_MS);
+      expect(delta).to.be.within(EVENT_TIMEOUT_MS - TOLERATE_MS, EVENT_TIMEOUT_MS + EYE_BLINK_MS);
       sinon.assert.calledOnce(replaceStub);
     });
 
@@ -388,7 +392,7 @@ module.exports = function () {
       sinon.assert.calledOnce(deleteStub);
       sinon.assert.calledWith(deleteStub, 'openebs.io', 'v1alpha1', 'namespace',
         'apples', 'name1');
-      expect(delta).to.be.within(EVENT_DELAY_MS - 2, EVENT_DELAY_MS + EYE_BLINK_MS);
+      expect(delta).to.be.within(EVENT_DELAY_MS - TOLERATE_MS, EVENT_DELAY_MS + EYE_BLINK_MS);
     });
 
     it('should timeout when "delete" event does not come after a delete', async () => {
@@ -401,7 +405,7 @@ module.exports = function () {
       await watcher.delete('name1');
       const delta = new Date() - startTime;
       sinon.assert.calledOnce(deleteStub);
-      expect(delta).to.be.within(EVENT_TIMEOUT_MS, EVENT_TIMEOUT_MS + EYE_BLINK_MS);
+      expect(delta).to.be.within(EVENT_TIMEOUT_MS - TOLERATE_MS, EVENT_TIMEOUT_MS + EYE_BLINK_MS);
     });
 
     it('should not try to delete object that does not exist', async () => {
@@ -425,7 +429,7 @@ module.exports = function () {
       timeout = setTimeout(() => watcher.emitKubeEvent('update', apple), EVENT_DELAY_MS);
       await watcher.addFinalizer('name1', 'test.finalizer.com');
       const delta = new Date() - startTime;
-      expect(delta).to.be.within(EVENT_DELAY_MS - 2, EVENT_DELAY_MS + EYE_BLINK_MS);
+      expect(delta).to.be.within(EVENT_DELAY_MS - TOLERATE_MS, EVENT_DELAY_MS + EYE_BLINK_MS);
       assertReplaceCalledWith(replaceStub, 'name1', apple, {
         metadata: {
           finalizers: ['test.finalizer.com']
@@ -443,7 +447,7 @@ module.exports = function () {
       timeout = setTimeout(() => watcher.emitKubeEvent('update', apple), EVENT_DELAY_MS);
       await watcher.addFinalizer('name1', 'new.finalizer.com');
       const delta = new Date() - startTime;
-      expect(delta).to.be.within(EVENT_DELAY_MS - 2, EVENT_DELAY_MS + EYE_BLINK_MS);
+      expect(delta).to.be.within(EVENT_DELAY_MS - TOLERATE_MS, EVENT_DELAY_MS + EYE_BLINK_MS);
       assertReplaceCalledWith(replaceStub, 'name1', apple, {
         metadata: {
           finalizers: ['new.finalizer.com', 'test.finalizer.com', 'test2.finalizer.com']
@@ -483,7 +487,7 @@ module.exports = function () {
       timeout = setTimeout(() => watcher.emitKubeEvent('update', apple), EVENT_DELAY_MS);
       await watcher.removeFinalizer('name1', 'test.finalizer.com');
       const delta = new Date() - startTime;
-      expect(delta).to.be.within(EVENT_DELAY_MS - 2, EVENT_DELAY_MS + EYE_BLINK_MS);
+      expect(delta).to.be.within(EVENT_DELAY_MS - TOLERATE_MS, EVENT_DELAY_MS + EYE_BLINK_MS);
       sinon.assert.calledOnce(replaceStub);
       assertReplaceCalledWith(replaceStub, 'name1', apple, {
         metadata: {


### PR DESCRIPTION
It's more a workaround for behaviour that normally should not happen.
On the other hand it does not really matter because it affects only
the test suite.

Resolves: CAS-760