### PR TITLE
feature(core): add spawn_local() for threads

### DIFF
--- a/mayastor/src/bin/mayastor.rs
+++ b/mayastor/src/bin/mayastor.rs
@@ -89,7 +89,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             .expect_err("reactor exit in abnormal state");
     });
 
-    Reactors::current().developer_delayed();
+    Reactors::current().running();
     Reactors::current().poll_reactor();
 
     ms.fini();

--- a/mayastor/src/core/thread.rs
+++ b/mayastor/src/core/thread.rs
@@ -211,7 +211,7 @@ impl Mthread {
             E: Send + Debug,
         {
             let mut ctx = unsafe { Box::from_raw(arg as *mut Ctx<F, R, E>) };
-            Reactors::current()
+            Reactors::master()
                 .spawn_local(async move {
                     let result = ctx.future.await;
                     ctx.sender

--- a/mayastor/src/core/thread.rs
+++ b/mayastor/src/core/thread.rs
@@ -14,8 +14,14 @@ use spdk_sys::{
     spdk_thread_send_msg,
 };
 
-use crate::core::{cpu_cores::CpuMask, Cores};
-use std::ptr::NonNull;
+use crate::core::{cpu_cores::CpuMask, CoreError, Cores, Reactor, Reactors};
+use futures::channel::oneshot::{channel, Receiver, Sender};
+use nix::errno::Errno;
+use std::{
+    fmt::{Debug, Display},
+    future::Future,
+    ptr::NonNull,
+};
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -176,6 +182,68 @@ impl Mthread {
             )
         };
         assert_eq!(rc, 0);
+    }
+
+    /// spawn a future on a core the current thread is running on returning a
+    /// channel which can be awaited. This decouples the SPDK runtime from the
+    /// future runtimes within rust.
+    pub fn spawn_local<F: 'static, R: 'static, E: 'static>(
+        &self,
+        f: F,
+    ) -> Result<Receiver<Result<R, E>>, CoreError>
+    where
+        F: Future<Output = Result<R, E>>,
+        R: Send + Debug,
+        E: Send + Display + Debug,
+    {
+        // context structure which is passed to the callback as argument
+        struct Ctx<F, R, E> {
+            future: F,
+            sender: Option<Sender<Result<R, E>>>,
+        }
+
+        // helper routine to unpack the closure and its arguments
+        extern "C" fn trampoline<F: 'static, R: 'static, E: 'static>(
+            arg: *mut c_void,
+        ) where
+            F: Future<Output = Result<R, E>>,
+            R: Send + Debug,
+            E: Send + Debug,
+        {
+            let mut ctx = unsafe { Box::from_raw(arg as *mut Ctx<F, R, E>) };
+            Reactors::current()
+                .spawn_local(async move {
+                    let result = ctx.future.await;
+                    ctx.sender
+                        .take()
+                        .expect("sender already taken")
+                        .send(result)
+                        .unwrap();
+                })
+                .detach();
+        }
+
+        let (s, r) = channel::<Result<R, E>>();
+
+        let ctx = Box::new(Ctx {
+            future: f,
+            sender: Some(s),
+        });
+
+        let rc = unsafe {
+            spdk_thread_send_msg(
+                self.0.as_ptr(),
+                Some(trampoline::<F, R, E>),
+                Box::into_raw(ctx).cast(),
+            )
+        };
+        if rc != 0 {
+            Err(CoreError::NotSupported {
+                source: Errno::UnknownErrno,
+            })
+        } else {
+            Ok(r)
+        }
     }
 
     /// spawns a thread and setting its affinity to the inverse cpu set of

--- a/mayastor/src/grpc/mod.rs
+++ b/mayastor/src/grpc/mod.rs
@@ -8,9 +8,11 @@ use tonic::{Response, Status};
 pub use server::MayastorGrpcServer;
 
 use crate::{
-    core::{Cores, Reactor},
+    core::{CoreError, Cores, Mthread, Reactor},
     subsys::Config,
 };
+use futures::channel::oneshot::Receiver;
+use std::fmt::{Debug, Display};
 
 fn print_error_chain(err: &dyn std::error::Error) -> String {
     let mut msg = format!("{}", err);
@@ -60,7 +62,6 @@ where
     L: Into<Status> + Error + 'static,
     A: 'static + From<I>,
 {
-    assert_eq!(Cores::current(), Cores::first());
     Reactor::block_on(future)
         .unwrap()
         .map(|r| Response::new(A::from(r)))

--- a/mayastor/src/subsys/nvmf/mod.rs
+++ b/mayastor/src/subsys/nvmf/mod.rs
@@ -93,9 +93,7 @@ impl Nvmf {
         admin_cmd::setup_create_snapshot_hdlr();
 
         if Config::get().nexus_opts.nvmf_enable {
-            NVMF_TGT.with(|tgt| {
-                tgt.borrow_mut().next_state();
-            });
+            NVMF_TGT.with(|tgt| dbg!(tgt.borrow_mut().next_state()));
         } else {
             debug!("nvmf target disabled");
             unsafe { spdk_subsystem_init_next(0) }

--- a/mayastor/tests/thread.rs
+++ b/mayastor/tests/thread.rs
@@ -1,0 +1,22 @@
+use mayastor::core::{MayastorCliArgs, Mthread};
+
+pub mod common;
+use common::MayastorTest;
+use mayastor::nexus_uri::bdev_create;
+
+#[tokio::test]
+async fn thread_tokio() {
+    let args = MayastorCliArgs {
+        reactor_mask: "0x3".into(),
+        ..Default::default()
+    };
+
+    let ms = MayastorTest::new(args);
+
+    let st = Mthread::get_init();
+    let name = "malloc:///malloc0?size_mb=4";
+    let rx = st.spawn_local(async move { bdev_create(name).await });
+    rx.unwrap().await.unwrap().unwrap();
+    drop(ms)
+}
+


### PR DESCRIPTION
This is preparation work to remove the macro's in our gRCP bits.
Functions must run with the context of a thread, which forces us
currently to run the executor on the first core. Follow up changes
will allow for creating additional threads, with no SPDK runtime that
can spawn futures and awaiting them on those threads.

IOW, lets say you have core mask 0x1 -- we will allow tokio to create
its own threads and unaffinitze them, and then use this interface to
spawn futures there who are !Send nor !Sync. The spawn_local() function
added here, returns a futures::oneshot::Receiver<T> which can be awaited
on threads that run somewhere but not on the specified mask.