### PR TITLE
feat(nexus): share over nvmf with controller ID range

### DIFF
--- a/mayastor/src/bdev/nexus/mod.rs
+++ b/mayastor/src/bdev/nexus/mod.rs
@@ -2,7 +2,13 @@
 
 use spdk_sys::spdk_bdev_module;
 
-use crate::bdev::nexus::{nexus_bdev::Nexus, nexus_fn_table::NexusFnTable};
+use crate::{
+    bdev::nexus::{nexus_bdev::Nexus, nexus_fn_table::NexusFnTable},
+    core::{Bdev, Share},
+    jsonrpc::{jsonrpc_register, Code, JsonRpcError, Result},
+};
+use futures::{future::Future, FutureExt};
+use std::pin::Pin;
 
 /// Allocate C string and return pointer to it.
 /// NOTE: The resulting string must be freed explicitly after use!
@@ -29,9 +35,79 @@ pub mod nexus_module;
 pub mod nexus_nbd;
 pub mod nexus_share;
 
+#[derive(Deserialize)]
+struct NexusShareArgs {
+    name: String,
+    protocol: String,
+    cntlid_min: u16,
+    cntlid_max: u16,
+}
+
+#[derive(Serialize)]
+struct NexusShareReply {
+    uri: String,
+}
+
 /// public function which simply calls register module
 pub fn register_module() {
-    nexus_module::register_module()
+    nexus_module::register_module();
+
+    jsonrpc_register(
+        "nexus_share",
+        |args: NexusShareArgs| -> Pin<Box<dyn Future<Output = Result<NexusShareReply>>>> {
+            // FIXME: shares bdev, not a nexus
+            let f = async move {
+                let proto = args.protocol;
+                if proto != "iscsi" && proto != "nvmf" {
+                    return Err(JsonRpcError {
+                        code: Code::InvalidParams,
+                        message: "invalid protocol".to_string(),
+                    });
+                }
+                if let Some(bdev) = Bdev::lookup_by_name(&args.name) {
+                    match proto.as_str() {
+                        "nvmf" => {
+                            bdev.share_nvmf(Some((args.cntlid_min, args.cntlid_max)))
+                                .await
+                                .map_err(|e| {
+                                    JsonRpcError {
+                                        code: Code::InternalError,
+                                        message: e.to_string(),
+                                    }
+                                })
+                                .map(|share| {
+                                    NexusShareReply {
+                                        uri: bdev.share_uri().unwrap_or(share),
+                                }
+                            })
+                        },
+                        "iscsi" => {
+                            bdev.share_iscsi()
+                                .await
+                                .map_err(|e| {
+                                    JsonRpcError {
+                                        code: Code::InternalError,
+                                        message: e.to_string(),
+                                    }
+                                })
+                                .map(|share| {
+                                    NexusShareReply {
+                                        uri: bdev.share_uri().unwrap_or(share),
+                                }
+                            })
+                        },
+                        _ => unreachable!(),
+                    }
+                } else {
+                    Err(JsonRpcError {
+                        code: Code::NotFound,
+                        message: "bdev not found".to_string(),
+                    })
+                }
+            };
+            Box::pin(f.boxed_local())
+        },
+    );
 }
 
 /// get a reference to the module

--- a/mayastor/src/bdev/nexus/nexus_share.rs
+++ b/mayastor/src/bdev/nexus/nexus_share.rs
@@ -50,12 +50,17 @@ impl Share for Nexus {
         Ok(self.share_uri().unwrap())
     }
 
