### PR TITLE
fix(fstype): add default fstype to csi provisioner container

### DIFF
--- a/chart/templates/moac-deployment.yaml
+++ b/chart/templates/moac-deployment.yaml
@@ -21,6 +21,7 @@ spec:
             - "--v=2"
             - "--csi-address=$(ADDRESS)"
             - "--feature-gates=Topology=true"
+            - "--default-fstype=ext4"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock

--- a/deploy/moac-deployment.yaml
+++ b/deploy/moac-deployment.yaml
@@ -24,6 +24,7 @@ spec:
             - "--csi-address=$(ADDRESS)"
             - "--feature-gates=Topology=true"
             - "--strict-topology=false"
+            - "--default-fstype=ext4"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock

--- a/deploy/storage-class.yaml
+++ b/deploy/storage-class.yaml
@@ -7,6 +7,8 @@ parameters:
   repl: '1'
   protocol: 'iscsi'
   local: 'yes'
+  # It is recommended to use xfs for Mayastor
+  # fsType: 'xfs'
 provisioner: io.openebs.csi-mayastor
 volumeBindingMode: WaitForFirstConsumer
 ---
@@ -19,6 +21,8 @@ parameters:
   protocol: 'nvmf'
   ioTimeout: '30'
   local: 'yes'
+  # It is recommended to use xfs for Mayastor
+  # fsType: 'xfs'
 provisioner: io.openebs.csi-mayastor
 volumeBindingMode: WaitForFirstConsumer
 ---
@@ -30,5 +34,7 @@ parameters:
   repl: '3'
   protocol: 'nvmf'
   ioTimeout: '30'
+  # It is recommended to use xfs for Mayastor
+  # fsType: 'xfs'
 provisioner: io.openebs.csi-mayastor
 volumeBindingMode: WaitForFirstConsumer


### PR DESCRIPTION
fixes: https://github.com/openebs/Mayastor/issues/822

Currently application deployments on mayastor volumes are not adhering to fsGroups, 
due to which the mount points are not always writable. This is because there is no 
fsType set by default.   fsType should either be mentioned in the storage class or 
should be set by default in csi provisioner container. fsType defined in Storage class 
overrides this default.

https://github.com/kubernetes/kubernetes/blob/master/pkg/volume/csi/csi_mounter.go#L391

Signed-off-by: Payes Anand <payes.anand@mayadata.io>