### PR TITLE
fix(nexus): retire replicas in response to I/O errors

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,7 @@ xray_nightly_testplan='MQ-17'
 xray_continuous_testplan='MQ-33'
 xray_test_execution_type='10059'
 // do not send xray reports as a result of "bors try"
-xray_send_report = (env.BRANCH_NAME == 'trying') ? false : true
+xray_send_report = false
 
 // if e2e run does not build its own images, which tag to use when pulling
 e2e_continuous_image_tag='v0.8.0'

--- a/mayastor/src/bdev/nexus/nexus_bdev_children.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev_children.rs
@@ -532,7 +532,7 @@ impl Nexus {
         blockcnt
     }
 
-    /// lookup a child by its name
+    /// Lookup a child by its device name.
     pub fn child_lookup(&self, name: &str) -> Option<&NexusChild> {
         self.children
             .iter()
@@ -540,6 +540,7 @@ impl Nexus {
             .find(|c| c.get_device().unwrap().device_name() == name)
     }
 
+    // Lookup a child by its URL.
     pub fn get_child_by_name(
         &mut self,
         name: &str,

--- a/mayastor/src/bdev/nexus/nexus_channel.rs
+++ b/mayastor/src/bdev/nexus/nexus_channel.rs
@@ -31,6 +31,7 @@ pub(crate) struct NexusChannelInner {
     pub(crate) writers: Vec<Box<dyn BlockDeviceHandle>>,
     pub(crate) readers: Vec<Box<dyn BlockDeviceHandle>>,
     pub(crate) previous: usize,
+    pub(crate) fail_fast: u32,
     device: *mut c_void,
 }
 
@@ -104,7 +105,6 @@ impl NexusChannelInner {
     /// online or offline. We don't know which child has gone, or was added, so
     /// we simply put back all the channels, and reopen the bdevs that are in
     /// the online state.
-
     pub(crate) fn refresh(&mut self) {
         let nexus = unsafe { Nexus::from_raw(self.device) };
         info!(
@@ -186,6 +186,7 @@ impl NexusChannel {
             readers: Vec::new(),
             previous: 0,
             device,
+            fail_fast: 0,
         });
 
         nexus

--- a/mayastor/src/bdev/nvmx/handle.rs
+++ b/mayastor/src/bdev/nvmx/handle.rs
@@ -298,7 +298,6 @@ extern "C" fn nvme_async_io_completion(
     ctx: *mut c_void,
     cpl: *const spdk_nvme_cpl,
 ) {
-    debug!("Async NVMe I/O completed !");
     done_cb(ctx, nvme_cpl_succeeded(cpl));
 }
 

--- a/mayastor/src/core/io_device.rs
+++ b/mayastor/src/core/io_device.rs
@@ -1,0 +1,133 @@
+use std::{os::raw::c_void, ptr::NonNull};
+
+use spdk_sys::{
+    spdk_for_each_channel,
+    spdk_for_each_channel_continue,
+    spdk_io_channel,
+    spdk_io_channel_iter,
+    spdk_io_channel_iter_get_channel,
+    spdk_io_channel_iter_get_ctx,
+    spdk_io_device_register,
+    spdk_io_device_unregister,
+};
+
+#[derive(Debug)]
+pub struct IoDevice(NonNull<c_void>);
+
+type IoDeviceCreateCb = unsafe extern "C" fn(*mut c_void, *mut c_void) -> i32;
+type IoDeviceDestroyCb = unsafe extern "C" fn(*mut c_void, *mut c_void);
+
+/// Abstraction around SPDK I/O device, which hides low-level SPDK
+/// API and provides high-level API for I/O channel traversal.
+impl IoDevice {
+    /// Create a new I/O device using target address as a unique
+    /// I/O device identifier.
+    pub fn new<C: Sized>(
+        devptr: NonNull<c_void>,
+        name: &str,
+        create_cb: Option<IoDeviceCreateCb>,
+        destroy_cb: Option<IoDeviceDestroyCb>,
+    ) -> Self {
+        unsafe {
+            spdk_io_device_register(
+                devptr.as_ptr(),
+                create_cb,
+                destroy_cb,
+                std::mem::size_of::<C>() as u32,
+                name.as_ptr() as *const i8,
+            )
+        }
+
+        debug!("{} I/O device registered at {:p}", name, devptr.as_ptr());
+
+        Self(devptr)
+    }
+
+    /// Iterate over all I/O channels associated with this I/O device.
+    pub fn traverse_io_channels<T, I: 'static>(
+        &self,
+        channel_cb: impl FnMut(&mut I, &mut T) -> i32 + 'static,
+        done_cb: impl FnMut(i32, T) + 'static,
+        ctx_getter: impl Fn(*mut spdk_io_channel) -> &'static mut I + 'static,
+        caller_ctx: T,
+    ) {
+        struct TraverseCtx<N, C: 'static> {
+            channel_cb: Box<dyn FnMut(&mut C, &mut N) -> i32 + 'static>,
+            done_cb: Box<dyn FnMut(i32, N) + 'static>,
+            ctx_getter:
+                Box<dyn Fn(*mut spdk_io_channel) -> &'static mut C + 'static>,
+            ctx: N,
+        }
+
+        let traverse_ctx = Box::into_raw(Box::new(TraverseCtx {
+            channel_cb: Box::new(channel_cb),
+            done_cb: Box::new(done_cb),
+            ctx_getter: Box::new(ctx_getter),
+            ctx: caller_ctx,
+        }));
+        assert!(
+            !traverse_ctx.is_null(),
+            "Failed to allocate context for I/O channels iteration"
+        );
+
+        /// Low-level per-channel visitor to be invoked by SPDK I/O channel
+        /// enumeration logic.
+        extern "C" fn _visit_channel<V, P: 'static>(
+            i: *mut spdk_io_channel_iter,
+        ) {
+            let traverse_ctx = unsafe {
+                let p =
+                    spdk_io_channel_iter_get_ctx(i) as *mut TraverseCtx<V, P>;
+                &mut *p
+            };
+            let io_channel = unsafe {
+                let ch = spdk_io_channel_iter_get_channel(i);
+                (traverse_ctx.ctx_getter)(ch)
+            };
+
+            let rc =
+                (traverse_ctx.channel_cb)(io_channel, &mut traverse_ctx.ctx);
+
+            unsafe {
+                spdk_for_each_channel_continue(i, rc);
+            }
+        }
+
+        /// Low-level completion callback for SPDK I/O channel enumeration
+        /// logic.
+        extern "C" fn _visit_channel_done<V, P: 'static>(
+            i: *mut spdk_io_channel_iter,
+            status: i32,
+        ) {
+            // Reconstruct the context box to let all the resources be properly
+            // dropped.
+            let mut traverse_ctx = unsafe {
+                Box::<TraverseCtx<V, P>>::from_raw(
+                    spdk_io_channel_iter_get_ctx(i) as *mut TraverseCtx<V, P>,
+                )
+            };
+
+            (traverse_ctx.done_cb)(status, traverse_ctx.ctx);
+        }
+
+        // Start I/O channel iteration via SPDK.
+        unsafe {
+            spdk_for_each_channel(
+                self.0.as_ptr(),
+                Some(_visit_channel::<T, I>),
+                traverse_ctx as *mut c_void,
+                Some(_visit_channel_done::<T, I>),
+            );
+        }
+    }
+}
+
+impl Drop for IoDevice {
+    fn drop(&mut self) {
+        debug!("unregistering I/O device at {:p}", self.0.as_ptr());
+
+        unsafe {
+            spdk_io_device_unregister(self.0.as_ptr(), None);
+        }
+    }
+}

--- a/mayastor/src/core/mod.rs
+++ b/mayastor/src/core/mod.rs
@@ -35,6 +35,7 @@ pub use env::{
 
 pub use bio::{Bio, IoStatus, IoType};
 pub use handle::BdevHandle;
+pub use io_device::IoDevice;
 pub use nvme::{
     nvme_admin_opc,
     nvme_nvm_opcode,
@@ -56,6 +57,7 @@ mod descriptor;
 mod dma;
 mod env;
 mod handle;
+mod io_device;
 pub mod io_driver;
 pub mod mempool;
 mod nvme;


### PR DESCRIPTION
1. Added support of fail-fast I/O completion for proper I/O error propagation.
2. Concurrent Nexus retire operations are now serialised and get executed
   sequentially in case different replicas experience I/O errors at the same
   time.
3. I/O submission errors can now also trigger device retire (solves edge cases
   when I/O channels are dropped concurrently by reset operation, triggered
   by I/O-unrelated operations (admin queue timeouts, etc).
4. Fixed a few misbehaviours in generic retire logic (like retiring healthy
   replicas in response to I/O errors from the faulty replica).

Implements CAS-868, CAS-865, CAS-866