### PR TITLE
ci(e2e): do not pass ENVIRONMENT param

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -408,11 +408,6 @@ pipeline {
                     wait: true,
                     parameters: [
                       [
-                        $class: 'StringParameterValue',
-                        name: "ENVIRONMENT",
-                        value: "${e2e_environment}"
-                      ],
-                      [
                         $class: 'RunParameterValue',
                         name: "BUILD",
                         runId:"${k8s_job.getProjectName()}#${k8s_job.getNumber()}"


### PR DESCRIPTION
It is not needed anymore as it is taken from build job run.

MQ-242