### PR TITLE
feat(csi): support WaitForFirstConsumer for mayastor volumes

### DIFF
--- a/chart/templates/moac-deployment.yaml
+++ b/chart/templates/moac-deployment.yaml
@@ -20,7 +20,7 @@ spec:
           args:
             - "--v=2"
             - "--csi-address=$(ADDRESS)"
-            - "--feature-gates=Topology=false"
+            - "--feature-gates=Topology=true"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock

--- a/csi/moac/.gitignore
+++ b/csi/moac/.gitignore
@@ -2,6 +2,7 @@
 /proto/
 /result
 /csi.js
+/index.js
 /nexus.js
 /node.js
 /node_operator.js

--- a/csi/moac/crds/mayastorvolume.yaml
+++ b/csi/moac/crds/mayastorvolume.yaml
@@ -35,6 +35,9 @@ spec:
                   description: The number of replicas used for the volume.
                   type: integer
                   minimum: 1
+                local:
+                  description: The app should run on the same node as the nexus.
+                  type: boolean
                 preferredNodes:
                   description: A list of preferred cluster nodes for the volume.
                   type: array

--- a/csi/moac/index.ts
+++ b/csi/moac/index.ts
@@ -1,21 +1,19 @@
-#!/usr/bin/env node
-
 // Main file of our control plane for mayastor.
 // It binds all components together to create a meaningful whole.
 
-'use strict';
-
 const { KubeConfig } = require('client-node-fixed-watcher');
 const yargs = require('yargs');
+
 const logger = require('./logger');
 const Registry = require('./registry');
-const { NodeOperator } = require('./node_operator');
-const { PoolOperator } = require('./pool_operator');
-const { Volumes } = require('./volumes');
-const { VolumeOperator } = require('./volume_operator');
 const ApiServer = require('./rest_api');
-const CsiServer = require('./csi').CsiServer;
 const { MessageBus } = require('./nats');
+
+import { NodeOperator } from './node_operator';
+import { PoolOperator } from './pool_operator';
+import { Volumes } from './volumes';
+import { VolumeOperator } from './volume_operator';
+import { CsiServer } from './csi';
 
 const log = new logger.Logger();
 
@@ -23,7 +21,7 @@ const log = new logger.Logger();
 //
 // @param   {string} [kubefile]    Kube config file.
 // @returns {object}  k8s client object.
