### PR TITLE
fix(nexus): io completed in case of submission errors

### DIFF
--- a/mayastor/src/bdev/nexus/nexus_io.rs
+++ b/mayastor/src/bdev/nexus/nexus_io.rs
@@ -339,9 +339,14 @@ impl NexusBio {
     fn do_readv(&mut self) -> Result<(), CoreError> {
         if let Some(i) = self.inner_channel().child_select() {
             let hdl = self.read_channel_at_index(i);
-            self.submit_read(hdl).map(|_| {
-                self.ctx_as_mut().in_flight += 1;
-            })
+            self.submit_read(hdl)
+                .map(|_| {
+                    self.ctx_as_mut().in_flight += 1;
+                })
+                .map_err(|e| {
+                    self.fail();
+                    e
+                })
         } else {
             self.fail();
             Err(CoreError::NoDevicesAvailable {})


### PR DESCRIPTION
Currently incoming READ I/O is not completed in case of submission
error, which might happen when the underlying I/O qpair is disconnected
in response to network errors. That leads to lost I/O on initiator.