### PR TITLE
fix(moac): moac assert when publishing a volume

### DIFF
--- a/csi/moac/node.ts
+++ b/csi/moac/node.ts
@@ -3,12 +3,12 @@
 // objects and notifications about the changes.
 
 import assert from 'assert';
+import events = require('events');
 import { Pool } from './pool';
 import { Nexus } from './nexus';
 import { Replica } from './replica';
 import { Workq } from './workq';
 
-const EventEmitter = require('events');
 const log = require('./logger').Logger('node');
 const { GrpcClient, GrpcCode, GrpcError } = require('./grpc_client');
 
@@ -24,7 +24,7 @@ type GrpcCallArgs = {
 // "node": node related events with payload { eventType: "sync", object: node }
 //         when the node is sync'd after previous sync failure(s).
 // "pool", "replica", "nexus": with eventType "new", "mod", "del".
-export class Node extends EventEmitter {
+export class Node extends events.EventEmitter {
   name: string;
   syncPeriod: number;
   syncRetry: number;

--- a/csi/moac/test/csi_test.js
+++ b/csi/moac/test/csi_test.js
@@ -8,6 +8,7 @@ const grpc = require('grpc-uds');
 const grpcPromise = require('grpc-promise');
 const sinon = require('sinon');
 const sleep = require('sleep-promise');
+const EventEmitter = require('events');
 const { CsiServer, csi } = require('../csi');
 const { GrpcError, GrpcCode } = require('../grpc_client');
 const Registry = require('../registry');
@@ -197,7 +198,7 @@ module.exports = function () {
       let server;
       // place-holder for return value from createVolume when we don't care
       // about the data (i.e. when testing error cases).
-      const returnedVolume = new Volume(UUID, registry, () => {}, {
+      const returnedVolume = new Volume(UUID, registry, new EventEmitter(), {
         replicaCount: 1,
         preferredNodes: [],
         requiredNodes: [],
@@ -572,7 +573,7 @@ module.exports = function () {
         const vols = [];
         for (let i = 0; i < 10; i++) {
           for (let j = 0; j < 10; j++) {
-            const vol = new Volume(uuidBase + i + j, registry, () => {}, {
+            const vol = new Volume(uuidBase + i + j, registry, new EventEmitter(), {
               replicaCount: 3,
               requiredBytes: 100,
               protocol: 'nvmf'
@@ -662,7 +663,7 @@ module.exports = function () {
 
       it('should publish volume', async () => {
         const nvmfUri = `nvmf://host/nqn-${UUID}`;
-        const volume = new Volume(UUID, registry, () => {}, {});
+        const volume = new Volume(UUID, registry, new EventEmitter(), {});
         const publishStub = sinon.stub(volume, 'publish');
         publishStub.resolves(nvmfUri);
         const getNodeNameStub = sinon.stub(volume, 'getNodeName');
@@ -704,7 +705,7 @@ module.exports = function () {
           },
           volumeContext: { protocol: 'iscsi' }
         };
-        const volume = new Volume(UUID, registry, () => {}, {});
+        const volume = new Volume(UUID, registry, new EventEmitter(), {});
         const publishStub = sinon.stub(volume, 'publish');
         // We must sleep in the stub. Otherwise reply is sent before the second
         // request comes in.
@@ -750,7 +751,7 @@ module.exports = function () {
       });
 
       it('should not publish readonly volume', async () => {
-        const volume = new Volume(UUID, registry, () => {}, {});
+        const volume = new Volume(UUID, registry, new EventEmitter(), {});
         const publishStub = sinon.stub(volume, 'publish');
         publishStub.resolves();
         const getNodeNameStub = sinon.stub(volume, 'getNodeName');
@@ -775,7 +776,7 @@ module.exports = function () {
       });
 
       it('should not publish volume with unsupported capability', async () => {
-        const volume = new Volume(UUID, registry, () => {}, {});
+        const volume = new Volume(UUID, registry, new EventEmitter(), {});
         const publishStub = sinon.stub(volume, 'publish');
         publishStub.resolves();
         const getNodeNameStub = sinon.stub(volume, 'getNodeName');
@@ -800,7 +801,7 @@ module.exports = function () {
       });
 
       it('should not publish volume on node with invalid ID', async () => {
-        const volume = new Volume(UUID, registry, () => {}, {});
+        const volume = new Volume(UUID, registry, new EventEmitter(), {});
         const publishStub = sinon.stub(volume, 'publish');
         publishStub.resolves();
         const getNodeNameStub = sinon.stub(volume, 'getNodeName');
@@ -825,7 +826,7 @@ module.exports = function () {
       });
 
       it('should not publish volume if share protocol is not specified', async () => {
-        const volume = new Volume(UUID, registry, () => {}, {});
+        const volume = new Volume(UUID, registry, new EventEmitter(), {});
         const publishStub = sinon.stub(volume, 'publish');
         publishStub.resolves();
         const getNodeNameStub = sinon.stub(volume, 'getNodeName');
@@ -879,7 +880,7 @@ module.exports = function () {
       });
 
       it('should not unpublish volume on pool with invalid ID', async () => {
-        const volume = new Volume(UUID, registry, () => {}, {});
+        const volume = new Volume(UUID, registry, new EventEmitter(), {});
         const unpublishStub = sinon.stub(volume, 'unpublish');
         unpublishStub.resolves();
         const getNodeNameStub = sinon.stub(volume, 'getNodeName');
@@ -895,7 +896,7 @@ module.exports = function () {
       });
 
       it('should unpublish volume', async () => {
-        const volume = new Volume(UUID, registry, () => {}, {});
+        const volume = new Volume(UUID, registry, new EventEmitter(), {});
         const unpublishStub = sinon.stub(volume, 'unpublish');
         unpublishStub.resolves();
         const getNodeNameStub = sinon.stub(volume, 'getNodeName');
@@ -913,7 +914,7 @@ module.exports = function () {
       });
 
       it('should unpublish volume even if on a different node', async () => {
-        const volume = new Volume(UUID, registry, () => {}, {});
+        const volume = new Volume(UUID, registry, new EventEmitter(), {});
         const unpublishStub = sinon.stub(volume, 'unpublish');
         unpublishStub.resolves();
         const getNodeNameStub = sinon.stub(volume, 'getNodeName');
@@ -935,7 +936,7 @@ module.exports = function () {
           volumeId: UUID,
           nodeId: 'mayastor://another-node'
         };
-        const volume = new Volume(UUID, registry, () => {}, {});
+        const volume = new Volume(UUID, registry, new EventEmitter(), {});
         const unpublishStub = sinon.stub(volume, 'unpublish');
         // We must sleep in the stub. Otherwise reply is sent before the second
         // request comes in.
@@ -971,7 +972,7 @@ module.exports = function () {
       });
 
       it('should report SINGLE_NODE_WRITER cap as valid', async () => {
-        const volume = new Volume(UUID, registry, () => {}, {});
+        const volume = new Volume(UUID, registry, new EventEmitter(), {});
         getVolumesStub.returns(volume);
         const caps = [
           'SINGLE_NODE_WRITER',
@@ -997,7 +998,7 @@ module.exports = function () {
       });
 
       it('should report other caps than SINGLE_NODE_WRITER as invalid', async () => {
-        const volume = new Volume(UUID, registry, () => {}, {});
+        const volume = new Volume(UUID, registry, new EventEmitter(), {});
         getVolumesStub.returns(volume);
         const caps = [
           'SINGLE_NODE_READER_ONLY',

--- a/csi/moac/test/event_stream_test.js
+++ b/csi/moac/test/event_stream_test.js
@@ -66,8 +66,8 @@ module.exports = function () {
       )
     ]);
     getVolumeStub.returns([
-      new Volume('volume1', registry, () => {}, {}),
-      new Volume('volume2', registry, () => {}, {})
+      new Volume('volume1', registry, new EventEmitter(), {}),
+      new Volume('volume2', registry, new EventEmitter(), {})
     ]);
 
     // set low high water mark to test buffered reads

--- a/csi/moac/test/volume_operator_test.js
+++ b/csi/moac/test/volume_operator_test.js
@@ -3,6 +3,7 @@
 'use strict';
 
 const _ = require('lodash');
+const EventEmitter = require('events');
 const expect = require('chai').expect;
 const sinon = require('sinon');
 const sleep = require('sleep-promise');
@@ -430,7 +431,7 @@ module.exports = function () {
       let stubs;
       const registry = new Registry();
       const volumes = new Volumes(registry);
-      const volume = new Volume(UUID, registry, () => {}, defaultSpec);
+      const volume = new Volume(UUID, registry, new EventEmitter(), defaultSpec);
       volume.size = 110;
       const fsaStub = sinon.stub(volume, 'fsa');
       fsaStub.returns();
@@ -478,7 +479,7 @@ module.exports = function () {
       let stubs;
       const registry = new Registry();
       const volumes = new Volumes(registry);
-      const volume = new Volume(UUID, registry, () => {}, defaultSpec);
+      const volume = new Volume(UUID, registry, new EventEmitter(), defaultSpec);
       volume.size = 110;
       const fsaStub = sinon.stub(volume, 'fsa');
       fsaStub.resolves();
@@ -524,7 +525,7 @@ module.exports = function () {
       let stubs;
       const registry = new Registry();
       const volumes = new Volumes(registry);
-      const volume = new Volume(UUID, registry, () => {}, defaultSpec);
+      const volume = new Volume(UUID, registry, new EventEmitter(), defaultSpec);
       volume.size = 110;
       const fsaStub = sinon.stub(volume, 'fsa');
       fsaStub.returns();
@@ -566,7 +567,7 @@ module.exports = function () {
     it('should create a resource upon "new" volume event', async () => {
       let stubs;
       const registry = new Registry();
-      const volume = new Volume(UUID, registry, () => {}, defaultSpec);
+      const volume = new Volume(UUID, registry, new EventEmitter(), defaultSpec);
       const volumes = new Volumes(registry);
       sinon
         .stub(volumes, 'get')
@@ -603,7 +604,7 @@ module.exports = function () {
       let stubs;
       const registry = new Registry();
       const volumes = new Volumes(registry);
-      const volume = new Volume(UUID, registry, () => {}, defaultSpec);
+      const volume = new Volume(UUID, registry, new EventEmitter(), defaultSpec);
       sinon.stub(volumes, 'get').returns([]);
 
       const volumeResource = createVolumeResource(UUID, defaultSpec);
@@ -630,7 +631,7 @@ module.exports = function () {
       const volumes = new Volumes(registry);
       const newSpec = _.cloneDeep(defaultSpec);
       newSpec.replicaCount += 1;
-      const volume = new Volume(UUID, registry, () => {}, newSpec);
+      const volume = new Volume(UUID, registry, new EventEmitter(), newSpec);
       sinon
         .stub(volumes, 'get')
         .withArgs(UUID)
@@ -658,7 +659,7 @@ module.exports = function () {
       let stubs;
       const registry = new Registry();
       const volumes = new Volumes(registry);
-      const volume = new Volume(UUID, registry, () => {}, defaultSpec, 'pending', 100, 'node2');
+      const volume = new Volume(UUID, registry, new EventEmitter(), defaultSpec, 'pending', 100, 'node2');
       sinon
         .stub(volumes, 'get')
         .withArgs(UUID)
@@ -708,7 +709,7 @@ module.exports = function () {
         limitBytes: 130,
         protocol: 'nvmf'
       };
-      const volume = new Volume(UUID, registry, () => {}, newSpec);
+      const volume = new Volume(UUID, registry, new EventEmitter(), newSpec);
       volumes.emit('volume', {
         eventType: 'mod',
         object: volume
@@ -734,7 +735,7 @@ module.exports = function () {
         stubs.updateStatus.resolves();
       });
 
-      const volume = new Volume(UUID, registry, () => {}, defaultSpec);
+      const volume = new Volume(UUID, registry, new EventEmitter(), defaultSpec);
       volumes.emit('volume', {
         eventType: 'mod',
         object: volume
@@ -767,7 +768,7 @@ module.exports = function () {
         limitBytes: 130,
         protocol: 'nvmf'
       };
-      const volume = new Volume(UUID, registry, () => {}, newSpec);
+      const volume = new Volume(UUID, registry, new EventEmitter(), newSpec);
       volumes.emit('volume', {
         eventType: 'mod',
         object: volume
@@ -797,7 +798,7 @@ module.exports = function () {
         limitBytes: 130,
         protocol: 'nvmf'
       };
-      const volume = new Volume(UUID, registry, () => {}, newSpec);
+      const volume = new Volume(UUID, registry, new EventEmitter(), newSpec);
       volumes.emit('volume', {
         eventType: 'mod',
         object: volume
@@ -822,7 +823,7 @@ module.exports = function () {
         stubs.delete.resolves();
       });
 
-      const volume = new Volume(UUID, registry, () => {}, defaultSpec);
+      const volume = new Volume(UUID, registry, new EventEmitter(), defaultSpec);
       volumes.emit('volume', {
         eventType: 'del',
         object: volume
@@ -845,7 +846,7 @@ module.exports = function () {
         stubs.delete.rejects(new Error('delete failed'));
       });
 
-      const volume = new Volume(UUID, registry, () => {}, defaultSpec);
+      const volume = new Volume(UUID, registry, new EventEmitter(), defaultSpec);
       volumes.emit('volume', {
         eventType: 'del',
         object: volume
@@ -867,7 +868,7 @@ module.exports = function () {
         stubs.delete.resolves();
       });
 
-      const volume = new Volume(UUID, registry, () => {}, defaultSpec);
+      const volume = new Volume(UUID, registry, new EventEmitter(), defaultSpec);
       volumes.emit('volume', {
         eventType: 'del',
         object: volume

--- a/csi/moac/watcher.ts
+++ b/csi/moac/watcher.ts
@@ -2,6 +2,7 @@
 // api with v1alpha1 version.
 
 import * as _ from 'lodash';
+import events = require('events');
 import {
   CustomObjectsApi,
   HttpError,
@@ -13,7 +14,6 @@ import {
   Watch,
 } from 'client-node-fixed-watcher';
 
-const EventEmitter = require('events');
 const log = require('./logger').Logger('watcher');
 
 // If listWatch errors out then we restart it after this many msecs.
@@ -143,7 +143,7 @@ class ConfirmOp {
 // It is a general implementation of watcher which can be used for any resource
 // operator. The operator should subscribe to "new", "mod" and "del" events that
 // are triggered when a resource is added, modified or deleted.
-export class CustomResourceCache<T> extends EventEmitter {
+export class CustomResourceCache<T> extends events.EventEmitter {
   name: string;
   plural: string;
   namespace: string;
@@ -493,7 +493,7 @@ export class CustomResourceCache<T> extends EventEmitter {
     let orig = this.get(name);
     if (orig === undefined) {
       log.warn(`Tried to delete ${this.name} "${name}" that does not exist`);
-      return new Promise((resolve) => resolve());
+      return new Promise((resolve) => resolve(undefined));
     }
     log.trace(`Deleting ${this.name} "${name}"`);
     await this._waitForEvent(


### PR DESCRIPTION
This happened when putting moac under a bit of stress and issuing
create/publish/unpublish/destroy requests in a quick succession.
It revealed a few race conditions. Basically, publish method was
running in "parallel" (interleaved) with FSA code, so the state of
the volume was changing in two places. That has an easy fix of
putting code that changes the state of the volume from publish
method to FSA itself. fsa() guarding method guarantees that we can
have only one _fsa() running at any given time. So that should fix
the race condition. What publish merely does is set a few volume
state variables that tell FSA what to do and kick off FSA that does
the rest. Notification mechanism for letting the publish method know
when the required changes are done is in place but had to be slightly
revamped to be useable for that.

The same change has been done for unpublish and destroy methods (the
same problem although that it wasn't reproduced so far).

Some of the volume object tests have been moved to volumes test
suite because they require to run the FSA now.

Rename children URIs used in the tests so that they reflect the
node where child is located (as it is in real world).

Use events.EventEmitter with type information where possible.

Resolves: CAS-728