### PR TITLE
feat(core): provide handle to external runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ test-yamls/*
 /node_modules
 artifacts/
 .idea
+**/.pytest_cache
+**/__pycache__

--- a/mayastor/src/core/mod.rs
+++ b/mayastor/src/core/mod.rs
@@ -43,6 +43,7 @@ pub use nvme::{
     NvmeStatus,
 };
 pub use reactor::{Reactor, ReactorState, Reactors, REACTOR_LIST};
+pub use runtime::spawn;
 pub use share::{Protocol, Share};
 pub use thread::Mthread;
 
@@ -60,6 +61,7 @@ pub mod mempool;
 mod nvme;
 pub mod poller;
 mod reactor;
+pub mod runtime;
 mod share;
 pub(crate) mod thread;
 pub mod uuid;

--- a/mayastor/src/core/runtime.rs
+++ b/mayastor/src/core/runtime.rs
@@ -1,0 +1,71 @@
+//!
+//! This allows us to send futures from within mayastor to the tokio
+//! runtime to do whatever it needs to do. The tokio threads are
+//! unaffinitized such that they do not run on any of our reactors.
+
+use futures::Future;
+use once_cell::sync::Lazy;
+use tokio::task::JoinHandle;
+
+use super::Mthread;
+
+/// spawn a future on the tiokio runtime.
+pub fn spawn(f: impl Future<Output = ()> + Send + 'static) {
+    RUNTIME.spawn(f);
+}
+
+/// block on the given future until it completes
+pub fn block_on(f: impl Future<Output = ()> + Send + 'static) {
+    RUNTIME.block_on(f);
+}
+
+/// spawn a future that might block on a seperate worker thread the
+/// number of threads available is determined by max_blocking_threads
+pub fn spawn_blocking<F, R>(f: F) -> JoinHandle<R>
+where
+    F: FnOnce() -> R + Send + 'static,
+    R: Send + 'static,
+{
+    RUNTIME.spawn_blocking(f)
+}
+
+pub struct Runtime {
+    rt: tokio::runtime::Runtime,
+}
+
+static RUNTIME: Lazy<Runtime> = Lazy::new(|| {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .worker_threads(4)
+        .max_blocking_threads(2)
+        .on_thread_start(Mthread::unaffinitize)
+        .build()
+        .unwrap();
+
+    Runtime {
+        rt,
+    }
+});
+
+impl Runtime {
+    fn block_on(&self, f: impl Future<Output = ()> + Send + 'static) {
+        self.rt.block_on(f);
+    }
+
+    fn spawn(&self, f: impl Future<Output = ()> + Send + 'static) {
+        let handle = self.rt.handle().clone();
+        handle.spawn(f);
+    }
+
+    pub fn spawn_blocking<F, R>(&self, f: F) -> JoinHandle<R>
+    where
+        F: FnOnce() -> R + Send + 'static,
+        R: Send + 'static,
+    {
+        let handle = self.rt.handle().clone();
+        handle.spawn_blocking(|| {
+            Mthread::unaffinitize();
+            f()
+        })
+    }
+}

--- a/mayastor/src/core/thread.rs
+++ b/mayastor/src/core/thread.rs
@@ -31,7 +31,7 @@ pub enum Error {
 /// analogous to a container to which you can submit work and poll it to drive
 /// the submitted work to completion.
 pub struct Mthread(NonNull<spdk_thread>);
-
+unsafe impl Send for Mthread {}
 impl From<*mut spdk_thread> for Mthread {
     fn from(t: *mut spdk_thread) -> Self {
         let t = NonNull::new(t).expect("thread may not be NULL");

--- a/mayastor/tests/thread.rs
+++ b/mayastor/tests/thread.rs
@@ -1,8 +1,48 @@
-use mayastor::core::{MayastorCliArgs, Mthread};
+use std::time::Duration;
+
+use mayastor::core::{Bdev, Cores, MayastorCliArgs, Mthread, Share};
 
 pub mod common;
 use common::MayastorTest;
 use mayastor::nexus_uri::bdev_create;
+
+async fn mayastor_to_runtime() {
+    // the future is created on mayastor and send to tokio. So assert we are
+    // running on something that is
+    assert_eq!(Cores::current(), Cores::first());
+    assert!(Mthread::current().is_some());
+
+    // now spawn something
+    mayastor::core::runtime::spawn(
+        // spawn a future to send something back to mayastor
+        runtime_to_mayastor(),
+    );
+}
+
+async fn runtime_to_mayastor() {
+    assert_eq!(Cores::current(), u32::MAX);
+    assert_eq!(Mthread::current(), None);
+
+    // we should not have a core here
+    assert_eq!(Cores::current(), u32::MAX);
+    tokio::time::sleep(Duration::from_micros(400)).await;
+    // simulate we perform some work
+
+    let st = Mthread::get_init();
+    let rx = st
+        .spawn_local(async move {
+            let bdev = Bdev::lookup_by_name("malloc0").unwrap();
+            bdev.share_nvmf(None).await.unwrap();
+        })
+        .unwrap();
+    let _ = rx.await;
+}
+
+fn running_on_thread() {
+    assert_eq!(Cores::current(), u32::MAX);
+    assert_eq!(Mthread::current(), None);
+    std::thread::sleep(Duration::from_secs(2));
+}
 
 #[tokio::test]
 async fn thread_tokio() {
@@ -16,6 +56,11 @@ async fn thread_tokio() {
     let st = Mthread::get_init();
     let name = "malloc:///malloc0?size_mb=4";
     let rx = st.spawn_local(async move { bdev_create(name).await });
+
+    ms.send(mayastor_to_runtime());
+
     rx.unwrap().await.unwrap().unwrap();
-    drop(ms)
+    let th = mayastor::core::runtime::spawn_blocking(running_on_thread);
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    th.await.unwrap();
 }

--- a/nix/pkgs/libiscsi/default.nix
+++ b/nix/pkgs/libiscsi/default.nix
@@ -6,7 +6,6 @@ stdenv.mkDerivation rec {
 
   src = sources.libiscsi;
 
-  outputs = [ "out" "bin" "lib" "dev" ];
   nativeBuildInputs = [ autoreconfHook ];
   meta = {
     description = "User space iscsi library";

--- a/nix/pkgs/libspdk/default.nix
+++ b/nix/pkgs/libspdk/default.nix
@@ -59,7 +59,7 @@ let
       binutils
       libtool
       libaio
-      libiscsi.dev
+      libiscsi
       liburing
       libuuid
       nasm

--- a/nix/pkgs/mayastor/cargo-package.nix
+++ b/nix/pkgs/mayastor/cargo-package.nix
@@ -73,7 +73,7 @@ let
       llvmPackages_11.libclang
       protobuf
       libaio
-      libiscsi.lib
+      libiscsi
       libudev
       liburing
       numactl

--- a/shell.nix
+++ b/shell.nix
@@ -37,7 +37,7 @@ mkShell {
     kubernetes-helm
     libaio
     libiscsi
-    libiscsi.bin
+    libiscsi
     libudev
     liburing
     llvmPackages.libclang


### PR DESCRIPTION
Mayastor has its own futures which are driven by polling of the "green" threads.
If however, we want to do something which does not need or can run on the
mayastor cores, we can dispatch it to a foreign runtime.

Additionally this also fixes a bug where we where interacting with the nvmf
target from an invalid thread.