### PR TITLE
feat(csi): ctrl_loss_tmo should be set to ioTimeout from SC

### DIFF
--- a/csi/src/dev.rs
+++ b/csi/src/dev.rs
@@ -48,12 +48,13 @@ pub type DeviceName = String;
 
 #[tonic::async_trait]
 pub trait Attach: Sync + Send {
-    async fn attach(&self) -> Result<(), DeviceError>;
-    async fn find(&self) -> Result<Option<DeviceName>, DeviceError>;
-    async fn fixup(
-        &self,
+    async fn parse_parameters(
+        &mut self,
         context: &HashMap<String, String>,
     ) -> Result<(), DeviceError>;
+    async fn attach(&self) -> Result<(), DeviceError>;
+    async fn find(&self) -> Result<Option<DeviceName>, DeviceError>;
+    async fn fixup(&self) -> Result<(), DeviceError>;
 }
 
 #[tonic::async_trait]

--- a/csi/src/dev/iscsi.rs
+++ b/csi/src/dev/iscsi.rs
@@ -116,6 +116,13 @@ impl TryFrom<&Url> for IscsiDevice {
 
 #[tonic::async_trait]
 impl Attach for IscsiAttach {
+    async fn parse_parameters(
+        &mut self,
+        _context: &HashMap<String, String>,
+    ) -> Result<(), DeviceError> {
+        Ok(())
+    }
+
     async fn attach(&self) -> Result<(), DeviceError> {
         match IscsiAdmin::find_session(&self.portal, &self.iqn) {
             Ok(found) => {
@@ -169,10 +176,7 @@ impl Attach for IscsiAttach {
         Ok(None)
     }
 
-    async fn fixup(
-        &self,
-        _context: &HashMap<String, String>,
-    ) -> Result<(), DeviceError> {
+    async fn fixup(&self) -> Result<(), DeviceError> {
         Ok(())
     }
 }

--- a/csi/src/dev/nbd.rs
+++ b/csi/src/dev/nbd.rs
@@ -37,6 +37,13 @@ impl TryFrom<&Url> for Nbd {
 
 #[tonic::async_trait]
 impl Attach for Nbd {
+    async fn parse_parameters(
+        &mut self,
+        _context: &HashMap<String, String>,
+    ) -> Result<(), DeviceError> {
+        Ok(())
+    }
+
     async fn attach(&self) -> Result<(), DeviceError> {
         Ok(())
     }
@@ -45,10 +52,7 @@ impl Attach for Nbd {
         Ok(Some(DeviceName::from(&self.path)))
     }
 
-    async fn fixup(
-        &self,
-        _context: &HashMap<String, String>,
-    ) -> Result<(), DeviceError> {
+    async fn fixup(&self) -> Result<(), DeviceError> {
         Ok(())
     }
 }


### PR DESCRIPTION
When the node with nexus target is down or isn't accessible for any
reason, one have to wait for 10-15 minutes with default linux settings
until the IO error is propagated back to the consumer of the volume
(i.e. app or filesystem). By setting ctrl_loss_tmo to ioTimeout from
storage class, we give the control over this to user. If ioTimeout is
not set in SC then default linux settings apply.

Resolves: CAS-823