### PR TITLE
feat(nvmeadm): add support for a few controller options

### DIFF
--- a/nvmeadm/src/error.rs
+++ b/nvmeadm/src/error.rs
@@ -48,6 +48,8 @@ pub enum NvmeError {
     UrlError { source: url::ParseError },
     #[snafu(display("Transport type {} not supported", trtype))]
     TransportError { trtype: String },
+    #[snafu(display("Invalid parameter: {}", text))]
+    InvalidParam { text: String },
 }
 
 impl From<std::io::Error> for NvmeError {

--- a/nvmeadm/src/nvme_uri.rs
+++ b/nvmeadm/src/nvme_uri.rs
@@ -5,10 +5,8 @@ use url::{ParseError, Url};
 use crate::{
     error::NvmeError,
     nvme_namespaces::{NvmeDevice, NvmeDeviceList},
-    nvmf_discovery::disconnect,
+    nvmf_discovery::{disconnect, ConnectArgsBuilder},
 };
-
-use super::nvmf_discovery::connect;
 
 pub struct NvmeTarget {
     host: String,
@@ -80,7 +78,13 @@ impl NvmeTarget {
             });
         }
 
-        connect(&self.host, self.port, &self.subsysnqn)?;
+        ConnectArgsBuilder::default()
+            .traddr(&self.host)
+            .trsvcid(self.port.to_string())
+            .nqn(&self.subsysnqn)
+            .build()
+            .map_err(|_| NvmeError::ParseError {})?
+            .connect()?;
 
         let mut retries = 10;
         let mut all_nvme_devices;


### PR DESCRIPTION
The behaviour of the controller can be tuned better instead of just
accepting the default values from kernel.

Avoid repeating code for connecting to a target and make the code
more rusty.

This work was originally done to address CAS-499 (Mayastor targets
should set sane io timeouts). As it evolved we decided it's better
to document the behavior and suggest how to avoid it instead of
overriding the defaults. Merging it and improving nvmeadm lib
capabilities does not make any harm.