### PR TITLE
feat(moac): nexus and app must run on the same node if possible

### DIFF
--- a/csi/moac/replica.ts
+++ b/csi/moac/replica.ts
@@ -120,7 +120,7 @@ export class Replica {
         `Failed to set share pcol for replica "${this}": ` + err
       );
     }
-    log.info(`Share pcol for replica "${this}" set to ${share} (${res.uri})`);
+    log.info(`Share pcol for replica "${this}" was set: ${res.uri}`);
     this.share = share;
     this.uri = res.uri;
     this.pool.node.emit('replica', {


### PR DESCRIPTION
This avoids some failure recovery scenarios that would be
difficult to handle otherwise. App and nexus are either both up
or down. If they are down, then k8s restarts the application on a
different node. That triggers unpublish and publish calls that
allow mayastor CSI plugin to move the nexus along with the app to
the new node. In the future, the restriction to run both on the
same node may be lifted once we provide redundancy at the nexus
level.

What users need to do to take advantage of this new code
improving stability? At this time they need to run stateful apps
strictly on storage nodes using any of the provided mechanisms
to influence k8s scheduler decisions (i.e. nodeSelector). In the
future, they won't need to do anything as the node affinity for
apps will be set by the CSI plugin. This will be added in the
followup commit.

Additional losely related change is that storage class parameters
are checked during volume creation rather than later during the
publish to detect errors rather sooner than later.

Resolves: CAS-818