-function createKubeConfig (kubefile) {
+function createKubeConfig (kubefile: string): any {
   const kubeConfig = new KubeConfig();
   try {
     if (kubefile) {
@@ -39,14 +37,13 @@ function createKubeConfig (kubefile) {
   return kubeConfig;
 }
 
-async function main () {
-  let apiServer;
-  let poolOper;
-  let volumeOper;
-  let csiNodeOper;
-  let nodeOper;
-  let kubeConfig;
-  let warmupTimer;
+export async function main () {
+  let apiServer: any;
+  let poolOper: PoolOperator;
+  let volumeOper: VolumeOperator;
+  let nodeOper: NodeOperator;
+  let kubeConfig: any;
+  let warmupTimer: NodeJS.Timeout | undefined;
 
   const opts = yargs
     .options({
@@ -130,7 +127,6 @@ async function main () {
     if (volumes) volumes.stop();
     if (!opts.s) {
       if (poolOper) poolOper.stop();
-      if (csiNodeOper) await csiNodeOper.stop();
       if (nodeOper) nodeOper.stop();
     }
     if (messageBus) messageBus.stop();
@@ -206,5 +202,3 @@ async function main () {
     log.info('MOAC is warmed up and ready to 🚀');
   }, warmupSecs * 1000);
 }
-
-main();

--- a/csi/moac/moac
+++ b/csi/moac/moac
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const MAIN_FILE = './index.js';
+
+try {
+  fs.statSync(path.join(__dirname, MAIN_FILE));
+} catch (err) {
+  console.error(`Missing ${MAIN_FILE}. You need to compile the code: "npm run compile"`);
+  process.exit(1);
+}
+
+const { main } = require(MAIN_FILE);
+main();

--- a/csi/moac/package.json
+++ b/csi/moac/package.json
@@ -2,9 +2,9 @@
   "name": "moac",
   "version": "0.1.0",
   "description": "Mayastor's control plane",
-  "main": "index.js",
+  "main": "moac",
   "bin": {
-    "moac": "./index.js",
+    "moac": "./moac",
     "mbus": "./mbus.js"
   },
   "repository": {
@@ -14,10 +14,10 @@
   },
   "scripts": {
     "prepare": "./bundle_protos.sh",
-    "clean": "rm -f csi.js node.js replica.js pool.js nexus.js watcher.js node_operator.js pool_operator.js volume.js volumes.js volume_operator.js workq.js *.js.map",
-    "purge": "rm -rf node_modules proto csi.js node.js replica.js pool.js nexus.js watcher.js node_operator.js pool_operator.js volume.js volumes.js volume_operator.js workq.js *.js.map",
+    "clean": "rm -f csi.js index.js node.js replica.js pool.js nexus.js watcher.js node_operator.js pool_operator.js volume.js volumes.js volume_operator.js workq.js *.js.map",
+    "purge": "rm -rf node_modules proto csi.js index.js node.js replica.js pool.js nexus.js watcher.js node_operator.js pool_operator.js volume.js volumes.js volume_operator.js workq.js *.js.map",
     "compile": "tsc --pretty",
-    "start": "./index.js",
+    "start": "./moac",
     "test": "mocha test/index.js",
     "check": "semistandard --verbose",
     "fix": "semistandard --fix"

--- a/csi/moac/test/event_stream_test.js
+++ b/csi/moac/test/event_stream_test.js
@@ -66,8 +66,24 @@ module.exports = function () {
       )
     ]);
     getVolumeStub.returns([
-      new Volume('volume1', registry, new EventEmitter(), {}),
-      new Volume('volume2', registry, new EventEmitter(), {})
+      new Volume('volume1', registry, new EventEmitter(), {
+        replicaCount: 1,
+        local: true,
+        preferredNodes: [],
+        requiredNodes: [],
+        requiredBytes: 100,
+        limitBytes: 0,
+        protocol: 'nvmf'
+      }),
+      new Volume('volume2', registry, new EventEmitter(), {
+        replicaCount: 1,
+        local: true,
+        preferredNodes: [],
+        requiredNodes: [],
+        requiredBytes: 100,
+        limitBytes: 0,
+        protocol: 'nvmf'
+      })
     ]);
 
     // set low high water mark to test buffered reads

--- a/csi/moac/test/index.js
+++ b/csi/moac/test/index.js
@@ -55,7 +55,7 @@ describe('moac', function () {
     // time when running in docker with FS mounted from non-linux host.
     this.timeout(5000);
 
-    const child = spawn(path.join(__dirname, '..', 'index.js'), [
+    const child = spawn(path.join(__dirname, '..', 'moac'), [
       '-s',
       // NATS does not run but just to verify that the option works
       '--message-bus=127.0.0.1',

--- a/csi/moac/test/volume_operator_test.js
+++ b/csi/moac/test/volume_operator_test.js
@@ -49,6 +49,7 @@ function defaultMeta (uuid) {
 
 const defaultSpec = {
   replicaCount: 1,
+  local: true,
   preferredNodes: ['node1', 'node2'],
   requiredNodes: ['node2'],
   requiredBytes: 100,
@@ -120,6 +121,7 @@ module.exports = function () {
         UUID,
         {
           replicaCount: 3,
+          local: true,
           preferredNodes: ['node1', 'node2'],
           requiredNodes: ['node2'],
           requiredBytes: 100,
@@ -152,6 +154,7 @@ module.exports = function () {
       );
       expect(res.metadata.name).to.equal(UUID);
       expect(res.spec.replicaCount).to.equal(3);
+      expect(res.spec.local).to.be.true();
       expect(res.spec.preferredNodes).to.have.lengthOf(2);
       expect(res.spec.preferredNodes[0]).to.equal('node1');
       expect(res.spec.preferredNodes[1]).to.equal('node2');
@@ -199,6 +202,7 @@ module.exports = function () {
         UUID,
         {
           replicaCount: 3,
+          local: false,
           preferredNodes: ['node1', 'node2'],
           requiredNodes: ['node2'],
           requiredBytes: 100,
@@ -214,6 +218,7 @@ module.exports = function () {
 
       expect(res.metadata.name).to.equal(UUID);
       expect(res.spec.replicaCount).to.equal(3);
+      expect(res.spec.local).to.be.false();
       expect(res.spec.preferredNodes).to.have.lengthOf(2);
       expect(res.spec.preferredNodes[0]).to.equal('node1');
       expect(res.spec.preferredNodes[1]).to.equal('node2');
@@ -231,6 +236,7 @@ module.exports = function () {
     it('should create mayastor volume without status', () => {
       const res = createVolumeResource(UUID, {
         replicaCount: 3,
+        local: true,
         preferredNodes: ['node1', 'node2'],
         requiredNodes: ['node2'],
         requiredBytes: 100,
@@ -247,6 +253,7 @@ module.exports = function () {
       });
       expect(res.metadata.name).to.equal(UUID);
       expect(res.spec.replicaCount).to.equal(1);
+      expect(res.spec.local).to.be.false();
       expect(res.spec.preferredNodes).to.have.lengthOf(0);
       expect(res.spec.requiredNodes).to.have.lengthOf(0);
       expect(res.spec.requiredBytes).to.equal(100);
@@ -257,6 +264,7 @@ module.exports = function () {
     it('should throw if requiredSize is missing', () => {
       expect(() => createVolumeResource(UUID, {
         replicaCount: 3,
+        local: true,
         preferredNodes: ['node1', 'node2'],
         requiredNodes: ['node2'],
         limitBytes: 120
@@ -266,6 +274,7 @@ module.exports = function () {
     it('should throw if UUID is invalid', () => {
       expect(() => createVolumeResource('blabla', {
         replicaCount: 3,
+        local: true,
         preferredNodes: ['node1', 'node2'],
         requiredNodes: ['node2'],
         requiredBytes: 100,
@@ -449,6 +458,7 @@ module.exports = function () {
         UUID,
         {
           replicaCount: 3,
+          local: true,
           preferredNodes: ['node1'],
           requiredNodes: [],
           requiredBytes: 90,
@@ -468,11 +478,12 @@ module.exports = function () {
       await sleep(EVENT_PROPAGATION_DELAY);
 
       sinon.assert.calledOnce(fsaStub);
-      expect(volume.replicaCount).to.equal(3);
-      expect(volume.preferredNodes).to.have.lengthOf(1);
-      expect(volume.requiredNodes).to.have.lengthOf(0);
-      expect(volume.requiredBytes).to.equal(90);
-      expect(volume.limitBytes).to.equal(130);
+      expect(volume.spec.replicaCount).to.equal(3);
+      expect(volume.spec.local).to.be.true();
+      expect(volume.spec.preferredNodes).to.have.lengthOf(1);
+      expect(volume.spec.requiredNodes).to.have.lengthOf(0);
+      expect(volume.spec.requiredBytes).to.equal(90);
+      expect(volume.spec.limitBytes).to.equal(130);
     });
 
     it('should not crash if update volume fails upon "mod" event', async () => {
@@ -497,6 +508,7 @@ module.exports = function () {
         UUID,
         {
           replicaCount: 3,
+          local: true,
           preferredNodes: ['node1'],
           requiredNodes: [],
           requiredBytes: 111,
@@ -516,9 +528,9 @@ module.exports = function () {
       await sleep(EVENT_PROPAGATION_DELAY);
 
       sinon.assert.notCalled(fsaStub);
-      expect(volume.replicaCount).to.equal(1);
-      expect(volume.requiredBytes).to.equal(100);
-      expect(volume.limitBytes).to.equal(120);
+      expect(volume.spec.replicaCount).to.equal(1);
+      expect(volume.spec.requiredBytes).to.equal(100);
+      expect(volume.spec.limitBytes).to.equal(120);
     });
 
     it('should not do anything if volume params stay the same upon "mod" event', async () => {
@@ -703,6 +715,7 @@ module.exports = function () {
 
       const newSpec = {
         replicaCount: 3,
+        local: true,
         preferredNodes: [],
         requiredNodes: [],
         requiredBytes: 90,
@@ -762,6 +775,7 @@ module.exports = function () {
 
       const newSpec = {
         replicaCount: 3,
+        local: true,
         preferredNodes: [],
         requiredNodes: [],
         requiredBytes: 90,
@@ -792,6 +806,7 @@ module.exports = function () {
 
       const newSpec = {
         replicaCount: 3,
+        local: true,
         preferredNodes: [],
         requiredNodes: [],
         requiredBytes: 90,

--- a/csi/moac/tsconfig.json
+++ b/csi/moac/tsconfig.json
@@ -62,6 +62,7 @@
   },
   "files": [
     "csi.ts",
+    "index.ts",
     "nexus.ts",
     "node.ts",
     "node_operator.ts",

--- a/csi/moac/volumes.ts
+++ b/csi/moac/volumes.ts
@@ -2,7 +2,7 @@
 
 import assert from 'assert';
 import events = require('events');
-import { Volume, VolumeState } from './volume';
+import { Volume, VolumeSpec, VolumeState } from './volume';
 import { Workq } from './workq';
 import { VolumeStatus } from './volume_operator';
 
@@ -13,7 +13,7 @@ const log = require('./logger').Logger('volumes');
 // Type used in "create volume" workq
 type CreateArgs = {
   uuid: string;
-  spec: any;
+  spec: VolumeSpec;
 }
 
 // Volume manager that emit events for new/modified/deleted volumes.
@@ -108,7 +108,7 @@ export class Volumes extends events.EventEmitter {
   // @params  {number}   spec.limitBytes      The volume should not be bigger than this.
   // @params  {string}   spec.protocol        The share protocol for the nexus.
   // @returns {object}   New volume object.
-  async createVolume(uuid: string, spec: any): Promise<Volume> {
+  async createVolume(uuid: string, spec: VolumeSpec): Promise<Volume> {
     return await this.createWorkq.push({uuid, spec}, (args: CreateArgs) => {
       return this._createVolume(args.uuid, args.spec);
     });
@@ -118,7 +118,7 @@ export class Volumes extends events.EventEmitter {
   // of volumes. The method is idempotent. If a volume with the same uuid
   // already exists, then update its parameters.
   //
-  async _createVolume(uuid: string, spec: any): Promise<Volume> {
+  async _createVolume(uuid: string, spec: VolumeSpec): Promise<Volume> {
     if (!spec.requiredBytes || spec.requiredBytes < 0) {
       throw new GrpcError(
         GrpcCode.INVALID_ARGUMENT,
@@ -187,7 +187,7 @@ export class Volumes extends events.EventEmitter {
   // @params  {string}    status.targetNodes   Node(s) where the volume is published.
   // @returns {object} New volume object.
   //
-  importVolume(uuid: string, spec: any, status?: VolumeStatus): Volume {
+  importVolume(uuid: string, spec: VolumeSpec, status?: VolumeStatus): Volume {
     let volume = this.volumes[uuid];
 
     if (volume) {

--- a/deploy/fio.yaml
+++ b/deploy/fio.yaml
@@ -3,6 +3,9 @@ apiVersion: v1
 metadata:
   name: fio
 spec:
+  # Run on a storage node so that the nexus is local to the app
+  nodeSelector:
+    openebs.io/engine: mayastor
   volumes:
     - name: ms-volume
       persistentVolumeClaim:

--- a/deploy/moac-deployment.yaml
+++ b/deploy/moac-deployment.yaml
@@ -22,7 +22,8 @@ spec:
           args:
             - "--v=2"
             - "--csi-address=$(ADDRESS)"
-            - "--feature-gates=Topology=false"
+            - "--feature-gates=Topology=true"
+            - "--strict-topology=false"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock

--- a/deploy/storage-class.yaml
+++ b/deploy/storage-class.yaml
@@ -1,3 +1,4 @@
+---
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
@@ -5,7 +6,9 @@ metadata:
 parameters:
   repl: '1'
   protocol: 'iscsi'
+  local: 'yes'
 provisioner: io.openebs.csi-mayastor
+volumeBindingMode: WaitForFirstConsumer
 ---
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
@@ -14,5 +17,18 @@ metadata:
 parameters:
   repl: '1'
   protocol: 'nvmf'
-  ioTimeout: 32
+  ioTimeout: '30'
+  local: 'yes'
 provisioner: io.openebs.csi-mayastor
+volumeBindingMode: WaitForFirstConsumer
+---
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: mayastor-nvmf-3
+parameters:
+  repl: '3'
+  protocol: 'nvmf'
+  ioTimeout: '30'
+provisioner: io.openebs.csi-mayastor
+volumeBindingMode: WaitForFirstConsumer

--- a/test/grpc/test_csi.js
+++ b/test/grpc/test_csi.js
@@ -317,10 +317,11 @@ describe('csi', function () {
           'mayastor://' + common.CSI_ID
         );
 
-        assert.isAbove(
+        // until we decide otherwise
+        assert.equal(
           parseInt(res.max_volumes_per_node, 10),
-          1,
-          'number of nbd devices should be above 1'
+          0,
+          'unlimited number of devices on the node'
         );
         done();
       });
@@ -409,7 +410,7 @@ function csiProtocolTest (protoName, shareType, timeoutMillis) {
           volume_id: UUID1,
           publish_context: {
             uri: publishedUris[UUID1].uri,
-            ioTimeout: '33',
+            ioTimeout: '33'
           },
           staging_target_path: mountTarget,
           volume_capability: {
@@ -447,10 +448,10 @@ function csiProtocolTest (protoName, shareType, timeoutMillis) {
           assert.equal(getFsType(mountTarget), 'xfs');
           // Other protocols than NVMF do not honor ioTimeout setting
           if (protoName !== 'NVMF') return done();
-          let major = getFsDevice(mountTarget).match(/nvme(\d+)n1/)[1];
+          const major = getFsDevice(mountTarget).match(/nvme(\d+)n1/)[1];
           glob(`/sys/class/nvme/nvme${major}/nvme*n1/queue/io_timeout`, (err, paths) => {
             if (err) return done(err);
-            let path = paths[0];
+            const path = paths[0];
             assert(path, `Path "${path}" not found`);
             fs.readFile(path, (err, data) => {
               if (err) return done(err);


### PR DESCRIPTION
We want to support late binding of mayastor volumes because we can
optimize distribution of the volume over the nodes. In particular we
can enforce that the nexus and one of the replicas is created on
the same node as the app when creating the volume.

There is a new storage class parameter "local" that enforces the
locality if set to true (the default in our storage class yaml).
If it is not possible to schedule the app on the same node as nexus
and replica and "local" is enabled, then the pod remains in
unscheduleable state until the user rectifies the situation.

There is one downside of local volumes though. Once the node
affinity is set during the volume creation it cannot be changed
later. Assuming that all nodes holding original replicas of the
volume would be removed from the cluster, then the app becomes
unschedulable although that the replicas might have been migrated
to new nodes already.

Convert index.js to typescript to catch more errors in the file and
provide simple moac script that calls index.ts:main().

Resolves: CAS-834