### PR TITLE
ci: allow e2e tests to run on arbitrary mayastor source tree MQ-430

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -338,7 +338,7 @@ pipeline {
 
                 script {
                   def tag = getTag()
-                  def cmd = "./scripts/e2e-test.sh --device /dev/sdb --tag \"${tag}\" --logs --profile \"${e2e_test_profile}\" --build_number \"${env.BUILD_NUMBER}\" "
+                  def cmd = "./scripts/e2e-test.sh --device /dev/sdb --tag \"${tag}\" --logs --profile \"${e2e_test_profile}\" --build_number \"${env.BUILD_NUMBER}\" --mayastor \"${env.WORKSPACE}\" "
                   // building images also means using the CI registry
                   if (e2e_build_images == true) {
                     cmd = cmd + " --registry \"" + env.REGISTRY + "\""

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -65,6 +65,9 @@ Options:
                             Behaviour for "uninstall" only differs if uninstall is in the list of tests (the default).
   --uninstall_cleanup <y|n> On uninstall cleanup for reusable cluster. default($uninstall_cleanup)
   --config                  config name or configuration file default(test/e2e/configurations/ci_e2e_config.yaml)
+  --mayastor                path to the mayastor source tree to use for testing.
+                            This is required so that the install test uses the yaml files as defined for that 
+                            revision of mayastor under test.
 
 Examples:
   $0 --device /dev/nvme0n1 --registry 127.0.0.1:5000 --tag a80ce0c

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -6,7 +6,6 @@ SCRIPTDIR=$(dirname "$(realpath "$0")")
 TESTDIR=$(realpath "$SCRIPTDIR/../test/e2e")
 REPORTSDIR=$(realpath "$SCRIPTDIR/..")
 ARTIFACTSDIR=$(realpath "$SCRIPTDIR/../artifacts")
-TOPDIR=$(realpath "$SCRIPTDIR/..")
 
 # List and Sequence of tests.
 #tests="install basic_volume_io csi replica rebuild node_disconnect/replica_pod_remove uninstall"
@@ -42,6 +41,7 @@ on_fail="stop"
 uninstall_cleanup="n"
 generate_logs=0
 logsdir="$ARTIFACTSDIR/logs"
+mayastor_root_dir=""
 
 help() {
   cat <<EOF
@@ -74,6 +74,10 @@ EOF
 # Parse arguments
 while [ "$#" -gt 0 ]; do
   case "$1" in
+    -m|--mayastor)
+      shift
+      mayastor_root_dir=$1
+      ;;
     -d|--device)
       shift
       device=$1
@@ -158,6 +162,12 @@ done
 
 export e2e_build_number="$build_number" # can be empty string
 
+if [ -z "$mayastor_root_dir" ]; then
+    echo "Root directory for mayastor is required"
+    exit $EXITV_MISSING_OPTION
+fi
+export e2e_mayastor_root_dir=$mayastor_root_dir 
+
 if [ -z "$device" ]; then
   echo "Device for storage pools must be specified"
   help
@@ -170,7 +180,7 @@ if [ -n "$tag" ]; then
 fi
 
 export e2e_docker_registry="$registry" # can be empty string
-export e2e_top_dir="$TOPDIR"
+export e2e_root_dir="$TESTDIR"
 
 if [ -n "$custom_tests" ]; then
   if [ "$profile" != "default" ]; then
@@ -247,8 +257,9 @@ contains() {
 }
 
 echo "Environment:"
-echo "    e2e_build_number=$build_number"
-echo "    e2e_top_dir=$e2e_top_dir"
+echo "    e2e_mayastor_root_dir=$e2e_mayastor_root_dir"
+echo "    e2e_build_number=$e2e_build_number"
+echo "    e2e_root_dir=$e2e_root_dir"
 echo "    e2e_pool_device=$e2e_pool_device"
 echo "    e2e_image_tag=$e2e_image_tag"
 echo "    e2e_docker_registry=$e2e_docker_registry"

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -53,7 +53,7 @@ can be run to do that.
 # Configuration
 The e2e test suite support runtime configuration to set parameters and variables,
 to suit the cluster under test. The configuration file can be specified using the `--config`
-option of `../../scripts/e2e-test/sh`
+option of `../../scripts/e2e-test.sh`
 
 The go package used to read (and write) configuration files supports the following formats
 1. `yaml`

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -39,14 +39,49 @@ docker_insecure_registry    = "52.58.174.24:5000"
 ### Create local cluster
 
 Many possibilities here. You could use libvirt based cluster created by
-terraform (in terraform/ in this repo). Or you could use the script from
-`setup` subdirectory using vagrant and kubespray.
+terraform (in terraform/ in this repo). 
 
 # Running the tests
 
 If you'd like to run the tests as a whole (as they are run in our CI/CD
-pipeline) then use the script `./scripts/e2e-test.sh`.
+pipeline) then use the script `../../scripts/e2e-test.sh`.
 
 To run particular test cd to the directory with tests and type `go test`.
 Most of the tests assume that mayastor is already installed. `install` test
 can be run to do that.
