### PR TITLE
test(e2e): add label to fio pods

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -131,7 +131,7 @@ if (params.e2e_continuous == true) {
 pipeline {
   agent none
   options {
-    timeout(time: 2, unit: 'HOURS')
+    timeout(time: 3, unit: 'HOURS')
   }
   parameters {
     booleanParam(defaultValue: false, name: 'e2e_continuous')

--- a/test/e2e/common/util_testpods.go
+++ b/test/e2e/common/util_testpods.go
@@ -5,12 +5,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os/exec"
+	"strings"
+
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"os/exec"
-	"strings"
 
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -112,6 +113,7 @@ func CreateFioPodDef(podName string, volName string, volType VolumeType, nameSpa
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      podName,
 			Namespace: nameSpace,
+			Labels:    map[string]string{"app": "fio"},
 		},
 		Spec: corev1.PodSpec{
 			RestartPolicy: corev1.RestartPolicyNever,


### PR DESCRIPTION
Ensure fio pods are run with a label to allow 
Grafana Loki  to gather logs from them.
Also extend timeout to 3 hours to allow e2e tests to
complete in time, which currently approach 2 hours.