### PR TITLE
fix(mayastor): replicas are reported incorrectly for multiple pools

### DIFF
--- a/mayastor/src/subsys/config/mod.rs
+++ b/mayastor/src/subsys/config/mod.rs
@@ -294,18 +294,20 @@ impl Config {
         let pools = PoolsIter::new()
             .map(|p| {
                 let base = p.get_base_bdev();
+                let name = p.get_name();
                 Pool {
-                    name: p.get_name().into(),
+                    name: name.to_string(),
                     disks: vec![base.bdev_uri().unwrap_or_else(|| base.name())],
                     replicas: ReplicaIter::new()
-                        .map(|p| Replica {
-                            name: p.get_uuid().to_string(),
-                            share: p.get_share_type(),
+                        .filter(|r| r.get_pool_name() == name)
+                        .map(|r| Replica {
+                            name: r.get_uuid().to_string(),
+                            share: r.get_share_type(),
                         })
-                        .collect::<Vec<_>>(),
+                        .collect(),
                 }
             })
-            .collect::<Vec<_>>();
+            .collect();
 
         current.pools = Some(pools);
 


### PR DESCRIPTION
BUG
If mayastore has multiple pools defined then, in the mayastore YAML config file,
all defined replicas are reported multiple times as belonging to each and every pool.

FIX
Each replica is now reported precisely once under the pool to which it belongs.