### PR TITLE
test(e2e): extend timeout as tests are being added

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -186,7 +186,7 @@ e2e_alias_tag = getAliasTag()
 pipeline {
   agent none
   options {
-    timeout(time: 3, unit: 'HOURS')
+    timeout(time: 5, unit: 'HOURS')
   }
   parameters {
     booleanParam(defaultValue: false, name: 'e2e_continuous')


### PR DESCRIPTION
Increase timeout from 3 to 5 hours for long nightly runs.
A recent test exceeded 3 hours without hanging. 