### PR TITLE
test(e2e): extend timeout for basic test

### DIFF
--- a/test/e2e/configurations/ci_e2e_config.yaml
+++ b/test/e2e/configurations/ci_e2e_config.yaml
@@ -41,7 +41,7 @@ uninstall:
 basicVolumeIO:
   replicas: 1
   # timeout units are seconds
-  fioTimeout: 60
+  fioTimeout: 90
   # volSizeMb units are MiB
   volSizeMb: 500
   # fsVolSizeMb units are MiB


### PR DESCRIPTION
The basic volume test failed because the fio run exceeded the timeout.
Raise timeout from 60s to 90s.