### PR TITLE
fix: disregard msp spec modifications

### DIFF
--- a/csi/moac/crds/mayastorpool.yaml
+++ b/csi/moac/crds/mayastorpool.yaml
@@ -39,6 +39,17 @@ spec:
               description: Status part updated by the pool controller.
               type: object
               properties:
+                spec:
+                  type: object
+                  properties:
+                    node:
+                      description: Name of the k8s node where the storage pool is located. (set on creation)
+                      type: string
+                    disks:
+                      description: Disk devices (paths or URIs) that should be used for the pool. (set on creation)
+                      type: array
+                      items:
+                        type: string
                 state:
                   description: Pool state.
                   type: string

--- a/csi/moac/test/pool_operator_test.js
+++ b/csi/moac/test/pool_operator_test.js
@@ -77,6 +77,12 @@ function createK8sPoolResource (
     if (reason != null) status.reason = reason;
     if (capacity != null) status.capacity = capacity;
     if (used != null) status.used = used;
+    if (state != null) {
+      status.spec = {
+        node: node,
+        disks: disks
+      };
+    }
     obj.status = status;
   }
   return obj;
@@ -90,7 +96,8 @@ function createPoolResource (
   state,
   reason,
   capacity,
-  used
+  used,
+  statusSpec
 ) {
   return new PoolResource(createK8sPoolResource(
     name,
@@ -100,7 +107,8 @@ function createPoolResource (
     state,
     reason,
     capacity,
-    used
+    used,
+    statusSpec
   ));
 }
 
@@ -217,11 +225,15 @@ module.exports = function () {
       it('should process resources that existed before the operator was started', async () => {
         let stubs;
         oper = createPoolOperator([]);
-        const poolResource = createPoolResource('pool', 'node', ['/dev/sdb']);
+        const poolResource1 = createPoolResource('pool', 'node', ['/dev/sdb']);
+        const poolResource2 = createPoolResource('pool', 'node', ['/dev/sdb']);
+        poolResource2.status.spec = { node: 'node', disks: ['/dev/sdb'] };
         mockCache(oper.watcher, (arg) => {
           stubs = arg;
-          stubs.get.returns(poolResource);
-          stubs.list.returns([poolResource]);
+          stubs.get.onCall(0).returns(poolResource1);
+          stubs.get.onCall(1).returns(poolResource2);
+          stubs.list.onCall(0).returns([poolResource1]);
+          stubs.list.onCall(1).returns([poolResource2]);
         });
         await oper.start();
         // give time to registry to install its callbacks
@@ -230,11 +242,14 @@ module.exports = function () {
         sinon.assert.notCalled(stubs.create);
         sinon.assert.notCalled(stubs.delete);
         sinon.assert.notCalled(stubs.update);
-        sinon.assert.calledOnce(stubs.updateStatus);
-        expect(stubs.updateStatus.args[0][5].metadata.name).to.equal('pool');
-        expect(stubs.updateStatus.args[0][5].status).to.deep.equal({
+        // twice because we update the status to match the spec
+        sinon.assert.calledTwice(stubs.updateStatus);
+        expect(stubs.updateStatus.args[1][5].metadata.name).to.equal('pool');
+        expect(stubs.updateStatus.args[1][5].status).to.deep.equal({
           state: 'pending',
-          reason: 'mayastor does not run on node "node"'
+          reason: 'mayastor does not run on node "node"',
+          disks: undefined,
+          spec: { node: 'node', disks: ['/dev/sdb'] }
         });
       });
 
@@ -275,7 +290,9 @@ module.exports = function () {
         expect(stubs.updateStatus.args[0][5].metadata.name).to.equal('pool');
         expect(stubs.updateStatus.args[0][5].status).to.deep.equal({
           state: 'pending',
-          reason: 'Creating the pool'
+          reason: 'Creating the pool',
+          disks: undefined,
+          spec: { node: 'node', disks: ['/dev/sdb'] }
         });
       });
 
@@ -354,7 +371,8 @@ module.exports = function () {
           reason: '',
           disks: ['aio:///dev/sdb'],
           capacity: 100,
-          used: 10
+          used: 10,
+          spec: { node: 'node', disks: ['/dev/sdb', '/dev/sdc'] }
         });
       });
 
@@ -402,7 +420,8 @@ module.exports = function () {
           reason: '',
           disks: ['aio:///dev/sdb'],
           capacity: 100,
-          used: 10
+          used: 10,
+          spec: { node: 'node2', disks: ['/dev/sdb', '/dev/sdc'] }
         });
       });
 
@@ -435,11 +454,15 @@ module.exports = function () {
         sinon.assert.calledTwice(stubs.updateStatus);
         expect(stubs.updateStatus.args[0][5].status).to.deep.equal({
           state: 'pending',
-          reason: 'Creating the pool'
+          reason: 'Creating the pool',
+          disks: undefined,
+          spec: { node: 'node', disks: ['/dev/sdb'] }
         });
         expect(stubs.updateStatus.args[1][5].status).to.deep.equal({
           state: 'error',
-          reason: 'Error: create failed'
+          reason: 'Error: create failed',
+          disks: undefined,
+          spec: { node: 'node', disks: ['/dev/sdb'] }
         });
       });
 
