### PR TITLE
chore: refine sync/send impls

### DIFF
--- a/mayastor/src/bdev/dev/nvme.rs
+++ b/mayastor/src/bdev/dev/nvme.rs
@@ -153,8 +153,6 @@ struct NvmeCreateContext {
     count: u32,
 }
 
-unsafe impl Send for NvmeCreateContext {}
-
 impl NvmeCreateContext {
     pub fn new(nvme: &NVMe) -> NvmeCreateContext {
         let mut trid = spdk_nvme_transport_id::default();

--- a/mayastor/src/bdev/dev/nvmf.rs
+++ b/mayastor/src/bdev/dev/nvmf.rs
@@ -259,8 +259,6 @@ struct NvmeCreateContext {
     count: u32,
 }
 
-unsafe impl Send for NvmeCreateContext {}
-
 impl NvmeCreateContext {
     pub fn new(nvmf: &Nvmf) -> NvmeCreateContext {
         let port = format!("{}", nvmf.port);

--- a/mayastor/src/bdev/nexus/nexus_bdev.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev.rs
@@ -350,9 +350,6 @@ pub struct Nexus {
     pub(crate) max_io_attempts: i32,
 }
 
-unsafe impl core::marker::Sync for Nexus {}
-unsafe impl core::marker::Send for Nexus {}
-
 #[derive(Debug, Serialize, Clone, Copy, PartialEq, PartialOrd)]
 pub enum NexusStatus {
     /// The nexus cannot perform any IO operation

--- a/mayastor/src/bdev/nexus/nexus_fn_table.rs
+++ b/mayastor/src/bdev/nexus/nexus_fn_table.rs
@@ -30,9 +30,6 @@ pub struct NexusFnTable {
     pub(crate) f_tbl: spdk_bdev_fn_table,
 }
 
-unsafe impl Sync for NexusFnTable {}
-unsafe impl Send for NexusFnTable {}
-
 /// The FN table are function pointers called by SPDK when work is sent
 /// our way. The functions are static, and shared between all instances.
 

--- a/mayastor/src/bdev/nexus/nexus_module.rs
+++ b/mayastor/src/bdev/nexus/nexus_module.rs
@@ -31,13 +31,26 @@ pub struct NexusInstances {
     inner: UnsafeCell<Vec<Box<Nexus>>>,
 }
 
+/// A wrapper around an SPDK Nexus bdev.
+///
+/// See https://spdk.io/doc/structspdk__bdev__module.html for more information.
+///
+/// # Safety
+///
+/// SPDK manages this and it is equivalent to Send/Sync. This means this type is Send/Sync.
 #[derive(Debug)]
 pub struct NexusModule(*mut spdk_bdev_module);
 
+// Safety: Pointer to SPDK managed structure.
 unsafe impl Sync for NexusModule {}
+
+// TODO: This is not safe.
 unsafe impl Sync for NexusInstances {}
 
+// Safety: Pointer to SPDK managed structure.
 unsafe impl Send for NexusModule {}
+
+// TODO: This is not safe.
 unsafe impl Send for NexusInstances {}
 
 impl Default for NexusModule {

--- a/mayastor/src/core/thread.rs
+++ b/mayastor/src/core/thread.rs
@@ -23,12 +23,25 @@ pub enum Error {
     InvalidThread {},
 }
 
-#[derive(Debug, PartialEq, Clone, Copy)]
-/// struct that wraps an SPDK thread. The name thread is chosen poorly and
-/// should not be confused with an actual thread. Consider it more to be
-/// analogous to a container to which you can submit work and poll it to drive
+/// A wrapper around an SPDK thread.
+///
+/// The name thread is chosen poorly and should not be confused with an actual thread. Consider it
+/// more to be analogous to a container to which you can submit work and poll it to drive
 /// the submitted work to completion.
+///
+/// # Safety
+///
+/// SPDK considers this threadsafe, so it is marked Send/Sync.
+///
+/// See: https://github.com/spdk/spdk/blob/fb27c710f2c5ee4e666d2b366237e04c08dda977/include/spdk_internal/thread.h#L95-L136
+#[derive(Debug, PartialEq, Clone, Copy)]
 pub struct Mthread(NonNull<spdk_thread>);
+
+// Safety: SPDK considers the inner `spdk_thread` threadsafe.
+unsafe impl Send for Mthread {}
+
+// Safety: SPDK considers the inner `spdk_thread` threadsafe.
+unsafe impl Sync for Mthread {}
 
 impl From<*mut spdk_thread> for Mthread {
     fn from(t: *mut spdk_thread) -> Self {

--- a/mayastor/src/subsys/nvmf/subsystem.rs
+++ b/mayastor/src/subsys/nvmf/subsystem.rs
@@ -66,7 +66,21 @@ impl Display for SubType {
     }
 }
 
+/// A wrapper around the SPDK NVMF subsystem.
+///
+/// # Safety
+///
+/// SPDK considers this structure threadsafe. This means this structure can be Send/Sync.
+///
+/// See more: https://github.com/spdk/spdk/blob/312a9d603dfc7dfb7061f33fa3f1fec766579dc7/lib/nvmf/nvmf_internal.h#L264-L305
 pub struct NvmfSubsystem(pub(crate) NonNull<spdk_nvmf_subsystem>);
+
+// Safety: SPDK considers the inner `spdk_nvmf_subsystem` threadsafe.
+unsafe impl Send for NvmfSubsystem {}
+
+// Safety: SPDK considers the inner `spdk_nvmf_subsystem` threadsafe.
+unsafe impl Sync for NvmfSubsystem {}
+
 pub struct NvmfSubsystemIterator(*mut spdk_nvmf_subsystem);
 
 impl Iterator for NvmfSubsystemIterator {


### PR DESCRIPTION
Went on a little fishing expedition and found some unnecessarily unsafe
implementations which we don't need.

This doesn't have any impact on functionality or users, just safety 
semantics for later.

Also documents some that are safe.

I could use some help ensuring these are correct. :)