### PR TITLE
feat(moac): new options for sync of storage nodes

### DIFF
--- a/csi/moac/.gitignore
+++ b/csi/moac/.gitignore
@@ -9,6 +9,7 @@
 /node_operator.js
 /pool.js
 /pool_operator.js
+/registry.js
 /replica.js
 /volume.js
 /volumes.js

--- a/csi/moac/event_stream.js
+++ b/csi/moac/event_stream.js
@@ -85,7 +85,7 @@ class EventStream extends Readable {
     // they appear as new.
     const self = this;
     if (self.registry) {
-      self.registry.getNode().forEach((node) => {
+      self.registry.getNodes().forEach((node) => {
         self.events.push({
           kind: 'node',
           eventType: 'new',

--- a/csi/moac/node.ts
+++ b/csi/moac/node.ts
@@ -18,6 +18,16 @@ type GrpcCallArgs = {
   args: any;
 }
 
+// Node options when created.
+export type NodeOpts = {
+  // How often to sync healthy node (in ms).
+  syncPeriod?: number;
+  // How often to retry sync if it failed (in ms).
+  syncRetry?: number;
+  // Flip the node to offline state after this many retries have failed.
+  syncBadLimit?: number;
+}
+
 // Object represents mayastor storage node.
 //
 // Node emits following events:
@@ -41,10 +51,7 @@ export class Node extends events.EventEmitter {
   //
   // @param {string} name              Node name.
   // @param {Object} [opts]            Options
-  // @param {number} opts.syncPeriod   How often to sync healthy node (in ms).
-  // @param {number} opts.syncRetry    How often to retry sync if it failed (in ms).
-  // @param {number} opts.syncBadLimit Flip the node to offline state after this many retries have failed.
-  constructor (name: string, opts: any) {
+  constructor (name: string, opts?: NodeOpts) {
     opts = opts || {};
 
     super();

--- a/csi/moac/package.json
+++ b/csi/moac/package.json
@@ -14,8 +14,8 @@
   },
   "scripts": {
     "prepare": "./bundle_protos.sh",
-    "clean": "rm -f csi.js grpc_client.js index.js node.js replica.js pool.js nexus.js watcher.js node_operator.js pool_operator.js volume.js volumes.js volume_operator.js workq.js *.js.map",
-    "purge": "rm -rf node_modules proto csi.js grpc_client.js index.js node.js replica.js pool.js nexus.js watcher.js node_operator.js pool_operator.js volume.js volumes.js volume_operator.js workq.js *.js.map",
+    "clean": "rm -f csi.js grpc_client.js index.js node.js registry.js replica.js pool.js nexus.js watcher.js node_operator.js pool_operator.js volume.js volumes.js volume_operator.js workq.js *.js.map",
+    "purge": "rm -rf node_modules proto csi.js grpc_client.js index.js node.js registry.js replica.js pool.js nexus.js watcher.js node_operator.js pool_operator.js volume.js volumes.js volume_operator.js workq.js *.js.map",
     "compile": "tsc --pretty",
     "start": "./moac",
     "test": "mocha test/index.js",

--- a/csi/moac/rest_api.js
+++ b/csi/moac/rest_api.js
@@ -16,7 +16,7 @@ const log = require('./logger').Logger('api');
 
 class ApiServer {
   constructor (registry) {
-    var self = this;
+    const self = this;
     this.registry = registry;
     this.app = express();
     this.app.get('/stats', (req, res) => {
@@ -42,9 +42,9 @@ class ApiServer {
 
   // TODO: should return stats for nexus rather than for replica
   async getStats () {
-    var self = this;
-    var vols = [];
-    var nodes = self.registry.getNode();
+    const self = this;
+    let vols = [];
+    const nodes = self.registry.getNodes();
 
     // TODO: stats can be retrieved in parallel
     for (let i = 0; i < nodes.length; i++) {

--- a/csi/moac/test/csi_test.js
+++ b/csi/moac/test/csi_test.js
@@ -11,7 +11,7 @@ const sleep = require('sleep-promise');
 const EventEmitter = require('events');
 const { CsiServer, csi } = require('../csi');
 const { GrpcError, grpcCode } = require('../grpc_client');
-const Registry = require('../registry');
+const { Registry } = require('../registry');
 const { Volume } = require('../volume');
 const { Volumes } = require('../volumes');
 const { shouldFailWith } = require('./utils');
@@ -118,7 +118,7 @@ module.exports = function () {
     async function mockedServer (pools, replicas, nexus) {
       const server = new CsiServer(SOCKPATH);
       await server.start();
-      registry = new Registry();
+      registry = new Registry({});
       volumes = new Volumes(registry);
       server.makeReady(registry, volumes);
       getCapacityStub = sinon.stub(registry, 'getCapacity');

--- a/csi/moac/test/event_stream_test.js
+++ b/csi/moac/test/event_stream_test.js
@@ -8,7 +8,7 @@ const sinon = require('sinon');
 const { Pool } = require('../pool');
 const { Replica } = require('../replica');
 const { Nexus } = require('../nexus');
-const Registry = require('../registry');
+const { Registry } = require('../registry');
 const { Volume } = require('../volume');
 const { Volumes } = require('../volumes');
 const EventStream = require('../event_stream');
@@ -32,14 +32,14 @@ module.exports = function () {
   }
 
   it('should read events from registry and volumes stream', (done) => {
-    const registry = new Registry();
+    const registry = new Registry({});
     const volumes = new Volumes(registry);
-    const getNodeStub = sinon.stub(registry, 'getNode');
+    const getNodesStub = sinon.stub(registry, 'getNodes');
     const getVolumeStub = sinon.stub(volumes, 'list');
     // The initial state of the nodes. "new" event should be written to the
     // stream for all these objects and one "sync" event for each node meaning
     // that the reader has caught up with the initial state.
-    getNodeStub.returns([
+    getNodesStub.returns([
       new FakeNode(
         'node1',
         [

--- a/csi/moac/test/index.js
+++ b/csi/moac/test/index.js
@@ -60,7 +60,11 @@ describe('moac', function () {
       // NATS does not run but just to verify that the option works
       '--message-bus=127.0.0.1',
       // shorten the warm up to make the test faster
-      '--heartbeat-interval=1'
+      '--heartbeat-interval=1',
+      // test various sync options
+      '--sync-period=10',
+      '--sync-retry=1',
+      '--sync-bad-limit=3'
     ]);
     let stderr = '';
 

--- a/csi/moac/test/nats_test.js
+++ b/csi/moac/test/nats_test.js
@@ -6,7 +6,7 @@ const expect = require('chai').expect;
 const { spawn } = require('child_process');
 const nats = require('nats');
 const sleep = require('sleep-promise');
-const Registry = require('../registry');
+const { Registry } = require('../registry');
 const { MessageBus } = require('../nats');
 const { waitUntil } = require('./utils');
 const NodeStub = require('./node_stub');
@@ -78,7 +78,7 @@ module.exports = function () {
 
   // Create registry, event bus object, nats client and start nat server
   before((done) => {
-    registry = new Registry();
+    registry = new Registry({});
     registry.Node = NodeStub;
     eventBus = new MessageBus(registry, RECONNECT_DELAY);
     startNats(err => {

--- a/csi/moac/test/node_operator_test.js
+++ b/csi/moac/test/node_operator_test.js
@@ -6,7 +6,7 @@ const expect = require('chai').expect;
 const sinon = require('sinon');
 const sleep = require('sleep-promise');
 const { KubeConfig } = require('client-node-fixed-watcher');
-const Registry = require('../registry');
+const { Registry } = require('../registry');
 const { NodeOperator, NodeResource } = require('../node_operator');
 const { mockCache } = require('./watcher_stub');
 const Node = require('./node_stub');
@@ -97,7 +97,7 @@ module.exports = function () {
     let kc, oper, fakeApiStub;
 
     beforeEach(() => {
-      const registry = new Registry();
+      const registry = new Registry({});
       kc = new KubeConfig();
       Object.assign(kc, fakeConfig);
       oper = new NodeOperator(NAMESPACE, kc, registry);
@@ -146,7 +146,7 @@ module.exports = function () {
     let stubs, registry, nodeResource;
 
     beforeEach(async () => {
-      registry = new Registry();
+      registry = new Registry({});
       registry.Node = Node;
 
       oper = createNodeOperator(registry);
@@ -210,7 +210,7 @@ module.exports = function () {
     let registry, oper;
 
     beforeEach(async () => {
-      registry = new Registry();
+      registry = new Registry({});
       registry.Node = Node;
       oper = createNodeOperator(registry);
     });

--- a/csi/moac/test/pool_operator_test.js
+++ b/csi/moac/test/pool_operator_test.js
@@ -15,7 +15,7 @@ const expect = require('chai').expect;
 const sinon = require('sinon');
 const sleep = require('sleep-promise');
 const { KubeConfig } = require('client-node-fixed-watcher');
-const Registry = require('../registry');
+const { Registry } = require('../registry');
 const { GrpcError, grpcCode } = require('../grpc_client');
 const { PoolOperator, PoolResource } = require('../pool_operator');
 const { Pool } = require('../pool');
@@ -114,7 +114,7 @@ function createPoolResource (
 
 // Create a pool operator object suitable for testing - with mocked watcher etc.
 function createPoolOperator (nodes) {
-  const registry = new Registry();
+  const registry = new Registry({});
   registry.Node = Node;
   nodes = nodes || [];
   nodes.forEach((n) => (registry.nodes[n.name] = n));
@@ -167,7 +167,7 @@ module.exports = function () {
     let kc, oper, fakeApiStub;
 
     beforeEach(() => {
-      const registry = new Registry();
+      const registry = new Registry({});
       kc = new KubeConfig();
       Object.assign(kc, fakeConfig);
       oper = new PoolOperator(NAMESPACE, kc, registry);

--- a/csi/moac/test/registry_test.js
+++ b/csi/moac/test/registry_test.js
@@ -3,7 +3,7 @@
 const _ = require('lodash');
 const expect = require('chai').expect;
 const sinon = require('sinon');
-const Registry = require('../registry');
+const { Registry } = require('../registry');
 const { Replica } = require('../replica');
 const { Pool } = require('../pool');
 const { Nexus } = require('../nexus');
@@ -11,9 +11,9 @@ const Node = require('./node_stub');
 
 module.exports = function () {
   it('should add a node to the registry and look up the node', () => {
-    const registry = new Registry();
+    const registry = new Registry({});
     registry.Node = Node;
-    var nodeEvent;
+    let nodeEvent;
 
     registry.once('node', (ev) => {
       nodeEvent = ev;
@@ -28,7 +28,7 @@ module.exports = function () {
     expect(node.endpoint).to.equal('127.0.0.1:123');
 
     // ensure the events from the node are relayed by the registry
-    var events = ['node', 'pool', 'replica', 'nexus'];
+    const events = ['node', 'pool', 'replica', 'nexus'];
     events.forEach((ev) => {
       registry.once(ev, () => {
         const idx = events.findIndex((ent) => ent === ev);
@@ -41,14 +41,14 @@ module.exports = function () {
   });
 
   it('should not do anything if the same node already exists in the registry', () => {
-    const registry = new Registry();
+    const registry = new Registry({});
     registry.Node = Node;
     const node = new Node('node');
     node.connect('127.0.0.1:123');
     const connectStub = sinon.stub(node, 'connect');
     registry.nodes.node = node;
 
-    var nodeEvent;
+    let nodeEvent;
     registry.once('node', (ev) => {
       nodeEvent = ev;
     });
@@ -59,14 +59,14 @@ module.exports = function () {
   });
 
   it('should reconnect node if it exists but grpc endpoint has changed', () => {
-    const registry = new Registry();
+    const registry = new Registry({});
     registry.Node = Node;
     const node = new Node('node');
     node.connect('127.0.0.1:123');
     const connectStub = sinon.stub(node, 'connect');
     registry.nodes.node = node;
 
-    var nodeEvent;
+    let nodeEvent;
     registry.once('node', (ev) => {
       nodeEvent = ev;
     });
@@ -79,19 +79,19 @@ module.exports = function () {
   });
 
   it('should get a list of nodes from registry', () => {
-    const registry = new Registry();
+    const registry = new Registry({});
     registry.nodes.node1 = new Node('node1');
     registry.nodes.node2 = new Node('node2');
     registry.nodes.node3 = new Node('node3');
-    const list = registry.getNode();
+    const list = registry.getNodes();
     expect(list).to.have.lengthOf(3);
   });
 
   it('should remove a node from the registry', () => {
-    const registry = new Registry();
+    const registry = new Registry({});
     const node = new Node('node');
     registry.nodes.node = node;
-    var nodeEvent;
+    let nodeEvent;
     registry.once('node', (ev) => {
       nodeEvent = ev;
     });
@@ -101,7 +101,7 @@ module.exports = function () {
     expect(nodeEvent.object.name).to.equal('node');
 
     // ensure the events from the node are not relayed
-    var events = ['node', 'pool', 'replica', 'nexus'];
+    const events = ['node', 'pool', 'replica', 'nexus'];
     events.forEach((ev) => {
       registry.on(ev, () => {
         throw new Error('Received event after the node was removed');
@@ -111,8 +111,8 @@ module.exports = function () {
   });
 
   it('should not do anything if removed node does not exist', () => {
-    const registry = new Registry();
-    var nodeEvent;
+    const registry = new Registry({});
+    let nodeEvent;
     registry.once('node', (ev) => {
       nodeEvent = ev;
     });
@@ -121,7 +121,7 @@ module.exports = function () {
   });
 
   it('should get a list of pools from registry', () => {
-    const registry = new Registry();
+    const registry = new Registry({});
     const node1 = new Node('node1', {}, [
       new Pool({ name: 'pool1', disks: [] })
     ]);
@@ -132,19 +132,21 @@ module.exports = function () {
     registry.nodes.node1 = node1;
     registry.nodes.node2 = node2;
 
-    const pools = registry.getPool();
+    const pools = registry.getPools();
     pools.sort();
     expect(pools).to.have.lengthOf(3);
     expect(pools[0].name).to.equal('pool1');
     expect(pools[1].name).to.equal('pool2a');
     expect(pools[2].name).to.equal('pool2b');
+    const pool = registry.getPool('pool2a');
+    expect(pool.name).to.equal('pool2a');
   });
 
   it('should get a list of nexus from registry', () => {
     const UUID1 = 'ba5e39e9-0c0e-4973-8a3a-0dccada09cb1';
     const UUID2 = 'ba5e39e9-0c0e-4973-8a3a-0dccada09cb2';
     const UUID3 = 'ba5e39e9-0c0e-4973-8a3a-0dccada09cb3';
-    const registry = new Registry();
+    const registry = new Registry({});
     const node1 = new Node('node1', {}, [], [new Nexus({ uuid: UUID1 })]);
     const node2 = new Node(
       'node2',
@@ -155,12 +157,14 @@ module.exports = function () {
     registry.nodes.node1 = node1;
     registry.nodes.node2 = node2;
 
-    const nexus = registry.getNexus();
-    nexus.sort();
-    expect(nexus).to.have.lengthOf(3);
-    expect(nexus[0].uuid).to.equal(UUID1);
-    expect(nexus[1].uuid).to.equal(UUID2);
-    expect(nexus[2].uuid).to.equal(UUID3);
+    const nexuses = registry.getNexuses();
+    nexuses.sort();
+    expect(nexuses).to.have.lengthOf(3);
+    expect(nexuses[0].uuid).to.equal(UUID1);
+    expect(nexuses[1].uuid).to.equal(UUID2);
+    expect(nexuses[2].uuid).to.equal(UUID3);
+    const nexus = registry.getNexus(UUID2);
+    expect(nexus.uuid).to.equal(UUID2);
   });
 
   it('should get a list of replicas from registry', () => {
@@ -174,7 +178,7 @@ module.exports = function () {
     node1.pools = [pool1];
     const node2 = new Node('node2');
     node2.pools = [pool2a, pool2b];
-    const registry = new Registry();
+    const registry = new Registry({});
     registry.nodes.node1 = node1;
     registry.nodes.node2 = node2;
     pool1.replicas = [
@@ -183,7 +187,7 @@ module.exports = function () {
     ];
     pool2b.replicas = [new Replica({ uuid: UUID3 })];
 
-    let replicas = registry.getReplicaSet();
+    let replicas = registry.getReplicas();
     replicas.sort();
     expect(replicas).to.have.lengthOf(3);
     expect(replicas[0].uuid).to.equal(UUID1);
@@ -195,7 +199,7 @@ module.exports = function () {
   });
 
   it('should close the registry', () => {
-    const registry = new Registry();
+    const registry = new Registry({});
     const node = new Node('node');
     const connectStub = sinon.stub(node, 'connect');
     const disconnectStub = sinon.stub(node, 'disconnect');
@@ -248,7 +252,7 @@ module.exports = function () {
     pool2a.bind(node2);
     pool2b.bind(node2);
     pool2c.bind(node2);
-    const registry = new Registry();
+    const registry = new Registry({});
     registry.nodes.node1 = node1;
     registry.nodes.node2 = node2;
 
@@ -285,7 +289,7 @@ module.exports = function () {
       const node1 = new Node('node1', {}, [pool1]);
       const node2 = new Node('node2', {}, [pool2]);
       const node3 = new Node('node3', {}, [pool3]);
-      const registry = new Registry();
+      const registry = new Registry({});
       registry.nodes.node1 = node1;
       registry.nodes.node2 = node2;
       registry.nodes.node3 = node3;
@@ -328,7 +332,7 @@ module.exports = function () {
       pool2.replicas = [new Replica({ uuid: UUID1 })];
       const node1 = new Node('node1', {}, [pool1]);
       const node2 = new Node('node2', {}, [pool2]);
-      const registry = new Registry();
+      const registry = new Registry({});
       registry.nodes.node1 = node1;
       registry.nodes.node2 = node2;
 
@@ -361,7 +365,7 @@ module.exports = function () {
       });
       const node1 = new Node('node1', {}, [pool1]);
       const node2 = new Node('node2', {}, [pool2]);
-      const registry = new Registry();
+      const registry = new Registry({});
       registry.nodes.node1 = node1;
       registry.nodes.node2 = node2;
 
@@ -404,7 +408,7 @@ module.exports = function () {
       const node1 = new Node('node1', {}, [pool1]);
       const node2 = new Node('node2', {}, [pool2]);
       const node3 = new Node('node3', {}, [pool3]);
-      const registry = new Registry();
+      const registry = new Registry({});
       registry.nodes.node1 = node1;
       registry.nodes.node2 = node2;
       registry.nodes.node3 = node3;
@@ -429,7 +433,7 @@ module.exports = function () {
         used: 10
       });
       const node1 = new Node('node1', {}, [pool1, pool2]);
-      const registry = new Registry();
+      const registry = new Registry({});
       registry.nodes.node1 = node1;
 
       const pools = registry.choosePools(75, [], []);
@@ -454,7 +458,7 @@ module.exports = function () {
       });
       const node1 = new Node('node1', {}, [pool1]);
       const node2 = new Node('node2', {}, [pool2]);
-      const registry = new Registry();
+      const registry = new Registry({});
       registry.nodes.node1 = node1;
       registry.nodes.node2 = node2;
 
@@ -481,7 +485,7 @@ module.exports = function () {
       });
       const node1 = new Node('node1', {}, [pool1]);
       const node2 = new Node('node2', {}, [pool2]);
-      const registry = new Registry();
+      const registry = new Registry({});
       registry.nodes.node1 = node1;
       registry.nodes.node2 = node2;
 

--- a/csi/moac/test/rest_api_test.js
+++ b/csi/moac/test/rest_api_test.js
@@ -5,7 +5,7 @@
 const expect = require('chai').expect;
 const http = require('http');
 const sinon = require('sinon');
-const Registry = require('../registry');
+const { Registry } = require('../registry');
 const { Node } = require('../node');
 const { GrpcError, grpcCode } = require('../grpc_client');
 const ApiServer = require('../rest_api');
@@ -25,7 +25,7 @@ module.exports = function () {
     const node2 = new Node('node2');
     const node3 = new Node('node3');
     const node4 = new Node('node4');
-    const registry = new Registry();
+    const registry = new Registry({});
     registry.nodes = {
       node1,
       node2,

--- a/csi/moac/test/volume_operator_test.js
+++ b/csi/moac/test/volume_operator_test.js
@@ -8,7 +8,7 @@ const expect = require('chai').expect;
 const sinon = require('sinon');
 const sleep = require('sleep-promise');
 const { KubeConfig } = require('client-node-fixed-watcher');
-const Registry = require('../registry');
+const { Registry } = require('../registry');
 const { Volume } = require('../volume');
 const { Volumes } = require('../volumes');
 const { VolumeOperator, VolumeResource } = require('../volume_operator');
@@ -287,7 +287,7 @@ module.exports = function () {
     let kc, oper, fakeApiStub;
 
     beforeEach(() => {
-      const registry = new Registry();
+      const registry = new Registry({});
       kc = new KubeConfig();
       Object.assign(kc, fakeConfig);
       oper = new VolumeOperator(NAMESPACE, kc, registry);
@@ -343,7 +343,7 @@ module.exports = function () {
 
     it('should call import volume for existing resources when starting the operator', async () => {
       let stubs;
-      const registry = new Registry();
+      const registry = new Registry({});
       const volumes = new Volumes(registry);
       const importVolumeStub = sinon.stub(volumes, 'importVolume');
       // return value is not used so just return something
@@ -365,7 +365,7 @@ module.exports = function () {
 
     it('should set reason in resource if volume import fails upon "new" event', async () => {
       let stubs;
-      const registry = new Registry();
+      const registry = new Registry({});
       const volumes = new Volumes(registry);
       const importVolumeStub = sinon.stub(volumes, 'importVolume');
       importVolumeStub.throws(
@@ -390,7 +390,7 @@ module.exports = function () {
 
     it('should destroy the volume upon "del" event', async () => {
       let stubs;
-      const registry = new Registry();
+      const registry = new Registry({});
       const volumes = new Volumes(registry);
       const destroyVolumeStub = sinon.stub(volumes, 'destroyVolume');
       destroyVolumeStub.resolves();
@@ -413,7 +413,7 @@ module.exports = function () {
 
     it('should handle gracefully if destroy of a volume fails upon "del" event', async () => {
       let stubs;
-      const registry = new Registry();
+      const registry = new Registry({});
       const volumes = new Volumes(registry);
       const destroyVolumeStub = sinon.stub(volumes, 'destroyVolume');
       destroyVolumeStub.rejects(
@@ -438,7 +438,7 @@ module.exports = function () {
 
     it('should modify the volume upon "mod" event', async () => {
       let stubs;
-      const registry = new Registry();
+      const registry = new Registry({});
       const volumes = new Volumes(registry);
       const volume = new Volume(UUID, registry, new EventEmitter(), defaultSpec);
       volume.size = 110;
@@ -488,7 +488,7 @@ module.exports = function () {
 
     it('should not crash if update volume fails upon "mod" event', async () => {
       let stubs;
-      const registry = new Registry();
+      const registry = new Registry({});
       const volumes = new Volumes(registry);
       const volume = new Volume(UUID, registry, new EventEmitter(), defaultSpec);
       volume.size = 110;
@@ -535,7 +535,7 @@ module.exports = function () {
 
     it('should not do anything if volume params stay the same upon "mod" event', async () => {
       let stubs;
-      const registry = new Registry();
+      const registry = new Registry({});
       const volumes = new Volumes(registry);
       const volume = new Volume(UUID, registry, new EventEmitter(), defaultSpec);
       volume.size = 110;
@@ -578,7 +578,7 @@ module.exports = function () {
 
     it('should create a resource upon "new" volume event', async () => {
       let stubs;
-      const registry = new Registry();
+      const registry = new Registry({});
       const volume = new Volume(UUID, registry, new EventEmitter(), defaultSpec);
       const volumes = new Volumes(registry);
       sinon
@@ -614,7 +614,7 @@ module.exports = function () {
 
     it('should not crash if POST fails upon "new" volume event', async () => {
       let stubs;
-      const registry = new Registry();
+      const registry = new Registry({});
       const volumes = new Volumes(registry);
       const volume = new Volume(UUID, registry, new EventEmitter(), defaultSpec);
       sinon.stub(volumes, 'get').returns([]);
@@ -639,7 +639,7 @@ module.exports = function () {
 
     it('should update the resource upon "new" volume event if it exists', async () => {
       let stubs;
-      const registry = new Registry();
+      const registry = new Registry({});
       const volumes = new Volumes(registry);
       const newSpec = _.cloneDeep(defaultSpec);
       newSpec.replicaCount += 1;
@@ -669,7 +669,7 @@ module.exports = function () {
 
     it('should not update the resource upon "new" volume event if it is the same', async () => {
       let stubs;
-      const registry = new Registry();
+      const registry = new Registry({});
       const volumes = new Volumes(registry);
       const volume = new Volume(UUID, registry, new EventEmitter(), defaultSpec, 'pending', 100, 'node2');
       sinon
@@ -701,7 +701,7 @@ module.exports = function () {
 
     it('should update the resource upon "mod" volume event', async () => {
       let stubs;
-      const registry = new Registry();
+      const registry = new Registry({});
       const volumes = new Volumes(registry);
       sinon.stub(volumes, 'get').returns([]);
 
@@ -736,7 +736,7 @@ module.exports = function () {
 
     it('should update just the status if spec has not changed upon "mod" volume event', async () => {
       let stubs;
-      const registry = new Registry();
+      const registry = new Registry({});
       const volumes = new Volumes(registry);
       sinon.stub(volumes, 'get').returns([]);
 
@@ -761,7 +761,7 @@ module.exports = function () {
 
     it('should not crash if PUT fails upon "mod" volume event', async () => {
       let stubs;
-      const registry = new Registry();
+      const registry = new Registry({});
       const volumes = new Volumes(registry);
       sinon.stub(volumes, 'get').returns([]);
 
@@ -795,7 +795,7 @@ module.exports = function () {
 
     it('should not crash if the resource does not exist upon "mod" volume event', async () => {
       let stubs;
-      const registry = new Registry();
+      const registry = new Registry({});
       const volumes = new Volumes(registry);
       sinon.stub(volumes, 'get').returns([]);
 
@@ -828,7 +828,7 @@ module.exports = function () {
     it('should delete the resource upon "del" volume event', async () => {
       let stubs;
       const volumeResource = createVolumeResource(UUID, defaultSpec);
-      const registry = new Registry();
+      const registry = new Registry({});
       const volumes = new Volumes(registry);
       sinon.stub(volumes, 'get').returns([]);
 
@@ -851,7 +851,7 @@ module.exports = function () {
     it('should not crash if DELETE fails upon "del" volume event', async () => {
       let stubs;
       const volumeResource = createVolumeResource(UUID, defaultSpec);
-      const registry = new Registry();
+      const registry = new Registry({});
       const volumes = new Volumes(registry);
       sinon.stub(volumes, 'get').returns([]);
 
@@ -873,7 +873,7 @@ module.exports = function () {
 
     it('should not crash if the resource does not exist upon "del" volume event', async () => {
       let stubs;
-      const registry = new Registry();
+      const registry = new Registry({});
       const volumes = new Volumes(registry);
       sinon.stub(volumes, 'get').returns([]);
 

--- a/csi/moac/test/volume_test.js
+++ b/csi/moac/test/volume_test.js
@@ -10,7 +10,7 @@ const EventEmitter = require('events');
 const expect = require('chai').expect;
 const sinon = require('sinon');
 const { Node } = require('../node');
-const Registry = require('../registry');
+const { Registry } = require('../registry');
 const { Volume } = require('../volume');
 const { shouldFailWith } = require('./utils');
 const { grpcCode } = require('../grpc_client');
@@ -28,26 +28,26 @@ const defaultOpts = {
 
 module.exports = function () {
   it('should stringify volume name', () => {
-    const registry = new Registry();
+    const registry = new Registry({});
     const volume = new Volume(UUID, registry, new EventEmitter(), defaultOpts);
     expect(volume.toString()).to.equal(UUID);
   });
 
   it('should get name of the node where the volume has been published', () => {
-    const registry = new Registry();
+    const registry = new Registry({});
     const volume = new Volume(UUID, registry, new EventEmitter(), defaultOpts, 'degraded', 100, 'node');
     expect(volume.getNodeName()).to.equal('node');
     expect(volume.state).to.equal('degraded');
   });
 
   it('should get zero size of a volume that has not been created yet', () => {
-    const registry = new Registry();
+    const registry = new Registry({});
     const volume = new Volume(UUID, registry, new EventEmitter(), defaultOpts);
     expect(volume.getSize()).to.equal(0);
   });
 
   it('should get the right size of a volume that has been imported', () => {
-    const registry = new Registry();
+    const registry = new Registry({});
     const volume = new Volume(UUID, registry, new EventEmitter(), defaultOpts, 'healthy', 100);
     expect(volume.getSize()).to.equal(100);
     expect(volume.state).to.equal('healthy');
@@ -55,7 +55,7 @@ module.exports = function () {
 
   it('should set the preferred nodes for the volume', () => {
     let modified = false;
-    const registry = new Registry();
+    const registry = new Registry({});
     const emitter = new EventEmitter();
     emitter.on('volume', (ev) => {
       if (ev.eventType === 'mod') {
@@ -70,7 +70,7 @@ module.exports = function () {
   });
 
   it('should not publish volume that is known to be broken', async () => {
-    const registry = new Registry();
+    const registry = new Registry({});
     const volume = new Volume(UUID, registry, new EventEmitter(), defaultOpts, 'faulted', 100);
     const node = new Node('node');
     const stub = sinon.stub(node, 'call');

--- a/csi/moac/test/volumes_test.js
+++ b/csi/moac/test/volumes_test.js
@@ -13,7 +13,7 @@ const sinon = require('sinon');
 const { Nexus } = require('../nexus');
 const { Node } = require('../node');
 const { Pool } = require('../pool');
-const Registry = require('../registry');
+const { Registry } = require('../registry');
 const { Replica } = require('../replica');
 const { Volume } = require('../volume');
 const { Volumes } = require('../volumes');
@@ -38,7 +38,7 @@ module.exports = function () {
 
   // Create pristine test env with 3 pools on 3 nodes
   function createTestEnv () {
-    registry = new Registry();
+    registry = new Registry({});
     volumes = new Volumes(registry);
     node1 = new Node('node1');
     node2 = new Node('node2');

--- a/csi/moac/tsconfig.json
+++ b/csi/moac/tsconfig.json
@@ -68,6 +68,7 @@
     "node.ts",
     "node_operator.ts",
     "replica.ts",
+    "registry.ts",
     "pool.ts",
     "pool_operator.ts",
     "volume.ts",


### PR DESCRIPTION
Users can control how often are synchronized the storage nodes and
when storage node moves to offline state. This is important even
more now as we still haven't implemented events from storage nodes
to the control plane.

The parameters are propagated from index to registry where they are
used for creating new node objects. While touching the registry code
it has been converted to typescript.

Resolves: CAS-85