### PR TITLE
fix: change to use mayadata/fio CAS-599

### DIFF
--- a/deploy/fio.yaml
+++ b/deploy/fio.yaml
@@ -9,8 +9,7 @@ spec:
        claimName: ms-volume-claim
   containers:
     - name: fio
-      image: nixery.dev/shell/fio/tini
-      command: [ "tini", "--" ]
+      image: mayadata/fio
       args:
         - sleep
         - "1000000"


### PR DESCRIPTION
Update deploy/fio.yaml to use the newly minted
mayadata/fio image on docker hub