### PR TITLE
ci: add disruptive pods to I/O soak test MQ-252

### DIFF
--- a/test/e2e/common/e2e_config/e2e_config.go
+++ b/test/e2e/common/e2e_config/e2e_config.go
@@ -15,7 +15,10 @@ import (
 type E2EConfig struct {
 	// Operational parameters
 	Cores         int      `yaml:"cores,omitempty"`
+	// Registry from where mayastor images are retrieved
 	Registry      string   `yaml:"registry" env:"e2e_docker_registry" env-default:"ci-registry.mayastor-ci.mayadata.io"`
+	// Registry from where CI testing images are retrieved
+	CIRegistry    string   `yaml:"ciRegistry" env:"e2e_ci_docker_registry" env-default:"ci-registry.mayastor-ci.mayadata.io"`
 	ImageTag      string   `yaml:"imageTag" env:"e2e_image_tag" env-default:"ci"`
 	PoolDevice    string   `yaml:"poolDevice" env:"e2e_pool_device"`
 	PoolYamlFiles []string `yaml:"poolYamlFiles" env:"e2e_pool_yaml_files"`
@@ -30,7 +33,7 @@ type E2EConfig struct {
 		Duration         string   `yaml:"duration" env-default:"10m"`
 		LoadFactor       int      `yaml:"loadFactor" env-default:"10"`
 		Protocols        []string `yaml:"protocols" env-default:"nvmf,iscsi"`
-		FioFixedDuration int      `yaml:"fioFixedDuration" env-default:"60"`
+		FioStartDelay    int      `yaml:"fioStartDelay" env-default:"60"`
 		Disrupt          struct {
 			PodCount   int `yaml:"podCount" env-default:"3"`
 			FaultAfter int `yaml:"faultAfter" env-default:"45"`

--- a/test/e2e/common/e2e_config/e2e_config.go
+++ b/test/e2e/common/e2e_config/e2e_config.go
@@ -14,9 +14,9 @@ import (
 // E2EConfig is a application configuration structure
 type E2EConfig struct {
 	// Operational parameters
-	Cores         int      `yaml:"cores,omitempty"`
+	Cores int `yaml:"cores,omitempty"`
 	// Registry from where mayastor images are retrieved
-	Registry      string   `yaml:"registry" env:"e2e_docker_registry" env-default:"ci-registry.mayastor-ci.mayadata.io"`
+	Registry string `yaml:"registry" env:"e2e_docker_registry" env-default:"ci-registry.mayastor-ci.mayadata.io"`
 	// Registry from where CI testing images are retrieved
 	CIRegistry    string   `yaml:"ciRegistry" env:"e2e_ci_docker_registry" env-default:"ci-registry.mayastor-ci.mayadata.io"`
 	ImageTag      string   `yaml:"imageTag" env:"e2e_image_tag" env-default:"ci"`
@@ -29,16 +29,22 @@ type E2EConfig struct {
 		CrudCycles int `yaml:"crudCycles" env-default:"20"`
 	} `yaml:"pvcStress"`
 	IOSoakTest struct {
-		Replicas         int      `yaml:"replicas" env-default:"2"`
-		Duration         string   `yaml:"duration" env-default:"10m"`
-		LoadFactor       int      `yaml:"loadFactor" env-default:"10"`
-		Protocols        []string `yaml:"protocols" env-default:"nvmf,iscsi"`
-		FioStartDelay    int      `yaml:"fioStartDelay" env-default:"60"`
-		Disrupt          struct {
-			PodCount   int `yaml:"podCount" env-default:"3"`
+		Replicas int    `yaml:"replicas" env-default:"2"`
+		Duration string `yaml:"duration" env-default:"10m"`
+		// Number of volumes for each mayastor instance
+		// volumes for disruptor pods are allocated from within this "pool"
+		LoadFactor int      `yaml:"loadFactor" env-default:"20"`
+		Protocols  []string `yaml:"protocols" env-default:"nvmf"`
+		// FioStartDelay units are seconds
+		FioStartDelay int `yaml:"fioStartDelay" env-default:"60"`
+		Disrupt       struct {
+			// Number of disruptor pods.
+			PodCount int `yaml:"podCount" env-default:"3"`
+			// FaultAfter units are seconds
 			FaultAfter int `yaml:"faultAfter" env-default:"45"`
 		} `yaml:"disrupt"`
 		FioDutyCycles []struct {
+			// ThinkTime units are microseconds
 			ThinkTime       int `yaml:"thinkTime"`
 			ThinkTimeBlocks int `yaml:"thinkTimeBlocks"`
 		} `yaml:"fioDutyCycles"`

--- a/test/e2e/common/util_testpods.go
+++ b/test/e2e/common/util_testpods.go
@@ -200,3 +200,12 @@ func CheckTestPodsHealth(namespace string) error {
 	}
 	return nil
 }
+
+func CheckPodCompleted(podName string, nameSpace string) (corev1.PodPhase, error) {
+	podApi := gTestEnv.KubeInt.CoreV1().Pods
+	pod, err := podApi(nameSpace).Get(context.TODO(), podName, metav1.GetOptions{})
+	if err != nil {
+		return corev1.PodUnknown, err
+	}
+	return pod.Status.Phase, err
+}

--- a/test/e2e/configurations/ci_e2e_config.yaml
+++ b/test/e2e/configurations/ci_e2e_config.yaml
@@ -6,11 +6,14 @@ pvcstress:
 ioSoakTest:
   replicas: 1
   duration: 10m
-  loadFactor: 2
+  loadFactor: 21
   protocols:
   - nvmf
 # - iscsi
-  fioFixedDuration: 60
+  disrupt:
+    podCount: 5
+    faultAfter: 51
+  fioStartDelay: 90
   fioDutyCycles:
   - thinkTime: 500000
     thinkTimeBlocks: 1000

--- a/test/e2e/configurations/ci_e2e_config.yaml
+++ b/test/e2e/configurations/ci_e2e_config.yaml
@@ -6,14 +6,19 @@ pvcstress:
 ioSoakTest:
   replicas: 1
   duration: 10m
+  # loadFactor is number of volumes for each mayastor instance
+  # volumes for disruptor pods are allocated from within this "pool"
   loadFactor: 21
   protocols:
   - nvmf
-# - iscsi
   disrupt:
+    # Number of disruptor pods
     podCount: 5
+    # faultAfter units are seconds
     faultAfter: 51
+  # fioStartDelay units are seconds
   fioStartDelay: 90
+  # thinkTime units are microseconds
   fioDutyCycles:
   - thinkTime: 500000
     thinkTimeBlocks: 1000

--- a/test/e2e/e2e-fio/Dockerfile
+++ b/test/e2e/e2e-fio/Dockerfile
@@ -1,0 +1,38 @@
+# VERSION 0.1
+FROM alpine
+
+MAINTAINER mayastor mayastor@mayadata.io
+
+# Install build deps + permanent dep: libaio
+RUN apk --no-cache add \
+    	make \
+	alpine-sdk \
+	zlib-dev \
+	libaio-dev \
+	linux-headers \
+	coreutils \
+	coreutils \
+	libaio && \
+    git clone https://github.com/axboe/fio && \
+    cd fio && \
+    ./configure && \
+    make -j`nproc` && \
+    make install && \
+    cd .. && \
+    rm -rf fio && \
+    apk --no-cache del \
+    	make \
+	alpine-sdk \
+	zlib-dev \
+	libaio-dev \
+	linux-headers \
+	coreutils 
+
+RUN apk --no-cache add \
+    	gcc musl-dev
+
+ADD e2e_fio.c /
+
+RUN gcc -Wall -o /e2e_fio e2e_fio.c
+
+ENTRYPOINT ["/e2e_fio"]

--- a/test/e2e/e2e-fio/Dockerfile
+++ b/test/e2e/e2e-fio/Dockerfile
@@ -3,36 +3,13 @@ FROM alpine
 
 MAINTAINER mayastor mayastor@mayadata.io
 
-# Install build deps + permanent dep: libaio
 RUN apk --no-cache add \
-    	make \
-	alpine-sdk \
-	zlib-dev \
-	libaio-dev \
-	linux-headers \
-	coreutils \
-	coreutils \
-	libaio && \
-    git clone https://github.com/axboe/fio && \
-    cd fio && \
-    ./configure && \
-    make -j`nproc` && \
-    make install && \
-    cd .. && \
-    rm -rf fio && \
-    apk --no-cache del \
-    	make \
-	alpine-sdk \
-	zlib-dev \
-	libaio-dev \
-	linux-headers \
-	coreutils 
-
-RUN apk --no-cache add \
-    	gcc musl-dev
+    	fio gcc musl-dev
 
 ADD e2e_fio.c /
 
 RUN gcc -Wall -o /e2e_fio e2e_fio.c
+RUN apk --no-cache del \
+        gcc musl-dev
 
 ENTRYPOINT ["/e2e_fio"]

--- a/test/e2e/e2e-fio/README.md
+++ b/test/e2e/e2e-fio/README.md
@@ -1,0 +1,22 @@
+# Mayastor E2E fio test pod
+## Introduction
+Derived from `dmonakhov/alpine-fio`
+
+Arguments
+ * sleep <sleep seconds>
+ * segfault-after <delay seconds>
+ * exitv <exit value>
+ * -- <fio argument list> 
+
+ 1. fio is only run if fio arguments are specified.
+ 2. fio is always run as a forked process.
+ 3. the segfault directive takes priority over the sleep directive
+ 4. exitv <v> override exit value - this is to aid test development specifically to validate error detection in the tests.
+ 5. argument parsing is simple, invalid specifications are skipped over for example `"sleep --"` => `sleep` is skipped over, parsing resumes from `--`. Execution does not fail. 
+
+## building
+Run `./build.sh`
+
+This builds the image `mayastor/e2e-fio` 
+
+

--- a/test/e2e/e2e-fio/README.md
+++ b/test/e2e/e2e-fio/README.md
@@ -17,6 +17,6 @@ Arguments
 ## building
 Run `./build.sh`
 
-This builds the image `mayastor/e2e-fio` 
+This builds the image `mayadata/e2e-fio` 
 
 

--- a/test/e2e/e2e-fio/README.md
+++ b/test/e2e/e2e-fio/README.md
@@ -11,7 +11,7 @@ Arguments
  1. fio is only run if fio arguments are specified.
  2. fio is always run as a forked process.
  3. the segfault directive takes priority over the sleep directive
- 4. exitv <v> override exit value - this is to aid test development specifically to validate error detection in the tests.
+ 4. exitv <v> override exit value - this is to simulate failure.
  5. argument parsing is simple, invalid specifications are skipped over for example `"sleep --"` => `sleep` is skipped over, parsing resumes from `--`. Execution does not fail. 
 
 ## building

--- a/test/e2e/e2e-fio/build.sh
+++ b/test/e2e/e2e-fio/build.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-docker build -t mayastor/e2e-fio .
+docker build -t mayadata/e2e-fio .

--- a/test/e2e/e2e-fio/build.sh
+++ b/test/e2e/e2e-fio/build.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+docker build -t mayastor/e2e-fio .

--- a/test/e2e/e2e-fio/e2e_fio.c
+++ b/test/e2e/e2e-fio/e2e_fio.c
@@ -43,12 +43,11 @@ void run_fio_sh(char** argv) {
 
 /*
  * Usage:
- * [sleep <sleep seconds>] [segfault-after <delay seconds>] [-- <fio argument list>] 
+ * [sleep <sleep seconds>] [segfault-after <delay seconds>] [-- <fio argument list>] [exitv <exit value>] 
  * 1. fio is only run if fio arguments are specified.
  * 2. fio is always run as a forked process.
  * 3. the segfault directive takes priority over the sleep directive
- * 4. exitv <v> override exit value - this is to aid test development.
- *      specifically to validate error detection in the tests.
+ * 4. exitv <v> override exit value - this is to simulate failure in the test pod.
  * 5. argument parsing is simple, invalid specifications are skipped over
  *  for example "sleep --" => sleep is skipped over, parsing resumes from "--"
  */

--- a/test/e2e/e2e-fio/e2e_fio.c
+++ b/test/e2e/e2e-fio/e2e_fio.c
@@ -54,11 +54,12 @@ void run_fio_sh(char** argv) {
  */
 int main(int argc, char **argv_in)
 {
-    unsigned sleep_time=0;
-    unsigned segfault_time=0;
+    unsigned sleep_time = 0;
+    unsigned segfault_time = 0;
     char** argv = argv_in;
-    pid_t   fio_pid=0;
-    int     exitv=0;
+    pid_t   fio_pid = 0;
+    int     running_fio = 0;
+    int     exitv = 0;
 
     /* skip over this programs name */
     argv += 1;
@@ -110,6 +111,8 @@ int main(int argc, char **argv_in)
         if ( 0 == fio_pid ) {
             run_fio_sh(argv);
             exit(0);
+        } else {
+            running_fio = 1;
         }
     }
 
@@ -132,7 +135,7 @@ int main(int argc, char **argv_in)
     }
 
     /* if fio was launched wait for it to complete */
-    if (0 != fio_pid) {
+    if (0 != running_fio) {
         int status;
         waitpid(fio_pid, &status, 0);
         if (exitv == 0) {

--- a/test/e2e/e2e-fio/e2e_fio.c
+++ b/test/e2e/e2e-fio/e2e_fio.c
@@ -1,0 +1,146 @@
+#include <stdio.h>
+#include <signal.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+
+void run_fio_sh(char** argv) {
+    char *cmd = NULL;
+    /* Tis' C so we do it the "hard way" */
+    char *pinsert;
+    const char *prefix = "fio ";
+    /* stop fio generatng curses output,  stdio is not a tty */
+    const char *suffix = " | cat";
+    size_t buflen = strlen(prefix) + strlen(suffix) + 1;
+    /* 1. work out the size of the buffer required to copy the arguments.*/
+    for(char **argv_scan=argv; *argv_scan != NULL; ++argv_scan) {
+        /* +1 for space delimiter */
+        buflen += strlen(*argv_scan) + 1;
+    }
+    /* 2. allocate a 0 intialised buffer so we can use strcat */
+    cmd = calloc(sizeof(unsigned char), buflen);
+    pinsert = cmd;
+    /* 3. construct the command line, using strcat */
+    if (cmd != NULL) {
+        strcat(pinsert, prefix);
+        pinsert += strlen(pinsert);
+        for(; *argv != NULL; ++argv) {
+            strcat(pinsert, *argv);
+            pinsert += strlen(pinsert);
+            *pinsert = ' ';
+            ++pinsert;
+        }
+        strcat(pinsert,suffix);
+        printf("exec %s\n",cmd);
+        execl("/bin/sh", "sh", "-c", cmd, NULL);
+        free(cmd);
+    } else {
+        puts("failed to allocate memory");
+    }
+}
+
+/*
+ * Usage:
+ * [sleep <sleep seconds>] [segfault-after <delay seconds>] [-- <fio argument list>] 
+ * 1. fio is only run if fio arguments are specified.
+ * 2. fio is always run as a forked process.
+ * 3. the segfault directive takes priority over the sleep directive
+ * 4. exitv <v> override exit value - this is to aid test development.
+ *      specifically to validate error detection in the tests.
+ * 5. argument parsing is simple, invalid specifications are skipped over
+ *  for example "sleep --" => sleep is skipped over, parsing resumes from "--"
+ */
+int main(int argc, char **argv_in)
+{
+    unsigned sleep_time=0;
+    unsigned segfault_time=0;
+    char** argv = argv_in;
+    pid_t   fio_pid=0;
+    int     exitv=0;
+
+    /* skip over this programs name */
+    argv += 1;
+    /* "parse" arguments -
+     * 1. segfault-after <n> number of seconds
+     * 2. sleep <n> number of seconds
+     * 3. anything after "--" is merely collected and passed to fio
+     *    -- also implies fio is launched.
+     * 4. exitv <v> override exit value - this is to aid test development.
+     *      specifically to validate error detection in the tests.
+     * For our simple purposes atoi is sufficient 
+     *
+     * For simplicity none of the arguments are mandatory
+     * if no arguments are supplied execution ends
+     * segfault-after is always handled before sleep
+     * fio is always run as a forked process so executes concurrently
+     * if fio is launched, we wait for it complete and return its exit value.
+     * Note you can use --status-interval=N as an argument to get fio to print status every N seconds
+     *
+     * Intended use cases are
+     * a) sleep N fio is executed using exec 
+     * b) segfault-after N, sleep for N then segfault terminating the pod or restarting the pod
+     * c) segfault-after N -- ...., run fio (in a different process) and segfault after N seconds
+     * d) -- ....., run fio, if fio completes, execution ends.
+     */
+    while(*argv != NULL) {
+        if (0 == strcmp(*argv,"sleep") && NULL != *(argv+1) && 0 != atoi(*(argv+1))) {
+            sleep_time = atoi(*(argv+1));
+            ++argv;
+        } else if (0 == strcmp(*argv,"segfault-after") && NULL != *(argv+1) && 0 != atoi(*(argv+1))) {
+            segfault_time = atoi(*(argv+1));
+            ++argv;
+        } else if (0 == strcmp(*argv, "--")) {
+            ++argv;
+            break;
+        } else if (0 == strcmp(*argv,"exitv") && NULL != *(argv+1) && 0 != atoi(*(argv+1))) {
+            exitv = atoi(*(argv+1));
+            printf("Overriding exit value to %d\n", exitv);
+            ++argv;
+        } else {
+            printf("Ignoring %s\n", *argv);
+        }
+        ++argv;
+    }
+
+    /* fio arguments have been supplied */
+    if (*argv != NULL) {
+        fio_pid = fork();
+        if ( 0 == fio_pid ) {
+            run_fio_sh(argv);
+            exit(0);
+        }
+    }
+
+    /* segfault has priority over sleep */
+    if (0 != segfault_time) {
+        printf("Segfaulting after %d seconds\n", segfault_time);
+        sleep(segfault_time);
+        if (0 != fio_pid) {
+            system("killall fio");
+            kill(fio_pid, SIGKILL);
+            sleep(1);
+        }
+        puts("Segfaulting now!");
+        raise(SIGSEGV);
+    }
+
+    if (0 != sleep_time) {
+        printf("sleeping %d seconds\n", sleep_time);
+        sleep(sleep_time);
+    }
+
+    /* if fio was launched wait for it to complete */
+    if (0 != fio_pid) {
+        int status;
+        waitpid(fio_pid, &status, 0);
+        if (exitv == 0) {
+            printf("Exit value is fio status, %d\n", status);
+            return status;
+        }
+    }
+
+    printf("Exit value is %d\n", exitv);
+    return exitv;
+}

--- a/test/e2e/io_soak/README.md
+++ b/test/e2e/io_soak/README.md
@@ -12,3 +12,18 @@ Runs fio with varying duty cycles concurrently on a number of volumes for an ext
 `e2e_io_soak_duration` is parsed using `golangs` library function `time.ParseDuration`.
 So `e2e_io_soak_duration` string is a sequence of decimal numbers, each with optional fraction and a unit suffix, such as "300ms", "-1.5h" or "2h45m".
 Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h". 
+
+## Notes:
+To facilitate creation of a largish number of test pods in a reasonable amount of time,
+all test pods (excluding the disruptor pods) run fio with a configurable delay,
+this is an attempt to makes the test setup more robust.
+The delay means CPU utilization on the cluster nodes for an initial period is low
+and should make it possible to create pods at a reasonable rate.
+As the number of volumes created increases, this period should be increased,
+otherwise timeouts for pods being ready will trigger and the test will fail.
+
+All fio runs including the disruptor pods run fio with verification on,
+though the disruptor fio run is not checked.
+
+The disruptor pods are identical to test pods execpt that they been configured
+to raise a SIGSEGV after a configurable delay.

--- a/test/e2e/io_soak/definitions.go
+++ b/test/e2e/io_soak/definitions.go
@@ -1,0 +1,25 @@
+package io_soak
+
+import (
+	"e2e-basic/common"
+	"k8s.io/api/core/v1"
+)
+
+const NSDisrupt = common.NSE2EPrefix + "-iosoak-disrupt"
+
+const NodeSelectorKey = "e2e-io-soak"
+const NodeSelectorAppValue = "e2e-app"
+const PodReadyTime = 5
+
+var AppNodeSelector = map[string]string{
+	NodeSelectorKey: NodeSelectorAppValue,
+}
+
+type IoSoakJob interface {
+	makeVolume()
+	makeTestPod(map[string]string) (*v1.Pod, error)
+	removeTestPod() error
+	removeVolume()
+	getPodName() string
+}
+

--- a/test/e2e/io_soak/disruptor_fio.go
+++ b/test/e2e/io_soak/disruptor_fio.go
@@ -40,7 +40,7 @@ func (job FioDisruptorJob) makeTestPod(selector map[string]string) (*coreV1.Pod,
 	pod.Spec.NodeSelector = selector
 	pod.Spec.RestartPolicy = coreV1.RestartPolicyAlways
 
-	image := "" + e2e_config.GetConfig().CIRegistry + "/mayadata/e2e-fio"
+	image := "mayadata/e2e-fio"
 	pod.Spec.Containers[0].Image = image
 
 	args := []string{

--- a/test/e2e/io_soak/disruptor_fio.go
+++ b/test/e2e/io_soak/disruptor_fio.go
@@ -24,7 +24,7 @@ type FioDisruptorJob struct {
 	podName    string
 	id         int
 	faultDelay int
-	ready 	   bool
+	ready      bool
 }
 
 func (job FioDisruptorJob) makeVolume() {
@@ -40,7 +40,7 @@ func (job FioDisruptorJob) makeTestPod(selector map[string]string) (*coreV1.Pod,
 	pod.Spec.NodeSelector = selector
 	pod.Spec.RestartPolicy = coreV1.RestartPolicyAlways
 
-	image := "" + e2e_config.GetConfig().CIRegistry + "/mayastor/e2e-fio"
+	image := "" + e2e_config.GetConfig().CIRegistry + "/mayadata/e2e-fio"
 	pod.Spec.Containers[0].Image = image
 
 	args := []string{
@@ -76,7 +76,7 @@ func MakeFioDisruptorJob(scName string, id int, segfaultDelay int) FioDisruptorJ
 		podName:    nm,
 		id:         id,
 		faultDelay: segfaultDelay,
-		ready: false,
+		ready:      false,
 	}
 }
 
@@ -140,8 +140,8 @@ func MakeDisruptors() {
 	// We try to detect the edge when disruptor pods transition
 	// to ready and latch that as the disruptor pod is "ready"
 	allReady := false
-	for to:=0; to< timeoutSecs && !allReady; to+=1 {
-		time.Sleep(1* time.Second)
+	for to := 0; to < timeoutSecs && !allReady; to += 1 {
+		time.Sleep(1 * time.Second)
 		allReady = true
 		for _, job := range disruptorJobs {
 			if !job.ready {

--- a/test/e2e/io_soak/disruptor_fio.go
+++ b/test/e2e/io_soak/disruptor_fio.go
@@ -1,0 +1,170 @@
+package io_soak
+
+import (
+	"e2e-basic/common"
+	"e2e-basic/common/e2e_config"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"fmt"
+	"time"
+
+	. "github.com/onsi/gomega"
+
+	coreV1 "k8s.io/api/core/v1"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+var disruptorJobs []FioDisruptorJob
+var disruptorScNames []string
+
+// IO soak disruptor fio  job
+type FioDisruptorJob struct {
+	volName    string
+	scName     string
+	podName    string
+	id         int
+	faultDelay int
+	ready 	   bool
+}
+
+func (job FioDisruptorJob) makeVolume() {
+	common.MkPVC(common.DefaultVolumeSizeMb, job.volName, job.scName, common.VolRawBlock, NSDisrupt)
+}
+
+func (job FioDisruptorJob) removeVolume() {
+	common.RmPVC(job.volName, job.scName, NSDisrupt)
+}
+
+func (job FioDisruptorJob) makeTestPod(selector map[string]string) (*coreV1.Pod, error) {
+	pod := common.CreateFioPodDef(job.podName, job.volName, common.VolRawBlock, NSDisrupt)
+	pod.Spec.NodeSelector = selector
+	pod.Spec.RestartPolicy = coreV1.RestartPolicyAlways
+
+	image := "" + e2e_config.GetConfig().CIRegistry + "/mayastor/e2e-fio"
+	pod.Spec.Containers[0].Image = image
+
+	args := []string{
+		"segfault-after",
+		fmt.Sprintf("%d", job.faultDelay),
+		"--",
+		"--time_based",
+		fmt.Sprintf("--runtime=%d", job.faultDelay+100),
+		fmt.Sprintf("--filename=%s", common.FioBlockFilename),
+		fmt.Sprintf("--thinktime=%d", GetThinkTime(job.id)),
+		fmt.Sprintf("--thinktime_blocks=%d", GetThinkTimeBlocks(job.id)),
+	}
+	args = append(args, FioArgs...)
+	pod.Spec.Containers[0].Args = args
+
+	pod, err := common.CreatePod(pod, NSDisrupt)
+	return pod, err
+}
+
+func (job FioDisruptorJob) removeTestPod() error {
+	return common.DeletePod(job.podName, NSDisrupt)
+}
+
+func (job FioDisruptorJob) getPodName() string {
+	return job.podName
+}
+
+func MakeFioDisruptorJob(scName string, id int, segfaultDelay int) FioDisruptorJob {
+	nm := fmt.Sprintf("fio-disruptor-%s-%d", scName, id)
+	return FioDisruptorJob{
+		volName:    nm,
+		scName:     scName,
+		podName:    nm,
+		id:         id,
+		faultDelay: segfaultDelay,
+		ready: false,
+	}
+}
+
+func DisruptorsInit(protocols []common.ShareProto, replicas int) {
+	for _, proto := range protocols {
+		scName := fmt.Sprintf("iosoak-disruptor-%s", proto)
+		logf.Log.Info("Creating", "storage class", scName)
+		err := common.MkStorageClass(scName, replicas, proto, common.NSDefault)
+		Expect(err).ToNot(HaveOccurred())
+		disruptorScNames = append(disruptorScNames, scName)
+	}
+}
+
+func DisruptorsDeinit() {
+	for _, scName := range disruptorScNames {
+		err := common.RmStorageClass(scName)
+		Expect(err).ToNot(HaveOccurred())
+	}
+}
+
+func MakeDisruptors() {
+	config := e2e_config.GetConfig().IOSoakTest.Disrupt
+	count := config.PodCount
+	err := common.MkNamespace(NSDisrupt)
+	Expect(err).ToNot(HaveOccurred(), "Create namespace %s", NSDisrupt)
+
+	idx := 1
+	for idx <= count {
+		for _, scName := range disruptorScNames {
+			if idx > count {
+				break
+			}
+			log.Log.Info("Creating", "job", "fio disruptor job", "id", idx)
+			disruptorJobs = append(disruptorJobs, MakeFioDisruptorJob(scName, idx, config.FaultAfter))
+			idx++
+		}
+	}
+
+	for _, job := range disruptorJobs {
+		job.makeVolume()
+	}
+
+	log.Log.Info("Creating disruptor test pods")
+	// Create the job test pods
+	for _, job := range disruptorJobs {
+		pod, err := job.makeTestPod(AppNodeSelector)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(pod).ToNot(BeNil())
+	}
+
+	// Empirically allocate  PodReadyTime seconds for each pod to transition to ready
+	timeoutSecs := PodReadyTime * len(disruptorJobs)
+	if timeoutSecs < 60 {
+		timeoutSecs = 60
+	}
+	logf.Log.Info("Waiting for disruptor pods to be ready", "timeout seconds", timeoutSecs, "jobs", len(disruptorJobs))
+
+	// Wait for the test pods to be ready,
+	// This is a bit tricky we want assert that all disruptor pods have started,
+	// however as disruptor pods restart, we have to be careful.
+	// We try to detect the edge when disruptor pods transition
+	// to ready and latch that as the disruptor pod is "ready"
+	allReady := false
+	for to:=0; to< timeoutSecs && !allReady; to+=1 {
+		time.Sleep(1* time.Second)
+		allReady = true
+		for _, job := range disruptorJobs {
+			if !job.ready {
+				job.ready = common.IsPodRunning(job.getPodName(), NSDisrupt)
+			}
+			allReady = allReady && job.ready
+		}
+	}
+	logf.Log.Info("DisruptorPods", "all ready", allReady)
+	Expect(allReady).To(BeTrue(), "Timeout waiting to disruptor jobs to be ready")
+}
+
+func DestroyDisruptors() {
+	for _, job := range disruptorJobs {
+		err := job.removeTestPod()
+		Expect(err).ToNot(HaveOccurred())
+	}
+
+	log.Log.Info("All runs complete, deleting volumes")
+	for _, job := range disruptorJobs {
+		job.removeVolume()
+	}
+
+	err := common.RmNamespace(NSDisrupt)
+	Expect(err).ToNot(HaveOccurred(), "Delete namespace %s", NSDisrupt)
+}

--- a/test/e2e/io_soak/disruptor_fio.go
+++ b/test/e2e/io_soak/disruptor_fio.go
@@ -44,11 +44,11 @@ func (job FioDisruptorJob) makeTestPod(selector map[string]string) (*coreV1.Pod,
 	pod.Spec.Containers[0].Image = image
 
 	args := []string{
-		"segfault-after",
-		fmt.Sprintf("%d", job.faultDelay),
+		"exitv",
+		"255",
 		"--",
 		"--time_based",
-		fmt.Sprintf("--runtime=%d", job.faultDelay+100),
+		fmt.Sprintf("--runtime=%d", job.faultDelay),
 		fmt.Sprintf("--filename=%s", common.FioBlockFilename),
 		fmt.Sprintf("--thinktime=%d", GetThinkTime(job.id)),
 		fmt.Sprintf("--thinktime_blocks=%d", GetThinkTimeBlocks(job.id)),

--- a/test/e2e/io_soak/filesystem_fio.go
+++ b/test/e2e/io_soak/filesystem_fio.go
@@ -12,10 +12,11 @@ import (
 
 // IO soak filesystem fio job
 type FioFsSoakJob struct {
-	volName string
-	scName  string
-	podName string
-	id      int
+	volName  string
+	scName   string
+	podName  string
+	id       int
+	duration int
 }
 
 func (job FioFsSoakJob) makeVolume() {
@@ -29,6 +30,24 @@ func (job FioFsSoakJob) removeVolume() {
 func (job FioFsSoakJob) makeTestPod(selector map[string]string) (*coreV1.Pod, error) {
 	pod := common.CreateFioPodDef(job.podName, job.volName, common.VolFileSystem, common.NSDefault)
 	pod.Spec.NodeSelector = selector
+
+	e2eCfg := e2e_config.GetConfig()
+	image := "" + e2eCfg.CIRegistry + "/mayastor/e2e-fio"
+	pod.Spec.Containers[0].Image = image
+
+	args := []string{
+		"--",
+		fmt.Sprintf("--startdelay=%d",e2eCfg.IOSoakTest.FioStartDelay),
+		"--time_based",
+		fmt.Sprintf("--runtime=%d", job.duration),
+		fmt.Sprintf("--filename=%s", common.FioFsFilename),
+		fmt.Sprintf("--thinktime=%d", GetThinkTime(job.id)),
+		fmt.Sprintf("--thinktime_blocks=%d", GetThinkTimeBlocks(job.id)),
+		fmt.Sprintf("--size=%dm", common.DefaultFioSizeMb),
+	}
+	args = append(args, FioArgs...)
+	pod.Spec.Containers[0].Args = args
+
 	pod, err := common.CreatePod(pod, common.NSDefault)
 	return pod, err
 }
@@ -37,42 +56,17 @@ func (job FioFsSoakJob) removeTestPod() error {
 	return common.DeletePod(job.podName, common.NSDefault)
 }
 
-func (job FioFsSoakJob) run(duration time.Duration, doneC chan<- string, errC chan<- error) {
-	thinkTime := 1 // 1 microsecond
-	thinkTimeBlocks := 1000
-
-	FioDutyCycles := e2e_config.GetConfig().IOSoakTest.FioDutyCycles
-	if len(FioDutyCycles) != 0 {
-		ixp := job.id % len(FioDutyCycles)
-		thinkTime = FioDutyCycles[ixp].ThinkTime
-		thinkTimeBlocks = FioDutyCycles[ixp].ThinkTimeBlocks
-	}
-
-	RunIoSoakFio(
-		job.podName,
-		duration,
-		thinkTime,
-		thinkTimeBlocks,
-		false,
-		doneC,
-		errC,
-	)
-}
-
 func (job FioFsSoakJob) getPodName() string {
 	return job.podName
 }
 
-func (job FioFsSoakJob) getId() int {
-	return job.id
-}
-
-func MakeFioFsJob(scName string, id int) FioFsSoakJob {
+func MakeFioFsJob(scName string, id int, duration time.Duration) FioFsSoakJob {
 	nm := fmt.Sprintf("fio-filesystem-%s-%d", scName, id)
 	return FioFsSoakJob{
-		volName: nm,
-		scName:  scName,
-		podName: nm,
-		id:      id,
+		volName:  nm,
+		scName:   scName,
+		podName:  nm,
+		id:       id,
+		duration: int(duration.Seconds()),
 	}
 }

--- a/test/e2e/io_soak/filesystem_fio.go
+++ b/test/e2e/io_soak/filesystem_fio.go
@@ -32,12 +32,12 @@ func (job FioFsSoakJob) makeTestPod(selector map[string]string) (*coreV1.Pod, er
 	pod.Spec.NodeSelector = selector
 
 	e2eCfg := e2e_config.GetConfig()
-	image := "" + e2eCfg.CIRegistry + "/mayastor/e2e-fio"
+	image := "" + e2eCfg.CIRegistry + "/mayadata/e2e-fio"
 	pod.Spec.Containers[0].Image = image
 
 	args := []string{
 		"--",
-		fmt.Sprintf("--startdelay=%d",e2eCfg.IOSoakTest.FioStartDelay),
+		fmt.Sprintf("--startdelay=%d", e2eCfg.IOSoakTest.FioStartDelay),
 		"--time_based",
 		fmt.Sprintf("--runtime=%d", job.duration),
 		fmt.Sprintf("--filename=%s", common.FioFsFilename),

--- a/test/e2e/io_soak/filesystem_fio.go
+++ b/test/e2e/io_soak/filesystem_fio.go
@@ -32,7 +32,7 @@ func (job FioFsSoakJob) makeTestPod(selector map[string]string) (*coreV1.Pod, er
 	pod.Spec.NodeSelector = selector
 
 	e2eCfg := e2e_config.GetConfig()
-	image := "" + e2eCfg.CIRegistry + "/mayadata/e2e-fio"
+	image := "mayadata/e2e-fio"
 	pod.Spec.Containers[0].Image = image
 
 	args := []string{

--- a/test/e2e/io_soak/fio.go
+++ b/test/e2e/io_soak/fio.go
@@ -1,72 +1,43 @@
 package io_soak
 
 import (
-	"e2e-basic/common"
 	"e2e-basic/common/e2e_config"
-
-	"fmt"
-	"io/ioutil"
-	"time"
-
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // see https://fio.readthedocs.io/en/latest/fio_doc.html#i-o-rate
-// run fio in a loop of fixed duration to fulfill a larger duration,
-// this to facilitate a relatively timely termination when an error
-// occurs elsewhere.
-// podName - name of the fio pod
-// duration - time in seconds to run fio
 // thinktime -  usecs, stall the job for the specified period of time after an I/O has completed before issuing the next
 // thinktime_blocks - how many blocks to issue, before waiting thinktime usecs.
-// rawBlock - false for filesystem volumes, true for raw block mounts.
-func RunIoSoakFio(podName string, duration time.Duration, thinkTime int, thinkTimeBlocks int, rawBlock bool, doneC chan<- string, errC chan<- error) {
-	secs := int(duration.Seconds())
-	argThinkTime := fmt.Sprintf("--thinktime=%d", thinkTime)
-	argThinkTimeBlocks := fmt.Sprintf("--thinktime_blocks=%d", thinkTimeBlocks)
 
-	logf.Log.Info("Running fio",
-		"pod", podName,
-		"duration", duration,
-		"thinktime", thinkTime,
-		"thinktime_blocks", thinkTimeBlocks,
-		"rawBlock", rawBlock,
-	)
-
-	fioFile := ""
-	if rawBlock {
-		fioFile = common.FioBlockFilename
-	} else {
-		fioFile = common.FioFsFilename
+func GetThinkTime(idx int) int {
+	thinkTime := 1 // 1 microsecond
+	FioDutyCycles := e2e_config.GetConfig().IOSoakTest.FioDutyCycles
+	if len(FioDutyCycles) != 0 {
+		ixp := idx % len(FioDutyCycles)
+		thinkTime = FioDutyCycles[ixp].ThinkTime
 	}
+	return thinkTime
+}
 
-	for ix := 1; secs > 0; ix++ {
-		runtime := e2e_config.GetConfig().IOSoakTest.FioFixedDuration
-		if runtime > secs {
-			runtime = secs
-		}
-		secs -= runtime
-
-		logf.Log.Info("run fio ",
-			"iteration", ix,
-			"pod", podName,
-			"duration", runtime,
-			"thinktime", thinkTime,
-			"thinktime_blocks", thinkTimeBlocks,
-			"rawBlock", rawBlock,
-			"fioFile", fioFile,
-		)
-		output, err := common.RunFio(podName, runtime, fioFile, common.DefaultFioSizeMb, argThinkTime, argThinkTimeBlocks)
-
-		//TODO: for now shove the output into /tmp
-		_ = ioutil.WriteFile("/tmp/"+podName+".out", output, 0644)
-		//logf.Log.Info(string(output))
-		if err != nil {
-			logf.Log.Info("Abort running fio", "pod", podName, "error", err)
-			errC <- err
-			return
-		}
+func GetThinkTimeBlocks(idx int) int {
+	thinkTimeBlocks := 1000 // 1 microsecond
+	FioDutyCycles := e2e_config.GetConfig().IOSoakTest.FioDutyCycles
+	if len(FioDutyCycles) != 0 {
+		ixp := idx % len(FioDutyCycles)
+		thinkTimeBlocks = FioDutyCycles[ixp].ThinkTimeBlocks
 	}
-	logf.Log.Info("Finished running fio", "pod", podName, "duration", duration)
-	doneC <- podName
+	return thinkTimeBlocks
+}
+
+var FioArgs = []string{
+	"--name=benchtest",
+	"--direct=1",
+	"--rw=randrw",
+	"--ioengine=libaio",
+	"--bs=4k",
+	"--iodepth=16",
+	"--numjobs=1",
+	"--verify=crc32",
+	"--verify_fatal=1",
+	"--verify_async=2",
+	"--status-interval=51",
 }

--- a/test/e2e/io_soak/io_soak_test.go
+++ b/test/e2e/io_soak/io_soak_test.go
@@ -5,6 +5,7 @@ package io_soak
 import (
 	"e2e-basic/common"
 	"e2e-basic/common/e2e_config"
+	corev1 "k8s.io/api/core/v1"
 
 	"fmt"
 	"sort"
@@ -14,27 +15,8 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	coreV1 "k8s.io/api/core/v1"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
-
-var defTimeoutSecs = "120s"
-
-type IoSoakJob interface {
-	makeVolume()
-	makeTestPod(map[string]string) (*coreV1.Pod, error)
-	removeTestPod() error
-	removeVolume()
-	run(time.Duration, chan<- string, chan<- error)
-	getPodName() string
-}
-
-const NodeSelectorKey = "e2e-io-soak"
-const NodeSelectorAppValue = "e2e-app"
-
-var AppNodeSelector = map[string]string{
-	NodeSelectorKey: NodeSelectorAppValue,
-}
 
 var scNames []string
 var jobs []IoSoakJob
@@ -44,29 +26,82 @@ func TestIOSoak(t *testing.T) {
 	common.InitTesting(t, "IO soak test, NVMe-oF TCP and iSCSI", "io-soak")
 }
 
-func monitor(errC chan<- error) {
-	logf.Log.Info("IOSoakTest monitor, checking mayastor and test pods")
-	for {
-		time.Sleep(30 * time.Second)
-		err := common.CheckTestPodsHealth(common.NSMayastor)
+func monitor() error {
+	var err error
+	var failedJobs []string
+	activeJobMap := make(map[string]IoSoakJob)
+	for _, job := range jobs {
+		activeJobMap[job.getPodName()] = job
+	}
+
+	podsSucceeded := 0
+	podsFailed := 0
+
+	logf.Log.Info("IOSoakTest monitor, checking mayastor and test pods", "jobCount", len(activeJobMap))
+	for ; len(activeJobMap) !=0 && len(failedJobs) == 0; {
+		time.Sleep(29 * time.Second)
+		err = common.CheckTestPodsHealth(common.NSMayastor)
 		if err != nil {
 			logf.Log.Info("IOSoakTest monitor", "namespace", common.NSMayastor, "error", err)
-			errC <- err
 			break
 		}
 		err = common.CheckTestPodsHealth(common.NSDefault)
 		if err != nil {
 			logf.Log.Info("IOSoakTest monitor", "namespace", common.NSDefault, "error", err)
-			errC <- err
 			break
 		}
+
+		podNames := make([]string, len(activeJobMap))
+		{
+			ix := 0
+			for k := range activeJobMap {
+				podNames[ix] = k
+				ix += 1
+			}
+		}
+
+		podsRunning := 0
+
+		for _, podName := range podNames {
+			res,err := common.CheckPodCompleted(podName, common.NSDefault)
+			if err != nil {
+				logf.Log.Info("Failed to access pod status", "podName", podName, "error", err)
+				break
+			} else {
+				switch res  {
+				case corev1.PodPending:
+					logf.Log.Info("Unexpected! pod status pending", "podName", podName)
+				case corev1.PodRunning:
+					podsRunning += 1
+				case corev1.PodSucceeded:
+					logf.Log.Info("Pod completed successfully", "podName", podName)
+					delete(activeJobMap, podName)
+					podsSucceeded += 1
+				case corev1.PodFailed:
+					logf.Log.Info("Pod completed with failures", "podName", podName)
+					delete(activeJobMap, podName)
+					failedJobs = append(failedJobs, podName)
+					podsFailed += 1
+				case corev1.PodUnknown:
+					logf.Log.Info("Unexpected! pod status is unknown", "podName", podName)
+				}
+			}
+		}
+		logf.Log.Info("IO Soak test pods",
+			"Running", podsRunning, "Succeeded", podsSucceeded, "Failed", podsFailed,
+			)
 	}
+
+	if err == nil && len(failedJobs) != 0 {
+		err = fmt.Errorf("failed jobs %v", failedJobs)
+	}
+	return err
 }
 
 /// proto - protocol "nvmf" or "isci"
 /// replicas - number of replicas for each volume
 /// loadFactor - number of volumes for each mayastor instance
-func IOSoakTest(protocols []common.ShareProto, replicas int, loadFactor int, duration time.Duration) {
+func IOSoakTest(protocols []common.ShareProto, replicas int, loadFactor int, duration time.Duration, disruptorCount int) {
 	nodeList, err := common.GetNodeLocs()
 	Expect(err).ToNot(HaveOccurred())
 
@@ -83,6 +118,8 @@ func IOSoakTest(protocols []common.ShareProto, replicas int, loadFactor int, dur
 			nodes = append(nodes, node.NodeName)
 		}
 	}
+
+	jobCount -= disruptorCount
 
 	for i, node := range nodes {
 		if i%2 == 0 {
@@ -109,14 +146,14 @@ func IOSoakTest(protocols []common.ShareProto, replicas int, loadFactor int, dur
 				break
 			}
 			logf.Log.Info("Creating", "job", "fio filesystem job", "id", idx)
-			jobs = append(jobs, MakeFioFsJob(scName, idx))
+			jobs = append(jobs, MakeFioFsJob(scName, idx, duration))
 			idx++
 
 			if idx > jobCount {
 				break
 			}
 			logf.Log.Info("Creating", "job", "fio raw block job", "id", idx)
-			jobs = append(jobs, MakeFioRawBlockJob(scName, idx))
+			jobs = append(jobs, MakeFioRawBlockJob(scName, idx, duration))
 			idx++
 		}
 	}
@@ -127,6 +164,10 @@ func IOSoakTest(protocols []common.ShareProto, replicas int, loadFactor int, dur
 		job.makeVolume()
 	}
 
+	logf.Log.Info("Starting disruptor pods")
+	DisruptorsInit(protocols, replicas)
+	MakeDisruptors()
+
 	logf.Log.Info("Creating test pods")
 	// Create the job test pods
 	for _, job := range jobs {
@@ -135,40 +176,41 @@ func IOSoakTest(protocols []common.ShareProto, replicas int, loadFactor int, dur
 		Expect(pod).ToNot(BeNil())
 	}
 
-	logf.Log.Info("Waiting for test pods to be ready")
+	// Empirically allocated PodReadyTime seconds for each pod to transition to ready
+	timeoutSecs := PodReadyTime * len(jobs)
+	if timeoutSecs < 60 {
+		timeoutSecs = 60
+	}
+	logf.Log.Info("Waiting for test pods to be ready", "timeout seconds", timeoutSecs, "jobCount", len(jobs))
+
 	// Wait for the test pods to be ready
-	for _, job := range jobs {
-		// Wait for the test Pod to transition to running
-		Eventually(func() bool {
-			return common.IsPodRunning(job.getPodName(), common.NSDefault)
-		},
-			defTimeoutSecs,
-			"1s",
-		).Should(Equal(true))
-	}
-
-	logf.Log.Info("Starting test execution in all test pods")
-	// Run the test jobs
-	doneC, errC := make(chan string), make(chan error)
-	go monitor(errC)
-	for _, job := range jobs {
-		go job.run(duration, doneC, errC)
-	}
-
-	logf.Log.Info("Waiting for test execution to complete on all test pods")
-	// Wait and check that all test pods have executed successfully
-	for range jobs {
-		select {
-		case podName := <-doneC:
-			logf.Log.Info("Completed", "pod", podName)
-		case err := <-errC:
-			close(doneC)
-			logf.Log.Info("fio run error", "error", err)
-			Expect(err).To(BeNil())
+	allReady := false
+	for to:=0; to< timeoutSecs && !allReady; to+=1 {
+		time.Sleep(1* time.Second)
+		allReady = true
+		readyCount := 0
+		for _, job := range jobs {
+			ready := common.IsPodRunning(job.getPodName(), common.NSDefault); if ready {
+				readyCount += 1
+			}
+			allReady = allReady && ready
+		}
+		if to % 10 == 0 {
+			logf.Log.Info("Test pods", "ready", readyCount, "expected", len(jobs))
 		}
 	}
 
+	logf.Log.Info("Test pods", "all ready", allReady)
+	Expect(allReady).To(BeTrue(), "Timeout waiting to jobs to be ready")
+
+	logf.Log.Info("Waiting for test execution to complete on all test pods")
+	err = monitor()
+	Expect(err).To(BeNil(), "Failed runs")
+
 	logf.Log.Info("All runs complete, deleting test pods")
+	DestroyDisruptors()
+	DisruptorsDeinit()
+
 	for _, job := range jobs {
 		err := job.removeTestPod()
 		Expect(err).ToNot(HaveOccurred())
@@ -203,17 +245,22 @@ var _ = Describe("Mayastor Volume IO soak test", func() {
 
 	It("should verify mayastor can process IO on multiple volumes simultaneously using NVMe-oF TCP", func() {
 		e2eCfg := e2e_config.GetConfig()
+		logf.Log.Info("IO soak test", "parameters", e2eCfg.IOSoakTest)
 		loadFactor := e2eCfg.IOSoakTest.LoadFactor
 		replicas := e2eCfg.IOSoakTest.Replicas
 		strProtocols := e2eCfg.IOSoakTest.Protocols
+		disruptorCount := e2eCfg.IOSoakTest.Disrupt.PodCount
 		var protocols []common.ShareProto
 		for _, proto := range strProtocols {
 			protocols = append(protocols, common.ShareProto(proto))
 		}
 		duration, err := time.ParseDuration(e2eCfg.IOSoakTest.Duration)
 		Expect(err).ToNot(HaveOccurred(), "Duration configuration string format is invalid.")
-		logf.Log.Info("Parameters", "replicas", replicas, "loadFactor", loadFactor, "duration", duration)
-		IOSoakTest(protocols, replicas, loadFactor, duration)
+		logf.Log.Info("Parameters",
+			"replicas", replicas, "loadFactor", loadFactor,
+			"duration", duration,
+			"disrupt", e2eCfg.IOSoakTest.Disrupt)
+		IOSoakTest(protocols, replicas, loadFactor, duration, disruptorCount)
 	})
 })
 

--- a/test/e2e/io_soak/rawblock_fio.go
+++ b/test/e2e/io_soak/rawblock_fio.go
@@ -33,7 +33,7 @@ func (job FioRawBlockSoakJob) makeTestPod(selector map[string]string) (*coreV1.P
 	pod.Spec.NodeSelector = selector
 
 	e2eCfg := e2e_config.GetConfig()
-	image := "" + e2eCfg.CIRegistry + "/mayadata/e2e-fio"
+	image := "mayadata/e2e-fio"
 	pod.Spec.Containers[0].Image = image
 
 	args := []string{

--- a/test/e2e/io_soak/rawblock_fio.go
+++ b/test/e2e/io_soak/rawblock_fio.go
@@ -13,10 +13,10 @@ import (
 // IO soak raw block fio  job
 
 type FioRawBlockSoakJob struct {
-	volName string
-	scName  string
-	podName string
-	id      int
+	volName  string
+	scName   string
+	podName  string
+	id       int
 	duration int
 }
 
@@ -33,12 +33,12 @@ func (job FioRawBlockSoakJob) makeTestPod(selector map[string]string) (*coreV1.P
 	pod.Spec.NodeSelector = selector
 
 	e2eCfg := e2e_config.GetConfig()
-	image := "" + e2eCfg.CIRegistry + "/mayastor/e2e-fio"
+	image := "" + e2eCfg.CIRegistry + "/mayadata/e2e-fio"
 	pod.Spec.Containers[0].Image = image
 
 	args := []string{
 		"--",
-		fmt.Sprintf("--startdelay=%d",e2eCfg.IOSoakTest.FioStartDelay),
+		fmt.Sprintf("--startdelay=%d", e2eCfg.IOSoakTest.FioStartDelay),
 		"--time_based",
 		fmt.Sprintf("--runtime=%d", job.duration),
 		fmt.Sprintf("--filename=%s", common.FioBlockFilename),
@@ -60,13 +60,13 @@ func (job FioRawBlockSoakJob) getPodName() string {
 	return job.podName
 }
 
-func MakeFioRawBlockJob(scName string, id int, duration time.Duration ) FioRawBlockSoakJob {
+func MakeFioRawBlockJob(scName string, id int, duration time.Duration) FioRawBlockSoakJob {
 	nm := fmt.Sprintf("fio-rawblock-%s-%d", scName, id)
 	return FioRawBlockSoakJob{
-		volName: nm,
-		scName:  scName,
-		podName: nm,
-		id:      id,
+		volName:  nm,
+		scName:   scName,
+		podName:  nm,
+		id:       id,
 		duration: int(duration.Seconds()),
 	}
 }


### PR DESCRIPTION
Create a fio docker image specifically designed for mayastor
e2e testing.
Add CIRegistry entry to e2econfig so that this image and future
test docker images are retrieved from the CI registry, independent
of Mayastor images.

Re-jig io soak tests to use the mayastor/e2e-fio docker image.
This removes the need to run multiple threads to run fio, as
the e2e-fio pod can be deployed to run fio on creation.

Add disruptor fio jobs which deploy pods running the e2e-fio image,
restart policy set to restart always, and configured to raise SIGSEGV
after a configurable delay, whilst running fio.

Update the CI configuration to scale up the number of test pods
and volumes to run as part of the IO soak test.