### PR TITLE
feat(nexus): acquire write exclusive reservation on adding a child

### DIFF
--- a/mayastor/src/bdev/nexus/nexus_bdev.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev.rs
@@ -150,6 +150,16 @@ pub enum Error {
     ChildMissing { child: String, name: String },
     #[snafu(display("Child {} of nexus {} has no error store", child, name))]
     ChildMissingErrStore { child: String, name: String },
+    #[snafu(display(
+        "Failed to acquire write exclusive reservation on child {} of nexus {}",
+        child,
+        name
+    ))]
+    ChildWriteExclusiveResvFailed {
+        source: ChildError,
+        child: String,
+        name: String,
+    },
     #[snafu(display("Failed to open child {} of nexus {}", child, name))]
     OpenChild {
         source: ChildError,

--- a/mayastor/src/bdev/nexus/nexus_bdev_children.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev_children.rs
@@ -178,20 +178,21 @@ impl Nexus {
             self.name.clone(),
             Some(child_bdev),
         );
-        match child.open(self.size) {
-            Ok(name) => {
-                // we have created the bdev, and created a nexusChild struct. To
-                // make use of the device itself the
-                // data and metadata must be validated. The child
-                // will be added and marked as faulted, once the rebuild has
-                // completed the device can transition to online
-                info!("{}: child opened successfully {}", self.name, name);
+        let mut child_name = child.open(self.size);
+        if let Ok(ref name) = child_name {
+            // we have created the bdev, and created a nexusChild struct. To
+            // make use of the device itself the
+            // data and metadata must be validated. The child
+            // will be added and marked as faulted, once the rebuild has
+            // completed the device can transition to online
+            info!("{}: child opened successfully {}", self.name, name);
 
-                // FIXME: use dummy key for now
-                if let Err(e) = child.resv_register(0x12345678).await {
-                    error!("Failed to register key with child: {}", e);
-                }
-
+            if let Err(e) = child.acquire_write_exclusive().await {
+                child_name = Err(e);
+            }
+        }
+        match child_name {
+            Ok(_) => {
                 // it can never take part in the IO path
                 // of the nexus until it's rebuilt from a healthy child.
                 child.fault(Reason::OutOfSync).await;
@@ -487,14 +488,31 @@ impl Nexus {
             });
         }
 
-        // FIXME: use dummy key for now
+        // acquire a write exclusive reservation on all children,
+        // if any one fails, close all children.
+        let mut we_err: Result<(), Error> = Ok(());
         for child in self.children.iter() {
-            if let Err(error) = child.resv_register(0x12345678).await {
-                error!(
-                    "{}: failed to register key {} for child {}",
-                    self.name, child.name, error
-                );
+            if let Err(error) = child.acquire_write_exclusive().await {
+                we_err = Err(Error::ChildWriteExclusiveResvFailed {
+                    source: error,
+                    child: child.name.clone(),
+                    name: self.name.clone(),
+                });
+                break;
             }
+        }
+        if let Err(error) = we_err {
+            for child in &mut self.children {
+                if let Err(error) = child.close().await {
+                    error!(
+                        "{}: child {} failed to close with error {}",
+                        self.name,
+                        &child.name,
+                        error.verbose()
+                    );
+                }
+            }
+            return Err(error);
         }
 
         for child in self.children.iter() {

--- a/mayastor/src/bdev/nvmx/controller_inner.rs
+++ b/mayastor/src/bdev/nvmx/controller_inner.rs
@@ -294,6 +294,11 @@ impl SpdkNvmeController {
     pub fn as_ptr(&self) -> *mut spdk_nvme_ctrlr {
         self.0.as_ptr()
     }
+
+    /// Returns extended host identifier
+    pub fn ext_host_id(&self) -> &[u8; 16] {
+        unsafe { &(*self.as_ptr()).opts.extended_host_id }
+    }
 }
 
 impl From<*mut spdk_nvme_ctrlr> for SpdkNvmeController {

--- a/mayastor/src/core/block_device.rs
+++ b/mayastor/src/core/block_device.rs
@@ -180,9 +180,30 @@ pub trait BlockDeviceHandle {
         _register_action: u8,
         _cptpl: u8,
     ) -> Result<(), CoreError> {
-        Err(CoreError::NvmeIoPassthruDispatch {
+        Err(CoreError::NotSupported {
             source: Errno::EOPNOTSUPP,
-            opcode: 0, // FIXME
+        })
+    }
+
+    async fn nvme_resv_acquire(
+        &self,
+        _current_key: u64,
+        _preempt_key: u64,
+        _acquire_action: u8,
+        _resv_type: u8,
+    ) -> Result<(), CoreError> {
+        Err(CoreError::NotSupported {
+            source: Errno::EOPNOTSUPP,
+        })
+    }
+
+    async fn nvme_resv_report(
+        &self,
+        _cdw11: u32,
+        _buffer: &mut DmaBuf,
+    ) -> Result<(), CoreError> {
+        Err(CoreError::NotSupported {
+            source: Errno::EOPNOTSUPP,
         })
     }
 
@@ -194,6 +215,12 @@ pub trait BlockDeviceHandle {
         Err(CoreError::NvmeIoPassthruDispatch {
             source: Errno::EOPNOTSUPP,
             opcode: nvme_cmd.opc(),
+        })
+    }
+
+    async fn host_id(&self) -> Result<[u8; 16], CoreError> {
+        Err(CoreError::NotSupported {
+            source: Errno::EOPNOTSUPP,
         })
     }
 }

--- a/mayastor/src/core/mod.rs
+++ b/mayastor/src/core/mod.rs
@@ -40,6 +40,10 @@ pub use io_device::IoDevice;
 pub use nvme::{
     nvme_admin_opc,
     nvme_nvm_opcode,
+    nvme_reservation_acquire_action,
+    nvme_reservation_register_action,
+    nvme_reservation_register_cptpl,
+    nvme_reservation_type,
     GenericStatusCode,
     NvmeCommandStatus,
     NvmeStatus,

--- a/mayastor/src/core/nvme.rs
+++ b/mayastor/src/core/nvme.rs
@@ -237,9 +237,36 @@ pub mod nvme_nvm_opcode {
     // pub const WRITE_ZEROES: u8 = 0x08;
     // pub const DATASET_MANAGEMENT: u8 = 0x09;
     pub const RESERVATION_REGISTER: u8 = 0x0d;
-    // pub const RESERVATION_REPORT: u8 = 0x0e;
-    // pub const RESERVATION_ACQUIRE: u8 = 0x11;
+    pub const RESERVATION_REPORT: u8 = 0x0e;
+    pub const RESERVATION_ACQUIRE: u8 = 0x11;
     // pub const RESERVATION_RELEASE: u8 = 0x15;
+}
+
+pub mod nvme_reservation_type {
+    pub const WRITE_EXCLUSIVE: u8 = 0x1;
+    pub const EXCLUSIVE_ACCESS: u8 = 0x2;
+    pub const WRITE_EXCLUSIVE_REG_ONLY: u8 = 0x3;
+    pub const EXCLUSIVE_ACCESS_REG_ONLY: u8 = 0x4;
+    pub const WRITE_EXCLUSIVE_ALL_REGS: u8 = 0x5;
+    pub const EXCLUSIVE_ACCESS_ALL_REGS: u8 = 0x6;
+}
+
+pub mod nvme_reservation_register_action {
+    pub const REGISTER_KEY: u8 = 0x0;
+    pub const UNREGISTER_KEY: u8 = 0x1;
+    pub const REPLACE_KEY: u8 = 0x2;
+}
+
+pub mod nvme_reservation_register_cptpl {
+    pub const NO_CHANGES: u8 = 0x0;
+    pub const CLEAR_POWER_ON: u8 = 0x2;
+    pub const PERSIST_POWER_LOSS: u8 = 0x2;
+}
+
+pub mod nvme_reservation_acquire_action {
+    pub const ACQUIRE: u8 = 0x0;
+    pub const PREEMPT: u8 = 0x1;
+    pub const PREEMPT_ABORT: u8 = 0x2;
 }
 
 impl NvmeCommandStatus {

--- a/mayastor/tests/nexus_multipath.rs
+++ b/mayastor/tests/nexus_multipath.rs
@@ -1,5 +1,5 @@
-//! Multipath NVMf tests
-//! Create the same nexus on both nodes with a replica on 1 node as their child.
+//! Multipath NVMf and reservation tests
+use common::bdev_io;
 use mayastor::{
     bdev::{nexus_create, nexus_lookup},
     core::MayastorCliArgs,
@@ -23,6 +23,24 @@ static POOL_NAME: &str = "tpool";
 static UUID: &str = "cdc2a7db-3ac3-403a-af80-7fadc1581c47";
 static HOSTNQN: &str = "nqn.2019-05.io.openebs";
 
+fn nvme_connect(target_addr: &str, nqn: &str) {
+    let status = Command::new("nvme")
+        .args(&["connect"])
+        .args(&["-t", "tcp"])
+        .args(&["-a", target_addr])
+        .args(&["-s", "8420"])
+        .args(&["-n", nqn])
+        .status()
+        .unwrap();
+    assert!(
+        status.success(),
+        "failed to connect to {}, nqn {}: {}",
+        target_addr,
+        nqn,
+        status
+    );
+}
+
 fn get_mayastor_nvme_device() -> String {
     let output_list = Command::new("nvme").args(&["list"]).output().unwrap();
     assert!(
@@ -40,9 +58,46 @@ fn get_mayastor_nvme_device() -> String {
     ns.to_string()
 }
 
+fn get_nvme_resv_report(nvme_dev: &str) -> serde_json::Value {
+    let output_resv = Command::new("nvme")
+        .args(&["resv-report"])
+        .args(&[nvme_dev])
+        .args(&["-c", "1"])
+        .args(&["-o", "json"])
+        .output()
+        .unwrap();
+    assert!(
+        output_resv.status.success(),
+        "failed to get reservation report from {}: {}",
+        nvme_dev,
+        output_resv.status
+    );
+    let resv_rep = String::from_utf8(output_resv.stdout).unwrap();
+    let v: serde_json::Value =
+        serde_json::from_str(&resv_rep).expect("JSON was not well-formatted");
+    v
+}
+
+fn nvme_disconnect_nqn(nqn: &str) {
+    let output_dis = Command::new("nvme")
+        .args(&["disconnect"])
+        .args(&["-n", nqn])
+        .output()
+        .unwrap();
+    assert!(
+        output_dis.status.success(),
+        "failed to disconnect from {}: {}",
+        nqn,
+        output_dis.status
+    );
+}
+
 #[tokio::test]
+#[ignore]
+/// Create the same nexus on both nodes with a replica on 1 node as their child.
 async fn nexus_multipath() {
     std::env::set_var("NEXUS_NVMF_ANA_ENABLE", "1");
+    std::env::set_var("NEXUS_NVMF_RESV_ENABLE", "1");
     // create a new composeTest
     let test = Builder::new()
         .name("nexus_shared_replica_test")
@@ -125,19 +180,7 @@ async fn nexus_multipath() {
         .unwrap();
 
     let nqn = format!("{}:nexus-{}", HOSTNQN, UUID);
-    let status = Command::new("nvme")
-        .args(&["connect"])
-        .args(&["-t", "tcp"])
-        .args(&["-a", "127.0.0.1"])
-        .args(&["-s", "8420"])
-        .args(&["-n", &nqn])
-        .status()
-        .unwrap();
-    assert!(
-        status.success(),
-        "failed to connect to local nexus, {}",
-        status
-    );
+    nvme_connect("127.0.0.1", &nqn);
 
     // The first attempt will fail with "Duplicate cntlid x with y" error from
     // kernel
@@ -214,37 +257,11 @@ async fn nexus_multipath() {
 
     // Connect to remote replica to check key registered
     let rep_nqn = format!("{}:{}", HOSTNQN, UUID);
-    let status = Command::new("nvme")
-        .args(&["connect"])
-        .args(&["-t", "tcp"])
-        .args(&["-a", &ip0.to_string()])
-        .args(&["-s", "8420"])
-        .args(&["-n", &rep_nqn])
-        .status()
-        .unwrap();
-    assert!(
-        status.success(),
-        "failed to connect to remote replica, {}",
-        status
-    );
+    nvme_connect(&ip0.to_string(), &rep_nqn);
 
     let rep_dev = get_mayastor_nvme_device();
 
-    let output_resv = Command::new("nvme")
-        .args(&["resv-report"])
-        .args(&[rep_dev])
-        .args(&["-c", "1"])
-        .args(&["-o", "json"])
-        .output()
-        .unwrap();
-    assert!(
-        output_resv.status.success(),
-        "failed to get reservation report from remote replica, {}",
-        output_resv.status
-    );
-    let resv_rep = String::from_utf8(output_resv.stdout).unwrap();
-    let v: serde_json::Value =
-        serde_json::from_str(&resv_rep).expect("JSON was not well-formatted");
+    let v = get_nvme_resv_report(&rep_dev);
     assert_eq!(v["rtype"], 0, "should have no reservation type");
     assert_eq!(v["regctl"], 1, "should have 1 registered controller");
     assert_eq!(
@@ -264,16 +281,7 @@ async fn nexus_multipath() {
         "should have default registered key"
     );
 
-    let output_dis2 = Command::new("nvme")
-        .args(&["disconnect"])
-        .args(&["-n", &rep_nqn])
-        .output()
-        .unwrap();
-    assert!(
-        output_dis2.status.success(),
-        "failed to disconnect from remote replica, {}",
-        output_dis2.status
-    );
+    nvme_disconnect_nqn(&rep_nqn);
 
     // destroy nexus on remote node
     hdls[0]
@@ -294,4 +302,154 @@ async fn nexus_multipath() {
         .replicas[0]
         .uri
         .contains("nvmf://"));
+}
+
+#[tokio::test]
+/// Create a nexus with a remote replica on 1 node as its child.
+/// Create another nexus with the same remote replica as its child, verifying
+/// that the write exclusive reservation has been acquired by the new nexus.
+async fn nexus_resv_acquire() {
+    std::env::set_var("NEXUS_NVMF_RESV_ENABLE", "1");
+    let test = Builder::new()
+        .name("nexus_resv_acquire_test")
+        .network("10.1.0.0/16")
+        .add_container_bin(
+            "ms2",
+            composer::Binary::from_dbg("mayastor")
+                .with_env("NEXUS_NVMF_RESV_ENABLE", "1"),
+        )
+        .add_container_bin(
+            "ms1",
+            composer::Binary::from_dbg("mayastor")
+                .with_env("NEXUS_NVMF_RESV_ENABLE", "1"),
+        )
+        .with_clean(true)
+        .build()
+        .await
+        .unwrap();
+
+    let mut hdls = test.grpc_handles().await.unwrap();
+
+    // create a pool on remote node 1
+    // grpc handles can be returned in any order, we simply define the first
+    // as "node 1"
+    hdls[0]
+        .mayastor
+        .create_pool(CreatePoolRequest {
+            name: POOL_NAME.to_string(),
+            disks: vec!["malloc:///disk0?size_mb=64".into()],
+        })
+        .await
+        .unwrap();
+
+    // create replica, shared over nvmf
+    hdls[0]
+        .mayastor
+        .create_replica(CreateReplicaRequest {
+            uuid: UUID.to_string(),
+            pool: POOL_NAME.to_string(),
+            size: 32 * 1024 * 1024,
+            thin: false,
+            share: 1,
+        })
+        .await
+        .unwrap();
+
+    let mayastor = MayastorTest::new(MayastorCliArgs::default());
+    let ip0 = hdls[0].endpoint.ip();
+    let nexus_name = format!("nexus-{}", UUID);
+    let name = nexus_name.clone();
+    mayastor
+        .spawn(async move {
+            // create nexus on local node with remote replica as child
+            nexus_create(
+                &name,
+                32 * 1024 * 1024,
+                Some(UUID),
+                &[format!("nvmf://{}:8420/{}:{}", ip0, HOSTNQN, UUID)],
+            )
+            .await
+            .unwrap();
+            bdev_io::write_some(&name, 0, 0xff).await.unwrap();
+            bdev_io::read_some(&name, 0, 0xff).await.unwrap();
+        })
+        .await;
+
+    // Connect to remote replica to check key registered
+    let rep_nqn = format!("{}:{}", HOSTNQN, UUID);
+    nvme_connect(&ip0.to_string(), &rep_nqn);
+
+    let rep_dev = get_mayastor_nvme_device();
+
+    let v = get_nvme_resv_report(&rep_dev);
+    assert_eq!(v["rtype"], 1, "should have write exclusive reservation");
+    assert_eq!(v["regctl"], 1, "should have 1 registered controller");
+    assert_eq!(
+        v["ptpls"], 0,
+        "should have Persist Through Power Loss State as 0"
+    );
+    assert_eq!(
+        v["regctlext"][0]["cntlid"], 0xffff,
+        "should have dynamic controller ID"
+    );
+    assert_eq!(
+        v["regctlext"][0]["rcsts"], 1,
+        "should have reservation status as reserved"
+    );
+    assert_eq!(
+        v["regctlext"][0]["rkey"], 0x12345678,
+        "should have default registered key"
+    );
+
+    // create nexus on remote node 2 with replica on node 1 as child
+    hdls[1]
+        .mayastor
+        .create_nexus(CreateNexusRequest {
+            uuid: UUID.to_string(),
+            size: 32 * 1024 * 1024,
+            children: [format!("nvmf://{}:8420/{}:{}", ip0, HOSTNQN, UUID)]
+                .to_vec(),
+        })
+        .await
+        .unwrap();
+
+    // Verify that it has grabbed the write exclusive reservation
+    let v2 = get_nvme_resv_report(&rep_dev);
+    assert_eq!(v2["rtype"], 1, "should have write exclusive reservation");
+    assert_eq!(v2["regctl"], 1, "should have 1 registered controller");
+    assert_eq!(
+        v2["ptpls"], 0,
+        "should have Persist Through Power Loss State as 0"
+    );
+    assert_eq!(
+        v2["regctlext"][0]["cntlid"], 0xffff,
+        "should have dynamic controller ID"
+    );
+    assert_eq!(
+        v2["regctlext"][0]["rcsts"], 1,
+        "should have reservation status as reserved"
+    );
+    assert_eq!(
+        v2["regctlext"][0]["rkey"], 0x12345678,
+        "should have default registered key"
+    );
+    // Until host IDs can be configured, different host ID is sufficient
+    assert_ne!(
+        v2["regctlext"][0]["hostid"], v["regctlext"][0]["hostid"],
+        "should have different hostid holding reservation"
+    );
+
+    let name = nexus_name.clone();
+    mayastor
+        .spawn(async move {
+            bdev_io::write_some(&name, 0, 0xff)
+                .await
+                .expect_err("writes should fail");
+            bdev_io::read_some(&name, 0, 0xff)
+                .await
+                .expect_err("reads should also fail after write failure");
+        })
+        .await;
+
+    nvme_disconnect_nqn(&rep_nqn);
 }

--- a/nix/pkgs/mayastor/cargo-package.nix
+++ b/nix/pkgs/mayastor/cargo-package.nix
@@ -1,5 +1,5 @@
 { stdenv
-, clang
+, clang_11
 , dockerTools
 , e2fsprogs
 , lib
@@ -9,7 +9,6 @@
 , libspdk-dev
 , libudev
 , liburing
-, llvmPackages
 , makeRustPlatform
 , numactl
 , openssl
@@ -61,7 +60,7 @@ let
 
     inherit version cargoBuildFlags;
     src = whitelistSource ../../../. src_list;
-    LIBCLANG_PATH = "${llvmPackages.libclang.lib}/lib";
+    LIBCLANG_PATH = "${llvmPackages_11.libclang.lib}/lib";
     PROTOC = "${protobuf}/bin/protoc";
     PROTOC_INCLUDE = "${protobuf}/include";
 

--- a/nix/pkgs/mayastor/default.nix
+++ b/nix/pkgs/mayastor/default.nix
@@ -1,5 +1,5 @@
 { stdenv
-, clang
+, clang_11
 , dockerTools
 , e2fsprogs
 , lib
@@ -9,7 +9,6 @@
 , libspdk-dev
 , libudev
 , liburing
-, llvmPackages
 , makeRustPlatform
 , numactl
 , openssl

--- a/nix/pkgs/mayastor/units.nix
+++ b/nix/pkgs/mayastor/units.nix
@@ -1,5 +1,5 @@
 { stdenv
-, clang
+, clang_11
 , dockerTools
 , e2fsprogs
 , lib
@@ -9,7 +9,6 @@
 , libspdk-dev
 , libudev
 , liburing
-, llvmPackages
 , makeRustPlatform
 , numactl
 , openssl

--- a/spdk-sys/build.rs
+++ b/spdk-sys/build.rs
@@ -91,6 +91,8 @@ fn main() {
         .allowlist_function("^nvme_qpair_.*")
         .allowlist_function("^nvme_ctrlr_.*")
         .blocklist_type("^longfunc")
+        .allowlist_type("^spdk_nvme_registered_ctrlr.*")
+        .allowlist_type("^spdk_nvme_reservation.*")
         .allowlist_var("^NVMF.*")
         .allowlist_var("^SPDK.*")
         .allowlist_var("^spdk.*")

--- a/spdk-sys/wrapper.h
+++ b/spdk-sys/wrapper.h
@@ -24,6 +24,7 @@
 #include <spdk/lvol.h>
 #include <spdk/nbd.h>
 #include <spdk/nvme.h>
+#include <nvme/nvme_internal.h>
 #include <spdk/nvmf.h>
 #include <nvmf/nvmf_internal.h>
 #include <spdk/rpc.h>


### PR DESCRIPTION
Refactor the existing reservation key code such that both code paths
that add a child call NexusChild::acquire_write_exclusive(), which
sends an NVMe Reservation Acquire command to acquire a write exclusive
reservation on the child, then a Reservation Report command to verify
that the reservation has been acquired, followed by with another
Reservation Acquire command to preempt an existing reservation, if
another host has it.

Add a test to verify that, refactoring the existing nexus_multipath
test as well as disabling it as the write exclusive reservation means
only one Nexus can write to a replica.

Fixes CAS-850