+
+# Configuration
+The e2e test suite support runtime configuration to set parameters and variables,
+to suit the cluster under test. The configuration file can be specified using the `--config`
+option of `../../scripts/e2e-test/sh`
+
+The go package used to read (and write) configuration files supports the following formats
+1. `yaml`
+2. `json`
+3. `toml`
+
+The mayastor e2e project uses `yaml` exclusively.
+If a configuration is not specified the configuration is defaulted to the `CI/CD` configuration file.
+
+The contents of the configuration are described in the file
+`./common/e2e_config/e2e_config.go` and is subject to change.
+
+The location of the default configuration file is *ALWAYS* defined relative to the root of the `e2e` directory as
+`/configurations` and the name of file is `ci_e2e_config.yaml`
+
+Other configuration files may be located in the same directory.
+
+The test scripts use the following algorithm to locate and load configuration files
+1. If environment variable `e2e_config_file` is not defined, environment variable `e2e_root_dir` *MUST* be defined. An attempt to load the default configuration as described earlier is made.
+2. Otherwise
+ * If the value of `e2e_config_file` is a path to a file, an attempt is made to load that file.
+ * Otherwise the value is considered to be a name of a file in the configuration directory and an attempt is made to load the configuration accordingly.
+
+The test scripts will fail (panic) if
+1. Both `e2e_config_file` and `e2e_root_dir` environment variables are not defined.
+2. The specified configuration file does not exist
+3. The contents of specified configuration are invalid
+
+Once the configuration has been loaded and all fields resolved, the contents are written out to the artefacts directory.
+
+This file can be used to replicate a configuration for future test runs.

--- a/test/e2e/common/locations/util_locations.go
+++ b/test/e2e/common/locations/util_locations.go
@@ -1,31 +1,15 @@
 package locations
 
