### PR TITLE
test(e2e): set the short commit length

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -71,7 +71,7 @@ def getTag() {
     }
     def tag = sh(
       // using printf to get rid of trailing newline
-      script: "printf \$(git rev-parse --short ${env.GIT_COMMIT})",
+      script: "printf \$(git rev-parse --short=12 ${env.GIT_COMMIT})",
       returnStdout: true
     )
     return tag

--- a/nix/lib/version.nix
+++ b/nix/lib/version.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation {
     cd $src
     vers=`${git}/bin/git tag --points-at HEAD`
     if [ -z "$vers" ]; then
-      vers=`${git}/bin/git rev-parse --short HEAD`
+      vers=`${git}/bin/git rev-parse --short=12 HEAD`
     fi
     echo -n $vers >$out
   '';

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -17,7 +17,7 @@ dockerhub_tag_exists() {
 get_tag() {
   vers=`git tag --points-at HEAD`
   if [ -z "$vers" ]; then
-    vers=`git rev-parse --short HEAD`
+    vers=`git rev-parse --short=12 HEAD`
   fi
   echo -n $vers
 }


### PR DESCRIPTION
The default length of the short commit can vary.
We use this to tag images so need have a definite length.