### PR TITLE
fix(nexus): remove alias from bdevs that are local

### DIFF
--- a/mayastor/src/bdev/loopback.rs
+++ b/mayastor/src/bdev/loopback.rs
@@ -91,6 +91,9 @@ impl CreateDestroy for Loopback {
         if let Some(child) = lookup_nexus_child(&self.name) {
             child.remove();
         }
+        if let Some(bdev) = Bdev::lookup_by_name(&self.name) {
+            bdev.remove_alias(&self.alias);
+        }
         Ok(())
     }
 }

--- a/mayastor/src/grpc/mayastor_grpc.rs
+++ b/mayastor/src/grpc/mayastor_grpc.rs
@@ -8,10 +8,8 @@
 //! grpc perspective we provide. Also, by doing his, we can test the methods
 //! without the need for setting up a grpc client.
 
-use tonic::{Request, Response, Status};
-use tracing::instrument;
-
 use ::rpc::mayastor::*;
+use tonic::{Request, Response, Status};
 
 use crate::{
     bdev::{
@@ -41,8 +39,6 @@ pub struct MayastorSvc;
 
 #[tonic::async_trait]
 impl mayastor_server::Mayastor for MayastorSvc {
-    #[instrument(level = "debug", err)]
-
     async fn create_pool(
         &self,
         request: Request<CreatePoolRequest>,
@@ -56,7 +52,6 @@ impl mayastor_server::Mayastor for MayastorSvc {
         sync_config(pool_grpc::create(args)).await
     }
 
-    #[instrument(level = "debug", err)]
     async fn destroy_pool(
         &self,
         request: Request<DestroyPoolRequest>,
@@ -65,7 +60,6 @@ impl mayastor_server::Mayastor for MayastorSvc {
         sync_config(pool_grpc::destroy(args)).await
     }
 
-    #[instrument(level = "debug", err)]
     async fn list_pools(
         &self,
         _request: Request<Null>,
@@ -73,7 +67,6 @@ impl mayastor_server::Mayastor for MayastorSvc {
         pool_grpc::list()
     }
 
-    #[instrument(level = "debug", err)]
     async fn create_replica(
         &self,
         request: Request<CreateReplicaRequest>,
@@ -82,7 +75,6 @@ impl mayastor_server::Mayastor for MayastorSvc {
         sync_config(pool_grpc::create_replica(args)).await
     }
 
-    #[instrument(level = "debug", err)]
     async fn destroy_replica(
         &self,
         request: Request<DestroyReplicaRequest>,
@@ -91,7 +83,6 @@ impl mayastor_server::Mayastor for MayastorSvc {
         sync_config(pool_grpc::destroy_replica(args)).await
     }
 
-    #[instrument(level = "debug", err)]
     async fn list_replicas(
         &self,
         _request: Request<Null>,
@@ -99,7 +90,6 @@ impl mayastor_server::Mayastor for MayastorSvc {
         pool_grpc::list_replicas()
     }
 
-    #[instrument(level = "debug", err)]
     // TODO; lost track of what this is supposed to do
     async fn stat_replicas(
         &self,
@@ -108,7 +98,6 @@ impl mayastor_server::Mayastor for MayastorSvc {
         pool_grpc::stat_replica().await
     }
 
-    #[instrument(level = "debug", err)]
     async fn share_replica(
         &self,
         request: Request<ShareReplicaRequest>,
@@ -117,7 +106,6 @@ impl mayastor_server::Mayastor for MayastorSvc {
         sync_config(pool_grpc::share_replica(args)).await
     }
 
-    #[instrument(level = "info", err)]
     async fn create_nexus(
         &self,
         request: Request<CreateNexusRequest>,
@@ -135,7 +123,6 @@ impl mayastor_server::Mayastor for MayastorSvc {
         }).await
     }
 
-    #[instrument(level = "debug", err)]
     async fn destroy_nexus(
         &self,
         request: Request<DestroyNexusRequest>,
@@ -151,7 +138,6 @@ impl mayastor_server::Mayastor for MayastorSvc {
         .await
     }
 
-    #[instrument(level = "debug", err)]
     async fn list_nexus(
         &self,
         request: Request<Null>,
@@ -168,7 +154,6 @@ impl mayastor_server::Mayastor for MayastorSvc {
         Ok(Response::new(reply))
     }
 
-    #[instrument(level = "debug", err)]
     async fn add_child_nexus(
         &self,
         request: Request<AddChildNexusRequest>,
@@ -187,7 +172,6 @@ impl mayastor_server::Mayastor for MayastorSvc {
         .await
     }
 
-    #[instrument(level = "debug", err)]
     async fn remove_child_nexus(
         &self,
         request: Request<RemoveChildNexusRequest>,
@@ -206,7 +190,6 @@ impl mayastor_server::Mayastor for MayastorSvc {
         .await
     }
 
-    #[instrument(level = "debug", err)]
     async fn fault_nexus_child(
         &self,
         request: Request<FaultNexusChildRequest>,
@@ -226,7 +209,6 @@ impl mayastor_server::Mayastor for MayastorSvc {
         .await
     }
 
-    #[instrument(level = "debug", err)]
     async fn publish_nexus(
         &self,
         request: Request<PublishNexusRequest>,
@@ -270,7 +252,6 @@ impl mayastor_server::Mayastor for MayastorSvc {
         .await
     }
 
-    #[instrument(level = "debug", err)]
     async fn unpublish_nexus(
         &self,
         request: Request<UnpublishNexusRequest>,
@@ -289,7 +270,6 @@ impl mayastor_server::Mayastor for MayastorSvc {
         .await
     }
 
-    #[instrument(level = "debug", err)]
     async fn get_nvme_ana_state(
         &self,
         request: Request<GetNvmeAnaStateRequest>,
@@ -308,7 +288,6 @@ impl mayastor_server::Mayastor for MayastorSvc {
         }))
     }
 
-    #[instrument(level = "debug", err)]
     async fn set_nvme_ana_state(
         &self,
         request: Request<SetNvmeAnaStateRequest>,
@@ -335,7 +314,6 @@ impl mayastor_server::Mayastor for MayastorSvc {
         Ok(Response::new(Null {}))
     }
 
-    #[instrument(level = "debug", err)]
     async fn child_operation(
         &self,
         request: Request<ChildNexusRequest>,
@@ -364,7 +342,6 @@ impl mayastor_server::Mayastor for MayastorSvc {
         .await
     }
 
-    #[instrument(level = "debug", err)]
     async fn start_rebuild(
         &self,
         request: Request<StartRebuildRequest>,
@@ -378,7 +355,6 @@ impl mayastor_server::Mayastor for MayastorSvc {
         Ok(Response::new(Null {}))
     }
 
-    #[instrument(level = "debug", err)]
     async fn stop_rebuild(
         &self,
         request: Request<StopRebuildRequest>,
@@ -392,7 +368,6 @@ impl mayastor_server::Mayastor for MayastorSvc {
         Ok(Response::new(Null {}))
     }
 
-    #[instrument(level = "debug", err)]
     async fn pause_rebuild(
         &self,
         request: Request<PauseRebuildRequest>,
@@ -405,7 +380,6 @@ impl mayastor_server::Mayastor for MayastorSvc {
         Ok(Response::new(Null {}))
     }
 
-    #[instrument(level = "debug", err)]
     async fn resume_rebuild(
         &self,
         request: Request<ResumeRebuildRequest>,
@@ -418,7 +392,6 @@ impl mayastor_server::Mayastor for MayastorSvc {
         Ok(Response::new(Null {}))
     }
 
-    #[instrument(level = "debug", err)]
     async fn get_rebuild_state(
         &self,
         request: Request<RebuildStateRequest>,
@@ -430,7 +403,6 @@ impl mayastor_server::Mayastor for MayastorSvc {
         }}))
     }
 
-    #[instrument(level = "debug", err)]
     async fn get_rebuild_stats(
         &self,
         request: Request<RebuildStatsRequest>,
@@ -442,7 +414,6 @@ impl mayastor_server::Mayastor for MayastorSvc {
         }}))
     }
 
-    #[instrument(level = "debug", err)]
     async fn get_rebuild_progress(
         &self,
         request: Request<RebuildProgressRequest>,
@@ -454,7 +425,6 @@ impl mayastor_server::Mayastor for MayastorSvc {
         }}))
     }
 
-    #[instrument(level = "debug", err)]
     async fn create_snapshot(
         &self,
         request: Request<CreateSnapshotRequest>,
@@ -473,7 +443,6 @@ impl mayastor_server::Mayastor for MayastorSvc {
         .await
     }
 
-    #[instrument(level = "debug", err)]
     async fn list_block_devices(
         &self,
         request: Request<ListBlockDevicesRequest>,
@@ -486,7 +455,6 @@ impl mayastor_server::Mayastor for MayastorSvc {
         Ok(Response::new(reply))
     }
 
-    #[instrument(level = "debug", err)]
     async fn get_resource_usage(
         &self,
         _request: Request<Null>,

--- a/mayastor/tests/nexus_with_local.rs
+++ b/mayastor/tests/nexus_with_local.rs
@@ -1,0 +1,129 @@
+pub mod common;
+use common::compose::Builder;
+use composer::{Binary, RpcHandle};
+
+use rpc::mayastor::{
+    AddChildNexusRequest,
+    BdevUri,
+    CreateNexusRequest,
+    CreatePoolRequest,
+    CreateReplicaRequest,
+    Null,
+    RemoveChildNexusRequest,
+};
+
+fn uuid() -> String {
+    "cdc2a7db-3ac3-403a-af80-7fadc1581c47".to_string()
+}
+
+fn pool() -> String {
+    "tpool".to_string()
+}
+
+async fn create_replicas(h: &mut RpcHandle) {
+    h.mayastor
+        .create_pool(CreatePoolRequest {
+            name: pool(),
+            disks: vec!["malloc:///disk0?size_mb=64".into()],
+        })
+        .await
+        .unwrap();
+
+    h.mayastor
+        .create_replica(CreateReplicaRequest {
+            uuid: uuid(),
+            pool: pool(),
+            size: 8 * 1024 * 1024,
+            thin: false,
+            share: 1,
+        })
+        .await
+        .unwrap();
+}
+
+async fn check_aliases(h: &mut RpcHandle, present: bool) {
+    let bdevs = h.bdev.list(Null {}).await.unwrap().into_inner();
+    assert_eq!(
+        bdevs
+            .bdevs
+            .into_iter()
+            .any(|b| b.aliases.contains("bdev:///")),
+        present
+    );
+}
+
+async fn create_nexus(h: &mut RpcHandle, children: Vec<String>) {
+    h.mayastor
+        .create_nexus(CreateNexusRequest {
+            uuid: uuid(),
+            size: 4 * 1024 * 1024,
+            children,
+        })
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn nexus_with_local() {
+    let test = Builder::new()
+        .name("cargo-test")
+        .network("10.1.0.0/16")
+        .with_default_tracing()
+        .add_container_bin(
+            "ms1",
+            Binary::from_dbg("mayastor").with_args(vec!["-l", "1"]),
+        )
+        .add_container_bin(
+            "ms2",
+            Binary::from_dbg("mayastor").with_args(vec!["-l", "2"]),
+        )
+        .with_clean(true)
+        .build()
+        .await
+        .unwrap();
+
+    let mut ms1 = test.grpc_handle("ms1").await.unwrap();
+    let mut ms2 = test.grpc_handle("ms2").await.unwrap();
+    // create and share a bdev on each container
+    create_replicas(&mut ms1).await;
+    create_replicas(&mut ms2).await;
+
+    let children = vec![
+        format!("bdev:///{}", uuid()),
+        format!(
+            "nvmf://{}/nqn.2019-05.io.openebs:{}",
+            ms2.endpoint.ip(),
+            uuid()
+        ),
+    ];
+
+    create_nexus(&mut ms1, children).await;
+    check_aliases(&mut ms1, true).await;
+
+    ms1.mayastor
+        .remove_child_nexus(RemoveChildNexusRequest {
+            uri: format!("bdev:///{}", uuid()),
+            uuid: uuid(),
+        })
+        .await
+        .unwrap();
+
+    check_aliases(&mut ms1, false).await;
+
+    ms1.mayastor
+        .add_child_nexus(AddChildNexusRequest {
+            uri: format!("bdev:///{}", uuid()),
+            uuid: uuid(),
+            norebuild: false,
+        })
+        .await
+        .unwrap();
+
+    check_aliases(&mut ms1, true).await;
+    ms1.bdev
+        .destroy(BdevUri {
+            uri: format!("bdev:///{}", uuid()),
+        })
+        .await
+        .unwrap();
+}


### PR DESCRIPTION
If the alias we try to set, is present, we return true rather then
failing the operation.

If the bdev is destroyed, we remove the URI from the alias.

While debugging this i've also decided to remove the tracing
of yield points as they make the calls to noise and have no
real value