### PR TITLE
test(e2e): temporarily disable pod remove test

### DIFF
--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -15,10 +15,10 @@ TOPDIR=$(realpath "$SCRIPTDIR/..")
 #       resource_check is a follow up check for the 3rd party CSI test suite.
 #   2. ms_pod_disruption SHOULD be the last test before uninstall
 #
-DEFAULT_TESTS="install basic_volume_io csi resource_check replica rebuild ms_pod_disruption uninstall"
+DEFAULT_TESTS="install basic_volume_io csi resource_check replica rebuild uninstall"
 ONDEMAND_TESTS="install basic_volume_io csi resource_check uninstall"
-EXTENDED_TESTS="install basic_volume_io csi resource_check replica rebuild io_soak ms_pod_disruption uninstall"
-CONTINUOUS_TESTS="install basic_volume_io csi resource_check replica rebuild io_soak ms_pod_disruption uninstall"
+EXTENDED_TESTS="install basic_volume_io csi resource_check replica rebuild io_soak uninstall"
+CONTINUOUS_TESTS="install basic_volume_io csi resource_check replica rebuild io_soak uninstall"
 
 #exit values
 EXITV_OK=0


### PR DESCRIPTION
Removed so as not to impede soak testing with false failures.
Will be reintroduced shortly when no longer
re-using the faulted node.