@@ -495,7 +518,9 @@ module.exports = function () {
         sinon.assert.calledOnce(stubs.updateStatus);
         expect(stubs.updateStatus.args[0][5].status).to.deep.equal({
           state: 'pending',
-          reason: 'mayastor does not run on node "node"'
+          reason: 'mayastor does not run on node "node"',
+          disks: undefined,
+          spec: { node: 'node', disks: ['/dev/sdb'] }
         });
       });
 
@@ -503,6 +528,8 @@ module.exports = function () {
         let stubs;
         oper = createPoolOperator([]);
         const poolResource = createPoolResource('pool', 'node', ['/dev/sdb']);
+        const poolResource2 = createPoolResource('pool', 'node', ['/dev/sdb']);
+        poolResource2.status.spec = { node: 'node', disks: ['/dev/sdb'] };
         mockCache(oper.watcher, (arg) => {
           stubs = arg;
           stubs.get.returns(poolResource);
@@ -515,10 +542,12 @@ module.exports = function () {
         sinon.assert.notCalled(stubs.create);
         sinon.assert.notCalled(stubs.delete);
         sinon.assert.notCalled(stubs.update);
-        sinon.assert.calledOnce(stubs.updateStatus);
-        expect(stubs.updateStatus.args[0][5].status).to.deep.equal({
+        sinon.assert.calledTwice(stubs.updateStatus);
+        expect(stubs.updateStatus.args[1][5].status).to.deep.equal({
           state: 'pending',
-          reason: 'mayastor does not run on node "node"'
+          reason: 'mayastor does not run on node "node"',
+          disks: undefined,
+          spec: undefined
         });
 
         const node = new Node('node');
@@ -533,14 +562,18 @@ module.exports = function () {
         await sleep(EVENT_PROPAGATION_DELAY);
 
         // node is not yet synced
-        sinon.assert.calledTwice(stubs.updateStatus);
-        expect(stubs.updateStatus.args[0][5].status).to.deep.equal({
-          state: 'pending',
-          reason: 'mayastor does not run on node "node"'
-        });
+        sinon.assert.callCount(stubs.updateStatus, 4);
         expect(stubs.updateStatus.args[1][5].status).to.deep.equal({
           state: 'pending',
-          reason: 'mayastor on node "node" is offline'
+          reason: 'mayastor does not run on node "node"',
+          disks: undefined,
+          spec: undefined
+        });
+        expect(stubs.updateStatus.args[3][5].status).to.deep.equal({
+          state: 'pending',
+          reason: 'mayastor on node "node" is offline',
+          disks: undefined,
+          spec: undefined
         });
 
         syncedStub.returns(true);
@@ -552,14 +585,18 @@ module.exports = function () {
         await sleep(EVENT_PROPAGATION_DELAY);
 
         // tried to create the pool but the node is a fake
-        sinon.assert.callCount(stubs.updateStatus, 4);
-        expect(stubs.updateStatus.args[2][5].status).to.deep.equal({
+        sinon.assert.callCount(stubs.updateStatus, 7);
+        expect(stubs.updateStatus.args[5][5].status).to.deep.equal({
           state: 'pending',
-          reason: 'Creating the pool'
+          reason: 'Creating the pool',
+          disks: undefined,
+          spec: undefined
         });
-        expect(stubs.updateStatus.args[3][5].status).to.deep.equal({
+        expect(stubs.updateStatus.args[6][5].status).to.deep.equal({
           state: 'error',
-          reason: 'Error: Broken connection to mayastor on node "node"'
+          reason: 'Error: Broken connection to mayastor on node "node"',
+          disks: undefined,
+          spec: undefined
         });
       });
     });
@@ -586,7 +623,8 @@ module.exports = function () {
           'degraded',
           '',
           100,
-          10
+          10,
+          { disks: ['/dev/sdb'], node: 'node' }
         );
         mockCache(oper.watcher, (arg) => {
           stubs = arg;
@@ -922,14 +960,18 @@ module.exports = function () {
       sinon.assert.calledTwice(stubs.updateStatus);
       expect(stubs.updateStatus.args[0][5].status).to.deep.equal({
         state: 'pending',
-        reason: 'mayastor on node "node" is offline'
+        reason: 'mayastor on node "node" is offline',
+        disks: ['aio:///dev/sdb'],
+        spec: { node: 'node', disks: ['/dev/sdb'] }
       });
       expect(stubs.updateStatus.args[1][5].status).to.deep.equal({
         state: 'pending',
-        reason: 'Creating the pool'
+        reason: 'Creating the pool',
+        disks: ['aio:///dev/sdb'],
+        spec: { node: 'node', disks: ['/dev/sdb'] }
       });
       sinon.assert.calledOnce(createPoolStub);
-      sinon.assert.calledWith(createPoolStub, 'pool', ['/dev/sdb']);
+      sinon.assert.calledWith(createPoolStub, 'pool', ['aio:///dev/sdb']);
     });
 
     it('should add finalizer for new pool resource', async () => {
@@ -1126,6 +1168,85 @@ module.exports = function () {
       sinon.assert.notCalled(createPoolStub2);
     });
 
+    it('should create pool with original spec if the resource spec changes', async () => {
+      let stubs;
+      const node = new Node('node');
+      const createPoolStub = sinon.stub(node, 'createPool');
+      createPoolStub.rejects(
+        new GrpcError(GrpcCode.INTERNAL, 'create failed')
+      );
+      const nodeNew = new Node('node_new');
+      const createPoolStubNew = sinon.stub(nodeNew, 'createPool');
+      createPoolStubNew.rejects(
+        new GrpcError(GrpcCode.INTERNAL, 'create failed')
+      );
+
+      oper = createPoolOperator([node]);
+      const poolResource = createPoolResource(
+        'pool',
+        // modified spec with new node and new disk
+        'node_new',
+        ['/dev/sdb_new']
+      );
+      // this is the original spec cached in the status
+      poolResource.status.spec = { node: 'node', disks: ['/dev/sdb'] };
+      poolResource.status.disks = undefined;
+      mockCache(oper.watcher, (arg) => {
+        stubs = arg;
+        stubs.get.returns(poolResource);
+        stubs.list.returns([poolResource]);
+      });
+      await oper.start();
+      // give time to registry to install its callbacks
+      await sleep(EVENT_PROPAGATION_DELAY);
+
+      sinon.assert.notCalled(stubs.create);
+      sinon.assert.notCalled(stubs.update);
+      sinon.assert.notCalled(stubs.delete);
+      sinon.assert.calledTwice(stubs.updateStatus);
+      // new SPEC points to node_new, but MOAC knows better
+      sinon.assert.notCalled(createPoolStubNew);
+      // instead, it tries to recreate the pool based on the original SPEC
+      sinon.assert.calledOnce(createPoolStub);
+      sinon.assert.calledWith(createPoolStub, 'pool', ['/dev/sdb']);
+    });
+
+    it('should recreate pool with original disk URI', async () => {
+      let stubs;
+      const node = new Node('node');
+      const createPoolStub = sinon.stub(node, 'createPool');
+      createPoolStub.rejects(
+        new GrpcError(GrpcCode.INTERNAL, 'create failed')
+      );
+
+      oper = createPoolOperator([node]);
+      // note this sets the disk URI
+      const poolResource = createPoolResource(
+        'pool',
+        'node',
+        ['/dev/sdb'],
+        '',
+        'pending'
+      );
+      // this is the original spec cached in the status
+      poolResource.status.spec = { node: 'node', disks: ['/dev/sdb'] };
+      mockCache(oper.watcher, (arg) => {
+        stubs = arg;
+        stubs.get.returns(poolResource);
+        stubs.list.returns([poolResource]);
+      });
+      await oper.start();
+      // give time to registry to install its callbacks
+      await sleep(EVENT_PROPAGATION_DELAY);
+
+      sinon.assert.notCalled(stubs.create);
+      sinon.assert.notCalled(stubs.update);
+      sinon.assert.notCalled(stubs.delete);
+      sinon.assert.callCount(stubs.updateStatus, 4);
+      sinon.assert.calledTwice(createPoolStub);
+      sinon.assert.calledWith(createPoolStub, 'pool', ['aio:///dev/sdb']);
+    });
+
     it('should remove pool upon pool new event if there is no pool resource', async () => {
       let stubs;
       const pool = new Pool({
@@ -1203,7 +1324,8 @@ module.exports = function () {
         reason: offlineReason,
         capacity: 100,
         disks: ['aio:///dev/sdb'],
-        used: 4
+        used: 4,
+        spec: { node: 'node1', disks: ['/dev/sdb'] }
       });
     });
 
@@ -1282,14 +1404,16 @@ module.exports = function () {
       await sleep(EVENT_PROPAGATION_DELAY);
 
       sinon.assert.calledOnce(createPoolStub);
-      sinon.assert.calledWith(createPoolStub, 'pool', ['/dev/sdb']);
+      sinon.assert.calledWith(createPoolStub, 'pool', ['aio:///dev/sdb']);
       sinon.assert.notCalled(stubs.create);
       sinon.assert.notCalled(stubs.update);
       sinon.assert.notCalled(stubs.delete);
       sinon.assert.calledOnce(stubs.updateStatus);
       expect(stubs.updateStatus.args[0][5].status).to.deep.equal({
         state: 'pending',
-        reason: 'Creating the pool'
+        reason: 'Creating the pool',
+        disks: ['aio:///dev/sdb'],
+        spec: { node: 'node', disks: ['/dev/sdb'] }
       });
     });
 


### PR DESCRIPTION
When MOAC restarts it checks the pool resources and may then attempt to
create pools based on specs, which could cause it to recreate pools on
different nodes for instance, if the user had modified the SPEC.

This change "caches" the original spec in the status part of the
resource which then MOAC refers to, rather then the resource SPEC.
Also, if a disk URI (retrieved from mayastor) is available, always use that one.

If a SPEC change is detected, then tag a message on the MSP reason
alerting the user to the fact that it will be ignored. It is removed
if the user reverts the SPEC to the original.

Resolves CAS-855