### PR TITLE
test(e2e): nightly test git sha

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -66,9 +66,6 @@ def getAliasTag() {
 
 def getTag() {
   if (e2e_build_images == true) {
-    if (isTimed() == true) {
-        return 'nightly'
-    }
     def tag = sh(
       // using printf to get rid of trailing newline
       script: "printf \$(git rev-parse --short=12 ${env.GIT_COMMIT})",


### PR DESCRIPTION
Nightly e2e runs should run against the build
tagged with the git sha, not nightly.