### PR TITLE
chore(thread): clean up thread guards

### DIFF
--- a/mayastor/src/subsys/nvmf/mod.rs
+++ b/mayastor/src/subsys/nvmf/mod.rs
@@ -93,7 +93,7 @@ impl Nvmf {
         admin_cmd::setup_create_snapshot_hdlr();
 
         if Config::get().nexus_opts.nvmf_enable {
-            NVMF_TGT.with(|tgt| dbg!(tgt.borrow_mut().next_state()));
+            NVMF_TGT.with(|tgt| tgt.borrow_mut().next_state());
         } else {
             debug!("nvmf target disabled");
             unsafe { spdk_subsystem_init_next(0) }


### PR DESCRIPTION
Use the associated output rather than enforcing Result<T, E> for these futures 