### PR TITLE
feat(nexus): register an NVMe reservation on adding a child

### DIFF
--- a/mayastor/src/bdev/nexus/nexus_bdev_children.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev_children.rs
@@ -177,6 +177,11 @@ impl Nexus {
                 // completed the device can transition to online
                 info!("{}: child opened successfully {}", self.name, name);
 
+                // FIXME: use dummy key for now
+                if let Err(e) = child.resv_register(0x12345678).await {
+                    error!("Failed to register key with child: {}", e);
+                }
+
                 // it can never take part in the IO path
                 // of the nexus until it's rebuilt from a healthy child.
                 child.fault(Reason::OutOfSync).await;
@@ -469,6 +474,16 @@ impl Nexus {
             return Err(Error::NexusIncomplete {
                 name: self.name.clone(),
             });
+        }
+
+        // FIXME: use dummy key for now
+        for c in &self.children {
+            if let Err(e) = c.resv_register(0x12345678).await {
+                error!(
+                    "{}: child {} failed to register key {}",
+                    self.name, c.name, e
+                );
+            }
         }
 
         self.children

--- a/mayastor/src/bdev/nvmx/controller.rs
+++ b/mayastor/src/bdev/nvmx/controller.rs
@@ -44,7 +44,12 @@ use crate::{
         },
         nvme_bdev_running_config,
         uri::NvmeControllerContext,
-        utils::{nvme_cpl_succeeded, NvmeAerInfoNotice, NvmeAerType},
+        utils::{
+            nvme_cpl_succeeded,
+            NvmeAerInfoNotice,
+            NvmeAerInfoNvmCommandSet,
+            NvmeAerType,
+        },
         NvmeControllerState,
         NvmeControllerState::*,
         NvmeNamespace,
@@ -773,6 +778,10 @@ extern "C" fn aer_cb(ctx: *mut c_void, cpl: *const spdk_nvme_cpl) {
                 );
             }
         }
+    } else if event_type == NvmeAerType::Io as u32
+        && event_info == NvmeAerInfoNvmCommandSet::ReservationLogAvail as u32
+    {
+        info!("Reservation log available");
     }
 }
 

--- a/mayastor/src/bdev/nvmx/utils.rs
+++ b/mayastor/src/bdev/nvmx/utils.rs
@@ -23,11 +23,18 @@ pub enum NvmeAerType {
     Error = 0x0,
     Smart = 0x1,
     Notice = 0x2,
+    Io = 0x6,
+    Vendor = 0x7,
 }
 
 #[derive(Debug, PartialEq)]
 pub enum NvmeAerInfoNotice {
     AttrChanged = 0x0,
+}
+
+#[derive(Debug, PartialEq)]
+pub enum NvmeAerInfoNvmCommandSet {
+    ReservationLogAvail = 0x0,
 }
 
 /// Check if the Completion Queue Entry indicates abnormal termination of

