### PR TITLE
test(e2e): update basic volume IO test MQ-377

### DIFF
--- a/test/e2e/common/e2e_config/e2e_config.go
+++ b/test/e2e/common/e2e_config/e2e_config.go
@@ -59,6 +59,12 @@ type E2EConfig struct {
 	} `yaml:"uninstall"`
 	BasicVolumeIO struct {
 		Replicas int `yaml:"replicas" env-default:"1"`
+		// FioTimeout is in seconds
+		FioTimeout int `yaml:"fioTimeout" env-default:"120"`
+		// VolSizeMb Units are MiB
+		VolSizeMb int `yaml:"volSizeMb" env-default:"1024"`
+		// FsVolSizeMb Units are MiB
+		FsVolSizeMb int `yaml:"fsVolSizeMb" env-default:"900"`
 	} `yaml:"basicVolumeIO"`
 	MultipleVolumesPodIO struct {
 		VolumeCount          int `yaml:"volumeCount" env-default:"2"`

--- a/test/e2e/common/util_pvc.go
+++ b/test/e2e/common/util_pvc.go
@@ -180,6 +180,7 @@ func MkPVC(volSizeMb int, volName string, scName string, volType VolumeType, nam
 		"1s",
 	).Should(Not(BeNil()))
 
+	logf.Log.Info("Created", "volume", volName, "uuid", pvc.ObjectMeta.UID, "storageClass", scName, "volume type", volType)
 	return string(pvc.ObjectMeta.UID)
 }
 

--- a/test/e2e/common/util_testpods.go
+++ b/test/e2e/common/util_testpods.go
@@ -21,6 +21,24 @@ const FioFsMountPoint = "/volume"
 const FioBlockFilename = "/dev/sdm"
 const FioFsFilename = FioFsMountPoint + "/fiotestfile"
 
