### PR TITLE
test(e2e): set loadfactor to 10 for io-soak tests

### DIFF
--- a/test/e2e/configurations/ci_e2e_config.yaml
+++ b/test/e2e/configurations/ci_e2e_config.yaml
@@ -8,12 +8,12 @@ ioSoakTest:
   duration: 60m
   # loadFactor is number of volumes for each mayastor instance
   # volumes for disruptor pods are allocated from within this "pool"
-  loadFactor: 21
+  loadFactor: 10
   protocols:
   - nvmf
   disrupt:
     # Number of disruptor pods
-    podCount: 5
+    podCount: 3
     # faultAfter units are seconds
     faultAfter: 51
   # fioStartDelay units are seconds


### PR DESCRIPTION
There have been a number of failures where fio fails to
start and returns with an exit value of 15.
We think this may be because of pressure on the host
system resources.
So reduce the pressure.
