### PR TITLE
fix(csi): update CSI external provisioner to 2.1.1

### DIFF
--- a/chart/templates/moac-deployment.yaml
+++ b/chart/templates/moac-deployment.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccount: moac
       containers:
         - name: csi-provisioner
-          image: quay.io/k8scsi/csi-provisioner:v2.1.0
+          image: quay.io/k8scsi/csi-provisioner:v2.1.1
           args:
             - "--v=2"
             - "--csi-address=$(ADDRESS)"

--- a/deploy/moac-deployment.yaml
+++ b/deploy/moac-deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccount: moac
       containers:
         - name: csi-provisioner
-          image: quay.io/k8scsi/csi-provisioner:v2.1.0
+          image: quay.io/k8scsi/csi-provisioner:v2.1.1
           args:
             - "--v=2"
             - "--csi-address=$(ADDRESS)"


### PR DESCRIPTION
Bug or Regression:
* External-provisioner may have stopped provisioning for a PVC depending
  on certain timing conditions (provisioning failed once, next attempt
  currently running, PVC update arrives from API server).
* Fix CSI translation issues with EBS, AzureFile and Cinder drivers
* Producing storage capacity may have failed with the object has been
  modified errors
* Fix topology translation during CSI migration for gce-pd, aws-ebs,
  cinder drivers