--- a/mayastor/src/core/mod.rs
+++ b/mayastor/src/core/mod.rs
@@ -37,6 +37,7 @@ pub use bio::{Bio, IoStatus, IoType};
 pub use handle::BdevHandle;
 pub use nvme::{
     nvme_admin_opc,
+    nvme_nvm_opcode,
     GenericStatusCode,
     NvmeCommandStatus,
     NvmeStatus,
@@ -105,11 +106,15 @@ pub enum CoreError {
         offset: u64,
         len: u64,
     },
-    #[snafu(display("Failed to dispatch reset",))]
+    #[snafu(display("Failed to dispatch reset: {}", source))]
     ResetDispatch {
         source: Errno,
     },
-    #[snafu(display("Failed to dispatch NVMe Admin command {:x}h", opcode))]
+    #[snafu(display(
+        "Failed to dispatch NVMe Admin command {:x}h: {}",
+        opcode,
+        source
+    ))]
     NvmeAdminDispatch {
         source: Errno,
         opcode: u16,
@@ -123,6 +128,15 @@ pub enum CoreError {
         source: Errno,
         offset: u64,
         len: u64,
+    },
+    #[snafu(display(
+        "Failed to dispatch NVMe IO passthru command {:x}h: {}",
+        opcode,
+        source
+    ))]
+    NvmeIoPassthruDispatch {
+        source: Errno,
+        opcode: u16,
     },
     #[snafu(display("Write failed at offset {} length {}", offset, len))]
     WriteFailed {
@@ -138,6 +152,10 @@ pub enum CoreError {
     ResetFailed {},
     #[snafu(display("NVMe Admin command {:x}h failed", opcode))]
     NvmeAdminFailed {
+        opcode: u16,
+    },
+    #[snafu(display("NVMe IO Passthru command {:x}h failed", opcode))]
+    NvmeIoPassthruFailed {
         opcode: u16,
     },
     #[snafu(display("failed to share {}", source))]

--- a/mayastor/src/core/nvme.rs
+++ b/mayastor/src/core/nvme.rs
@@ -63,6 +63,13 @@ pub enum GenericStatusCode {
     CommandAbortPreemt,
     SanitizeFailed,
     SanitizeInProgress,
+    SGLDataBlockGranularityInvalid,
+    CommandInvalidInCMB,
+    LBAOutOfRange,
+    CapacityExceeded,
+    NamespaceNotReady,
+    ReservationConflict,
+    FormatInProgress,
     Reserved,
 }
 #[derive(Debug, Copy, Clone, Eq, PartialOrd, PartialEq)]
@@ -107,8 +114,15 @@ impl From<i32> for GenericStatusCode {
             0x1B => Self::CommandAbortPreemt,
             0x1C => Self::SanitizeFailed,
             0x1D => Self::SanitizeInProgress,
+            0x1E => Self::SGLDataBlockGranularityInvalid,
+            0x1F => Self::CommandInvalidInCMB,
+            0x80 => Self::LBAOutOfRange,
+            0x81 => Self::CapacityExceeded,
+            0x82 => Self::NamespaceNotReady,
+            0x83 => Self::ReservationConflict,
+            0x84 => Self::FormatInProgress,
             _ => {
-                error!("unknown code {}", i);
+                error!("unknown code {:x}", i);
                 Self::Reserved
             }
         }
@@ -211,6 +225,21 @@ pub mod nvme_admin_opc {
     // pub const GET_FEATURES: u8 = 0x0a;
     // Vendor-specific
     pub const CREATE_SNAPSHOT: u8 = 0xc0;
+}
+
+/// NVM command set opcodes, from nvme_spec.h
+pub mod nvme_nvm_opcode {
+    // pub const FLUSH: u8 = 0x00;
+    // pub const WRITE: u8 = 0x01;
+    // pub const READ: u8 = 0x02;
+    // pub const WRITE_UNCORRECTABLE: u8 = 0x04;
+    // pub const COMPARE: u8 = 0x05;
+    // pub const WRITE_ZEROES: u8 = 0x08;
+    // pub const DATASET_MANAGEMENT: u8 = 0x09;
+    pub const RESERVATION_REGISTER: u8 = 0x0d;
+    // pub const RESERVATION_REPORT: u8 = 0x0e;
+    // pub const RESERVATION_ACQUIRE: u8 = 0x11;
+    // pub const RESERVATION_RELEASE: u8 = 0x15;
 }
 
 impl NvmeCommandStatus {

--- a/mayastor/tests/nexus_multipath.rs
+++ b/mayastor/tests/nexus_multipath.rs
@@ -21,6 +21,23 @@ static POOL_NAME: &str = "tpool";
 static UUID: &str = "cdc2a7db-3ac3-403a-af80-7fadc1581c47";
 static HOSTNQN: &str = "nqn.2019-05.io.openebs";
 
+fn get_mayastor_nvme_device() -> String {
+    let output_list = Command::new("nvme").args(&["list"]).output().unwrap();
+    assert!(
+        output_list.status.success(),
+        "failed to list nvme devices, {}",
+        output_list.status
+    );
+    let sl = String::from_utf8(output_list.stdout).unwrap();
+    let nvmems: Vec<&str> = sl
+        .lines()
+        .filter(|line| line.contains("Mayastor NVMe controller"))
+        .collect();
+    assert_eq!(nvmems.len(), 1);
+    let ns = nvmems[0].split(' ').collect::<Vec<_>>()[0];
+    ns.to_string()
+}
+
 #[tokio::test]
 async fn nexus_multipath() {
     std::env::set_var("NEXUS_NVMF_ANA_ENABLE", "1");
@@ -141,19 +158,7 @@ async fn nexus_multipath() {
         );
     }
 
-    let output_list = Command::new("nvme").args(&["list"]).output().unwrap();
-    assert!(
-        output_list.status.success(),
-        "failed to list nvme devices, {}",
-        output_list.status
-    );
-    let sl = String::from_utf8(output_list.stdout).unwrap();
-    let nvmems: Vec<&str> = sl
-        .lines()
-        .filter(|line| line.contains("Mayastor NVMe controller"))
-        .collect();
-    assert_eq!(nvmems.len(), 1);
-    let ns = nvmems[0].split(' ').collect::<Vec<_>>()[0];
+    let ns = get_mayastor_nvme_device();
 
     mayastor
         .spawn(async move {
@@ -204,4 +209,67 @@ async fn nexus_multipath() {
     assert_eq!(v[1], "disconnected");
     assert_eq!(v[0], format!("NQN:{}", &nqn), "mismatched NQN disconnected");
     assert_eq!(v[2], "2", "mismatched number of controllers disconnected");
+
+    // Connect to remote replica to check key registered
+    let rep_nqn = format!("{}:{}", HOSTNQN, UUID);
+    let status = Command::new("nvme")
+        .args(&["connect"])
+        .args(&["-t", "tcp"])
+        .args(&["-a", &ip0.to_string()])
+        .args(&["-s", "8420"])
+        .args(&["-n", &rep_nqn])
+        .status()
+        .unwrap();
+    assert!(
+        status.success(),
+        "failed to connect to remote replica, {}",
+        status
+    );
+
+    let rep_dev = get_mayastor_nvme_device();
+
+    let output_resv = Command::new("nvme")
+        .args(&["resv-report"])
+        .args(&[rep_dev])
+        .args(&["-c", "1"])
+        .args(&["-o", "json"])
+        .output()
+        .unwrap();
+    assert!(
+        output_resv.status.success(),
+        "failed to get reservation report from remote replica, {}",
+        output_resv.status
+    );
+    let resv_rep = String::from_utf8(output_resv.stdout).unwrap();
+    let v: serde_json::Value =
+        serde_json::from_str(&resv_rep).expect("JSON was not well-formatted");
+    assert_eq!(v["rtype"], 0, "should have no reservation type");
+    assert_eq!(v["regctl"], 1, "should have 1 registered controller");
+    assert_eq!(
+        v["ptpls"], 0,
+        "should have Persist Through Power Loss State as 0"
+    );
+    assert_eq!(
+        v["regctlext"][0]["cntlid"], 0xffff,
+        "should have dynamic controller ID"
+    );
+    assert_eq!(
+        v["regctlext"][0]["rcsts"], 0,
+        "should have reservation status as no reservation"
+    );
+    assert_eq!(
+        v["regctlext"][0]["rkey"], 0x12345678,
+        "should have default registered key"
+    );
+
+    let output_dis2 = Command::new("nvme")
+        .args(&["disconnect"])
+        .args(&["-n", &rep_nqn])
+        .output()
+        .unwrap();
+    assert!(
+        output_dis2.status.success(),
+        "failed to disconnect from remote replica, {}",
+        output_dis2.status
+    );
 }


### PR DESCRIPTION
Implement NexusChild::resv_register() which sends an NVMe
Reservation Register command as an NVMe IO Passthru command via
BlockDeviceHandle::{nvme_resv_register,io_passthru} when adding a
new child or when creating a nexus with children, though only to NVMe
child devices.

Add a Rust integration test, tacked on to nexus_multipath as that
already sets up a remote child, to verify that the key has been
registered.

Use a hard-coded key for now as this just lays the groundwork for
subsequent commits to acquire the reservation.

Fixes CAS-849