### PR TITLE
feat(nexus): make ANA reporting configurable

### DIFF
--- a/mayastor/src/subsys/nvmf/subsystem.rs
+++ b/mayastor/src/subsys/nvmf/subsystem.rs
@@ -247,6 +247,16 @@ impl NvmfSubsystem {
 
     /// enable Asymmetric Namespace Access (ANA) reporting
     pub fn set_ana_reporting(&self, enable: bool) -> Result<(), Error> {
+        match std::env::var("NEXUS_NVMF_ANA_ENABLE") {
+            Ok(s) => {
+                if s != "1" {
+                    return Ok(());
+                }
+            }
+            Err(_) => {
+                return Ok(());
+            }
+        }
         unsafe {
             spdk_nvmf_subsystem_set_ana_reporting(self.0.as_ptr(), enable)
         }

--- a/mayastor/src/subsys/nvmf/subsystem.rs
+++ b/mayastor/src/subsys/nvmf/subsystem.rs
@@ -19,7 +19,7 @@ use spdk_sys::{
     spdk_nvmf_ns_opts,
     spdk_nvmf_subsystem,
     spdk_nvmf_subsystem_add_listener,
-    spdk_nvmf_subsystem_add_ns,
+    spdk_nvmf_subsystem_add_ns_ext,
     spdk_nvmf_subsystem_create,
     spdk_nvmf_subsystem_destroy,
     spdk_nvmf_subsystem_get_first,
@@ -200,10 +200,11 @@ impl NvmfSubsystem {
             nguid: bdev.uuid().as_bytes(),
             ..Default::default()
         };
+        let bdev_cname = CString::new(bdev.name()).unwrap();
         let ns_id = unsafe {
-            spdk_nvmf_subsystem_add_ns(
+            spdk_nvmf_subsystem_add_ns_ext(
                 self.0.as_ptr(),
-                bdev.as_ptr(),
+                bdev_cname.as_ptr(),
                 &opts as *const _,
                 size_of::<spdk_bdev_nvme_opts>() as u64,
                 ptr::null_mut(),

--- a/mayastor/tests/nexus_multipath.rs
+++ b/mayastor/tests/nexus_multipath.rs
@@ -23,6 +23,7 @@ static HOSTNQN: &str = "nqn.2019-05.io.openebs";
 
 #[tokio::test]
 async fn nexus_multipath() {
+    std::env::set_var("NEXUS_NVMF_ANA_ENABLE", "1");
     // create a new composeTest
     let test = Builder::new()
         .name("nexus_shared_replica_test")
@@ -119,7 +120,7 @@ async fn nexus_multipath() {
         status
     );
 
-    // The first attempt often fails with "Duplicate cntlid x with y" error from
+    // The first attempt will fail with "Duplicate cntlid x with y" error from
     // kernel
     for i in 0 .. 2 {
         let status_c0 = Command::new("nvme")

--- a/test/grpc/test_nexus.js
+++ b/test/grpc/test_nexus.js
@@ -297,7 +297,8 @@ describe('nexus', function () {
           next();
         },
         (next) => {
-          common.startMayastor(configNexus, ['-r', common.SOCK, '-g', common.grpcEndpoint, '-s', 386]);
+          common.startMayastor(configNexus, ['-r', common.SOCK, '-g', common.grpcEndpoint, '-s', 384],
+            { NEXUS_NVMF_ANA_ENABLE: '1' });
 
           common.waitFor((pingDone) => {
             // use harmless method to test if the mayastor is up and running


### PR DESCRIPTION
Leave ANA reporting disabled when publishing a Nexus over NVMf unless
the environment variable NEXUS_NVMF_ANA_ENABLE is defined when
creating a Nexus.

Include a chore to switch away from deprecated spdk_nvmf functions.

Fixes CAS-789, CAS-791.