+// For now the relative paths are hardcoded, there may be a case to make this
+// more generic and data driven.
+
 import (
+	"e2e-basic/common/e2e_config"
 	"os"
 	"path"
-	"runtime"
-	"sync"
 
 	. "github.com/onsi/gomega"
-
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
-
-var once sync.Once
-var topDir string
-
-func init() {
-	once.Do(func() {
-		value, ok := os.LookupEnv("e2e_top_dir")
-		if !ok {
-			_, filename, _, _ := runtime.Caller(0)
-			topDir = path.Clean(filename + "/../../../../")
-		} else {
-			topDir = value
-		}
-		logf.Log.Info("Repo", "top directory", topDir)
-	})
-}
 
 func locationExists(path string) string {
 	_, err := os.Stat(path)
@@ -33,19 +17,15 @@ func locationExists(path string) string {
 	return path
 }
 
-func GetDeployDir() string {
-	return locationExists(path.Clean(topDir + "/deploy"))
+func GetMayastorDeployDir() string {
+	return locationExists(path.Clean(e2e_config.GetConfig().MayastorRootDir + "/deploy"))
 }
 
-func GetScriptsDir() string {
-	return locationExists(path.Clean(topDir + "/scripts"))
-}
-
-func GetArtifactsDir() string {
-	return path.Clean(topDir + "/artifacts")
+func GetMayastorScriptsDir() string {
+	return locationExists(path.Clean(e2e_config.GetConfig().MayastorRootDir + "/scripts"))
 }
 
 // This is a generate directory, so may not exist yet.
 func GetGeneratedYamlsDir() string {
-	return path.Clean(topDir + "/artifacts/install/yamls")
+	return path.Clean(e2e_config.GetConfig().E2eRootDir + "/artifacts/install/yamls")
 }

--- a/test/e2e/configurations/ci_e2e_config.yaml
+++ b/test/e2e/configurations/ci_e2e_config.yaml
@@ -6,7 +6,7 @@ pvcstress:
   crudCycles: 10
 ioSoakTest:
   replicas: 1
-  duration: 6m
+  duration: 60m
   # loadFactor is number of volumes for each mayastor instance
   # volumes for disruptor pods are allocated from within this "pool"
   loadFactor: 10

--- a/test/e2e/configurations/ci_e2e_config.yaml
+++ b/test/e2e/configurations/ci_e2e_config.yaml
@@ -1,11 +1,12 @@
 # configuration/parameters for CI/CD e2e test runs
+configName: CI
 pvcstress:
   replicas: 1
   cdCycles: 100
   crudCycles: 10
 ioSoakTest:
   replicas: 1
-  duration: 60m
+  duration: 6m
   # loadFactor is number of volumes for each mayastor instance
   # volumes for disruptor pods are allocated from within this "pool"
   loadFactor: 10

--- a/test/e2e/install/install_test.go
+++ b/test/e2e/install/install_test.go
@@ -36,7 +36,7 @@ func generateYamlFiles(imageTag string, mayastorNodes []string, e2eCfg *e2e_conf
 
 	bashCmd := fmt.Sprintf(
 		"%s/generate-deploy-yamls.sh -o %s -t '%s' %s %s %s test",
-		locations.GetScriptsDir(),
+		locations.GetMayastorScriptsDir(),
 		locations.GetGeneratedYamlsDir(),
 		imageTag, registryDirective, coresDirective, poolDirectives,
 	)
@@ -108,7 +108,7 @@ func installMayastor() {
 	logf.Log.Info("Install", "tag", imageTag, "registry", registry, "# of mayastor instances", numMayastorInstances)
 
 	generateYamlFiles(imageTag, mayastorNodes, &e2eCfg)
-	deployDir := locations.GetDeployDir()
+	deployDir := locations.GetMayastorDeployDir()
 	yamlsDir := locations.GetGeneratedYamlsDir()
 
 	err = common.MkNamespace(common.NSMayastor)

--- a/test/e2e/uninstall/uninstall_test.go
+++ b/test/e2e/uninstall/uninstall_test.go
@@ -100,7 +100,7 @@ func teardownMayastor() {
 		}
 	}
 
-	deployDir := locations.GetDeployDir()
+	deployDir := locations.GetMayastorDeployDir()
 	common.KubeCtlDeleteYaml("mayastorpoolcrd.yaml", deployDir)
 	common.KubeCtlDeleteYaml("moac-rbac.yaml", yamlsDir)
 


### PR DESCRIPTION
I preparation for moving the e2e tests to separate repository,
allow e2e tests to run on arbitrary mayastor repo trees.
The e2e tests will use yaml files in the mayastor source
tree to deploy mayastor as defined for the revision of mayastor
that exists in the mayastor source tree

1. Stop using relative paths to locate files in the directory trees,
instead rely on 2 absolute paths
    1. mayastor source tree root
    2. e2e test tree root
2. Reduce reliance on environment variables (which are transient and not
recorded automatically) in favour of using the configuration entity.
3. Document more clearly where the configuration file is searched for and loaded.