### PR TITLE
fix: add missing nats namespace to the helm charts

### DIFF
--- a/chart/templates/nats-deployment.yaml
+++ b/chart/templates/nats-deployment.yaml
@@ -22,8 +22,8 @@ data:
       port: 6222
 
       routes [
-        {{- range untilStep 0 (int .Values.nats.cluster.replicas) 1 }}
-        nats://nats-{{ . }}.nats.default.svc:6222
+        {{- range $index, $end := until (.Values.nats.cluster.replicas | int) }}
+        {{ printf "nats://nats-%d.nats.%s.svc:6222" $index $.Release.Namespace }}
         {{- end }}
       ]
 


### PR DESCRIPTION
The NatsConfig route was missing the namespace which meant nats services
 would not talk to each other and thus events were lost.