### PR TITLE
fix(moac): failed to provision volume on RKE

### DIFF
--- a/chart/templates/mayastor-daemonset.yaml
+++ b/chart/templates/mayastor-daemonset.yaml
@@ -65,8 +65,6 @@ spec:
           mountPath: /dev/shm
         - name: configlocation
           mountPath: /var/local/mayastor/
-        - name: config
-          mountPath: /var/local/mayastor/config.yaml
         resources:
           # NOTE: Each container must have mem/cpu limits defined in order to
           # belong to Guaranteed QoS class, hence can never get evicted in case of
@@ -103,7 +101,3 @@ spec:
         hostPath:
           path: /var/local/mayastor/
           type: DirectoryOrCreate
-      - name: config
-        hostPath:
-          path: /var/local/mayastor/config.yaml
-          type: FileOrCreate

--- a/csi/moac/test/volumes_test.js
+++ b/csi/moac/test/volumes_test.js
@@ -784,6 +784,13 @@ module.exports = function () {
       expect(volume.state).to.equal('healthy');
       expect(volEvents).to.have.lengthOf(4);
     });
+
+    it('should import a volume without status', async () => {
+      volumes.start();
+      volume = volumes.importVolume(UUID, volumeSpec);
+      expect(volume.state).to.equal('unknown');
+      expect(volume.size).to.equal(0);
+    });
   });
 
   describe('publish volume', function () {

--- a/csi/moac/volume_operator.ts
+++ b/csi/moac/volume_operator.ts
@@ -77,7 +77,7 @@ type VolumeSpec = {
 };
 
 // Optional status part in volume resource
-type VolumeStatus = {
+export type VolumeStatus = {
   size: number,
   state: VolumeState,
   reason?: string,

--- a/deploy/mayastor-daemonset.yaml
+++ b/deploy/mayastor-daemonset.yaml
@@ -67,8 +67,6 @@ spec:
           mountPath: /dev/shm
         - name: configlocation
           mountPath: /var/local/mayastor/
-        - name: config
-          mountPath: /var/local/mayastor/config.yaml
         resources:
           # NOTE: Each container must have mem/cpu limits defined in order to
           # belong to Guaranteed QoS class, hence can never get evicted in case of
@@ -105,7 +103,3 @@ spec:
         hostPath:
           path: /var/local/mayastor/
           type: DirectoryOrCreate
-      - name: config
-        hostPath:
-          path: /var/local/mayastor/config.yaml
-          type: FileOrCreate


### PR DESCRIPTION
Two issues, described in great depth in #772 github ticket, were
encountered by a user while trying to provision mayastor volume on
RKE cluster:

1. Mayastor config file was mounted as a directory instead as a file
2. Unhandled exception in Moac (result of partially created volume)

Both issues are fixed in this commit.

Add 1. There does not seem to be a good reason for mounting config
file instead of just the whole config directory so I have removed
that mount. It's not the first time we see this issue and although it
is probably caused by a bug in k8s/OS it can be easily avoided.