### PR TITLE
test(e2e): update IO soak and basic volume IO tests

### DIFF
--- a/test/e2e/basic_volume_io/basic_volume_io_test.go
+++ b/test/e2e/basic_volume_io/basic_volume_io_test.go
@@ -5,11 +5,12 @@ package basic_volume_io_test
 import (
 	"e2e-basic/common"
 	"e2e-basic/common/e2e_config"
-
 	"testing"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	storagev1 "k8s.io/api/storage/v1"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -28,20 +29,21 @@ func TestBasicVolumeIO(t *testing.T) {
 	common.InitTesting(t, "Basic volume IO tests, NVMe-oF TCP and iSCSI", "basic-volume-io")
 }
 
-func basicVolumeIOTest(protocol common.ShareProto) {
+func basicVolumeIOTest(protocol common.ShareProto, volumeType common.VolumeType, mode storagev1.VolumeBindingMode) {
 	scName := "basic-vol-io-test-" + string(protocol)
-	err := common.MkStorageClass(scName, e2e_config.GetConfig().BasicVolumeIO.Replicas, protocol, common.NSDefault)
+	err := common.MakeStorageClass(scName, e2e_config.GetConfig().BasicVolumeIO.Replicas, protocol, common.NSDefault, &mode)
 	Expect(err).ToNot(HaveOccurred(), "Creating storage class %s", scName)
 
 	volName := "basic-vol-io-test-" + string(protocol)
 	// Create the volume
-	common.MkPVC(common.DefaultVolumeSizeMb, volName, scName, common.VolFileSystem, common.NSDefault)
+	uid := common.MkPVC(common.DefaultVolumeSizeMb, volName, scName, volumeType, common.NSDefault)
+	logf.Log.Info("Volume", "uid", uid)
 	tmp := volSc{volName, scName}
 	volNames = append(volNames, tmp)
 
 	// Create the fio Pod
 	fioPodName := "fio-" + volName
-	pod, err := common.CreateFioPod(fioPodName, volName, common.VolFileSystem, common.NSDefault)
+	pod, err := common.CreateFioPod(fioPodName, volName, volumeType, common.NSDefault)
 	Expect(err).ToNot(HaveOccurred())
 	Expect(pod).ToNot(BeNil())
 	podNames = append(podNames, fioPodName)
@@ -54,8 +56,19 @@ func basicVolumeIOTest(protocol common.ShareProto) {
 		"1s",
 	).Should(Equal(true))
 
+	fioFilename := ""
+	fioSize := 0
 	// Run the fio test
-	_, err = common.RunFio(fioPodName, 20, common.FioFsFilename, common.DefaultFioSizeMb)
+	switch volumeType {
+	case common.VolFileSystem:
+		fioFilename = common.FioFsFilename
+		fioSize = common.DefaultFioSizeMb
+	case common.VolRawBlock:
+		fioFilename = common.FioBlockFilename
+		fioSize = 0
+	}
+
+	_, err = common.RunFio(fioPodName, 20, fioFilename, fioSize)
 	Expect(err).ToNot(HaveOccurred())
 
 	podNames = podNames[:len(podNames)-1]
@@ -82,12 +95,26 @@ var _ = Describe("Mayastor Volume IO test", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	It("should verify an NVMe-oF TCP volume can process IO", func() {
-		basicVolumeIOTest(common.ShareProtoNvmf)
+	It("should verify an NVMe-oF TCP volume can process IO on a Filesystem volume with immediate binding", func() {
+		basicVolumeIOTest(common.ShareProtoNvmf, common.VolFileSystem, storagev1.VolumeBindingImmediate)
 	})
-	It("should verify an iSCSI volume can process IO", func() {
-		basicVolumeIOTest(common.ShareProtoIscsi)
+
+	It("should verify an NVMe-oF TCP volume can process IO on a Raw Block volume with immediate binding", func() {
+		basicVolumeIOTest(common.ShareProtoNvmf, common.VolRawBlock, storagev1.VolumeBindingImmediate)
 	})
+
+	It("should verify an NVMe-oF TCP volume can process IO on a Filesystem volume with delayed binding", func() {
+		basicVolumeIOTest(common.ShareProtoNvmf, common.VolFileSystem, storagev1.VolumeBindingWaitForFirstConsumer)
+	})
+
+	It("should verify an NVMe-oF TCP volume can process IO on a Raw Block volume with delayed binding", func() {
+		basicVolumeIOTest(common.ShareProtoNvmf, common.VolRawBlock, storagev1.VolumeBindingWaitForFirstConsumer)
+	})
+
+	It("should verify an iSCSI volume can process IO on a Filesystem volume with immediate binding", func() {
+		basicVolumeIOTest(common.ShareProtoIscsi, common.VolFileSystem, storagev1.VolumeBindingImmediate)
+	})
+
 })
 
 var _ = BeforeSuite(func(done Done) {

--- a/test/e2e/common/util_testpods.go
+++ b/test/e2e/common/util_testpods.go
@@ -16,9 +16,9 @@ import (
 )
 
 //  These variables match the settings used in createFioPodDef
-var FioFsMountPoint = "/volume"
-var FioBlockFilename = "/dev/sdm"
-var FioFsFilename = FioFsMountPoint + "/fiotestfile"
+const FioFsMountPoint = "/volume"
+const FioBlockFilename = "/dev/sdm"
+const FioFsFilename = FioFsMountPoint + "/fiotestfile"
 
 // FIXME: this function runs fio with a bunch of parameters which are not configurable.
 // sizeMb should be 0 for fio to use the entire block device
@@ -118,7 +118,7 @@ func CreateFioPodDef(podName string, volName string, volType VolumeType, nameSpa
 			Containers: []corev1.Container{
 				{
 					Name:  podName,
-					Image: "dmonakhov/alpine-fio",
+					Image: "mayadata/e2e-fio",
 					Args:  []string{"sleep", "1000000"},
 				},
 			},
@@ -145,7 +145,7 @@ func CreateFioPodDef(podName string, volName string, volType VolumeType, nameSpa
 /// Create a test fio pod in default namespace, no options and no context
 /// mayastor volume is mounted on /volume
 func CreateFioPod(podName string, volName string, volType VolumeType, nameSpace string) (*corev1.Pod, error) {
-	logf.Log.Info("Creating fio pod definition", "name", podName, "volume type", "filesystem")
+	logf.Log.Info("Creating fio pod definition", "name", podName, "volume type", volType)
 	podDef := CreateFioPodDef(podName, volName, volType, nameSpace)
 	return CreatePod(podDef, NSDefault)
 }

--- a/test/e2e/configurations/ci_e2e_config.yaml
+++ b/test/e2e/configurations/ci_e2e_config.yaml
@@ -5,7 +5,7 @@ pvcstress:
   crudCycles: 10
 ioSoakTest:
   replicas: 1
-  duration: 10m
+  duration: 60m
   # loadFactor is number of volumes for each mayastor instance
   # volumes for disruptor pods are allocated from within this "pool"
   loadFactor: 21

--- a/test/e2e/io_soak/fio.go
+++ b/test/e2e/io_soak/fio.go
@@ -39,5 +39,6 @@ var FioArgs = []string{
 	"--verify=crc32",
 	"--verify_fatal=1",
 	"--verify_async=2",
-	"--status-interval=51",
+	"--status-interval=120",
+	"--output-format=terse",
 }


### PR DESCRIPTION
IO soak test:
- monitor health of all MSVs
- monitor online state of all pools

Basic volume IO test:
Add functionality for late binding of volumes,
ie WaitForFirstConsumer

for NVMe-of volumes the test matrix is now
    - Filesystem volume with immediate binding
    - Filesystem volume with delayed binding
    - Raw block volume with immediate binding
    - Raw block volume with delayed binding
iSCSI volume testing is unchanged

Make a few global var strings constants
Add function so that VolumeType vars are printed as
human readable strings.