### PR TITLE
feat(nvmx): abstract block devices for nexus children

### DIFF
--- a/mayastor/src/bdev/dev/nvmx/controller.rs
+++ b/mayastor/src/bdev/dev/nvmx/controller.rs
@@ -330,6 +330,7 @@ impl<'a> NvmeController<'a> {
 
         // Reset the controller to complete all remaining I/O requests after all
         // I/O channels are closed.
+        // TODO: fail the controller via spdk_nvme_ctrlr_fail() upon shutdown ?
         debug!("{} resetting NVMe controller", ctx.name);
         let rc = unsafe { spdk_nvme_ctrlr_reset(controller.ctrlr_as_ptr()) };
         if rc != 0 {

--- a/mayastor/src/bdev/dev/nvmx/controller_inner.rs
+++ b/mayastor/src/bdev/dev/nvmx/controller_inner.rs
@@ -1,5 +1,10 @@
 use crossbeam::atomic::AtomicCell;
-use std::{convert::TryFrom, os::raw::c_void, ptr::NonNull};
+use std::{
+    convert::TryFrom,
+    os::raw::c_void,
+    ptr::NonNull,
+    time::{Duration, Instant},
+};
 
 use crate::{
     bdev::dev::nvmx::{
@@ -44,11 +49,26 @@ impl TryFrom<u32> for DeviceTimeoutAction {
     }
 }
 
+/// Maximum number of controller reset attempts to be taken in case
+/// controller reset fails. Once this limit is reached, the next possible
+/// controller reset will be allowed only when reset cooldown interval
+/// elapses.
+/// This is done to prevent the storm of reset requests in response to
+/// frequent I/O errors in a controller (including errors while processing
+/// admin queue completions).
+const MAX_RESET_ATTEMPTS: u32 = 5;
+
+/// Time to wait till reset attempts can be recharged to maximum
+/// after all current reset attempts have been used.
+const RESET_COOLDOWN_INTERVAL: u64 = 30;
+
 pub(crate) struct TimeoutConfig {
     pub name: String,
     timeout_action: AtomicCell<DeviceTimeoutAction>,
     reset_in_progress: AtomicCell<bool>,
     pub ctrlr: *mut spdk_nvme_ctrlr,
+    reset_attempts: u32,
+    next_reset_time: Instant,
 }
 
 impl Drop for TimeoutConfig {
@@ -66,6 +86,8 @@ impl TimeoutConfig {
             timeout_action: AtomicCell::new(DeviceTimeoutAction::Ignore),
             reset_in_progress: AtomicCell::new(false),
             ctrlr: std::ptr::null_mut(),
+            reset_attempts: MAX_RESET_ATTEMPTS,
+            next_reset_time: Instant::now(),
         }
     }
 
@@ -77,11 +99,25 @@ impl TimeoutConfig {
                 "{} controller successfully reset in response to I/O timeout",
                 timeout_ctx.name
             );
+            // In case of successful reset, also reset the allowed number of
+            // reset attempts.
+            timeout_ctx.reset_attempts = MAX_RESET_ATTEMPTS;
         } else {
             error!(
                 "{} failed to reset controller in response to I/O timeout",
                 timeout_ctx.name
             );
+
+            // Setup the reset cooldown interval in case of the last
+            // failed reset attempt.
+            if timeout_ctx.reset_attempts == 0 {
+                timeout_ctx.next_reset_time = Instant::now()
+                    + Duration::from_secs(RESET_COOLDOWN_INTERVAL);
+                info!(
+                    "{} reset cooldown interval activated ({} secs)",
+                    timeout_ctx.name, RESET_COOLDOWN_INTERVAL,
+                );
+            }
         }
 
         // Clear the flag as we are the exclusive owner.
@@ -93,33 +129,54 @@ impl TimeoutConfig {
 
     /// Resets controller exclusively, taking into account existing active
     /// resets related to I/O timeout.
-    pub fn reset_controller(&mut self) {
+    pub(crate) fn reset_controller(&mut self) {
         // Make sure no other resets are in progress.
         if self.reset_in_progress.compare_and_swap(false, true) {
             return;
         }
 
-        if let Some(c) = NVME_CONTROLLERS.lookup_by_name(self.name.to_string())
-        {
-            let mut c = c.lock().expect("controller lock poisoned");
-            if let Err(e) = c.reset(
-                TimeoutConfig::reset_cb,
-                self as *mut TimeoutConfig as *mut c_void,
-                false,
-            ) {
-                error!(
-                    "{}: failed to initiate controller reset: {}",
-                    self.name, e
+        // Check if the maximum number of resets exceeded and we need
+        // to adjust the number of attempts based on time reset cooldown period.
+        if self.reset_attempts == 0 {
+            if Instant::now() >= self.next_reset_time {
+                self.reset_attempts = MAX_RESET_ATTEMPTS;
+                info!(
+                    "{} reset cooldown period elapsed, reset enabled.",
+                    self.name,
                 );
-            } else {
-                info!("{} controller reset initiated", self.name);
-                return;
             }
-        } else {
-            error!(
-                "No controller instance found for {}, reset not possible",
-                self.name
-            );
+        }
+
+        if self.reset_attempts > 0 {
+            // Account reset attempt.
+            self.reset_attempts -= 1;
+
+            if let Some(c) =
+                NVME_CONTROLLERS.lookup_by_name(self.name.to_string())
+            {
+                let mut c = c.lock().expect("controller lock poisoned");
+                if let Err(e) = c.reset(
+                    TimeoutConfig::reset_cb,
+                    self as *mut TimeoutConfig as *mut c_void,
+                    false,
+                ) {
+                    error!(
+                        "{}: failed to initiate controller reset: {}",
+                        self.name, e
+                    );
+                } else {
+                    info!(
+                        "{} controller reset initiated ({} reset attempts left)",
+                        self.name, self.reset_attempts
+                    );
+                    return;
+                }
+            } else {
+                error!(
+                    "No controller instance found for {}, reset not possible",
+                    self.name
+                );
+            }
         }
 
         // Clear the flag as we are the exclusive owner.
@@ -248,24 +305,33 @@ impl<'a> NvmeController<'a> {
         match timeout_action {
             DeviceTimeoutAction::Abort | DeviceTimeoutAction::Reset => {
                 if timeout_action == DeviceTimeoutAction::Abort {
-                    error!("{}: aborting CID {}", timeout_cfg.name, cid);
-                    let rc = spdk_ctrlr.abort_queued_command(
-                        qpair,
-                        cid,
-                        Some(NvmeController::command_abort_handler),
-                        cb_arg,
-                    );
-                    if rc == 0 {
-                        info!(
-                            "{}: initiated abort for CID {}",
+                    // Abort commands only for non-admin queue, fallthrough
+                    // to reset otherwise.
+                    if !qpair.is_null() {
+                        error!("{}: aborting CID {}", timeout_cfg.name, cid);
+                        let rc = spdk_ctrlr.abort_queued_command(
+                            qpair,
+                            cid,
+                            Some(NvmeController::command_abort_handler),
+                            cb_arg,
+                        );
+                        if rc == 0 {
+                            info!(
+                                "{}: initiated abort for CID {}",
+                                timeout_cfg.name, cid
+                            );
+                            return;
+                        }
+                        error!(
+                            "{}: unable to abort CID {}, reset required",
                             timeout_cfg.name, cid
                         );
-                        return;
+                    } else {
+                        info!(
+                            "{}: skipping Abort timeout action for admin qpair",
+                            timeout_cfg.name
+                        );
                     }
-                    error!(
-                        "{}: unable to abort CID {}, reset required",
-                        timeout_cfg.name, cid
-                    );
                     // Fallthrough to perform controller reset in case abort
                     // fails.
                 }

--- a/mayastor/src/bdev/dev/nvmx/device.rs
+++ b/mayastor/src/bdev/dev/nvmx/device.rs
@@ -72,6 +72,20 @@ impl BlockDeviceDescriptor for NvmeDeviceDescriptor {
         Box::new(NvmeBlockDevice::from_ns(&self.name, Arc::clone(&self.ns)))
     }
 
+    fn get_io_handle(&self) -> Result<Box<dyn BlockDeviceHandle>, CoreError> {
+        Ok(Box::new(NvmeDeviceHandle::create(
+            &self.name,
+            self.io_device_id,
+            self.ctrlr.clone(),
+            Arc::clone(&self.ns),
+            self.prchk_flags,
+        )?))
+    }
+
+    fn unclaim(&self) {
+        warn!("unclaim() is not implemented for NvmeDeviceDescriptor yet");
+    }
+
     fn into_handle(
         self: Box<Self>,
     ) -> Result<Box<dyn BlockDeviceHandle>, CoreError> {

--- a/mayastor/src/bdev/nexus/nexus_bdev.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev.rs
@@ -523,7 +523,7 @@ impl Nexus {
                         error!(
                             "{}: child {} failed to close with error {}",
                             nexus.name,
-                            child.name,
+                            child.get_name(),
                             e.verbose()
                         );
                     }
@@ -564,16 +564,16 @@ impl Nexus {
         // wait for all rebuild jobs to be cancelled before proceeding with the
         // destruction of the nexus
         for child in self.children.iter() {
-            self.cancel_child_rebuild_jobs(&child.name).await;
+            self.cancel_child_rebuild_jobs(child.get_name()).await;
         }
 
         for child in self.children.iter_mut() {
-            info!("Destroying child bdev {}", child.name);
+            info!("Destroying child bdev {}", child.get_name());
             if let Err(e) = child.close().await {
                 // TODO: should an error be returned here?
                 error!(
                     "Failed to close child {} with error {}",
-                    child.name,
+                    child.get_name(),
                     e.verbose()
                 );
             }
@@ -695,7 +695,7 @@ impl Nexus {
                         error!(
                             "{}: child {} failed to close with error {}",
                             self.name,
-                            child.name,
+                            child.get_name(),
                             e.verbose()
                         );
                     }
@@ -724,7 +724,7 @@ impl Nexus {
     pub fn io_is_supported(&self, io_type: IoType) -> bool {
         self.children
             .iter()
-            .filter_map(|e| e.bdev.as_ref())
+            .filter_map(|e| e.get_device().ok())
             .any(|b| b.io_type_supported(io_type))
     }
 

--- a/mayastor/src/bdev/nexus/nexus_bdev_children.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev_children.rs
@@ -28,6 +28,9 @@ use snafu::ResultExt;
 
 use crate::{
     bdev::{
+        device_create,
+        device_destroy,
+        device_lookup,
         nexus::{
             nexus_bdev::{
                 CreateChild,
@@ -44,8 +47,7 @@ use crate::{
         Reason,
         VerboseError,
     },
-    core::Bdev,
-    nexus_uri::{bdev_create, bdev_destroy, NexusBdevError},
+    nexus_uri::NexusBdevError,
 };
 
 impl Nexus {
@@ -61,7 +63,7 @@ impl Nexus {
                 self.children.push(NexusChild::new(
                     c.clone(),
                     self.name.clone(),
-                    Bdev::lookup_by_name(c),
+                    device_lookup(c),
                 ))
             })
             .for_each(drop);
@@ -74,11 +76,11 @@ impl Nexus {
         uri: &str,
     ) -> Result<(), NexusBdevError> {
         assert_eq!(*self.state.lock().unwrap(), NexusState::Init);
-        let name = bdev_create(&uri).await?;
+        let name = device_create(&uri).await?;
         self.children.push(NexusChild::new(
             uri.to_string(),
             self.name.clone(),
-            Bdev::lookup_by_name(&name),
+            device_lookup(&name),
         ));
 
         self.child_count += 1;
@@ -127,16 +129,16 @@ impl Nexus {
         &mut self,
         uri: &str,
     ) -> Result<NexusStatus, Error> {
-        let name = bdev_create(&uri).await.context(CreateChild {
+        let name = device_create(&uri).await.context(CreateChild {
             name: self.name.clone(),
         })?;
 
-        let child_bdev = match Bdev::lookup_by_name(&name) {
+        let child_bdev = match device_lookup(&name) {
             Some(child) => {
-                if child.block_len() != self.bdev.block_len()
+                if child.block_len() as u32 != self.bdev.block_len()
                     || self.min_num_blocks() > child.num_blocks()
                 {
-                    if let Err(err) = bdev_destroy(uri).await {
+                    if let Err(err) = device_destroy(uri).await {
                         error!(
                             "Failed to destroy child bdev with wrong geometry: {}",
                             err
@@ -191,7 +193,7 @@ impl Nexus {
                 Ok(self.status())
             }
             Err(e) => {
-                if let Err(err) = bdev_destroy(uri).await {
+                if let Err(err) = device_destroy(uri).await {
                     error!(
                         "Failed to destroy child which failed to open: {}",
                         err
@@ -218,7 +220,7 @@ impl Nexus {
         let cancelled_rebuilding_children =
             self.cancel_child_rebuild_jobs(uri).await;
 
-        let idx = match self.children.iter().position(|c| c.name == uri) {
+        let idx = match self.children.iter().position(|c| c.get_name() == uri) {
             None => return Ok(()),
             Some(val) => val,
         };
@@ -226,7 +228,7 @@ impl Nexus {
         if let Err(e) = self.children[idx].close().await {
             return Err(Error::CloseChild {
                 name: self.name.clone(),
-                child: self.children[idx].name.clone(),
+                child: self.children[idx].get_name().to_string(),
                 source: e,
             });
         }
@@ -251,7 +253,9 @@ impl Nexus {
         let cancelled_rebuilding_children =
             self.cancel_child_rebuild_jobs(name).await;
 
-        if let Some(child) = self.children.iter_mut().find(|c| c.name == name) {
+        if let Some(child) =
+            self.children.iter_mut().find(|c| c.get_name() == name)
+        {
             child.offline().await;
         } else {
             return Err(Error::ChildNotFound {
@@ -287,7 +291,8 @@ impl Nexus {
             .filter(|c| c.state() == ChildState::Open)
             .collect::<Vec<_>>();
 
-        if healthy_children.len() == 1 && healthy_children[0].name == name {
+        if healthy_children.len() == 1 && healthy_children[0].get_name() == name
+        {
             // the last healthy child cannot be faulted
             return Err(Error::FaultingLastHealthyChild {
                 name: self.name.clone(),
@@ -298,23 +303,24 @@ impl Nexus {
         let cancelled_rebuilding_children =
             self.cancel_child_rebuild_jobs(name).await;
 
-        let result = match self.children.iter_mut().find(|c| c.name == name) {
-            Some(child) => {
-                match child.state() {
-                    ChildState::Faulted(_) => {}
-                    _ => {
-                        child.fault(reason).await;
-                        NexusChild::save_state_change();
-                        self.reconfigure(DrEvent::ChildFault).await;
+        let result =
+            match self.children.iter_mut().find(|c| c.get_name() == name) {
+                Some(child) => {
+                    match child.state() {
+                        ChildState::Faulted(_) => {}
+                        _ => {
+                            child.fault(reason).await;
+                            NexusChild::save_state_change();
+                            self.reconfigure(DrEvent::ChildFault).await;
+                        }
                     }
+                    Ok(())
                 }
-                Ok(())
-            }
-            None => Err(Error::ChildNotFound {
-                name: self.name.clone(),
-                child: name.to_owned(),
-            }),
-        };
+                None => Err(Error::ChildNotFound {
+                    name: self.name.clone(),
+                    child: name.to_owned(),
+                }),
+            };
 
         // start rebuilding the children that previously had their rebuild jobs
         // cancelled, in spite of whether or not the child was correctly faulted
@@ -331,7 +337,9 @@ impl Nexus {
     ) -> Result<NexusStatus, Error> {
         trace!("{} Online child request", self.name);
 
-        if let Some(child) = self.children.iter_mut().find(|c| c.name == name) {
+        if let Some(child) =
+            self.children.iter_mut().find(|c| c.get_name() == name)
+        {
             child.online(self.size).await.context(OpenChild {
                 child: name.to_owned(),
                 name: self.name.clone(),
@@ -355,44 +363,29 @@ impl Nexus {
         }
     }
 
-    /// Add a child to the configuration when an example callback is run.
-    /// The nexus is not opened implicitly, call .open() for this manually.
-    pub fn examine_child(&mut self, name: &str) -> bool {
-        self.children
-            .iter_mut()
-            .filter(|c| c.state() == ChildState::Init && c.name == name)
-            .any(|c| {
-                if let Some(bdev) = Bdev::lookup_by_name(name) {
-                    c.bdev = Some(bdev);
-                    return true;
-                }
-                false
-            })
-    }
-
     /// try to open all the child devices
     pub(crate) async fn try_open_children(&mut self) -> Result<(), Error> {
         if self.children.is_empty()
-            || self.children.iter().any(|c| c.bdev.is_none())
+            || self.children.iter().any(|c| c.get_device().is_err())
         {
             return Err(Error::NexusIncomplete {
                 name: self.name.clone(),
             });
         }
 
-        let blk_size = self.children[0].bdev.as_ref().unwrap().block_len();
+        let blk_size = self.children[0].get_device().unwrap().block_len();
 
         if self
             .children
             .iter()
-            .any(|b| b.bdev.as_ref().unwrap().block_len() != blk_size)
+            .any(|b| b.get_device().unwrap().block_len() != blk_size)
         {
             return Err(Error::MixedBlockSizes {
                 name: self.name.clone(),
             });
         }
 
-        self.bdev.set_block_len(blk_size);
+        self.bdev.set_block_len(blk_size as u32);
 
         let size = self.size;
 
@@ -405,12 +398,11 @@ impl Nexus {
         // depending on IO consistency policies, we might be able to go online
         // even if one of the children failed to open. This is work is not
         // completed yet so we fail the registration all together for now.
-
         if !error.is_empty() {
             for open_child in open {
                 let name = open_child.unwrap();
                 if let Some(child) =
-                    self.children.iter_mut().find(|c| c.name == name)
+                    self.children.iter_mut().find(|c| c.get_name() == name)
                 {
                     if let Err(e) = child.close().await {
                         error!(
@@ -431,7 +423,7 @@ impl Nexus {
 
         self.children
             .iter()
-            .map(|c| c.bdev.as_ref().unwrap().alignment())
+            .map(|c| c.get_device().as_ref().unwrap().alignment())
             .collect::<Vec<_>>()
             .iter()
             .map(|s| {
@@ -457,7 +449,7 @@ impl Nexus {
         self.children
             .iter()
             .filter(|c| c.state() == ChildState::Open)
-            .map(|c| c.bdev.as_ref().unwrap().num_blocks())
+            .map(|c| c.get_device().unwrap().num_blocks())
             .collect::<Vec<_>>()
             .iter()
             .map(|s| {
@@ -473,15 +465,15 @@ impl Nexus {
     pub fn child_lookup(&self, name: &str) -> Option<&NexusChild> {
         self.children
             .iter()
-            .filter(|c| c.bdev.as_ref().is_some())
-            .find(|c| c.bdev.as_ref().unwrap().name() == name)
+            .filter(|c| c.get_device().is_ok())
+            .find(|c| c.get_device().unwrap().device_name() == name)
     }
 
     pub fn get_child_by_name(
         &mut self,
         name: &str,
     ) -> Result<&mut NexusChild, Error> {
-        match self.children.iter_mut().find(|c| c.name == name) {
+        match self.children.iter_mut().find(|c| c.get_name() == name) {
             Some(child) => Ok(child),
             None => Err(Error::ChildNotFound {
                 child: name.to_owned(),

--- a/mayastor/src/bdev/nexus/nexus_bdev_rebuild.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev_rebuild.rs
@@ -46,20 +46,20 @@ impl Nexus {
         let src_child_name = match self
             .children
             .iter()
-            .find(|c| c.state() == ChildState::Open && c.name != name)
+            .find(|c| c.state() == ChildState::Open && c.get_name() != name)
         {
-            Some(child) => Ok(child.name.clone()),
+            Some(child) => Ok(child.get_name().clone()),
             None => Err(Error::NoRebuildSource {
                 name: self.name.clone(),
             }),
         }?;
 
         let dst_child_name =
-            match self.children.iter_mut().find(|c| c.name == name) {
+            match self.children.iter().find(|c| c.get_name() == name) {
                 Some(c)
                     if c.state() == ChildState::Faulted(Reason::OutOfSync) =>
                 {
-                    Ok(c.name.clone())
+                    Ok(c.get_name().clone())
                 }
                 Some(c) => Err(Error::ChildNotDegraded {
                     child: name.to_owned(),
@@ -264,7 +264,7 @@ impl Nexus {
                 NexusChild::save_state_change();
                 info!(
                     "Child {} has been rebuilt successfully",
-                    recovering_child.name
+                    recovering_child.get_name()
                 );
             }
             RebuildState::Stopped => {

--- a/mayastor/src/bdev/nexus/nexus_child_status_config.rs
+++ b/mayastor/src/bdev/nexus/nexus_child_status_config.rs
@@ -85,10 +85,11 @@ impl ChildStatusConfig {
         let store = &ChildStatusConfig::get().status;
         for nexus in instances() {
             nexus.children.iter_mut().for_each(|child| {
-                if let Some(status) = store.get(&child.name) {
+                if let Some(status) = store.get(child.get_name()) {
                     info!(
                         "Apply state to child {}, reasons {:?}",
-                        child.name, status
+                        child.get_name(),
+                        status
                     );
                     child.set_state(*status);
                 }
@@ -126,7 +127,9 @@ impl ChildStatusConfig {
 
         instances().iter().for_each(|nexus| {
             nexus.children.iter().for_each(|child| {
-                status_cfg.status.insert(child.name.clone(), child.state());
+                status_cfg
+                    .status
+                    .insert(child.get_name().to_string(), child.state());
             });
         });
 
@@ -152,7 +155,8 @@ impl ChildStatusConfig {
         let mut cfg = ChildStatusConfig {
             status: HashMap::new(),
         };
-        cfg.status.insert(child.name.clone(), child.state());
+        cfg.status
+            .insert(child.get_name().to_string(), child.state());
         ChildStatusConfig::do_save(Some(cfg))
     }
 

--- a/mayastor/src/bdev/nexus/nexus_metadata.rs
+++ b/mayastor/src/bdev/nexus/nexus_metadata.rs
@@ -708,7 +708,10 @@ impl NexusChild {
                 && partition.ent_name.name == "MayaMeta"
             {
                 let mut metadata = NexusMetaData {
-                    header: MetaDataHeader::new(bdev.block_len(), &partition),
+                    header: MetaDataHeader::new(
+                        bdev.block_len() as u32,
+                        &partition,
+                    ),
                     index: Vec::new(),
                 };
                 self.sync_metadata(&mut metadata).await?;

--- a/mayastor/src/bdev/nexus/nexus_module.rs
+++ b/mayastor/src/bdev/nexus/nexus_module.rs
@@ -5,7 +5,6 @@ use serde_json::json;
 
 use spdk_sys::{
     spdk_bdev_module,
-    spdk_bdev_module_examine_done,
     spdk_bdev_module_list_add,
     spdk_get_thread,
     spdk_json_write_ctx,
@@ -13,10 +12,7 @@ use spdk_sys::{
 };
 
 use crate::{
-    bdev::nexus::{
-        nexus_bdev::{Nexus, NexusState},
-        nexus_io::NioCtx,
-    },
+    bdev::nexus::{nexus_bdev::Nexus, nexus_io::NioCtx},
     core::{Bdev, Reactor},
 };
 
@@ -58,7 +54,7 @@ impl NexusModule {
         module.module_init = Some(Self::nexus_mod_init);
         module.module_fini = Some(Self::nexus_mod_fini);
         module.get_ctx_size = Some(Self::nexus_ctx_size);
-        module.examine_config = Some(Self::examine);
+        module.examine_config = None;
         module.examine_disk = None;
         module.config_json = Some(Self::config_json);
         NexusModule(Box::into_raw(module))
@@ -116,40 +112,6 @@ impl NexusModule {
         Self::get_instances().clear();
     }
 
-    /// called for each bdev that gets added to the system
-    extern "C" fn examine(new_device: *mut spdk_sys::spdk_bdev) {
-        let name = Bdev::from(new_device).name();
-        let instances = Self::get_instances();
-
-        instances
-            .iter_mut()
-            .filter(|nexus| *nexus.state.lock().unwrap() == NexusState::Init)
-            .any(|nexus| {
-                if nexus.examine_child(&name) {
-                    info!(
-                        "child {} for nexus {} came online",
-                        name, nexus.name
-                    );
-                    // we use block on here as it makes any log message
-                    // show in within proper order. We can also dispatch
-                    // a future and have it executed at the next poll, but
-                    // this is more inline with what the other modules are
-                    // doing as well.
-                    Reactor::block_on(async move {
-                        if nexus.open().await.is_err() {
-                            debug!("nexus {} still not completed", nexus.name);
-                        }
-                    });
-                    return true;
-                }
-                false
-            });
-
-        unsafe {
-            spdk_bdev_module_examine_done(NEXUS_MODULE.0 as *const _ as *mut _)
-        }
-    }
-
     extern "C" fn nexus_ctx_size() -> i32 {
         std::mem::size_of::<NioCtx>() as i32
     }
@@ -164,7 +126,7 @@ impl NexusModule {
             let uris = nexus
                 .children
                 .iter()
-                .map(|c| c.name.clone())
+                .map(|c| c.get_name().to_string())
                 .collect::<Vec<String>>();
 
             let json = json!({

--- a/mayastor/src/core/block_device.rs
+++ b/mayastor/src/core/block_device.rs
@@ -85,6 +85,8 @@ pub trait BlockDeviceDescriptor {
     fn into_handle(
         self: Box<Self>,
     ) -> Result<Box<dyn BlockDeviceHandle>, CoreError>;
+    fn get_io_handle(&self) -> Result<Box<dyn BlockDeviceHandle>, CoreError>;
+    fn unclaim(&self);
 }
 
 pub type IoCompletionCallbackArg = *mut c_void;
@@ -141,8 +143,8 @@ pub trait BlockDeviceHandle {
 
     fn reset(
         &self,
-        cb: OpCompletionCallback,
-        cb_arg: OpCompletionCallbackArg,
+        cb: IoCompletionCallback,
+        cb_arg: IoCompletionCallbackArg,
     ) -> Result<(), CoreError>;
 
     fn unmap_blocks(

--- a/mayastor/src/core/mod.rs
+++ b/mayastor/src/core/mod.rs
@@ -171,6 +171,8 @@ pub enum CoreError {
     DeviceStatisticsError {
         source: Errno,
     },
+    #[snafu(display("No devices available for I/O"))]
+    NoDevicesAvailable {},
 }
 
 // Generic I/O completion status for block devices, which supports per-protocol

--- a/mayastor/src/grpc/nexus_grpc.rs
+++ b/mayastor/src/grpc/nexus_grpc.rs
@@ -47,7 +47,7 @@ impl NexusChild {
     /// All we have is a reference to a child.
     pub fn to_grpc(&self) -> rpc::Child {
         rpc::Child {
-            uri: self.name.clone(),
+            uri: self.get_name().to_string(),
             state: rpc::ChildState::from(self.state()) as i32,
             rebuild_progress: self.get_rebuild_progress(),
         }

--- a/mayastor/src/subsys/config/mod.rs
+++ b/mayastor/src/subsys/config/mod.rs
@@ -269,7 +269,7 @@ impl Config {
                 children: nexus
                     .children
                     .iter()
-                    .map(|child| child.name.clone())
+                    .map(|child| child.get_name().to_string())
                     .collect::<Vec<_>>(),
             })
             .collect::<Vec<_>>();
@@ -438,9 +438,9 @@ impl Config {
                         .expect("Failed to find nexus");
 
                     for child in degraded_children {
-                        dbg!("Start rebuilding child {}", &child.name);
+                        dbg!("Start rebuilding child {}", child.get_name());
                         if nexus_instance
-                            .start_rebuild(&child.name)
+                            .start_rebuild(child.get_name())
                             .await
                             .is_err()
                         {


### PR DESCRIPTION
Nexus now treats all its replica devices as abstract block devices,
which allows clear separation, and uses abstract block device I/O
handles for serving child I/O.

In order to prevent start of controller resets in response to I/O errors
(mostly connection failures), maximum number of controller resets
introduced along with reset cool down interval.

Per-channel I/O operation accounting is introduced to have better I/O
observability/statistics.

Implements CAS-781