### PR TITLE
feat(nexus): cancel active io for the replica being retired

### DIFF
--- a/mayastor/src/bdev/device.rs
+++ b/mayastor/src/bdev/device.rs
@@ -436,6 +436,16 @@ impl BlockDeviceHandle for SpdkBlockDeviceHandle {
         }
     }
 
+    fn close(&mut self) -> Result<(), CoreError> {
+        warn!(
+            "{} close() method is not implemented for native bdev I/O handles",
+            self.device.device_name(),
+        );
+        Err(CoreError::NotSupported {
+            source: Errno::ENXIO,
+        })
+    }
+
     fn reset(
         &self,
         cb: IoCompletionCallback,

--- a/mayastor/src/bdev/nexus/nexus_io.rs
+++ b/mayastor/src/bdev/nexus/nexus_io.rs
@@ -640,7 +640,7 @@ impl NexusBio {
                             // inconsistency in reading/updating nexus
                             // configuration.
                             nexus.pause().await.unwrap();
-                            nexus.set_failfast().await.unwrap();
+                            nexus.set_failfast(device.clone()).await.unwrap();
                             nexus.reconfigure(DrEvent::ChildFault).await;
 
                             // Lookup child once more and finally remove it.

--- a/mayastor/src/bdev/nvmx/handle.rs
+++ b/mayastor/src/bdev/nvmx/handle.rs
@@ -747,6 +747,15 @@ impl BlockDeviceHandle for NvmeDeviceHandle {
         }
     }
 
+    fn close(&mut self) -> Result<(), CoreError> {
+        let channel = self.io_channel.as_ptr();
+        let inner = NvmeIoChannel::inner_from_channel(channel);
+
+        let rc = inner.shutdown();
+        info!("{} device handle closed, rc={}", self.name, rc);
+        Ok(())
+    }
+
     fn reset(
         &self,
         cb: IoCompletionCallback,

--- a/mayastor/src/core/block_device.rs
+++ b/mayastor/src/core/block_device.rs
@@ -163,6 +163,12 @@ pub trait BlockDeviceHandle {
         cb_arg: IoCompletionCallbackArg,
     ) -> Result<(), CoreError>;
 
+    /// Cancel all outstanding I/O operations associated with this handle and
+    /// release all its resources, making the handle unusable for further
+    /// I/O submissions. This function must be called only by the thread
+    /// that initially opened the handle: otherwise it might panic.
+    fn close(&mut self) -> Result<(), CoreError>;
+
     // NVMe only.
     async fn nvme_admin_custom(&self, opcode: u8) -> Result<(), CoreError>;
     async fn nvme_admin(


### PR DESCRIPTION
Upon retiring a replica all its active I/O operations are forcibly canceled
via new close() method, which is available now for BlockDeviceHandle.

Implements CAS-887