### PR TITLE
test(e2e): add io_soak to extended tests

### DIFF
--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -18,7 +18,7 @@ TOPDIR=$(realpath "$SCRIPTDIR/..")
 #TESTS="install basic_volume_io csi replica rebuild node_disconnect/replica_pod_remove uninstall"
 DEFAULT_TESTS="install basic_volume_io csi resource_check replica rebuild uninstall"
 ONDEMAND_TESTS="install basic_volume_io csi resource_check uninstall"
-EXTENDED_TESTS="install basic_volume_io csi resource_check uninstall"
+EXTENDED_TESTS="install basic_volume_io csi resource_check replica rebuild io_soak uninstall"
 CONTINUOUS_TESTS="install basic_volume_io csi resource_check replica rebuild io_soak uninstall"
 
 #exit values

--- a/test/e2e/configurations/ci_e2e_config.yaml
+++ b/test/e2e/configurations/ci_e2e_config.yaml
@@ -1,4 +1,4 @@
-# configuration/parameters for CI/CD e2e test runs 
+# configuration/parameters for CI/CD e2e test runs
 pvcstress:
   replicas: 1
   cdCycles: 100
@@ -6,10 +6,10 @@ pvcstress:
 ioSoakTest:
   replicas: 1
   duration: 10m
-  loadFactor: 10
+  loadFactor: 2
   protocols:
   - nvmf
-  - iscsi
+# - iscsi
   fioFixedDuration: 60
   fioDutyCycles:
   - thinkTime: 500000

--- a/test/e2e/io_soak/io_soak_test.go
+++ b/test/e2e/io_soak/io_soak_test.go
@@ -201,7 +201,7 @@ var _ = Describe("Mayastor Volume IO soak test", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	It("should verify an NVMe-oF TCP volume can process IO on multiple volumes simultaneously", func() {
+	It("should verify mayastor can process IO on multiple volumes simultaneously using NVMe-oF TCP", func() {
 		e2eCfg := e2e_config.GetConfig()
 		loadFactor := e2eCfg.IOSoakTest.LoadFactor
 		replicas := e2eCfg.IOSoakTest.Replicas


### PR DESCRIPTION
Run soak tests, as well as replica and
rebuild tests on overnight builds.
Fixed ginkgo test strings to match Xray test definition
for io_soak test.
Removed iscsi from the config list of soak protocols.  
Reduce load factor in soak tests so they
can be run on Hetzner clusters, until we
have larger nodes available or until the new 
e2e-fio image is in use.