### PR TITLE
fix(moac): cannot unpublish nexus on a node that is down

### DIFF
--- a/csi/moac/test/node_test.js
+++ b/csi/moac/test/node_test.js
@@ -455,10 +455,10 @@ module.exports = function () {
           expect(ev.object.state).to.equal('POOL_OFFLINE');
           expect(node.isSynced()).to.be.false();
           expect(Date.now() - firstSync).to.be.above(
-            syncPeriod + syncRetry * 2
+            syncPeriod + syncRetry * 2 - 1
           );
           expect(Date.now() - firstSync).to.be.below(
-            syncPeriod + syncRetry * 4
+            syncPeriod + syncRetry * 4 + 1
           );
           done();
         });


### PR DESCRIPTION
This introduces a new volume state "offline" that is used for
volumes that are inaccessible (the node with the nexus is down).
It is important distinction from "faulted" state that has been
used for this case previously.  "faulted" speaks for the data
(data loss), while "offline" speaks for availability of the data
(access). FSA has been fixed to handle this new state properly so
it is possible to:

1. create pod with mounted volume (on a different node than nexus),
2. bring the node with nexus down,
3. delete pod with the mounted volume,
4. recreate the pod with the same volume again.

This gives a chance to manually recover the volume by the user
action in case that the node with nexus never comes back online.

What happens in the background is that a series of CSI calls
(unpublish/publish) brings the volume to the state when it can be
used again. Making this process more smooth without requiring the
manual intervention is out of scope of this ticket.

Resolves: CAS-816