+// default fio arguments for E2E fio runs
+var fioArgs = []string{
+	"--name=benchtest",
+	"--direct=1",
+	"--rw=randrw",
+	"--ioengine=libaio",
+	"--bs=4k",
+	"--iodepth=16",
+	"--numjobs=1",
+	"--verify=crc32",
+	"--verify_fatal=1",
+	"--verify_async=2",
+}
+
+func GetFioArgs() []string {
+	return fioArgs
+}
+
 // FIXME: this function runs fio with a bunch of parameters which are not configurable.
 // sizeMb should be 0 for fio to use the entire block device
 func RunFio(podName string, duration int, filename string, sizeMb int, args ...string) ([]byte, error) {

--- a/test/e2e/configurations/ci_e2e_config.yaml
+++ b/test/e2e/configurations/ci_e2e_config.yaml
@@ -40,6 +40,12 @@ uninstall:
   cleanup: 0
 basicVolumeIO:
   replicas: 1
+  # timeout units are seconds
+  fioTimeout: 60
+  # volSizeMb units are MiB
+  volSizeMb: 500
+  # fsVolSizeMb units are MiB
+  fsVolSizeMb: 450
 multiVolumesPodIO:
   volumeCount: 6
   replicas: 2

--- a/test/e2e/io_soak/definitions.go
+++ b/test/e2e/io_soak/definitions.go
@@ -21,5 +21,5 @@ type IoSoakJob interface {
 	removeTestPod() error
 	removeVolume()
 	getPodName() string
+	describe() string
 }
-

--- a/test/e2e/io_soak/disruptor_fio.go
+++ b/test/e2e/io_soak/disruptor_fio.go
@@ -23,12 +23,13 @@ type FioDisruptorJob struct {
 	scName     string
 	podName    string
 	id         int
+	volUUID    string
 	faultDelay int
 	ready      bool
 }
 
 func (job FioDisruptorJob) makeVolume() {
-	common.MkPVC(common.DefaultVolumeSizeMb, job.volName, job.scName, common.VolRawBlock, NSDisrupt)
+	job.volUUID = common.MkPVC(common.DefaultVolumeSizeMb, job.volName, job.scName, common.VolRawBlock, NSDisrupt)
 }
 
 func (job FioDisruptorJob) removeVolume() {
@@ -63,6 +64,10 @@ func (job FioDisruptorJob) removeTestPod() error {
 
 func (job FioDisruptorJob) getPodName() string {
 	return job.podName
+}
+
+func (job FioDisruptorJob) describe() string {
+	return fmt.Sprintf("pod: %s, vol: %s, volUUID: %s", job.podName, job.podName, job.volUUID)
 }
 
 func MakeFioDisruptorJob(scName string, id int, segfaultDelay int) FioDisruptorJob {

--- a/test/e2e/io_soak/disruptor_fio.go
+++ b/test/e2e/io_soak/disruptor_fio.go
@@ -40,9 +40,6 @@ func (job FioDisruptorJob) makeTestPod(selector map[string]string) (*coreV1.Pod,
 	pod.Spec.NodeSelector = selector
 	pod.Spec.RestartPolicy = coreV1.RestartPolicyAlways
 
-	image := "mayadata/e2e-fio"
-	pod.Spec.Containers[0].Image = image
-
 	args := []string{
 		"exitv",
 		"255",
@@ -53,7 +50,7 @@ func (job FioDisruptorJob) makeTestPod(selector map[string]string) (*coreV1.Pod,
 		fmt.Sprintf("--thinktime=%d", GetThinkTime(job.id)),
 		fmt.Sprintf("--thinktime_blocks=%d", GetThinkTimeBlocks(job.id)),
 	}
-	args = append(args, FioArgs...)
+	args = append(args, GetIOSoakFioArgs()...)
 	pod.Spec.Containers[0].Args = args
 
 	pod, err := common.CreatePod(pod, NSDisrupt)

--- a/test/e2e/io_soak/filesystem_fio.go
+++ b/test/e2e/io_soak/filesystem_fio.go
@@ -17,10 +17,11 @@ type FioFsSoakJob struct {
 	podName  string
 	id       int
 	duration int
+	volUUID  string
 }
 
 func (job FioFsSoakJob) makeVolume() {
-	common.MkPVC(common.DefaultVolumeSizeMb, job.volName, job.scName, common.VolFileSystem, common.NSDefault)
+	job.volUUID = common.MkPVC(common.DefaultVolumeSizeMb, job.volName, job.scName, common.VolFileSystem, common.NSDefault)
 }
 
 func (job FioFsSoakJob) removeVolume() {
@@ -56,6 +57,10 @@ func (job FioFsSoakJob) removeTestPod() error {
 
 func (job FioFsSoakJob) getPodName() string {
 	return job.podName
+}
+
+func (job FioFsSoakJob) describe() string {
+	return fmt.Sprintf("pod: %s, vol: %s, volUUID: %s", job.podName, job.podName, job.volUUID)
 }
 
 func MakeFioFsJob(scName string, id int, duration time.Duration) FioFsSoakJob {

--- a/test/e2e/io_soak/filesystem_fio.go
+++ b/test/e2e/io_soak/filesystem_fio.go
@@ -32,8 +32,6 @@ func (job FioFsSoakJob) makeTestPod(selector map[string]string) (*coreV1.Pod, er
 	pod.Spec.NodeSelector = selector
 
 	e2eCfg := e2e_config.GetConfig()
-	image := "mayadata/e2e-fio"
-	pod.Spec.Containers[0].Image = image
 
 	args := []string{
 		"--",
@@ -45,7 +43,7 @@ func (job FioFsSoakJob) makeTestPod(selector map[string]string) (*coreV1.Pod, er
 		fmt.Sprintf("--thinktime_blocks=%d", GetThinkTimeBlocks(job.id)),
 		fmt.Sprintf("--size=%dm", common.DefaultFioSizeMb),
 	}
-	args = append(args, FioArgs...)
+	args = append(args, GetIOSoakFioArgs()...)
 	pod.Spec.Containers[0].Args = args
 
 	pod, err := common.CreatePod(pod, common.NSDefault)

--- a/test/e2e/io_soak/fio.go
+++ b/test/e2e/io_soak/fio.go
@@ -1,6 +1,7 @@
 package io_soak
 
 import (
+	"e2e-basic/common"
 	"e2e-basic/common/e2e_config"
 )
 
@@ -28,17 +29,8 @@ func GetThinkTimeBlocks(idx int) int {
 	return thinkTimeBlocks
 }
 
-var FioArgs = []string{
-	"--name=benchtest",
-	"--direct=1",
-	"--rw=randrw",
-	"--ioengine=libaio",
-	"--bs=4k",
-	"--iodepth=16",
-	"--numjobs=1",
-	"--verify=crc32",
-	"--verify_fatal=1",
-	"--verify_async=2",
-	"--status-interval=120",
-	"--output-format=terse",
+func GetIOSoakFioArgs() []string {
+	args := common.GetFioArgs()
+	args = append(args, []string{"--status-interval=120", "--output-format=terse"}...)
+	return args
 }

--- a/test/e2e/io_soak/io_soak_test.go
+++ b/test/e2e/io_soak/io_soak_test.go
@@ -92,7 +92,9 @@ func monitor() error {
 					delete(activeJobMap, podName)
 					podsSucceeded += 1
 				case corev1.PodFailed:
-					logf.Log.Info("Pod completed with failures", "podName", podName)
+
+					logf.Log.Info("Pod completed with failures",
+						"Job", activeJobMap[podName].describe())
 					delete(activeJobMap, podName)
 					failedJobs = append(failedJobs, podName)
 					podsFailed += 1
@@ -221,6 +223,15 @@ func IOSoakTest(protocols []common.ShareProto, replicas int, loadFactor int, dur
 		}
 	}
 
+	if !allReady {
+		for _, job := range jobs {
+			if !common.IsPodRunning(job.getPodName(), common.NSDefault) {
+				logf.Log.Info("Not ready",
+					"Job", job.describe(),
+				)
+			}
+		}
+	}
 	logf.Log.Info("Test pods", "all ready", allReady)
 	Expect(allReady).To(BeTrue(), "Timeout waiting to jobs to be ready")
 

--- a/test/e2e/io_soak/rawblock_fio.go
+++ b/test/e2e/io_soak/rawblock_fio.go
@@ -33,8 +33,6 @@ func (job FioRawBlockSoakJob) makeTestPod(selector map[string]string) (*coreV1.P
 	pod.Spec.NodeSelector = selector
 
 	e2eCfg := e2e_config.GetConfig()
-	image := "mayadata/e2e-fio"
-	pod.Spec.Containers[0].Image = image
 
 	args := []string{
 		"--",
@@ -45,7 +43,7 @@ func (job FioRawBlockSoakJob) makeTestPod(selector map[string]string) (*coreV1.P
 		fmt.Sprintf("--thinktime=%d", GetThinkTime(job.id)),
 		fmt.Sprintf("--thinktime_blocks=%d", GetThinkTimeBlocks(job.id)),
 	}
-	args = append(args, FioArgs...)
+	args = append(args, GetIOSoakFioArgs()...)
 	pod.Spec.Containers[0].Args = args
 
 	pod, err := common.CreatePod(pod, common.NSDefault)

--- a/test/e2e/io_soak/rawblock_fio.go
+++ b/test/e2e/io_soak/rawblock_fio.go
@@ -18,10 +18,11 @@ type FioRawBlockSoakJob struct {
 	podName  string
 	id       int
 	duration int
+	volUUID  string
 }
 
 func (job FioRawBlockSoakJob) makeVolume() {
-	common.MkPVC(common.DefaultVolumeSizeMb, job.volName, job.scName, common.VolRawBlock, common.NSDefault)
+	job.volUUID = common.MkPVC(common.DefaultVolumeSizeMb, job.volName, job.scName, common.VolRawBlock, common.NSDefault)
 }
 
 func (job FioRawBlockSoakJob) removeVolume() {
@@ -56,6 +57,10 @@ func (job FioRawBlockSoakJob) removeTestPod() error {
 
 func (job FioRawBlockSoakJob) getPodName() string {
 	return job.podName
+}
+
+func (job FioRawBlockSoakJob) describe() string {
+	return fmt.Sprintf("pod: %s, vol: %s, volUUID: %s", job.podName, job.podName, job.volUUID)
 }
 
 func MakeFioRawBlockJob(scName string, id int, duration time.Duration) FioRawBlockSoakJob {


### PR DESCRIPTION
Update the basic volume IO test so that
    it uses fio "self-running" pods
    it uses 500Mb volumes
    volumes size configurable.

minor refactor for io-soak,
    - remove the image override, common code
        uses mayastor-e2e now
    - common up fio argument array code.