### PR TITLE
fix: add error message when we fail to send registration hb

### DIFF
--- a/mayastor/src/subsys/mbus/mod.rs
+++ b/mayastor/src/subsys/mbus/mod.rs
@@ -24,8 +24,11 @@ pub fn mbus_endpoint(endpoint: Option<String>) -> Option<String> {
             let (address_or_ip, port) = if endpoint.contains(':') {
                 let mut s = endpoint.split(':');
                 (
-                    s.next().unwrap(),
-                    s.next().unwrap().parse::<u16>().expect("Invalid Port"),
+                    s.next().expect("Invalid NATS endpoint"),
+                    s.next()
+                        .unwrap()
+                        .parse::<u16>()
+                        .expect("Invalid NATS endpoint port"),
                 )
             } else {
                 (endpoint.as_str(), 4222)
@@ -37,8 +40,8 @@ pub fn mbus_endpoint(endpoint: Option<String>) -> Option<String> {
                     .expect("Invalid Ipv4 Address");
                 debug!("Nats endpoint found at {}", nats);
             } else {
-                let nats =
-                    lookup_host(&address_or_ip).expect("Invalid Host Name");
+                let nats = lookup_host(&address_or_ip)
+                    .expect("Failed to lookup the NATS endpoint");
                 debug!("Nats endpoint found at {:?}", nats);
             }
 
@@ -68,7 +71,9 @@ impl MessageBusSubsystem {
         debug!("mayastor mbus subsystem fini");
         let args = MayastorEnvironment::global_or_default();
         if args.mbus_endpoint.is_some() && args.grpc_endpoint.is_some() {
-            Registration::get().fini();
+            if let Some(registration) = Registration::get() {
+                registration.fini();
+            }
         }
         unsafe { spdk_subsystem_fini_next() }
     }

--- a/mbus-api/src/lib.rs
+++ b/mbus-api/src/lib.rs
@@ -487,6 +487,11 @@ pub trait Bus: Clone + Send + Sync {
     ) -> BusResult<BusMessage>;
     /// Flush queued messages to the server
     async fn flush(&self) -> BusResult<()>;
+    /// Flush queued messages to the server with a timeout
+    async fn flush_timeout(
+        &self,
+        timeout: std::time::Duration,
+    ) -> BusResult<()>;
     /// Create a subscription on the given channel which can be
     /// polled for messages until it is either explicitly closed or
     /// when the bus is closed

--- a/test/grpc/test_nats.js
+++ b/test/grpc/test_nats.js
@@ -87,7 +87,8 @@ describe('nats', function () {
         '-n', NATS_ENDPOINT,
         '-N', NODE_NAME
       ], {
-        MAYASTOR_HB_INTERVAL: HB_INTERVAL
+        MAYASTOR_HB_INTERVAL_SEC: HB_INTERVAL,
+        MAYASTOR_HB_TIMEOUT_SEC: HB_INTERVAL
       });
       // wait for the register message
       const sid = client.subscribe('v0/registry', (msg) => {


### PR DESCRIPTION
NATS messages get queued by the nats client and so we may not get an error when we try
to send a message. So, attempt to flush the queue after each send with a default timeout
of 5 seconds. If the flush fails then we'll log the error. Subsequent sends will then be
failed by the NATS client until such a time connection is reestablished.

Also add connect/disconnect logging to the NATS server.