### PR TITLE
fix(nvmx): nexus children removed in response to events

### DIFF
--- a/mayastor/src/bdev/dev/loopback.rs
+++ b/mayastor/src/bdev/dev/loopback.rs
@@ -7,7 +7,7 @@ use url::Url;
 use crate::{
     bdev::{
         dev::reject_unknown_parameters,
-        lookup_child_from_bdev,
+        lookup_nexus_child,
         util::uri,
         CreateDestroy,
         GetName,

--- a/mayastor/src/bdev/mod.rs
+++ b/mayastor/src/bdev/mod.rs
@@ -9,7 +9,7 @@ pub use nexus::{
         NexusStatus,
         VerboseError,
     },
-    nexus_child::{lookup_child_from_bdev, ChildState, Reason},
+    nexus_child::{lookup_nexus_child, ChildState, Reason},
     nexus_child_status_config,
     nexus_label::{GptEntry, GptHeader},
     nexus_metadata_content::{

--- a/mayastor/src/core/bdev.rs
+++ b/mayastor/src/core/bdev.rs
@@ -32,7 +32,7 @@ use spdk_sys::{
 };
 
 use crate::{
-    bdev::lookup_child_from_bdev,
+    bdev::lookup_nexus_child,
     core::{
         share::{Protocol, Share},
         uuid::Uuid,
@@ -167,7 +167,7 @@ impl Bdev {
         match event {
             spdk_sys::SPDK_BDEV_EVENT_REMOVE => {
                 info!("Received remove event for bdev {}", bdev.name());
-                if let Some(child) = lookup_child_from_bdev(&bdev.name()) {
+                if let Some(child) = lookup_nexus_child(&bdev.name()) {
                     child.remove();
                 }
             }


### PR DESCRIPTION
Nexus now registers a listener for all its children and finalizes
child removal in response to device removal event.