-    async fn share_nvmf(&self) -> Result<Self::Output, Self::Error> {
+    async fn share_nvmf(
+        &self,
+        cntlid_range: Option<(u16, u16)>,
+    ) -> Result<Self::Output, Self::Error> {
         match self.shared() {
             Some(Protocol::Off) | None => {
-                self.bdev.share_nvmf().await.context(ShareNvmfNexus {
-                    name: self.name.clone(),
-                })?;
+                self.bdev.share_nvmf(cntlid_range).await.context(
+                    ShareNvmfNexus {
+                        name: self.name.clone(),
+                    },
+                )?;
             }
             Some(Protocol::Nvmf) => {}
             Some(protocol) => {
@@ -136,7 +141,7 @@ impl Nexus {
                 Ok(uri)
             }
             ShareProtocolNexus::NexusNvmf => {
-                let uri = self.share_nvmf().await?;
+                let uri = self.share_nvmf(None).await?;
                 self.nexus_target = Some(NexusTarget::NexusNvmfTarget);
                 Ok(uri)
             }

--- a/mayastor/src/bin/nvmet.rs
+++ b/mayastor/src/bin/nvmet.rs
@@ -37,7 +37,7 @@ async fn create_nexus(args: &ArgMatches<'_>) {
         .unwrap();
 
     let nexus = nexus_lookup(NEXUS).unwrap();
-    nexus.share_nvmf().await.unwrap();
+    nexus.share_nvmf(None).await.unwrap();
 }
 
 fn main() {
@@ -51,7 +51,7 @@ fn main() {
             .required(true)
             .default_value("64")
             .short("s")
-            .long("size") 
+            .long("size")
             .help("Size of the nexus to create in MB")
         )
         .arg(

--- a/mayastor/src/core/bdev.rs
+++ b/mayastor/src/core/bdev.rs
@@ -77,9 +77,17 @@ impl Share for Bdev {
     }
 
     /// share the bdev over NVMe-OF TCP
-    async fn share_nvmf(&self) -> Result<Self::Output, Self::Error> {
+    async fn share_nvmf(
+        &self,
+        cntlid_range: Option<(u16, u16)>,
+    ) -> Result<Self::Output, Self::Error> {
         let subsystem =
             NvmfSubsystem::try_from(self.clone()).context(ShareNvmf {})?;
+        if let Some((cntlid_min, cntlid_max)) = cntlid_range {
+            subsystem
+                .set_cntlid_range(cntlid_min, cntlid_max)
+                .context(ShareNvmf {})?;
+        }
         subsystem.start().await.context(ShareNvmf {})
     }
 

--- a/mayastor/src/core/share.rs
+++ b/mayastor/src/core/share.rs
@@ -47,7 +47,10 @@ pub trait Share: std::fmt::Debug {
     type Error;
     type Output: std::fmt::Display + std::fmt::Debug;
     async fn share_iscsi(&self) -> Result<Self::Output, Self::Error>;
-    async fn share_nvmf(&self) -> Result<Self::Output, Self::Error>;
+    async fn share_nvmf(
+        &self,
+        cntlid_range: Option<(u16, u16)>,
+    ) -> Result<Self::Output, Self::Error>;
     async fn unshare(&self) -> Result<Self::Output, Self::Error>;
     fn shared(&self) -> Option<Protocol>;
     fn share_uri(&self) -> Option<String>;

--- a/mayastor/src/grpc/bdev_grpc.rs
+++ b/mayastor/src/grpc/bdev_grpc.rs
@@ -120,7 +120,7 @@ impl BdevRpc for BdevSvc {
             match proto.as_str() {
                 "nvmf" => Reactors::master().spawn_local(async move {
                     let bdev = Bdev::lookup_by_name(&bdev_name).unwrap();
-                    bdev.share_nvmf()
+                    bdev.share_nvmf(None)
                         .await
                         .map_err(|e| Status::internal(e.to_string()))
                 }),

--- a/mayastor/src/grpc/pool_grpc.rs
+++ b/mayastor/src/grpc/pool_grpc.rs
@@ -155,7 +155,7 @@ pub async fn create_replica(args: CreateReplicaRequest) -> GrpcResult<Replica> {
         let p = Lvs::lookup(&args.pool).unwrap();
         match p.create_lvol(&args.uuid, args.size, false).await {
             Ok(lvol) if Protocol::try_from(args.share)? == Protocol::Nvmf => {
-                match lvol.share_nvmf().await {
+                match lvol.share_nvmf(None).await {
                     Ok(s) => {
                         debug!("created and shared {} as {}", lvol, s);
                         Ok(lvol)
@@ -238,7 +238,7 @@ pub async fn share_replica(
                 }
 
                 Protocol::Nvmf => {
-                    lvol.share_nvmf().await.map(|_| ShareReplicaReply {
+                    lvol.share_nvmf(None).await.map(|_| ShareReplicaReply {
                         uri: lvol.share_uri().unwrap(),
                     })
                 }

--- a/mayastor/src/lvs/lvol.rs
+++ b/mayastor/src/lvs/lvol.rs
@@ -122,13 +122,17 @@ impl Share for Lvol {
 
     /// share the lvol as a nvmf target
     #[instrument(level = "debug", err)]
-    async fn share_nvmf(&self) -> Result<Self::Output, Self::Error> {
-        let share = self.as_bdev().share_nvmf().await.map_err(|e| {
-            Error::LvolShare {
-                source: e,
-                name: self.name(),
-            }
-        })?;
+    async fn share_nvmf(
+        &self,
+        cntlid_range: Option<(u16, u16)>,
+    ) -> Result<Self::Output, Self::Error> {
+        let share =
+            self.as_bdev().share_nvmf(cntlid_range).await.map_err(|e| {
+                Error::LvolShare {
+                    source: e,
+                    name: self.name(),
+                }
+            })?;
 
         self.set(PropValue::Shared(true)).await?;
         info!("shared {}", self);

--- a/mayastor/src/lvs/lvs_pool.rs
+++ b/mayastor/src/lvs/lvs_pool.rs
@@ -436,7 +436,7 @@ impl Lvs {
                 if let Ok(prop) = l.get(PropName::Shared).await {
                     match prop {
                         PropValue::Shared(true) => {
-                            if let Err(e) = l.share_nvmf().await {
+                            if let Err(e) = l.share_nvmf(None).await {
                                 error!(
                                     "failed to share {} {}",
                                     l.name(),

--- a/mayastor/src/subsys/config/mod.rs
+++ b/mayastor/src/subsys/config/mod.rs
@@ -476,6 +476,7 @@ impl Config {
                 }
 
                 if let Ok(ss) = NvmfSubsystem::new_with_uuid(&uuid, &my_bdev) {
+                    // TODO: ss.set_cntlid_range(min, max);
                     ss.start()
                         .await
                         .map_err(|_| {

--- a/mayastor/src/subsys/nvmf/subsystem.rs
+++ b/mayastor/src/subsys/nvmf/subsystem.rs
@@ -14,6 +14,7 @@ use nix::errno::Errno;
 use spdk_sys::{
     nvmf_subsystem_find_listener,
     nvmf_subsystem_set_ana_state,
+    nvmf_subsystem_set_cntlid_range,
     spdk_bdev_nvme_opts,
     spdk_nvmf_ns_get_bdev,
     spdk_nvmf_ns_opts,
@@ -265,6 +266,30 @@ impl NvmfSubsystem {
             source: Errno::from_i32(e),
             nqn: self.get_nqn(),
             msg: format!("failed to set ANA reporting, enable {}", enable),
+        })?;
+        Ok(())
+    }
+
+    /// set controller ID range
+    pub fn set_cntlid_range(
+        &self,
+        cntlid_min: u16,
+        cntlid_max: u16,
+    ) -> Result<(), Error> {
+        unsafe {
+            nvmf_subsystem_set_cntlid_range(
+                self.0.as_ptr(),
+                cntlid_min,
+                cntlid_max,
+            )
+        }
+        .to_result(|e| Error::Subsystem {
+            source: Errno::from_i32(e),
+            nqn: self.get_nqn(),
+            msg: format!(
+                "failed to set controller ID range [{}, {}]",
+                cntlid_min, cntlid_max
+            ),
         })?;
         Ok(())
     }

--- a/mayastor/tests/aio_unmap.rs
+++ b/mayastor/tests/aio_unmap.rs
@@ -480,7 +480,7 @@ async fn unmap_share_test() {
             let mut targets: Vec<NvmeTarget> = Vec::new();
 
             for vol in pool.lvols().unwrap() {
-                vol.share_nvmf().await.unwrap();
+                vol.share_nvmf(None).await.unwrap();
                 let uri = vol.share_uri().unwrap();
                 info!("lvol {} shared as: {}", vol.name(), uri);
                 targets.push(NvmeTarget::try_from(uri).unwrap());

--- a/mayastor/tests/lvs_pool.rs
+++ b/mayastor/tests/lvs_pool.rs
@@ -204,7 +204,7 @@ async fn lvs_pool_test() {
     ms.spawn(async {
         let pool2 = Lvs::lookup("tpool2").unwrap();
         for l in pool2.lvols().unwrap() {
-            l.share_nvmf().await.unwrap();
+            l.share_nvmf(None).await.unwrap();
         }
     })
     .await;
@@ -239,7 +239,7 @@ async fn lvs_pool_test() {
 
         // sharing should set the property on disk
 
-        lvol.share_nvmf().await.unwrap();
+        lvol.share_nvmf(None).await.unwrap();
 
         assert_eq!(
             lvol.get(PropName::Shared).await.unwrap(),
@@ -268,7 +268,7 @@ async fn lvs_pool_test() {
         }
 
         for l in pool.lvols().unwrap() {
-            l.share_nvmf().await.unwrap();
+            l.share_nvmf(None).await.unwrap();
         }
 
         pool.create_lvol("notshared", 4 * 1024, true).await.unwrap();

--- a/mayastor/tests/nexus_add_remove.rs
+++ b/mayastor/tests/nexus_add_remove.rs
@@ -42,7 +42,7 @@ async fn nexus_3_way_create() {
             .unwrap();
 
             let n = nexus_lookup("nexus0").unwrap();
-            n.share_nvmf().await.unwrap();
+            n.share_nvmf(None).await.unwrap();
         })
         .await;
 }
@@ -58,7 +58,7 @@ async fn nexus_destroy() {
 }
 async fn nexus_share() {
     let n = nexus_lookup("nexus0").unwrap();
-    n.share_nvmf().await.unwrap();
+    n.share_nvmf(None).await.unwrap();
 }
 
 async fn nexus_create_2_way_add_one() {

--- a/mayastor/tests/nexus_children_add_remove.rs
+++ b/mayastor/tests/nexus_children_add_remove.rs
@@ -64,7 +64,7 @@ async fn remove_children_from_nexus() {
     ms.spawn(async {
         let nexus =
             nexus_lookup("remove_from_nexus").expect("nexus is not found!");
-        nexus.share_nvmf().await
+        nexus.share_nvmf(None).await
     })
     .await
     .expect("failed to share nexus over nvmf");
@@ -117,7 +117,7 @@ async fn nexus_add_child() {
         let nexus =
             nexus_lookup("nexus_add_child").expect("nexus is not found!");
         nexus
-            .share_nvmf()
+            .share_nvmf(None)
             .await
             .expect("failed to share nexus over nvmf");
     })

--- a/mayastor/tests/nexus_share.rs
+++ b/mayastor/tests/nexus_share.rs
@@ -50,7 +50,7 @@ async fn nexus_share_test() {
             // sharing the nexus over nvmf should fail
             Reactor::block_on(async {
                 let nexus = nexus_lookup("nexus0").unwrap();
-                assert_eq!(nexus.share_nvmf().await.is_err(), true);
+                assert_eq!(nexus.share_nvmf(None).await.is_err(), true);
                 assert_eq!(nexus.shared(), Some(Protocol::Iscsi));
             });
 
@@ -61,8 +61,8 @@ async fn nexus_share_test() {
                 let shared = nexus.shared();
                 assert_eq!(shared, Some(Protocol::Off));
 
-                let shared = nexus.share_nvmf().await.unwrap();
-                let shared2 = nexus.share_nvmf().await.unwrap();
+                let shared = nexus.share_nvmf(None).await.unwrap();
+                let shared2 = nexus.share_nvmf(None).await.unwrap();
 
                 assert_eq!(shared, shared2);
                 assert_eq!(nexus.shared(), Some(Protocol::Nvmf));
@@ -73,7 +73,7 @@ async fn nexus_share_test() {
             Reactor::block_on(async {
                 let bdev = Bdev::lookup_by_name("nexus0").unwrap();
                 assert_eq!(bdev.share_iscsi().await.is_err(), true);
-                assert_eq!(bdev.share_nvmf().await.is_err(), true);
+                assert_eq!(bdev.share_nvmf(None).await.is_err(), true);
             });
 
             // unshare the nexus

--- a/nix/pkgs/libspdk/default.nix
+++ b/nix/pkgs/libspdk/default.nix
@@ -39,8 +39,8 @@ let
     src = fetchFromGitHub {
       owner = "openebs";
       repo = "spdk";
-      rev = "f180b1d0a5fbac77c3e7caf2047ea51683ec7795";
-      sha256 = "14k816074hh0r1gkqkfyipfcqvl49d2qz7qqwcpsk399f0s3dds0";
+      rev = "3f85fb587d7a1013f3fab9304805dd943d95c0a2";
+      sha256 = "0z7iw5xa2l4xrbl3zd4139mdyfd236gkswmysnkswmpmw7s6krsc";
       #sha256 = stdenv.lib.fakeSha256;
       fetchSubmodules = true;
     };
@@ -85,9 +85,9 @@ let
         "--target-arch=armv8-a+crypto"
       ]
     else
-      []
+      [ ]
     ) ++
-    (if (targetPlatform.config != buildPlatform.config) then [ "--cross-prefix=${targetPlatform.config}" ] else []) ++
+    (if (targetPlatform.config != buildPlatform.config) then [ "--cross-prefix=${targetPlatform.config}" ] else [ ]) ++
     [
       "--without-isal"
       "--with-iscsi-initiator"

--- a/spdk-sys/build.rs
+++ b/spdk-sys/build.rs
@@ -86,6 +86,7 @@ fn main() {
         .whitelist_function("^nvme_status_.*")
         .whitelist_function("^nvmf_subsystem_find_listener")
         .whitelist_function("^nvmf_subsystem_set_ana_state")
+        .whitelist_function("^nvmf_subsystem_set_cntlid_range")
         .whitelist_function("^nvmf_tgt_accept")
         .blacklist_type("^longfunc")
         .whitelist_var("^NVMF.*")


### PR DESCRIPTION
Add a nexus_share JSON RPC that allows a nexus bdev to be shared over
nvmf with a specified controller ID range. This allows the same nexus
on different Mayastor instances to use non-overlapping controller ID
ranges thereby allowing the initiator to connect to same nexus over
multiple paths.

Add a mocha test to test_nexus to verify that the specified controller
ID range is used when sharing the nexus over nvmf.

Fixes CAS-779