### PR TITLE
fix: restore pre-commit hook

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -73,6 +73,7 @@ mkShell {
     ${pkgs.lib.optionalString (norust) "cowsay ${norust_moth}"}
     ${pkgs.lib.optionalString (norust) "echo 'Hint: use rustup tool.'"}
     ${pkgs.lib.optionalString (norust) "echo"}
+    pre-commit install
     pre-commit install --hook commit-msg
   '';
 }


### PR DESCRIPTION
Restore the pre-commit hook installation that was inadvertently
removed.

Fixes: 98f8a06b  ("style(lint): lint commit messages")