### PR TITLE
fix(nexus): io_retire

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,24 +4,24 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.14.1"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55f82cfe485775d02112886f4169bde0c5894d75e79ead7eafe7e40a25e45f7"
+checksum = "03345e98af8f3d786b6d9f656ccfa6ac316d954e92bc4841f0bba20789d5fb5a"
 dependencies = [
  "gimli",
 ]
 
 [[package]]
 name = "adler"
-version = "0.2.3"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.15"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
 dependencies = [
  "memchr",
 ]
@@ -46,9 +46,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afddf7f520a80dbf76e6f50a35bca42a2331ef227a28b3b6dc5c2e2338d114b1"
+checksum = "28b2cd92db5cbd74e8e5028f7e27dd7aa3090e89e4f2a197cc7c8dfb69c7063b"
 
 [[package]]
 name = "assert_matches"
@@ -69,16 +69,16 @@ dependencies = [
 
 [[package]]
 name = "async-executor"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb877970c7b440ead138f6321a3b5395d6061183af779340b65e20c0fede9146"
+checksum = "871f9bb5e0a22eeb7e8cf16641feb87c9dc67032ccf8ff49e772eb9941d3a965"
 dependencies = [
  "async-task",
  "concurrent-queue",
  "fastrand",
  "futures-lite",
  "once_cell",
- "vec-arena",
+ "slab",
 ]
 
 [[package]]
@@ -94,38 +94,38 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "1.3.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9315f8f07556761c3e48fec2e6b276004acf426e6dc068b2c2251854d65ee0fd"
+checksum = "4bbfd5cf2794b1e908ea8457e6c45f8f8f1f6ec5f74617bf4662623f47503c3b"
 dependencies = [
  "concurrent-queue",
  "fastrand",
  "futures-lite",
  "libc",
  "log",
- "nb-connect",
  "once_cell",
  "parking",
  "polling",
- "vec-arena",
+ "slab",
+ "socket2",
  "waker-fn",
  "winapi",
 ]
 
 [[package]]
 name = "async-lock"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1996609732bde4a9988bc42125f55f2af5f3c36370e27c778d5191a4a1b63bfb"
+checksum = "e6a8ea61bf9947a1007c5cada31e647dbc77b103c679858150003ba697ea798b"
 dependencies = [
  "event-listener",
 ]
 
 [[package]]
 name = "async-net"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06de475c85affe184648202401d7622afb32f0f74e02192857d0201a16defbe5"
+checksum = "69b0a74e7f70af3c8cf1aa539edbd044795706659ac52b78a71dc1a205ecefdf"
 dependencies = [
  "async-io",
  "blocking",
@@ -135,17 +135,18 @@ dependencies = [
 
 [[package]]
 name = "async-process"
-version = "1.0.2"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef37b86e2fa961bae5a4d212708ea0154f904ce31d1a4a7f47e1bbc33a0c040b"
+checksum = "a8f38756dd9ac84671c428afbf7c9f7495feff9ec5b0710f17100098e5b354ac"
 dependencies = [
  "async-io",
  "blocking",
  "cfg-if 1.0.0",
  "event-listener",
  "futures-lite",
+ "libc",
  "once_cell",
- "signal-hook 0.3.4",
+ "signal-hook 0.3.8",
  "winapi",
 ]
 
@@ -162,9 +163,9 @@ dependencies = [
 
 [[package]]
 name = "async-stream"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3670df70cbc01729f901f94c887814b3c68db038aad1329a418bae178bc5295c"
+checksum = "171374e7e3b2504e0e5236e3b59260560f9fe94bfe9ac39ba5e4e929c5590625"
 dependencies = [
  "async-stream-impl",
  "futures-core",
@@ -172,9 +173,9 @@ dependencies = [
 
 [[package]]
 name = "async-stream-impl"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3548b8efc9f8e8a5a0a2808c5bd8451a9031b9e5b879a79590304ae928b0a70"
+checksum = "648ed8c8d2ce5409ccd57453d9d1b214b342a0d69376a6feda1fd6cae3299308"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -189,9 +190,9 @@ checksum = "e91831deabf0d6d7ec49552e489aed63b7456a7a3c46cff62adad428110b0af0"
 
 [[package]]
 name = "async-trait"
-version = "0.1.42"
+version = "0.1.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d3a45e77e34375a7923b1e8febb049bb011f064714a8e17a1a616fef01da13d"
+checksum = "0b98e84bbb4cbcdd97da190ba0c58a1bb0de2c1fdf67d159e192ed766aeca722"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -223,11 +224,12 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "backtrace"
-version = "0.3.56"
+version = "0.3.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d117600f438b1707d4e4ae15d3595657288f8235a0eb593e80ecc98ab34e1bc"
+checksum = "4717cfcbfaa661a0fd48f8453951837ae7e8f81e481fbb136e3202d72805a744"
 dependencies = [
  "addr2line",
+ "cc",
  "cfg-if 1.0.0",
  "libc",
  "miniz_oxide",
@@ -249,20 +251,19 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "base64-url"
-version = "1.4.8"
+version = "1.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8a7558a139be0909d407d70873248681e70bac73595c3ded9dba98a625c8acb"
+checksum = "44265cf903f576fcaa1c2f23b32ec2dadaa8ec9d6b7c6212704d72a417bfbeef"
 dependencies = [
  "base64 0.13.0",
 ]
 
 [[package]]
 name = "bincode"
-version = "1.3.1"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f30d3a39baa26f9651f17b375061f3233dde33424a8b72b0dbe93a68a0bc896d"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
- "byteorder",
  "serde",
 ]
 
@@ -380,9 +381,9 @@ dependencies = [
 
 [[package]]
 name = "build_const"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39092a32794787acd8525ee150305ff051b0aa6cc2abaf193924f5ab05425f39"
+checksum = "b4ae4235e6dac0694637c763029ecea1a2ec9e4e06ec2729bd21ba4d9c863eb7"
 
 [[package]]
 name = "bumpalo"
@@ -398,9 +399,9 @@ checksum = "415301c9de11005d4b92193c0eb7ac7adc37e5a49e0ac9bed0a42343512744b8"
 
 [[package]]
 name = "byteorder"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae44d1a3d5a19df61dd0c8beb138458ac2a53a7ac09eba97d55592540004306b"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
@@ -416,9 +417,9 @@ checksum = "631ae5198c9be5e753e5cc215e1bd73c2b466a3565173db433f52bb9d3e66dba"
 
 [[package]]
 name = "cc"
-version = "1.0.66"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c0496836a84f8d0495758516b8621a622beb77c0fed418570e50764093ced48"
+checksum = "e3c69b077ad434294d3ce9f1f6143a2a4b89a8a2d54ef813d85003a4fd1137fd"
 
 [[package]]
 name = "cexpr"
@@ -457,9 +458,9 @@ dependencies = [
 
 [[package]]
 name = "clang-sys"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cb92721cb37482245ed88428f72253ce422b3b4ee169c70a0642521bb5db4cc"
+checksum = "853eda514c284c2287f4bf20ae614f8781f40a81d32ecda6e91449304dfe077c"
 dependencies = [
  "glob",
  "libc",
@@ -535,10 +536,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
 
 [[package]]
-name = "cpuid-bool"
-version = "0.1.2"
+name = "cpufeatures"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
+checksum = "ed00c67cb5d0a7d64a44f6ad2668db7e7530311dd53ea79bcd4fb022c64911c8"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "crc"
@@ -676,9 +680,9 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "3.0.2"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f627126b946c25a4638eec0ea634fc52506dea98db118aae985118ce7c3d723f"
+checksum = "639891fde0dbea823fc3d798a0fdf9d2f9440a42d64a78ab3488b0ca025117b3"
 dependencies = [
  "byteorder",
  "digest",
@@ -689,9 +693,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.12.0"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11947000d710ff98138229f633039982f0fef2d9a3f546c21d610fee5f8631d5"
+checksum = "5f2c43f534ea4b0b049015d00269734195e6d3f0f6635cb692251aca6f9f8b3c"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -699,9 +703,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.12.0"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae53b4d9cc89c40314ccf2bf9e6ff1eb19c31e3434542445a41893dbf041aec2"
+checksum = "8e91455b86830a1c21799d94524df0845183fa55bafd9aa137b01c7d1065fa36"
 dependencies = [
  "fnv",
  "ident_case",
@@ -713,9 +717,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.12.0"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9cd9ac4d50d023af5e710cae1501afb063efcd917bd3fc026e8ed6493cc9755"
+checksum = "29b5acf0dea37a7f66f7b25d2c5e93fd46f8f6968b1a5d7a3e02e97768afc95a"
 dependencies = [
  "darling_core",
  "quote",
@@ -730,19 +734,18 @@ checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
 
 [[package]]
 name = "derive_builder"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ef25735c9f0d0c547d2794701600c94abf030ecb740fad1673fa64461f3573"
+checksum = "d13202debe11181040ae9063d739fa32cfcaaebe2275fe387703460ae2365b30"
 dependencies = [
- "derive_builder_core",
  "derive_builder_macro",
 ]
 
 [[package]]
 name = "derive_builder_core"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3150f1e84602847b99d3eeb702487fc364f7d6c94f634e944a68fdbaea09e457"
+checksum = "66e616858f6187ed828df7c64a6d71720d83767a7f19740b2d1b6fe6327b36e5"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -752,9 +755,9 @@ dependencies = [
 
 [[package]]
 name = "derive_builder_macro"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca1008bddefdc08d1e734aeb27b94f384390af261b4d1a8fb51fe19c577f05c"
+checksum = "58a94ace95092c5acb1e97a7e846b310cfbd499652f72297da7493f618a98d73"
 dependencies = [
  "derive_builder_core",
  "syn",
@@ -802,9 +805,9 @@ dependencies = [
 
 [[package]]
 name = "dns-lookup"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "093d88961fd18c4ecacb8c80cd0b356463ba941ba11e0e01f9cf5271380b79dc"
+checksum = "eb4c5ce3a7034c5eb66720bb16e9ac820e01b29032ddc06dd0fe47072acf7454"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -820,9 +823,9 @@ checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "dtoa"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d7ed2934d741c6b37e33e3832298e8850b53fd2d2bea03873375596c7cea4e"
+checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
 
 [[package]]
 name = "dyn-clonable"
@@ -853,9 +856,9 @@ checksum = "ee2626afccd7561a06cf1367e2950c4718ea04565e20fb5029b6c7d8ad09abcf"
 
 [[package]]
 name = "ed25519"
-version = "1.0.3"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37c66a534cbb46ab4ea03477eae19d5c22c01da8258030280b7bd9d8433fb6ef"
+checksum = "8d0860415b12243916284c67a9be413e044ee6668247b99ba26d94b2bc06c8f6"
 dependencies = [
  "signature",
 ]
@@ -969,9 +972,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca5faf057445ce5c9d4329e382b2ce7ca38550ef3b73a5348362d5f24e0c7fe3"
+checksum = "77b705829d1e87f762c2df6da140b26af5839e1033aa84aa5f56bb688e4e1bdb"
 dependencies = [
  "instant",
 ]
@@ -1000,19 +1003,19 @@ dependencies = [
 
 [[package]]
 name = "fsio"
-version = "0.1.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1fd087255f739f4f1aeea69f11b72f8080e9c2e7645cd06955dad4a178a49e3"
+checksum = "a50045aa8931ae01afbc5d72439e8f57f326becb8c70d07dfc816778eff3d167"
 dependencies = [
- "rand 0.7.3",
+ "rand 0.8.3",
  "users",
 ]
 
 [[package]]
 name = "futures"
-version = "0.3.12"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da9052a1a50244d8d5aa9bf55cbc2fb6f357c86cc52e46c62ed390a7180cf150"
+checksum = "0e7e43a803dae2fa37c1f6a8fe121e1f7bf9548b4dfc0522a42f34145dadfc27"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1025,9 +1028,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.12"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2d31b7ec7efab6eefc7c57233bb10b847986139d88cc2f5a02a1ae6871a1846"
+checksum = "e682a68b29a882df0545c143dc3646daefe80ba479bcdede94d5a703de2871e2"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1035,15 +1038,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.12"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79e5145dde8da7d1b3892dad07a9c98fc04bc39892b1ecc9692cf53e2b780a65"
+checksum = "0402f765d8a89a26043b889b26ce3c4679d268fa6bb22cd7c6aad98340e179d1"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.12"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9e59fdc009a4b3096bf94f740a0f2424c082521f20a9b08c5c07c48d90fd9b9"
+checksum = "badaa6a909fac9e7236d0620a2f57f7664640c56575b71a7552fbd68deafab79"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1052,9 +1055,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.12"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28be053525281ad8259d47e4de5de657b25e7bac113458555bb4b70bc6870500"
+checksum = "acc499defb3b348f8d8f3f66415835a9131856ff7714bf10dadfc4ec4bdb29a1"
 
 [[package]]
 name = "futures-lite"
@@ -1073,10 +1076,11 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.12"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c287d25add322d9f9abdcdc5927ca398917996600182178774032e9f8258fedd"
+checksum = "a4c40298486cdf52cc00cd6d6987892ba502c7656a16a4192a9992b1ccedd121"
 dependencies = [
+ "autocfg",
  "proc-macro-hack",
  "proc-macro2",
  "quote",
@@ -1085,25 +1089,23 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.12"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf5c69029bda2e743fddd0582d1083951d65cc9539aebf8812f36c3491342d6"
+checksum = "a57bead0ceff0d6dde8f465ecd96c9338121bb7717d3e7b108059531870c4282"
 
 [[package]]
 name = "futures-task"
-version = "0.3.12"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13de07eb8ea81ae445aca7b69f5f7bf15d7bf4912d8ca37d6645c77ae8a58d86"
-dependencies = [
- "once_cell",
-]
+checksum = "8a16bef9fc1a4dddb5bee51c989e3fbba26569cbb0e31f5b303c184e3dd33dae"
 
 [[package]]
 name = "futures-util"
-version = "0.3.12"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "632a8cd0f2a4b3fdea1657f08bde063848c3bd00f9bbf6e256b8be78802e624b"
+checksum = "feb5c238d27e2bf94ffdfd27b2c29e3df4a68c4193bb6427384259e2bf191967"
 dependencies = [
+ "autocfg",
  "futures-channel",
  "futures-core",
  "futures-io",
@@ -1147,20 +1149,20 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
+checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
+ "wasi 0.10.2+wasi-snapshot-preview1",
 ]
 
 [[package]]
 name = "gimli"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6503fe142514ca4799d4c26297c4248239fe8838d827db6bd6065c6ed29a6ce"
+checksum = "0e4075386626662786ddb0ec9081e7c7eeb1ba31951f447ca780ef9f5d568189"
 
 [[package]]
 name = "git-version"
@@ -1192,8 +1194,8 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "h2"
-version = "0.3.1"
-source = "git+https://github.com/openebs/h2?branch=bump-authority-workaround#c4d0b9925c354c6a7d0681f8e886abfdea459ca5"
+version = "0.3.3"
+source = "git+https://github.com/openebs/h2?branch=v0.3.3#64033595cbf9211e670481c519a9c0ac7691891e"
 dependencies = [
  "bytes",
  "fnv",
@@ -1234,15 +1236,15 @@ dependencies = [
 
 [[package]]
 name = "hex"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7245cd7449cc792608c3c8a9eaf69bd4eabbabf802713748fd739c98b82f0747"
+checksum = "527e8c9ac747e28542699a951517aa9a6945af506cd1f2e1b53a576c17b6cc11"
 dependencies = [
  "bytes",
  "fnv",
@@ -1251,25 +1253,26 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2861bd27ee074e5ee891e8b539837a9430012e249d7f0ca2d795650f579c1994"
+checksum = "60daa14be0e0786db0f03a9e57cb404c9d756eed2b6c62b9ea98ec5743ec75a9"
 dependencies = [
  "bytes",
  "http",
+ "pin-project-lite",
 ]
 
 [[package]]
 name = "httparse"
-version = "1.3.5"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "615caabe2c3160b313d52ccc905335f4ed5f10881dd63dc5699d47e90be85691"
+checksum = "f3a87b616e37e93c22fb19bcd386f02f3af5ea98a25670ad0fce773de23c5e68"
 
 [[package]]
 name = "httpdate"
-version = "0.3.2"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
+checksum = "05842d0d43232b23ccb7060ecb0f0626922c21f30012e97b767b30afd4a5d4b9"
 
 [[package]]
 name = "humantime"
@@ -1279,9 +1282,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.4"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8e946c2b1349055e0b72ae281b238baf1a3ea7307c7e9f9d64673bdd9c26ac7"
+checksum = "1e5f105c494081baa3bf9e200b279e27ec1623895cd504c7dbef8d0b080fcf54"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1322,9 +1325,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89829a5d69c23d348314a7ac337fe39173b61149a9864deabd260983aed48c21"
+checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
 dependencies = [
  "matches",
  "unicode-bidi",
@@ -1333,9 +1336,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.6.1"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb1fa934250de4de8aef298d81c729a7d33d8c239daa3a7575e6b92bfc7313b"
+checksum = "824845a0bf897a9042383849b02c1bc219c2383772efcd5c6f9766fa4b81aef3"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -1392,9 +1395,9 @@ checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "js-sys"
-version = "0.3.47"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cfb73131c35423a367daf8cbd24100af0d077668c8c2943f0e7dd775fef0f65"
+checksum = "83bdfbace3a0e81a4253f73b49e960b053e396a11012cbd49b9b74d6a2b67062"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1432,15 +1435,15 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.86"
+version = "0.2.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7282d924be3275cec7f6756ff4121987bc6481325397dde6ba3e7802b1a8b1c"
+checksum = "18794a8ad5b29321f790b55d93dfba91e125cb1a9edbd4f8e3150acc771c1a5e"
 
 [[package]]
 name = "libloading"
-version = "0.6.7"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "351a32417a12d5f7e82c368a66781e307834dae04c6ce0cd4456d52989229883"
+checksum = "6f84d96438c15fcd6c3f244c8fce01d1e2b9c6b5623e9c711dc9286d8fc92d6a"
 dependencies = [
  "cfg-if 1.0.0",
  "winapi",
@@ -1464,9 +1467,9 @@ checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 
 [[package]]
 name = "lock_api"
-version = "0.4.2"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd96ffd135b2fd7b973ac026d28085defbe8983df057ced3eb4f2130b0831312"
+checksum = "0382880606dff6d15c9476c416d18690b72742aa7b605bb6dd6ec9030fbf07eb"
 dependencies = [
  "scopeguard",
 ]
@@ -1542,6 +1545,7 @@ dependencies = [
  "nix",
  "nvmeadm",
  "once_cell",
+ "parking_lot",
  "pin-utils",
  "proc-mounts",
  "prost",
@@ -1609,9 +1613,9 @@ checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"
-version = "2.3.4"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
+checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
 
 [[package]]
 name = "memoffset"
@@ -1646,9 +1650,9 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f2d26ec3309788e423cfbf68ad1800f061638098d76a83681af979dc4eda19d"
+checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
 dependencies = [
  "adler",
  "autocfg",
@@ -1656,9 +1660,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.7.9"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5dede4e2065b3842b8b0af444119f3aa331cc7cc2dd20388bfb0f5d5a38823a"
+checksum = "cf80d3e903b34e0bd7282b218398aec54e082c840d9baf8339e0080a0c542956"
 dependencies = [
  "libc",
  "log",
@@ -1669,19 +1673,18 @@ dependencies = [
 
 [[package]]
 name = "miow"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a33c1b55807fbed163481b5ba66db4b2fa6cde694a5027be10fb724206c5897"
+checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
 dependencies = [
- "socket2",
  "winapi",
 ]
 
 [[package]]
 name = "multimap"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1255076139a83bb467426e7f8d0134968a8118844faa755985e077cf31850333"
+checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
 name = "nats"
@@ -1707,16 +1710,6 @@ dependencies = [
  "once_cell",
  "regex",
  "rustls-native-certs",
-]
-
-[[package]]
-name = "nb-connect"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670361df1bc2399ee1ff50406a0d422587dd3bb0da596e1978fe8e05dabddf4f"
-dependencies = [
- "libc",
- "socket2",
 ]
 
 [[package]]
@@ -1822,15 +1815,15 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9a7ab5d64814df0fe4a4b5ead45ed6c5f181ee3ff04ba344313a6c80446c5d4"
+checksum = "1a5b3dd1c072ee7963717671d1ca129f1048fda25edea6b752bfc71ac8854170"
 
 [[package]]
 name = "once_cell"
-version = "1.6.0"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ad167a2f54e832b82dbe003a046280dceffe5227b5f79e08e363a29638cfddd"
+checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
 
 [[package]]
 name = "opaque-debug"
@@ -1840,9 +1833,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
+checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
 
 [[package]]
 name = "parking"
@@ -1867,11 +1860,14 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa7a782938e745763fe6907fc6ba86946d72f49fe7e21de074e08128a99fb018"
 dependencies = [
+ "backtrace",
  "cfg-if 1.0.0",
  "instant",
  "libc",
- "redox_syscall",
+ "petgraph",
+ "redox_syscall 0.2.8",
  "smallvec",
+ "thread-id",
  "winapi",
 ]
 
@@ -1907,18 +1903,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.0.5"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96fa8ebb90271c4477f144354485b8068bd8f6b78b428b01ba892ca26caf0b63"
+checksum = "c7509cc106041c40a4518d2af7a61530e1eed0e6285296a3d8c5472806ccc4a4"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.5"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758669ae3558c6f74bd2a18b41f7ac0b5a195aea6639d6a9b5e5d1ad5ba24c0b"
+checksum = "48c950132583b500556b1efd71d45b319029f2b71518d979fcc208e16b42426f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1945,11 +1941,11 @@ checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
 
 [[package]]
 name = "polling"
-version = "2.0.2"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2a7bc6b2a29e632e45451c941832803a18cce6781db04de8a04696cdca8bde4"
+checksum = "4fc12d774e799ee9ebae13f4076ca003b40d18a11ac0f3641e6f899618580b7b"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "libc",
  "log",
  "wepoll-sys",
@@ -2000,9 +1996,9 @@ checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.24"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
+checksum = "f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038"
 dependencies = [
  "unicode-xid",
 ]
@@ -2042,7 +2038,7 @@ dependencies = [
  "prost",
  "prost-types",
  "tempfile",
- "which 4.0.2",
+ "which 4.1.0",
 ]
 
 [[package]]
@@ -2137,7 +2133,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
 dependencies = [
- "getrandom 0.2.2",
+ "getrandom 0.2.3",
 ]
 
 [[package]]
@@ -2160,9 +2156,15 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.5"
+version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94341e4e44e24f6b591b59e47a8a027df12e008d73fd5672dbea9cc22f4507d9"
+checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
+
+[[package]]
+name = "redox_syscall"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "742739e41cd49414de871ea5e549afb7e2a3ac77b589bcbebe8c82fab37147fc"
 dependencies = [
  "bitflags",
 ]
@@ -2173,20 +2175,19 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
 dependencies = [
- "getrandom 0.2.2",
- "redox_syscall",
+ "getrandom 0.2.3",
+ "redox_syscall 0.2.8",
 ]
 
 [[package]]
 name = "regex"
-version = "1.4.3"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9251239e129e16308e70d853559389de218ac275b515068abc96829d05b948a"
+checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
 dependencies = [
  "aho-corasick",
  "memchr",
  "regex-syntax",
- "thread_local",
 ]
 
 [[package]]
@@ -2201,9 +2202,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.22"
+version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5eb417147ba9860a96cfe72a0b93bf88fee1744b5636ec99ab20c1aa9376581"
+checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
 name = "remove_dir_all"
@@ -2246,18 +2247,18 @@ dependencies = [
 
 [[package]]
 name = "run_script"
-version = "0.6.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8e8fc35067815a04a35fe2144361e1257b0f1041f0d413664f38e44d1a73cb4"
+checksum = "7fa4becc694242c537d43695743701f362b43c42cb11a3d44c8a01eb0cd18ded"
 dependencies = [
  "fsio",
 ]
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e3bad0ee36814ca07d7968269dd4b7ec89ec2da10c4bb613928d3077083c232"
+checksum = "410f7acf3cb3a44527c5d9546bad4bf4e6c460915d5f9f2fc524498bfe8f70ce"
 
 [[package]]
 name = "rustc-hash"
@@ -2292,9 +2293,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb5d2a036dc6d2d8fd16fde3498b04306e29bd193bf306a57427019b823d5acd"
+checksum = "61b3909d758bb75c79f23d4736fac9433868679d3ad2ea7a61e3c25cfda9a088"
 
 [[package]]
 name = "ryu"
@@ -2320,9 +2321,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "sct"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3042af939fca8c3453b7af0f1c66e533a15a86169e39de2657310ade8f98d3c"
+checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
 dependencies = [
  "ring",
  "untrusted",
@@ -2353,18 +2354,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.123"
+version = "1.0.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92d5161132722baa40d802cc70b15262b98258453e85e5d1d365c757c73869ae"
+checksum = "ec7505abeacaec74ae4778d9d9328fe5a5d04253220a85c4ee022239fc996d03"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.123"
+version = "1.0.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9391c295d64fc0abb2c556bad848f33cb8296276b1ad2677d1ae1ace4f258f31"
+checksum = "963a7dbc9895aeac7ac90e74f34a5d5261828f79df35cbed41e10189d3804d43"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2373,9 +2374,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.62"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea1c6153794552ea7cf7cf63b1231a25de00ec90db326ba6264440fa08e31486"
+checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
 dependencies = [
  "itoa",
  "ryu",
@@ -2396,10 +2397,11 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "1.6.4"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b44be9227e214a0420707c9ca74c2d4991d9955bae9415a8f93f05cebf561be5"
+checksum = "edeeaecd5445109b937a3a335dc52780ca7779c4b4b7374cc6340dedfe44cfca"
 dependencies = [
+ "rustversion",
  "serde",
  "serde_with_macros",
 ]
@@ -2430,13 +2432,13 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.9.3"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa827a14b29ab7f44778d14a88d3cb76e949c45083f7dbfa507d0cb699dc12de"
+checksum = "b362ae5752fd2137731f9fa25fd4d9058af34666ca1966fb969119cc35719f12"
 dependencies = [
  "block-buffer",
  "cfg-if 1.0.0",
- "cpuid-bool",
+ "cpufeatures",
  "digest",
  "opaque-debug",
 ]
@@ -2468,9 +2470,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook"
-version = "0.3.4"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "780f5e3fe0c66f67197236097d89de1e86216f1f6fdeaf47c442f854ab46c240"
+checksum = "ef33d6d0cd06e0840fba9985aab098c147e67e05cee14d412d3345ed14ff30ac"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -2505,9 +2507,9 @@ checksum = "0f0242b8e50dd9accdd56170e94ca1ebd223b098eb9c83539a6e367d0f36ae68"
 
 [[package]]
 name = "slab"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
+checksum = "f173ac3d1a7e3b28003f40de0b5ce7fe2710f9b9dc3fc38664cebee46b3b6527"
 
 [[package]]
 name = "smallvec"
@@ -2556,11 +2558,10 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.3.19"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "122e570113d28d773067fab24266b66753f6ea915758651696b6e35e49f88d6e"
+checksum = "9e3dfc207c526015c632472a77be09cf1b6e46866581aecae5cc38fb4235dea2"
 dependencies = [
- "cfg-if 1.0.0",
  "libc",
  "winapi",
 ]
@@ -2650,9 +2651,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.60"
+version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c700597eca8a5a762beb35753ef6b94df201c81cca676604f547495a0d7f0081"
+checksum = "a1e8cdbefb79a9a5a65e0db8b47b723ee907b7c7f8496c76a1770b5c310bab82"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2695,7 +2696,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "rand 0.8.3",
- "redox_syscall",
+ "redox_syscall 0.2.8",
  "remove_dir_all",
  "winapi",
 ]
@@ -2720,22 +2721,33 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0f4a65597094d4483ddaed134f409b2cb7c1beccf25201a9f73c719254fa98e"
+checksum = "fa6f76457f59514c7eeb4e59d891395fab0b2fd1d40723ae737d64153392e9c6"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7765189610d8241a44529806d6fd1f2e0a08734313a35d5b3a556f92b381f3c0"
+checksum = "8a36768c0fbf1bb15eca10defa29526bda730a2376c2ab4393ccfa16fb1a318d"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread-id"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7fbf4c9d56b320106cd64fd024dadfa0be7cb4706725fc44a7d7ce952d820c1"
+dependencies = [
+ "libc",
+ "redox_syscall 0.1.57",
+ "winapi",
 ]
 
 [[package]]
@@ -2749,20 +2761,19 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.44"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi",
 ]
 
 [[package]]
 name = "tinyvec"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317cca572a0e89c3ce0ca1f1bdc9369547fe318a683418e42ac8f59d14701023"
+checksum = "5b5220f05bb7de7f3f53c7c065e1199b3172696fe2db9f9c4d8ad9b4ee74c342"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -2775,9 +2786,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.3.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d56477f6ed99e10225f38f9f75f872f29b8b8bd8c0b946f63345bb144e9eeda"
+checksum = "bd3076b5c8cc18138b8f8814895c11eb4de37114a5d127bafdc5e55798ceef37"
 dependencies = [
  "autocfg",
  "bytes",
@@ -2795,9 +2806,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf7b11a536f46a809a8a9f0bb4237020f70ecbf115b842360afb127ea2fda57"
+checksum = "c49e3df43841dafb86046472506755d8501c5615673955f6aa17181125d13c37"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2806,9 +2817,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.4"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c535f53c0cfa1acace62995a8994fc9cc1f12d202420da96ff306ee24d576469"
+checksum = "f8864d706fdb3cc0843a49647ac892720dac98a6eeb818b77190592cf4994066"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -2817,9 +2828,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.6.4"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec31e5cc6b46e653cf57762f36f71d5e6386391d88a72fd6db4508f8f676fb29"
+checksum = "1caa0b0c8d94a049db56b5acf8cba99dc0623aab1b26d5b5f5e2d945846b3592"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2831,9 +2842,9 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.4.0"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ba8f479158947373b6df40cf48f4779bb25c99ca3c661bd95e0ab1963ad8b0e"
+checksum = "2ac42cd97ac6bd2339af5bcabf105540e21e45636ec6fa6aae5e85d44db31be0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2860,9 +2871,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e8546fd40d56d28089835c0a81bb396848103b00f888aea42d46eb5974df07"
+checksum = "c695de27302f4697191dda1c7178131a8cb805463dda02864acb80fe1322fdcf"
 dependencies = [
  "proc-macro2",
  "prost-build",
@@ -2872,9 +2883,9 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f715efe02c0862926eb463e49368d38ddb119383475686178e32e26d15d06a66"
+checksum = "bf0aa6dfc29148c3826708dabbfa83c121eeb84df4d1468220825e3a33651687"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -2904,9 +2915,9 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.24"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f77d3842f76ca899ff2dbcf231c5c65813dea431301d6eb686279c15c4464f12"
+checksum = "09adeb8c97449311ccd28a427f96fb563e7fd31aabf994189879d9da2394b89d"
 dependencies = [
  "cfg-if 1.0.0",
  "log",
@@ -2917,9 +2928,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.13"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8a9bd1db7706f2373a190b0d067146caa39350c486f3d455b0e33b431f94c07"
+checksum = "c42e6fa53307c8a17e4ccd4dc81cf5ec38db9209f59b222210375b54ee40d1e2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2928,9 +2939,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50de3927f93d202783f4513cda820ab47ef17f624b03c096e86ef00c67e6b5f"
+checksum = "a9ff14f98b1a4b289c6248a023c1c2fa1491062964e9fed67ab29c4e4da4a052"
 dependencies = [
  "lazy_static",
 ]
@@ -2947,9 +2958,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-log"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e0f8c7178e13481ff6765bd169b33e8d554c5d2bbede5e32c356194be02b9b9"
+checksum = "a6923477a48e41c1951f1999ef8bb5a3023eb723ceadafe78ffb65dc366761e3"
 dependencies = [
  "lazy_static",
  "log",
@@ -2968,9 +2979,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.15"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1fa8f0c8f4c594e4fc9debc1990deab13238077271ba84dd853d54902ee3401"
+checksum = "aa5553bf0883ba7c9cbe493b085c29926bd41b66afc31ff72cf17ff4fb60dcd5"
 dependencies = [
  "ansi_term 0.12.1",
  "chrono",
@@ -2996,9 +3007,9 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "typenum"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
+checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
 
 [[package]]
 name = "udev"
@@ -3013,9 +3024,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
+checksum = "eeb8be209bb1c96b7c177c7420d26e04eccacb0eeae6b980e35fcb74678107e0"
 dependencies = [
  "matches",
 ]
@@ -3043,9 +3054,9 @@ checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
+checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "untrusted"
@@ -3055,9 +3066,9 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "url"
-version = "2.2.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ccd964113622c8e9322cfac19eb1004a07e636c545f325da085d5cdde6f1f8b"
+checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -3067,9 +3078,9 @@ dependencies = [
 
 [[package]]
 name = "users"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa4227e95324a443c9fcb06e03d4d85e91aabe9a5a02aa818688b6918b6af486"
+checksum = "24cc0f6d6f267b73e5a2cadf007ba8f9bc39c6a6f9666f8cf25ea809a153b032"
 dependencies = [
  "libc",
  "log",
@@ -3081,14 +3092,8 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
- "getrandom 0.2.2",
+ "getrandom 0.2.3",
 ]
-
-[[package]]
-name = "vec-arena"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eafc1b9b2dfc6f5529177b62cf806484db55b32dc7c9658a118e11bbeb33061d"
 
 [[package]]
 name = "vec_map"
@@ -3098,9 +3103,9 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
+checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
 name = "waker-fn"
@@ -3126,15 +3131,15 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
+version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.70"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55c0f7123de74f0dab9b7d00fd614e7b19349cd1e2f5252bbe9b1754b59433be"
+checksum = "d54ee1d4ed486f78874278e63e4069fc1ab9f6a18ca492076ffb90c5eb2997fd"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen-macro",
@@ -3142,9 +3147,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.70"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bc45447f0d4573f3d65720f636bbcc3dd6ce920ed704670118650bcd47764c7"
+checksum = "3b33f6a0694ccfea53d94db8b2ed1c3a8a4c86dd936b13b9f0a15ec4a451b900"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -3157,9 +3162,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.70"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b8853882eef39593ad4174dd26fc9865a64e84026d223f63bb2c42affcbba2c"
+checksum = "088169ca61430fe1e58b8096c24975251700e7b1f6fd91cc9d59b04fb9b18bd4"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3167,9 +3172,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.70"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4133b5e7f2a531fa413b3a1695e925038a05a71cf67e87dafa295cb645a01385"
+checksum = "be2241542ff3d9f241f5e2cb6dd09b37efe786df8851c54957683a49f0987a97"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3180,15 +3185,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.70"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd4945e4943ae02d15c13962b38a5b1e81eadd4b71214eee75af64a4d6a4fd64"
+checksum = "d7cff876b8f18eed75a66cf49b65e7f967cb354a7aa16003fb55dbfd25b44b4f"
 
 [[package]]
 name = "web-sys"
-version = "0.3.47"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c40dc691fc48003eba817c38da7113c15698142da971298003cac3ef175680b3"
+checksum = "e828417b379f3df7111d3a2a9e5753706cae29c41f7c4029ee9fd77f3e09e582"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3225,12 +3230,12 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "4.0.2"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87c14ef7e1b8b8ecfc75d5eca37949410046e66f15d185c01d70824f1f8111ef"
+checksum = "b55551e42cbdf2ce2bedd2203d0cc08dba002c27510f86dab6d0ce304cba3dfe"
 dependencies = [
+ "either",
  "libc",
- "thiserror",
 ]
 
 [[package]]
@@ -3275,18 +3280,18 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81a974bcdd357f0dca4d41677db03436324d45a4c9ed2d0b873a5a360ce41c36"
+checksum = "4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3f369ddb18862aba61aa49bf31e74d29f0f162dec753063200e1dc084345d16"
+checksum = "a2c1e130bebaeab2f23886bf9acbaca14b092408c452543c857f66399cd6dab1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [patch.crates-io]
 partition-identity = { git = "https://github.com/openebs/partition-identity.git" }
-h2 = { git = "https://github.com/openebs/h2", branch = "bump-authority-workaround"}
+h2 = { git = "https://github.com/openebs/h2", branch = "v0.3.3"}
 
 [profile.dev]
 panic = "abort"

--- a/mayastor/Cargo.toml
+++ b/mayastor/Cargo.toml
@@ -85,6 +85,8 @@ url = "2.1"
 smol = "1.0.0"
 dns-lookup = "1.0.4"
 mbus_api = { path = "../mbus-api" }
+parking_lot = {version = "0.11.1", features = ["deadlock_detection"] }
+
 
 [dependencies.rpc]
 path = "../rpc"

--- a/mayastor/src/bdev/dev.rs
+++ b/mayastor/src/bdev/dev.rs
@@ -45,17 +45,14 @@ impl Uri {
         })?;
 
         match url.scheme() {
-            // backend NVMF target - fairly unstable (as of Linux 5.2)
-            "nvmf" => Ok(Box::new(nvmx::NvmfDeviceTemplate::try_from(&url)?)),
-            "malloc" => Ok(Box::new(malloc::Malloc::try_from(&url)?)),
             "aio" => Ok(Box::new(aio::Aio::try_from(&url)?)),
             "bdev" => Ok(Box::new(loopback::Loopback::try_from(&url)?)),
-            "null" => Ok(Box::new(null::Null::try_from(&url)?)),
-            "loopback" => Ok(Box::new(loopback::Loopback::try_from(&url)?)),
             "iscsi" => Ok(Box::new(iscsi::Iscsi::try_from(&url)?)),
+            "loopback" => Ok(Box::new(loopback::Loopback::try_from(&url)?)),
+            "malloc" => Ok(Box::new(malloc::Malloc::try_from(&url)?)),
+            "null" => Ok(Box::new(null::Null::try_from(&url)?)),
+            "nvmf" => Ok(Box::new(nvmx::NvmfDeviceTemplate::try_from(&url)?)),
             "pcie" => Ok(Box::new(nvme::NVMe::try_from(&url)?)),
-
-            // also for testing - requires Linux 5.1 or higher
             "uring" => Ok(Box::new(uring::Uring::try_from(&url)?)),
 
             scheme => Err(NexusBdevError::UriSchemeUnsupported {
@@ -94,17 +91,14 @@ pub fn device_lookup(name: &str) -> Option<Box<dyn BlockDevice>> {
     nvmx::lookup_by_name(name).or_else(|| SpdkBlockDevice::lookup_by_name(name))
 }
 
-#[instrument]
 pub async fn device_create(uri: &str) -> Result<String, NexusBdevError> {
     Uri::parse(uri)?.create().await
 }
 
-#[instrument]
 pub async fn device_destroy(uri: &str) -> Result<(), NexusBdevError> {
     Uri::parse(uri)?.destroy().await
 }
 
-#[instrument]
 pub fn device_open(
     name: &str,
     read_write: bool,

--- a/mayastor/src/bdev/nexus/nexus_bdev_children.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev_children.rs
@@ -56,7 +56,7 @@ impl Nexus {
     /// register children with the nexus, only allowed during the nexus init
     /// phase
     pub fn register_children(&mut self, dev_name: &[String]) {
-        assert_eq!(*self.state.lock().unwrap(), NexusState::Init);
+        assert_eq!(*self.state.lock(), NexusState::Init);
         self.child_count = dev_name.len() as u32;
         dev_name
             .iter()
@@ -77,7 +77,7 @@ impl Nexus {
         &mut self,
         uri: &str,
     ) -> Result<(), NexusBdevError> {
-        assert_eq!(*self.state.lock().unwrap(), NexusState::Init);
+        assert_eq!(*self.state.lock(), NexusState::Init);
         let name = device_create(&uri).await?;
         self.children.push(NexusChild::new(
             uri.to_string(),

--- a/mayastor/src/bdev/nexus/nexus_channel.rs
+++ b/mayastor/src/bdev/nexus/nexus_channel.rs
@@ -16,7 +16,7 @@ use spdk_sys::{
 
 use crate::{
     bdev::{nexus::nexus_child::ChildState, Nexus, Reason},
-    core::{BlockDeviceHandle, Mthread},
+    core::{BlockDeviceHandle, Cores, Mthread},
 };
 
 /// io channel, per core
@@ -101,7 +101,64 @@ impl NexusChannelInner {
         }
     }
 
-    /// refreshing our channels simply means that we either have a child going
+    /// Remove a child from the readers and/or writers
+    pub fn remove_child_in_submit(&mut self, name: &str) -> bool {
+        let nexus = unsafe { Nexus::from_raw(self.device) };
+        trace!(
+            ?name,
+            "core: {} thread: {} removing from during submission channels",
+            Cores::current(),
+            Mthread::current().unwrap().name()
+        );
+        trace!(
+            "{}: Current number of IO channels write: {} read: {}",
+            nexus.name,
+            self.writers.len(),
+            self.readers.len(),
+        );
+        self.readers
+            .retain(|c| c.get_device().device_name() != name);
+        self.writers
+            .retain(|c| c.get_device().device_name() != name);
+
+        trace!(
+            "{}: New number of IO channels write:{} read:{} out of {} children",
+            nexus.name,
+            self.writers.len(),
+            self.readers.len(),
+            nexus.children.len()
+        );
+        self.fault_child(name)
+    }
+
+    /// Fault the child by marking its status.
+    pub fn fault_child(&mut self, name: &str) -> bool {
+        let nexus = unsafe { Nexus::from_raw(self.device) };
+        nexus
+            .children
+            .iter()
+            .filter(|c| c.state() == ChildState::Open)
+            .filter(|c| {
+                // If there where previous retires, we do not have a referece
+                // to a BlockDevice. We do however, know it cant be the device
+                // we are attempting to retire in the first place so this
+                // condition is fine.
+                if let Ok(child) = c.get_device().as_ref() {
+                    child.device_name() == name
+                } else {
+                    false
+                }
+            })
+            .any(|c| {
+                ChildState::Open
+                    == c.state.compare_and_swap(
+                        ChildState::Open,
+                        ChildState::Faulted(Reason::IoError),
+                    )
+            })
+    }
+
+    /// Refreshing our channels simply means that we either have a child going
     /// online or offline. We don't know which child has gone, or was added, so
     /// we simply put back all the channels, and reopen the bdevs that are in
     /// the online state.

--- a/mayastor/src/bdev/nexus/nexus_io.rs
+++ b/mayastor/src/bdev/nexus/nexus_io.rs
@@ -6,20 +6,17 @@ use std::{
 
 use libc::c_void;
 use nix::errno::Errno;
-
 use spdk_sys::{spdk_bdev_io, spdk_bdev_io_get_buf, spdk_io_channel};
 
 use crate::{
     bdev::{
         nexus::{
             nexus_bdev::NEXUS_PRODUCT_ID,
-            nexus_channel::{DrEvent, NexusChannel, NexusChannelInner},
+            nexus_channel::{NexusChannel, NexusChannelInner},
         },
         nexus_lookup,
-        ChildState,
         Nexus,
         NexusStatus,
-        Reason,
     },
     core::{
         Bio,
@@ -33,6 +30,7 @@ use crate::{
         IoType,
         Mthread,
         NvmeCommandStatus,
+        Reactor,
         Reactors,
     },
 };
@@ -81,37 +79,31 @@ impl From<*mut spdk_bdev_io> for NexusBio {
     }
 }
 
+impl NexusBio {
+    fn as_ptr(&self) -> *mut spdk_bdev_io {
+        self.0.as_ptr()
+    }
+}
+
 #[derive(Debug)]
 #[repr(C)]
 pub struct NioCtx {
-    in_flight: u8,
-    num_ok: u8,
+    /// number of IO's submitted. Nexus IO's may never be freed until this
+    /// counter drops to zero.
+    pub in_flight: u8,
+    /// intermediate status of the IO
     status: IoStatus,
+    /// a refence to  our channel
     channel: NonNull<spdk_io_channel>,
-    core: u32,
-}
-
-#[derive(Debug, Clone)]
-#[repr(C)]
-enum Disposition {
-    /// All IOs are completed, and the final status of the IO should be set to
-    /// the enum variant
-    Complete(IoStatus),
-    /// IOs are still in flight status of the last IO that failed
-    Flying(IoStatus),
-    /// retire the current child
-    Retire(IoStatus),
+    /// the IO must fail regardless of when it completes
+    must_fail: bool,
+    /// the IO experienced an error condition during submission. This must be
+    /// handled differently
+    submission_failure: bool,
 }
 
 pub(crate) fn nexus_submit_io(mut io: NexusBio) {
-    // Fail-fast all incoming I/O if the flag is set.
-    let inner = io.inner_channel();
-    if inner.fail_fast > 0 {
-        io.fail();
-        return;
-    }
-
-    if let Err(_e) = match io.cmd() {
+    if let Err(e) = match io.cmd() {
         IoType::Read => io.readv(),
         // these IOs are submitted to all the underlying children
         IoType::Write | IoType::WriteZeros | IoType::Reset | IoType::Unmap => {
@@ -135,12 +127,7 @@ pub(crate) fn nexus_submit_io(mut io: NexusBio) {
             })
         }
     } {
-        // TODO: Displaying a message in response to every
-        // submission error might result in log files flooded with
-        // zillions of similar error messages for faulted nexuses.
-        // Need to rethink the approach for error notifications here.
-
-        // error!(?e, ?io, "Error during IO submission");
+        trace!(?e, ?io, "Error during IO submission");
     }
 }
 
@@ -154,15 +141,15 @@ impl NexusBio {
         let mut bio = NexusBio::from(io);
         let ctx = bio.ctx_as_mut();
         // for verification purposes when retiring a child
-        ctx.core = Cores::current();
         ctx.channel = NonNull::new(channel).unwrap();
         ctx.status = IoStatus::Pending;
         ctx.in_flight = 0;
-        ctx.num_ok = 0;
+        ctx.must_fail = false;
+        ctx.submission_failure = false;
         bio
     }
 
-    /// invoked when a nexus Io completes
+    /// invoked when a nexus IO completes
     fn child_completion(
         device: &dyn BlockDevice,
         status: IoCompletionStatus,
@@ -174,66 +161,14 @@ impl NexusBio {
 
     #[inline(always)]
     /// a mutable reference to the IO context
-    fn ctx_as_mut(&mut self) -> &mut NioCtx {
+    pub fn ctx_as_mut(&mut self) -> &mut NioCtx {
         self.specific_as_mut::<NioCtx>()
     }
 
     #[inline(always)]
     /// immutable reference to the IO context
-    fn ctx(&self) -> &NioCtx {
+    pub fn ctx(&self) -> &NioCtx {
         self.specific::<NioCtx>()
-    }
-
-    /// Determine what to do with the IO if anything. In principle, it's the
-    /// same way any other IO is completed but, it wrapped by the
-    /// disposition. The general approach is if we return Disposition::
-    /// Retire(IoStatus::Success) it means that we retire the current child and
-    /// then, return mark the IO successful.
-    fn disposition(&mut self, success: bool) -> Disposition {
-        let ctx = self.ctx_as_mut();
-        match ctx.status {
-            // all child IO's completed, complete the parent IO
-            IoStatus::Pending if ctx.in_flight == 0 => {
-                Disposition::Complete(IoStatus::Success)
-            }
-            // some child IO has completed, but not all
-            IoStatus::Pending if ctx.in_flight != 0 => {
-                Disposition::Flying(IoStatus::Success)
-            }
-
-            // Other IO are still inflight we encountered an error, retire this
-            // child.
-            IoStatus::Failed if ctx.in_flight != 0 => {
-                Disposition::Retire(IoStatus::Pending)
-            }
-
-            // this IO failed, but we have seen successfully IO's for the parent
-            // already retire it
-            IoStatus::Failed if ctx.num_ok != 0 && ctx.in_flight == 0 => {
-                // Do not retire the current device if the error was triggered
-                // by I/Os on other replicas.
-                if success {
-                    Disposition::Complete(IoStatus::Failed)
-                } else {
-                    Disposition::Retire(IoStatus::Failed)
-                }
-            }
-
-            // ALL io's have failed
-            IoStatus::Failed if ctx.num_ok == 0 && ctx.in_flight == 0 => {
-                Disposition::Retire(IoStatus::Failed)
-            }
-            // all IOs that where partially submitted completed, no bubble up
-            // the ENOMEM to the upper layer we do not care if the
-            // IO failed or complete, the whole IO must be resubmitted
-            IoStatus::NoMemory if ctx.in_flight == 0 => {
-                Disposition::Complete(IoStatus::NoMemory)
-            }
-            _ => {
-                error!("{:?}", ctx);
-                Disposition::Complete(IoStatus::Failed)
-            }
-        }
     }
 
     /// returns the type of command for this IO
@@ -249,95 +184,54 @@ impl NexusBio {
         status: IoCompletionStatus,
     ) {
         let success = status == IoCompletionStatus::Success;
-        // If the IO failed it is possible that completion callback is
-        // called from a different core.
-        if success {
-            assert_eq!(self.ctx().core, Cores::current());
-        }
 
-        // decrement the counter of in flight IO
         self.ctx_as_mut().in_flight -= 1;
 
-        // record the state of at least one of the IO's.
         if success {
-            self.ctx_as_mut().num_ok += 1;
+            self.ok_checked();
         } else {
+            // IO failure, mark the IO failed and taka the child out
+            error!(?self, "{} IO completion failed", child.device_name());
             self.ctx_as_mut().status = IoStatus::Failed;
+            self.ctx_as_mut().must_fail = true;
+            self.handle_failure(child, status);
         }
+    }
 
-        match self.disposition(success) {
-            // the happy path, all is good
-            Disposition::Complete(IoStatus::Success) => {
-                // Check if the operation has to be explicitly failed still.
-                if self.inner_channel().fail_fast > 0 {
-                    error!(
-                        "{} failing the {:?} operation due to fail-fast request",
-                        child.device_name(),
-                        self.cmd(),
-                    );
-                    self.fail()
-                } else {
-                    self.ok()
-                }
-            }
-            // All of IO's have failed but all remaining in flights completed
-            // now as well depending on the error we can attempt to
-            // do a retry.
-            Disposition::Complete(IoStatus::Failed) => self.fail(),
-
-            // IOs were submitted before we bumped into ENOMEM. The IO has
-            // now completed, so we can finally report back to the
-            // callee that we encountered ENOMEM during submission
-            Disposition::Complete(IoStatus::NoMemory) => self.no_mem(),
-
-            // We can mark the IO as success but before we do we need to retire
-            // this child. This typically would only match when the last IO
-            // has failed i.e [ok,ok,fail]
-            Disposition::Retire(IoStatus::Success) => {
-                let device_name = child.device_name();
-                //assert!(!success);
-                error!(
-                    ?self,
-                    ?device_name,
-                    "{}:{}",
-                    Cores::current(),
-                    "last child IO failed completion"
-                );
-
-                self.try_retire(child, status);
+    /// Complete the IO marking at as succesfull when all child IO's have been
+    /// accounted for. Failing to account for all child IO's will result in
+    /// a lockup.
+    fn ok_checked(&mut self) {
+        if self.ctx().in_flight == 0 {
+            if self.ctx().submission_failure {
+                self.retry_checked();
+            } else {
                 self.ok();
             }
+        }
+    }
 
-            // IO still in flight (pending) fail this IO and continue by setting
-            // the parent status back to pending for example [ok,
-            // fail, pending]
-            Disposition::Retire(IoStatus::Pending) => {
-                let device_name = child.device_name();
+    /// Complete the IO marking it as failed.
+    pub fn fail_checked(&mut self) {
+        if self.ctx().in_flight == 0 {
+            self.fail();
+        }
+    }
 
-                error!(
-                    ?self,
-                    ?device_name,
-                    "{}:{}",
-                    Cores::current(),
-                    "child IO completion failed"
-                );
-                self.try_retire(child, status);
-                // more IO is pending ensure we set the proper context state
-                self.ctx_as_mut().status = IoStatus::Pending;
-            }
-
-            Disposition::Retire(IoStatus::Failed) => {
-                //assert_eq!(success, false);
-                error!(
-                    ?self,
-                    "{}:{}",
-                    Cores::current(),
-                    "last child IO failed completion"
-                );
-                self.try_retire(child, status);
-                self.fail();
-            }
-            _ => {}
+    /// retry this IO
+    pub fn retry_checked(&mut self) {
+        if self.ctx().in_flight == 0 {
+            let bio = unsafe {
+                Self::nexus_bio_setup(
+                    self.ctx().channel.as_ptr(),
+                    self.as_ptr(),
+                )
+            };
+            nexus_submit_io(bio);
+        } else {
+            // we can not resubmit the IO now as there is an IO in flight
+            // the retry operation may be retried at a later stage.
+            error!(?self, "resubmitted with inflight IO's");
         }
     }
 
@@ -376,26 +270,13 @@ impl NexusBio {
         )
     }
 
+    /// submit a read operation
     fn do_readv(&mut self) -> Result<(), CoreError> {
         let inner = self.inner_channel();
 
-        // Upon buffer allocation we might have been rescheduled, so check
-        // the fail-fast flag once more.
-        if inner.fail_fast > 0 {
-            self.fail();
-            return Err(CoreError::ReadDispatch {
-                source: Errno::ENXIO,
-                offset: self.offset(),
-                len: self.num_blocks(),
-            });
-        }
-
         if let Some(i) = inner.child_select() {
             let hdl = self.read_channel_at_index(i);
-            let r = self.submit_read(hdl).map_err(|e| {
-                self.fail();
-                e
-            });
+            let r = self.submit_read(hdl);
 
             if r.is_err() {
                 // Such a situation can happen when there is no active I/O in
@@ -407,16 +288,21 @@ impl NexusBio {
                 // start device retire.
                 // TODO: ENOMEM and ENXIO should be handled differently and
                 // device should not be retired in case of ENOMEM.
-                info!(
-                    "{} initiating retire in response to READ submission error",
-                    hdl.get_device().device_name(),
-                );
-                self.do_retire(hdl.get_device().device_name());
+
+                let device = hdl.get_device().device_name();
+                trace!(
+                    "(core: {} thread: {}): read IO to {} submission failed with error {:?}",
+                    Cores::current(), Mthread::current().unwrap().name(), device, r);
+                inner.remove_child_in_submit(&device);
+                self.fail();
             } else {
                 self.ctx_as_mut().in_flight += 1;
             }
             r
         } else {
+            trace!(
+                    "(core: {} thread: {}): read IO submission failed no children available",
+                    Cores::current(), Mthread::current().unwrap().name());
             self.fail();
             Err(CoreError::NoDevicesAvailable {})
         }
@@ -430,11 +316,15 @@ impl NexusBio {
         let mut bio = NexusBio::from(io);
 
         if !success {
-            error!("Failed to get io buffer for io");
+            trace!(
+                "(core: {} thread: {}): get_buf() failed",
+                Cores::current(),
+                Mthread::current().unwrap().name()
+            );
             bio.no_mem();
-        } else if let Err(e) = bio.do_readv() {
-            error!("Failed to submit I/O after iovec allocation: {:?}", e,);
         }
+
+        let _ = bio.do_readv();
     }
 
     /// submit read IO to some child
@@ -509,17 +399,16 @@ impl NexusBio {
     /// be submitted to all the underlying children.
     fn submit_all(&mut self) -> Result<(), CoreError> {
         let mut inflight = 0;
-        let mut status = IoStatus::Pending;
         // Name of the device which experiences I/O submission failures.
         let mut failed_device = None;
 
-        let cmd = self.cmd();
+        // stops at first error
         let result = self.inner_channel().writers.iter().try_for_each(|h| {
-            match cmd {
-                IoType::Write => self.submit_write(&**h),
-                IoType::Unmap => self.submit_unmap(&**h),
-                IoType::WriteZeros => self.submit_write_zeroes(&**h),
-                IoType::Reset => self.submit_reset(&**h),
+            match self.cmd() {
+                IoType::Write => self.submit_write(h.as_ref()),
+                IoType::Unmap => self.submit_unmap(h.as_ref()),
+                IoType::WriteZeros => self.submit_write_zeroes(h.as_ref()),
+                IoType::Reset => self.submit_reset(h.as_ref()),
                 // we should never reach here, if we do it is a bug.
                 _ => unreachable!(),
             }
@@ -527,10 +416,9 @@ impl NexusBio {
                 inflight += 1;
             })
             .map_err(|se| {
-                status = IoStatus::Failed;
                 error!(
-                    "IO submission failed with error {:?}, I/Os submitted: {}",
-                    se, inflight
+                    "(core: {} thread: {}): IO submission failed with error {:?}, I/Os submitted: {}",
+                    Cores::current(), Mthread::current().unwrap().name(), se, inflight
                 );
 
                 // Record the name of the device for immediat retire.
@@ -550,36 +438,50 @@ impl NexusBio {
         // device should not be retired in case of ENOMEM.
         if result.is_err() {
             let device = failed_device.unwrap();
-            info!(
-                "{}: retiring device in response to submission error={:?}",
-                device, result,
-            );
-            self.do_retire(device);
+            // set the IO as failed in the submission stage.
+            self.ctx_as_mut().submission_failure = true;
+            let need_retire =
+                self.inner_channel().remove_child_in_submit(&device);
+            if need_retire {
+                self.do_retire(device);
+            }
         }
 
         if inflight != 0 {
+            // An error was experienced during submission. Some IO however, has
+            // been submitted succesfully prior to the error condition.
             self.ctx_as_mut().in_flight = inflight;
-            self.ctx_as_mut().status = status;
-        } else {
-            // if no IO was submitted at all, we can fail the IO now.
-            // TODO: Support of IoStatus::NoMemory in ENOMEM-related errors.
-            self.fail();
+            self.ctx_as_mut().status = IoStatus::Success;
         }
+
+        self.fail_checked();
+
         result
     }
 
     fn do_retire(&self, child: String) {
-        Reactors::master().send_future(Self::child_retire(
-            self.nexus_as_ref().name.clone(),
-            child,
-        ));
+        let nexus = self.nexus_as_ref().name.clone();
+        Reactors::master().send_future(async move {
+            Reactor::block_on(Self::child_retire(nexus, child.clone()));
+        });
     }
 
-    fn try_retire(
+    fn handle_failure(
         &mut self,
         child: &dyn BlockDevice,
         status: IoCompletionStatus,
     ) {
+        // We have experienced a failure on one of the child devices. We need to
+        // ensure we do not submit more IOs to this child. We do not need to
+        // tell other cores about this because they will experience the
+        // same ekrors on their own channels, and handle it on their own.
+        //
+        // We differentiate between errors in the submission and completion.
+        // When we have a completion error, it typically means that the
+        // child has lost the connection to the nexus. In order for
+        // outstanding IO to complete, the IO's to that child must be
+        // aborted. The abortion is implicit when removing the device.
+
         trace!(?status);
 
         if let IoCompletionStatus::NvmeError(nvme_status) = status {
@@ -595,88 +497,79 @@ impl NexusBio {
                 return;
             }
         }
-        info!("{} try_retire() called", child.device_name());
-        self.do_retire(child.device_name());
+
+        let child = child.device_name();
+
+        // Fault the child -- removing a bad having child from the group
+        // and have it "sit and think" seems to work reasonable.
+        let needs_retire = self.inner_channel().fault_child(&child);
+
+        // The child state was not faulted yet, so this is the first IO
+        // to this child for which we encounterd an error.
+        if needs_retire {
+            self.do_retire(child);
+        }
+
+        // if there are channels left -- retry the IO other wise fail the IO.
+        // TODO: succesfull IO's would not require a retry.
+        if self.inner_channel().writers.is_empty()
+            || self.inner_channel().readers.is_empty()
+        {
+            self.fail_checked();
+        } else {
+            self.retry_checked();
+        }
     }
 
     /// Retire a child for this nexus.
     async fn child_retire(nexus: String, device: String) {
         match nexus_lookup(&nexus) {
             Some(nexus) => {
-                // Narrow nexus child scope to not interfere with mutually
-                // borrowed nexus object.
-                let child_state = {
-                    if let Some(child) = nexus.child_lookup(&device) {
-                        let current_state = child.state.compare_and_swap(
-                            ChildState::Open,
-                            ChildState::Faulted(Reason::IoError),
-                        );
-                        Some(current_state)
-                    } else {
-                        None
-                    }
-                };
+                warn!(
+                    "nexus: {} core: {}, thread {:?}, faulting child {}",
+                    nexus,
+                    Cores::current(),
+                    Mthread::current(),
+                    device,
+                );
 
-                match child_state {
-                    None => {
-                        debug!(
-                            "{} does not belong (anymore) to nexus {}",
-                            device, nexus
-                        );
-                    }
-                    Some(current_state) => {
-                        if current_state == ChildState::Open {
-                            warn!(
-                                "core {} thread {:?}, faulting child {}",
-                                Cores::current(),
-                                Mthread::current(),
-                                device,
+                // Pausing a nexus acts like entering a critical
+                // section allowing only one retire request to run at a
+                // time, which prevents  inconsistency in reading/updating nexus
+                // configuration.
+
+                nexus.pause().await.unwrap();
+                // Lookup child once more and finally remove it.
+                match nexus.child_lookup(&device) {
+                    Some(child) => {
+                        // TODO: an error can occur here if a
+                        // separate task,
+                        // e.g. grpc request is also deleting the
+                        // child.
+                        if let Err(err) = child.destroy().await {
+                            error!(
+                                "{}: destroying child {} failed {}",
+                                nexus, child, err
                             );
-
-                            // Pausing a nexus acts like entering a critical
-                            // section,
-                            // allowing only one retire request to run at a
-                            // time, which prevents
-                            // inconsistency in reading/updating nexus
-                            // configuration.
-                            nexus.pause().await.unwrap();
-                            nexus.set_failfast().await.unwrap();
-                            nexus.reconfigure(DrEvent::ChildFault).await;
-
-                            // Lookup child once more and finally remove it.
-                            match nexus.child_lookup(&device) {
-                                Some(child) => {
-                                    // TODO: an error can occur here if a
-                                    // separate task,
-                                    // e.g. grpc request is also deleting the
-                                    // child.
-                                    if let Err(err) = child.destroy().await {
-                                        error!(
-                                            "{}: destroying child {} failed {}",
-                                            nexus, child, err
-                                        );
-                                    }
-                                }
-                                None => {
-                                    warn!(
-                                        "{} no longer belongs to nexus {}, skipping child removal",
-                                        device, nexus
-                                    );
-                                }
-                            }
-
-                            nexus.clear_failfast().await.unwrap();
-                            nexus.resume().await.unwrap();
-
-                            if nexus.status() == NexusStatus::Faulted {
-                                error!(":{} has no children left... ", nexus);
-                            }
                         }
                     }
+                    None => {
+                        warn!(":{} no longer belongs to nexus {}, skipping child removal", device, nexus);
+                    }
                 }
+
+                //nexus.clear_failfast().await.unwrap();
+                nexus.resume().await.unwrap();
+
+                if nexus.status() == NexusStatus::Faulted {
+                    warn!(":{} has no children left... ", nexus);
+                }
+
+                info!(":{} retire of {} completed", nexus, device);
             }
+
             None => {
-                debug!("{} Nexus does not exist anymore", nexus);
+                debug!("Nexus: {} found", nexus);
             }
         }
     }

--- a/mayastor/src/bdev/nvmx/controller.rs
+++ b/mayastor/src/bdev/nvmx/controller.rs
@@ -248,7 +248,7 @@ impl<'a> NvmeController<'a> {
 
         // Deactivate existing namespace in case it is no longer active.
         if !ns_active && !ctrlr_inner.namespaces.is_empty() {
-            info!("{}: deactivating existing namespace", self.name);
+            debug!("{}: deactivating existing namespace", self.name);
             notify_listeners = true;
         }
 
@@ -259,7 +259,7 @@ impl<'a> NvmeController<'a> {
             );
             vec![]
         } else {
-            info!("{}: namespace successfully populated", self.name);
+            debug!("{}: namespace successfully populated", self.name);
             vec![Arc::new(NvmeNamespace::from_ptr(ns))]
         };
 
@@ -318,7 +318,7 @@ impl<'a> NvmeController<'a> {
                 }
             })?;
 
-        info!(
+        debug!(
             "{} initiating controller reset, failover = {}",
             self.name, failover
         );
@@ -342,7 +342,7 @@ impl<'a> NvmeController<'a> {
             shutdown_in_progress: false,
         };
 
-        info!("{}: starting reset", self.name);
+        debug!("{}: starting reset", self.name);
         let inner = self.inner.as_mut().unwrap();
         // Iterate over all I/O channels and reset/configure them one by one.
         inner.io_device.traverse_io_channels(
@@ -372,12 +372,12 @@ impl<'a> NvmeController<'a> {
     }
 
     fn _shutdown_channels_done(result: i32, ctx: ShutdownCtx) {
-        info!("{} all I/O channels shutted down", ctx.name);
+        debug!("{} all I/O channels shutted down", ctx.name);
 
         let controller = NVME_CONTROLLERS
             .lookup_by_name(&ctx.name)
             .expect("Controller disappeared while being shutdown");
-        let mut controller = controller.lock().expect("lock poisoned");
+        let mut controller = controller.lock();
 
         // In case I/O channels didn't shutdown successfully, mark
         // the controller as Faulted.
@@ -393,11 +393,11 @@ impl<'a> NvmeController<'a> {
         // Reset the controller to complete all remaining I/O requests after all
         // I/O channels are closed.
         // TODO: fail the controller via spdk_nvme_ctrlr_fail() upon shutdown ?
-        debug!("{} resetting NVMe controller", ctx.name);
-        let rc = unsafe { spdk_nvme_ctrlr_reset(controller.ctrlr_as_ptr()) };
-        if rc != 0 {
-            error!("{} failed to reset controller, rc = {}", ctx.name, rc);
-        }
+        //debug!("{} resetting NVMe controller", ctx.name);
+        //let rc = unsafe { spdk_nvme_ctrlr_reset(controller.ctrlr_as_ptr()) };
+        //if rc != 0 {
+        //    error!("{} failed to reset controller, rc = {}", ctx.name, rc);
+        //}
 
         // Finalize controller shutdown and invoke callback.
         controller.clear_namespaces();
@@ -407,7 +407,7 @@ impl<'a> NvmeController<'a> {
             .expect("failed to transition controller to Unconfigured state");
 
         drop(controller);
-        info!("{} shutdown complete, result = {}", ctx.name, result);
+        debug!("{} shutdown complete, result = {}", ctx.name, result);
         (ctx.cb)(result == 0, ctx.cb_arg);
     }
 
@@ -505,7 +505,7 @@ impl<'a> NvmeController<'a> {
             }
         })?;
 
-        info!("{} shutting down the controller", self.name);
+        debug!("{} shutting down the controller", self.name);
 
         let ctx = ShutdownCtx {
             name: self.get_name(),
@@ -529,7 +529,7 @@ impl<'a> NvmeController<'a> {
         // in progress.
         let c = NVME_CONTROLLERS.lookup_by_name(reset_ctx.name);
         if let Some(controller) = c {
-            let mut controller = controller.lock().expect("lock poisoned");
+            let mut controller = controller.lock();
 
             // If controller exists, its state must reflect active reset
             // operation, as no other operations are allowed upon
@@ -594,11 +594,11 @@ impl<'a> NvmeController<'a> {
             return;
         }
 
-        info!("{}: all I/O channels successfully reset", reset_ctx.name);
+        debug!("{}: all I/O channels successfully reset", reset_ctx.name);
         // In case shutdown is active, don't reset the controller as its
         // being removed.
         if reset_ctx.shutdown_in_progress {
-            info!(
+            warn!(
                 "{}: controller shutdown detected, skipping reset",
                 reset_ctx.name
             );
@@ -615,7 +615,7 @@ impl<'a> NvmeController<'a> {
 
             NvmeController::_complete_reset(reset_ctx, rc);
         } else {
-            info!(
+            debug!(
                 "{} controller successfully reset, reinitializing I/O channels",
                 reset_ctx.name
             );
@@ -650,13 +650,13 @@ impl<'a> NvmeController<'a> {
                 reset_ctx.name, rc
             );
         } else {
-            info!("{} I/O channel successfully reinitialized", reset_ctx.name);
+            debug!("{} I/O channel successfully reinitialized", reset_ctx.name);
         }
         rc
     }
 
     fn _reset_create_channels_done(status: i32, reset_ctx: ResetCtx) {
-        info!(
+        debug!(
             "{} controller reset completed, status = {}",
             reset_ctx.name, status
         );
@@ -728,7 +728,7 @@ impl<'a> Drop for NvmeController<'a> {
             inner.adminq_poller.stop();
 
             assert_eq!(rc, 0, "Failed to detach NVMe controller");
-            debug!(
+            info!(
                 ?self.name,
                 "NVMe controller successfully detached"
             );
@@ -754,7 +754,7 @@ extern "C" fn aer_cb(ctx: *mut c_void, cpl: *const spdk_nvme_cpl) {
         (event.bits.async_event_type(), event.bits.async_event_info())
     };
 
-    info!(
+    debug!(
         "Received AER event: event_type={:?}, event_info={:?}",
         event_type, event_info
     );
@@ -767,8 +767,8 @@ extern "C" fn aer_cb(ctx: *mut c_void, cpl: *const spdk_nvme_cpl) {
 
         match NVME_CONTROLLERS.lookup_by_name(cid.to_string()) {
             Some(c) => {
-                let mut ctrlr = c.lock().expect("lock poisoned");
-                info!(
+                let mut ctrlr = c.lock();
+                debug!(
                     "{}: populating namespaces in response to AER",
                     ctrlr.get_name()
                 );
@@ -784,7 +784,7 @@ extern "C" fn aer_cb(ctx: *mut c_void, cpl: *const spdk_nvme_cpl) {
     } else if event_type == NvmeAerType::Io as u32
         && event_info == NvmeAerInfoNvmCommandSet::ReservationLogAvail as u32
     {
-        info!("Reservation log available");
+        debug!("Reservation log available");
     }
 }
 
@@ -794,11 +794,11 @@ pub extern "C" fn nvme_poll_adminq(ctx: *mut c_void) -> i32 {
     let mut context = NonNull::<TimeoutConfig>::new(ctx.cast())
         .expect("ctx pointer may never be null");
     let context = unsafe { context.as_mut() };
-
     let rc =
         unsafe { spdk_nvme_ctrlr_process_admin_completions(context.ctrlr) };
     if rc < 0 {
-        context.reset_controller();
+        //  unsafe { spdk_nvme_ctrlr_fail(context.ctrlr) };
+        // context.reset_controller();
     }
 
     if rc == 0 {
@@ -820,7 +820,7 @@ pub(crate) async fn destroy_device(name: String) -> Result<(), NexusBdevError> {
     // of the controller.
     let (s, r) = oneshot::channel::<bool>();
     {
-        let mut controller = carc.lock().expect("lock poisoned");
+        let mut controller = carc.lock();
 
         fn _shutdown_callback(success: bool, ctx: *mut c_void) {
             done_cb(ctx, success);
@@ -855,7 +855,7 @@ pub(crate) async fn destroy_device(name: String) -> Result<(), NexusBdevError> {
 
     // Notify the listeners.
     debug!(?name, "notifying listeners about device removal");
-    let controller = carc.lock().unwrap();
+    let controller = carc.lock();
     let num_listeners = controller.notify_event(DeviceEventType::DeviceRemoved);
     debug!(
         ?name,
@@ -882,7 +882,7 @@ pub(crate) fn connected_attached_cb(
 
     // clone it now such that we can lock the original, and insert it later.
     let ctl = Arc::clone(&controller);
-    let mut controller = controller.lock().unwrap();
+    let mut controller = controller.lock();
     controller
         .state_machine
         .transition(Initializing)
@@ -1044,6 +1044,7 @@ pub(crate) mod options {
                 };
             }
 
+            opts.0.disable_error_logging = true;
             opts
         }
     }

--- a/mayastor/src/bdev/nvmx/controller_inner.rs
+++ b/mayastor/src/bdev/nvmx/controller_inner.rs
@@ -58,7 +58,7 @@ impl TryFrom<u32> for DeviceTimeoutAction {
 /// This is done to prevent the storm of reset requests in response to
 /// frequent I/O errors in a controller (including errors while processing
 /// admin queue completions).
-const MAX_RESET_ATTEMPTS: u32 = 5;
+const MAX_RESET_ATTEMPTS: u32 = 1;
 
 /// Time to wait till reset attempts can be recharged to maximum
 /// after all current reset attempts have been used.
@@ -154,7 +154,7 @@ impl TimeoutConfig {
             self.reset_attempts -= 1;
 
             if let Some(c) = NVME_CONTROLLERS.lookup_by_name(&self.name) {
-                let mut c = c.lock().expect("controller lock poisoned");
+                let mut c = c.lock();
                 if let Err(e) = c.reset(
                     TimeoutConfig::reset_cb,
                     self as *mut TimeoutConfig as *mut c_void,

--- a/mayastor/src/bdev/nvmx/handle.rs
+++ b/mayastor/src/bdev/nvmx/handle.rs
@@ -757,7 +757,7 @@ impl BlockDeviceHandle for NvmeDeviceHandle {
                 name: self.name.to_string(),
             },
         )?;
-        let mut controller = controller.lock().expect("lock poisoned");
+        let mut controller = controller.lock();
 
         let ctx = Box::new(ResetCtx {
             cb,

--- a/mayastor/src/bdev/nvmx/mod.rs
+++ b/mayastor/src/bdev/nvmx/mod.rs
@@ -1,10 +1,7 @@
-use std::{
-    collections::HashMap,
-    fmt::Display,
-    sync::{Arc, Mutex, RwLock, RwLockReadGuard, RwLockWriteGuard},
-};
+use std::{collections::HashMap, fmt::Display, sync::Arc};
 
 use once_cell::sync::Lazy;
+use parking_lot::{Mutex, RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 pub use channel::{NvmeControllerIoChannel, NvmeIoChannel, NvmeIoChannelInner};
 pub use controller::NvmeController;
@@ -39,13 +36,13 @@ impl<'a> NVMeCtlrList<'a> {
     fn write_lock(
         &self,
     ) -> RwLockWriteGuard<HashMap<String, Arc<Mutex<NvmeController<'a>>>>> {
-        self.entries.write().expect("rwlock poisoned")
+        self.entries.write()
     }
 
     fn read_lock(
         &self,
     ) -> RwLockReadGuard<HashMap<String, Arc<Mutex<NvmeController<'a>>>>> {
-        self.entries.read().expect("rwlock poisoned")
+        self.entries.read()
     }
 
     /// lookup a NVMe controller
@@ -73,7 +70,7 @@ impl<'a> NVMeCtlrList<'a> {
 
         // Remove 'controller name -> controller' mapping.
         let e = entries.remove(&name.to_string()).unwrap();
-        let controller = e.lock().unwrap();
+        let controller = e.lock();
 
         // Remove 'controller id->controller' mapping. This will remove the last
         // reference as causes the controller to be dropped.

--- a/mayastor/src/core/bio.rs
+++ b/mayastor/src/core/bio.rs
@@ -172,6 +172,7 @@ impl Bio {
     #[inline]
     pub(crate) fn fail(&self) {
         unsafe {
+            trace!(?self, "failed");
             spdk_bdev_io_complete(self.0.as_ptr(), IoStatus::Failed.into())
         }
     }

--- a/mayastor/src/grpc/bdev_grpc.rs
+++ b/mayastor/src/grpc/bdev_grpc.rs
@@ -39,7 +39,19 @@ impl From<Bdev> for RpcBdev {
 }
 
 #[derive(Debug)]
-pub struct BdevSvc;
+pub struct BdevSvc {}
+
+impl BdevSvc {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl Default for BdevSvc {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 #[tonic::async_trait]
 impl BdevRpc for BdevSvc {

--- a/mayastor/src/grpc/mayastor_grpc.rs
+++ b/mayastor/src/grpc/mayastor_grpc.rs
@@ -46,7 +46,7 @@ impl From<LvsError> for Status {
             LvsError::Import {
                 ..
             } => Status::invalid_argument(e.to_string()),
-            LvsError::Create {
+            LvsError::RepCreate {
                 source, ..
             } => {
                 if source == Errno::ENOSPC {

--- a/mayastor/src/grpc/server.rs
+++ b/mayastor/src/grpc/server.rs
@@ -21,7 +21,7 @@ impl MayastorGrpcServer {
         info!("gRPC server configured at address {}", endpoint);
         let svc = Server::builder()
             .add_service(MayastorRpcServer::new(MayastorSvc))
-            .add_service(BdevRpcServer::new(BdevSvc))
+            .add_service(BdevRpcServer::new(BdevSvc::new()))
             .add_service(JsonRpcServer::new(JsonRpcSvc {
                 rpc_addr,
             }))

--- a/mayastor/src/lvs/error.rs
+++ b/mayastor/src/lvs/error.rs
@@ -9,8 +9,8 @@ pub enum Error {
     #[snafu(display("failed to import pool {}", name))]
     Import { source: Errno, name: String },
 
-    #[snafu(display("failed to create pool {}", name))]
-    Create { source: Errno, name: String },
+    #[snafu(display("errno: {} failed to create pool {}", source, name))]
+    PoolCreate { source: Errno, name: String },
 
     #[snafu(display("failed to export pool {}", name))]
     Export { source: Errno, name: String },
@@ -26,13 +26,13 @@ pub enum Error {
         name: String,
     },
 
-    #[snafu(display("errno {}: {}", source.to_string(), msg))]
+    #[snafu(display("errno {}: {}", source, msg))]
     Invalid { source: Errno, msg: String },
 
     #[snafu(display("lvol exists {}", name))]
     RepExists { source: Errno, name: String },
 
-    #[snafu(display("failed to create lvol {}", name))]
+    #[snafu(display("errno: {} failed to create lvol {}", source, name))]
     RepCreate { source: Errno, name: String },
 
     #[snafu(display("failed to destroy lvol {}", name))]

--- a/mayastor/src/lvs/lvs_pool.rs
+++ b/mayastor/src/lvs/lvs_pool.rs
@@ -259,7 +259,7 @@ impl Lvs {
                 cb_arg(sender),
             )
         }
-        .to_result(|e| Error::Create {
+        .to_result(|e| Error::PoolCreate {
             source: Errno::from_i32(e),
             name: name.to_string(),
         })?;
@@ -267,7 +267,7 @@ impl Lvs {
         receiver
             .await
             .expect("Cancellation is not supported")
-            .map_err(|err| Error::Create {
+            .map_err(|err| Error::PoolCreate {
                 source: err,
                 name: name.to_string(),
             })?;
@@ -277,7 +277,7 @@ impl Lvs {
                 info!("The pool '{}' has been created on {}", name, bdev);
                 Ok(pool)
             }
-            None => Err(Error::Create {
+            None => Err(Error::PoolCreate {
                 source: Errno::ENOENT,
                 name: name.to_string(),
             }),
@@ -322,7 +322,7 @@ impl Lvs {
             return if pool.base_bdev().name() == parsed.get_name() {
                 Ok(pool)
             } else {
-                Err(Error::Create {
+                Err(Error::PoolCreate {
                     source: Errno::EEXIST,
                     name: args.name.clone(),
                 })

--- a/mayastor/src/subsys/config/opts.rs
+++ b/mayastor/src/subsys/config/opts.rs
@@ -178,15 +178,15 @@ where
 impl Default for NvmfTcpTransportOpts {
     fn default() -> Self {
         Self {
-            max_queue_depth: try_from_env("NVMF_TCP_MAX_QUEUE_DEPTH", 64),
+            max_queue_depth: try_from_env("NVMF_TCP_MAX_QUEUE_DEPTH", 32),
             in_capsule_data_size: 4096,
             max_io_size: 131_072,
             io_unit_size: 131_072,
-            max_qpairs_per_ctrl: 128,
+            max_qpairs_per_ctrl: 32,
             num_shared_buf: try_from_env("NVMF_TCP_NUM_SHARED_BUF", 2048),
             buf_cache_size: try_from_env("NVMF_TCP_BUF_CACHE_SIZE", 64),
             dif_insert_or_strip: false,
-            max_aq_depth: 128,
+            max_aq_depth: 32,
             abort_timeout_sec: 1,
         }
     }
@@ -268,8 +268,8 @@ impl Default for NvmeBdevOpts {
     fn default() -> Self {
         Self {
             action_on_timeout: SPDK_BDEV_NVME_TIMEOUT_ACTION_ABORT,
-            timeout_us: try_from_env("NVME_TIMEOUT_US", 30_000_000),
-            keep_alive_timeout_ms: try_from_env("NVME_KATO_MS", 10_000),
+            timeout_us: try_from_env("NVME_TIMEOUT_US", 5_000_000),
+            keep_alive_timeout_ms: try_from_env("NVME_KATO_MS", 0),
             retry_count: try_from_env("NVME_RETRY_COUNT", 3),
             arbitration_burst: 0,
             low_priority_weight: 0,
@@ -277,7 +277,7 @@ impl Default for NvmeBdevOpts {
             high_priority_weight: 0,
             nvme_adminq_poll_period_us: try_from_env(
                 "NVME_ADMINQ_POLL_PERIOD_US",
-                0,
+                10_000,
             ),
             nvme_ioq_poll_period_us: try_from_env("NVME_IOQ_POLL_PERIOD_US", 0),
             io_queue_requests: 0,

--- a/nix/mayastor-overlay.nix
+++ b/nix/mayastor-overlay.nix
@@ -1,4 +1,5 @@
 self: super: {
+  fio = super.callPackage ./pkgs/fio { };
   libiscsi = super.callPackage ./pkgs/libiscsi { };
   nvmet-cli = super.callPackage ./pkgs/nvmet-cli { };
   libspdk = (super.callPackage ./pkgs/libspdk { }).release;

--- a/nix/pkgs/fio/default.nix
+++ b/nix/pkgs/fio/default.nix
@@ -1,0 +1,55 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, makeWrapper
+, libaio
+, python3
+, zlib
+, withGnuplot ? false
+, gnuplot ? null
+}:
+
+stdenv.mkDerivation rec {
+  pname = "fio";
+  version = "3.26";
+
+  src = fetchFromGitHub {
+    owner = "axboe";
+    repo = "fio";
+    rev = "fio-${version}";
+    sha256 = "sha256-/Si0McndJ6Xp3ifDr+BStv89LmZyAgof95QkHGT8MGQ=";
+  };
+
+  buildInputs = [ python3 zlib ]
+    ++ lib.optional (!stdenv.isDarwin) libaio;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  strictDeps = true;
+
+  enableParallelBuilding = true;
+
+  postPatch = ''
+    substituteInPlace Makefile \
+      --replace "mandir = /usr/share/man" "mandir = \$(prefix)/man" \
+      --replace "sharedir = /usr/share/fio" "sharedir = \$(prefix)/share/fio"
+    substituteInPlace tools/plot/fio2gnuplot --replace /usr/share/fio $out/share/fio
+  '';
+
+  preInstall = ''
+    mkdir -p $out/include
+    cp -p --parents $(find . -name "*.h") $out/include
+  '';
+
+  postInstall = lib.optionalString withGnuplot ''
+    wrapProgram $out/bin/fio2gnuplot \
+      --prefix PATH : ${lib.makeBinPath [ gnuplot ]}
+  '';
+
+  meta = with lib; {
+    description = "Flexible IO Tester - an IO benchmark tool";
+    homepage = "https://git.kernel.dk/cgit/fio/";
+    license = licenses.gpl2;
+    platforms = platforms.unix;
+  };
+}

--- a/nix/pkgs/libspdk/default.nix
+++ b/nix/pkgs/libspdk/default.nix
@@ -14,6 +14,7 @@
 , libexecinfo
 , nasm
 , cmake
+, fio
 , ninja
 , jansson
 , meson
@@ -28,13 +29,14 @@
 , buildPlatform
 , buildPackages
 , llvmPackages_11
+, pkgs
 , gcc
 , zlib
 }:
 let
   # Derivation attributes for production version of libspdk
   drvAttrs = rec {
-    version = "21.01";
+    version = "21.01-3f85fb5";
 
     src = fetchFromGitHub {
       owner = "openebs";
@@ -57,6 +59,7 @@ let
 
     buildInputs = [
       binutils
+      fio
       libtool
       libaio
       libiscsi
@@ -92,9 +95,9 @@ let
       "--without-isal"
       "--with-iscsi-initiator"
       "--with-uring"
-      "--disable-examples"
       "--disable-unit-tests"
       "--disable-tests"
+      "--with-fio=${pkgs.fio}/include"
     ];
 
     enableParallelBuilding = true;
@@ -130,6 +133,7 @@ let
     installPhase = ''
       mkdir -p $out/lib
       mkdir $out/bin
+      mkdir $out/fio
 
       pushd include
       find . -type f -name "*.h" -exec install -D "{}" $out/include/{} \;
@@ -149,6 +153,8 @@ let
 
       echo $(find $out -type f -name '*.a*' -delete)
       find . -executable -type f -name 'bdevperf' -exec install -D "{}" $out/bin \;
+
+      cp build/fio/spdk_* $out/fio
     '';
   };
 in

--- a/nix/pkgs/mayastor/cargo-package.nix
+++ b/nix/pkgs/mayastor/cargo-package.nix
@@ -57,7 +57,7 @@ let
   buildProps = rec {
     name = "mayastor";
     #cargoSha256 = "0000000000000000000000000000000000000000000000000000";
-    cargoSha256 = "1rqp5w0148sajcdwg6dafbknsi62zkmd6i8m2c5zfghdlg4ripxc";
+    cargoSha256 = "04g33g147m6mg347fc6nqn07qy9qxxq5lpv7381v3gfk2zkg2amq";
     inherit version cargoBuildFlags;
     src = whitelistSource ../../../. src_list;
     LIBCLANG_PATH = "${llvmPackages.libclang}/lib";

--- a/shell.nix
+++ b/shell.nix
@@ -37,7 +37,6 @@ mkShell {
     kubernetes-helm
     libaio
     libiscsi
-    libiscsi
     libudev
     liburing
     llvmPackages.libclang

--- a/spdk-sys/build.sh
+++ b/spdk-sys/build.sh
@@ -15,7 +15,8 @@ rm libspdk.so
 	--with-iscsi-initiator \
 	--with-crypto \
 	--with-uring \
-	--enable-unit-tests
+	--enable-unit-tests \
+	--with-fio=$(which fio | sed s';bin/fio;include;')
 
 make -j $(nproc)
 

--- a/spdk-sys/build.sh
+++ b/spdk-sys/build.sh
@@ -18,7 +18,7 @@ rm libspdk.so
 	--enable-unit-tests \
 	--with-fio=$(which fio | sed s';bin/fio;include;')
 
-make -j $(nproc)
+bear -- make -j $(nproc)
 
 # delete things we for sure do not want link
 find . -type f -name 'libspdk_event_nvmf.a' -delete

--- a/test/python/README.md
+++ b/test/python/README.md
@@ -1,0 +1,63 @@
+# Purpose
+To test things in containers but on the same host, we have the composer library in Rust.
+This works pretty well but has the downside that if you want to add something to
+that test, you have to recompile the tests all the time, and you can not leave the
+containers running when the test fails without modifying the tests either. This is
+because those tests are part of our CI/CD pipeline, so we must clean them up.
+
+Additionally, when working on the data plane and you want to test, let us say,
+"child retire" logic. It can be rather a pain to do that manually, even when
+scripted. To fill this cap, we can use pytest, which can a far richer than bash
+scripts - and it can leverage docker-compose.  Upside is that the test suites
+can run with -- or without starting the containers.
+
+So all in all, the purpose is to create reproducible tests/environments.
+
+For example, I can start my containers and run:
+```
+docker-compose up
+pytest nexus.py --docker-compose-no-build --use-running-containers
+```
+This allows me to see the logs in real-time, and on failure, figure out why it
+failed and so forth.
+
+Without the extra arguments however, the test suite will create and destroy
+the containers
+
+# Setup
+
+Depending on the used OS/distro of choice you will need to install some
+python packages. To make it easier. You can also use virtual environments.
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+```
+
+Install python packages:
+
+
+```bash
+pip install -r requirements.txt
+```
+
+# Protobuf
+
+`shell.nix` contains a few python3 packages in particular for proto generation.
+From within the `rpc/proto` run:
+
+```bash
+python -m grpc_tools.protoc -I . --proto_path=. --python_out=. --grpc_python_out=. mayastor.proto
+```
+
+And copy them (yes -- on the TODO list) over when they where updated, such that:
+
+```bash
+docker-compose.yml  mayastor_pb2_grpc.py  mayastor_pb2.py  nexus.py  README.md  requirements.txt
+```
+
+# TODO:
+ [ ] fix proto generation
+ [ ] create test suite layout such that the tests fixtures can be re-used
+ [ ] create test that run fio, do "create 110" volumes etc type like tests
+ [ ] ...

--- a/test/python/README.md
+++ b/test/python/README.md
@@ -22,39 +22,11 @@ This allows me to see the logs in real-time, and on failure, figure out why it
 failed and so forth.
 
 Without the extra arguments however, the test suite will create and destroy
-the containers
+the containers automatically. This is done by making use of the pytest fixtures
 
 # Setup
 
-Depending on the used OS/distro of choice you will need to install some
-python packages. To make it easier. You can also use virtual environments.
-
-```bash
-python3 -m venv .venv
-source .venv/bin/activate
-```
-
-Install python packages:
-
-
-```bash
-pip install -r requirements.txt
-```
-
-# Protobuf
-
-`shell.nix` contains a few python3 packages in particular for proto generation.
-From within the `rpc/proto` run:
-
-```bash
-python -m grpc_tools.protoc -I . --proto_path=. --python_out=. --grpc_python_out=. mayastor.proto
-```
-
-And copy them (yes -- on the TODO list) over when they where updated, such that:
-
-```bash
-docker-compose.yml  mayastor_pb2_grpc.py  mayastor_pb2.py  nexus.py  README.md  requirements.txt
-```
+`nix-shell` and have fun.
 
 # TODO:
  [ ] fix proto generation

--- a/test/python/common/command.py
+++ b/test/python/common/command.py
@@ -1,0 +1,34 @@
+import asyncio
+from collections import namedtuple
+
+CommandReturn = namedtuple("CommandReturn", "returncode stdout stderr")
+
+
+async def run_cmd_async(cmd):
+    proc = await asyncio.create_subprocess_shell(
+        cmd,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE)
+    stdout, stderr = await proc.communicate()
+
+    output_message = f"\n[{proc.pid}] Command:\n{cmd}"
+    # Append stdout/stderr to the output message
+    if stdout.decode() != "":
+        output_message += f"\n[{proc.pid}] stdout:\n{stdout.decode()}"
+    if stderr.decode() != "":
+        output_message += f"\n[{proc.pid}] stderr:\n{stderr.decode()}"
+
+    # If a non-zero return code was thrown, raise an exception
+    if proc.returncode != 0:
+        output_message += \
+            f"\nReturned error code: {proc.returncode}"
+
+        if stderr.decode() != "":
+            output_message += \
+                f"\nstderr:\n{stderr.decode()}"
+        raise ChildProcessError(output_message)
+
+    return CommandReturn(
+        proc.returncode,
+        stdout.decode(),
+        stderr.decode())

--- a/test/python/common/command.py
+++ b/test/python/common/command.py
@@ -60,6 +60,7 @@ async def run_cmd_async_at(host, cmd):
             if result.stderr != "":
                 output_message += \
                     f"\nstderr:\n{result.stderr}"
+            print(output_message)
             raise ChildProcessError(output_message)
 
         return CommandReturn(

--- a/test/python/common/command.py
+++ b/test/python/common/command.py
@@ -1,7 +1,12 @@
 import asyncio
 from collections import namedtuple
 import asyncssh
+import subprocess
 CommandReturn = namedtuple("CommandReturn", "returncode stdout stderr")
+
+
+def run_cmd(cmd, check=True):
+    subprocess.run(cmd, shell=True, check=check)
 
 
 async def run_cmd_async(cmd):

--- a/test/python/common/fio.py
+++ b/test/python/common/fio.py
@@ -15,10 +15,18 @@ class Fio(object):
         self.runtime = runtime
 
     def build(self) -> str:
+        if isinstance(self.device, str):
+            devs = [self.device]
+        else:
+            devs = self.device
+
         command = ("sudo fio --ioengine=linuxaio --direct=1 --bs=4k "
                    "--time_based=1 --rw={} "
                    "--group_reporting=1 --norandommap=1 --iodepth=64 "
-                   "--runtime={} --name={} --filename={}").format(
-            self.rw, self.runtime, self.name, self.device)
+                   "--runtime={} --name={} --filename={}").format(self.rw,
+                                                       self.runtime,
+                                                       self.name,
+                                                       " --filename=".join(map(str,
+                                                                               devs)))
 
         return command

--- a/test/python/common/fio.py
+++ b/test/python/common/fio.py
@@ -1,8 +1,7 @@
-import sys
-import subprocess
 import shutil
 from common.command import run_cmd_async
 import asyncio
+
 
 class Fio(object):
 
@@ -15,11 +14,11 @@ class Fio(object):
         self.success = {}
         self.runtime = runtime
 
-    async def run(self):
+    def build(self) -> str:
         command = ("sudo fio --ioengine=linuxaio --direct=1 --bs=4k "
                    "--time_based=1 --rw={} "
                    "--group_reporting=1 --norandommap=1 --iodepth=64 "
                    "--runtime={} --name={} --filename={}").format(
             self.rw, self.runtime, self.name, self.device)
 
-        await asyncio.wait_for(run_cmd_async(command), self.runtime + 5)
+        return command

--- a/test/python/common/fio.py
+++ b/test/python/common/fio.py
@@ -1,0 +1,25 @@
+import sys
+import subprocess
+import shutil
+from common.command import run_cmd_async
+import asyncio
+
+class Fio(object):
+
+    def __init__(self, name, rw, device, runtime=15):
+        self.name = name
+        self.rw = rw
+        self.device = device
+        self.cmd = shutil.which("fio")
+        self.output = {}
+        self.success = {}
+        self.runtime = runtime
+
+    async def run(self):
+        command = ("sudo fio --ioengine=linuxaio --direct=1 --bs=4k "
+                   "--time_based=1 --rw={} "
+                   "--group_reporting=1 --norandommap=1 --iodepth=64 "
+                   "--runtime={} --name={} --filename={}").format(
+            self.rw, self.runtime, self.name, self.device)
+
+        await asyncio.wait_for(run_cmd_async(command), self.runtime + 5)

--- a/test/python/common/fio_spdk.py
+++ b/test/python/common/fio_spdk.py
@@ -1,0 +1,31 @@
+import asyncio
+import os
+import shutil
+from common.command import run_cmd_async
+from urllib.parse import urlparse
+
+class FioSpdk(object):
+
+    def __init__(self, name, rw, uri, runtime=15):
+        self.name = name
+        self.rw = rw
+        u = urlparse(uri)
+        self.host = u.hostname
+        self.port = u.port
+        self.nqn = u.path[1:]
+        self.cmd = shutil.which("fio")
+        self.runtime = runtime
+
+    async def run(self):
+        spdk_path = os.environ.get('SPDK_PATH')
+        if spdk_path == None:
+            spdk_path = os.getcwd() + '/../../spdk-sys/spdk/build'
+        command = ("sudo LD_PRELOAD={}/fio/spdk_nvme fio --ioengine=spdk "
+                   "--direct=1 --bs=4k --time_based=1 --runtime=15 "
+                   "--thread=1 --rw={} --group_reporting=1 --norandommap=1 "
+                   "--iodepth=64 --name={} --filename=\'trtype=tcp "
+                   "adrfam=IPv4 traddr={} trsvcid={} subnqn={} ns=1\'").format(
+            spdk_path, self.rw, self.name, self.host, self.port,
+            self.nqn.replace(":", "\\:"))
+
+        await asyncio.wait_for(run_cmd_async(command), self.runtime + 5)

--- a/test/python/common/fio_spdk.py
+++ b/test/python/common/fio_spdk.py
@@ -4,6 +4,7 @@ import shutil
 from common.command import run_cmd_async
 from urllib.parse import urlparse
 
+
 class FioSpdk(object):
 
     def __init__(self, name, rw, uri, runtime=15):
@@ -18,7 +19,7 @@ class FioSpdk(object):
 
     async def run(self):
         spdk_path = os.environ.get('SPDK_PATH')
-        if spdk_path == None:
+        if spdk_path is None:
             spdk_path = os.getcwd() + '/../../spdk-sys/spdk/build'
         command = ("sudo LD_PRELOAD={}/fio/spdk_nvme fio --ioengine=spdk "
                    "--direct=1 --bs=4k --time_based=1 --runtime=15 "

--- a/test/python/common/hdl.py
+++ b/test/python/common/hdl.py
@@ -92,6 +92,10 @@ class MayastorHandle(object):
         """Unpublish the nexus."""
         return self.ms.UnpublishNexus(pb.UnpublishNexusRequest(uuid=uuid))
 
+    def nexus_list(self):
+        """List all the  the nexus devices."""
+        return self.ms.ListNexus(pb.Null()).nexus_list
+
     def bdev_list(self):
         """"List all bdevs found within the system."""
         return self.bdev.List(pb.Null(), wait_for_ready=True)

--- a/test/python/common/hdl.py
+++ b/test/python/common/hdl.py
@@ -18,6 +18,13 @@ class MayastorHandle(object):
         self.bdev_list()
         self.pool_list()
 
+    def reconnect(self):
+        self.channel = grpc.insecure_channel(("%s:10124") % self.ip_v4)
+        self.bdev = rpc.BdevRpcStub(self.channel)
+        self.ms = rpc.MayastorStub(self.channel)
+        self.bdev_list()
+        self.pool_list()
+
     def __del__(self):
         del self.channel
 
@@ -69,6 +76,9 @@ class MayastorHandle(object):
         """Destroy the replica by the UUID, the pool is resolved within
         mayastor."""
         return self.ms.DestroyReplica(pb.DestroyReplicaRequest(uuid=uuid))
+
+    def replica_list(self):
+        return self.ms.ListReplicas(pb.Null())
 
     def nexus_create(self, uuid, size, children):
         """Create a nexus with the given uuid and size. The children are

--- a/test/python/common/hdl.py
+++ b/test/python/common/hdl.py
@@ -50,7 +50,13 @@ class MayastorHandle(object):
         mayastor as this is for testing, we do not want to prevent parsing
         invalid schemes."""
 
-        return self.bdev.Create(pb.BdevUri(uri=uri)).uri
+        return self.bdev.Create(pb.BdevUri(uri=uri))
+
+    def bdev_share(self, name):
+        return self.bdev.Share(
+            pb.BdevShareRequest(
+                name=str(name),
+                proto="nvmf")).uri
 
     def pool_create(self, name, bdev):
         """Create a pool with given name on this node using the bdev as the
@@ -108,7 +114,7 @@ class MayastorHandle(object):
 
     def bdev_list(self):
         """"List all bdevs found within the system."""
-        return self.bdev.List(pb.Null(), wait_for_ready=True)
+        return self.bdev.List(pb.Null(), wait_for_ready=True).bdevs
 
     def pool_list(self):
         """Only list pools"""

--- a/test/python/common/hdl.py
+++ b/test/python/common/hdl.py
@@ -96,11 +96,11 @@ class MayastorHandle(object):
         by the control plane."""
         return self.ms.PublishNexus(
             pb.PublishNexusRequest(
-                uuid=uuid, key="", share=1)).device_uri
+                uuid=str(uuid), key="", share=1)).device_uri
 
     def nexus_unpublish(self, uuid):
         """Unpublish the nexus."""
-        return self.ms.UnpublishNexus(pb.UnpublishNexusRequest(uuid=uuid))
+        return self.ms.UnpublishNexus(pb.UnpublishNexusRequest(uuid=str(uuid)))
 
     def nexus_list(self):
         """List all the  the nexus devices."""

--- a/test/python/common/hdl.py
+++ b/test/python/common/hdl.py
@@ -1,0 +1,110 @@
+"""Common code that represents a mayastor handle."""
+import mayastor_pb2 as pb
+import grpc
+import mayastor_pb2_grpc as rpc
+
+pytest_plugins = ["docker_compose"]
+
+
+class MayastorHandle(object):
+    """Mayastor gRPC handle."""
+
+    def __init__(self, ip_v4):
+        """Init."""
+        self.ip_v4 = ip_v4
+        self.channel = grpc.insecure_channel(("%s:10124") % self.ip_v4)
+        self.bdev = rpc.BdevRpcStub(self.channel)
+        self.ms = rpc.MayastorStub(self.channel)
+        self.bdev_list()
+        self.pool_list()
+
+    def __del__(self):
+        del self.channel
+
+    def close(self):
+        self.__del__()
+
+    def as_target(self) -> str:
+        """Returns this node as scheme which is used to designate this node to
+        be used as the node where the nexus shall be created on."""
+        node = "nvmt://{0}".format(self.ip_v4)
+        return node
+
+    def bdev_create(self, uri):
+        """create the bdev using the specific URI where URI can be one of the
+        following supported schemes:
+
+            nvmf://
+            aio://
+            uring://
+            malloc://
+
+        Note that we do not check the URI schemes, as this should be done in
+        mayastor as this is for testing, we do not want to prevent parsing
+        invalid schemes."""
+
+        return self.bdev.Create(pb.BdevUri(uri=uri)).uri
+
+    def pool_create(self, name, bdev):
+        """Create a pool with given name on this node using the bdev as the
+        backend device. The bdev is implicitly created."""
+
+        disks = []
+        disks.append(bdev)
+        return self.ms.CreatePool(pb.CreatePoolRequest(name=name, disks=disks))
+
+    def pool_destroy(self, name):
+        """Destroy  the pool."""
+        return self.ms.DestroyPool(pb.DestroyPoolRequest(name=name))
+
+    def replica_create(self, pool, uuid, size):
+        """Create  a replica on the pool with the specified UUID and size."""
+        return self.ms.CreateReplica(
+            pb.CreateReplicaRequest(
+                pool=pool, uuid=str(uuid), size=size, thin=False, share=1
+            )
+        )
+
+    def replica_destroy(self, uuid):
+        """Destroy the replica by the UUID, the pool is resolved within
+        mayastor."""
+        return self.ms.DestroyReplica(pb.DestroyReplicaRequest(uuid=uuid))
+
+    def nexus_create(self, uuid, size, children):
+        """Create a nexus with the given uuid and size. The children are
+        should be an array of nvmf URIs."""
+        return self.ms.CreateNexus(
+            pb.CreateNexusRequest(uuid=str(uuid), size=size, children=children)
+        )
+
+    def nexus_destroy(self, uuid):
+        """Destroy the nexus."""
+        return self.ms.DestroyNexus(pb.DestroyNexusRequest(uuid=uuid))
+
+    def nexus_publish(self, uuid):
+        """Publish the nexus. this is the same as bdev_share() but is not used
+        by the control plane."""
+        return self.ms.PublishNexus(
+            pb.PublishNexusRequest(
+                uuid=uuid, key="", share=1)).device_uri
+
+    def nexus_unpublish(self, uuid):
+        """Unpublish the nexus."""
+        return self.ms.UnpublishNexus(pb.UnpublishNexusRequest(uuid=uuid))
+
+    def bdev_list(self):
+        """"List all bdevs found within the system."""
+        return self.bdev.List(pb.Null(), wait_for_ready=True)
+
+    def pool_list(self):
+        """Only list pools"""
+        return self.ms.ListPools(pb.Null(), wait_for_ready=True)
+
+    def pools_as_uris(self):
+        """Return a list of pools as found on the system."""
+        uris = []
+        pools = self.ms.ListPools(pb.Null(), wait_for_ready=True)
+        for p in pools.pools:
+            uri = "pool://{0}/{1}".format(self.ip_v4, p.name)
+            uris.append(uri)
+        return uris

--- a/test/python/common/nvme.py
+++ b/test/python/common/nvme.py
@@ -2,20 +2,69 @@ from urllib.parse import urlparse
 import subprocess
 import time
 import json
+from common.command import run_cmd_async_at
 
 
-def nvme_connect(uri):
+async def nvme_remote_connect(remote, uri):
     """Connect to the remote nvmf target on this host."""
     u = urlparse(uri)
     port = u.port
     host = u.hostname
     nqn = u.path[1:]
-    uuid = nqn.split("nexus-")
+
+    command = "sudo nvme connect -t tcp -s {0} -a {1} -n {2}".format(
+        port, host, nqn)
+
+    await run_cmd_async_at(remote, command)
+    time.sleep(1)
+    command = "sudo nvme list -v -o json"
+
+    discover = await run_cmd_async_at(remote, command)
+    discover = json.loads(discover.stdout)
+
+    dev = list(
+        filter(
+            lambda d: nqn in d.get("SubsystemNQN"),
+            discover.get("Devices")))
+
+    # we should only have one connection
+    assert len(dev) == 1
+    dev_path = dev[0].get('Controllers')[0].get(
+        'Namespaces')[0].get('NameSpace')
+
+    return f"/dev/{dev_path}"
+
+
+async def nvme_remote_disconnect(remote, uri):
+    """Disconnect the given URI on this host."""
+    u = urlparse(uri)
+    nqn = u.path[1:]
+
+    command = "sudo nvme disconnect -n {0}".format(nqn)
+    await run_cmd_async_at(remote, command)
+
+
+async def nvme_remote_discover(remote, uri):
+    """Discover target."""
+    u = urlparse(uri)
+    port = u.port
+    host = u.hostname
+
+    command = "sudo nvme discover -t tcp -s {0} -a {1}".format(port, host)
+    output = await run_cmd_async_at(remote, command).stdout
+    if not u.path[1:] in str(output.stdout):
+        raise ValueError("uri {} is not discovered".format(u.path[1:]))
+
+
+def nvme_connect(uri):
+    u = urlparse(uri)
+    port = u.port
+    host = u.hostname
+    nqn = u.path[1:]
 
     command = "sudo nvme connect -t tcp -s {0} -a {1} -n {2}".format(
         port, host, nqn)
     subprocess.run(command, check=True, shell=True, capture_output=False)
-    print("connected to {}".format(uri))
     time.sleep(1)
     command = "sudo nvme list -v -o json"
     discover = json.loads(
@@ -50,7 +99,6 @@ def nvme_discover(uri):
         shell=True,
         capture_output=True,
         encoding="utf-8")
-    print(output.stdout)
     if not u.path[1:] in str(output.stdout):
         raise ValueError("uri {} is not discovered".format(u.path[1:]))
 
@@ -61,9 +109,4 @@ def nvme_disconnect(uri):
     nqn = u.path[1:]
 
     command = "sudo nvme disconnect -n {0}".format(nqn)
-    print(subprocess.run(command, check=True, shell=True, capture_output=True))
-    time.sleep(1)
-
-
-def nvme_read():
-    pass
+    subprocess.run(command, check=True, shell=True, capture_output=True)

--- a/test/python/common/nvme.py
+++ b/test/python/common/nvme.py
@@ -1,0 +1,69 @@
+from urllib.parse import urlparse
+import subprocess
+import time
+import json
+
+
+def nvme_connect(uri):
+    """Connect to the remote nvmf target on this host."""
+    u = urlparse(uri)
+    port = u.port
+    host = u.hostname
+    nqn = u.path[1:]
+    uuid = nqn.split("nexus-")
+
+    command = "sudo nvme connect -t tcp -s {0} -a {1} -n {2}".format(
+        port, host, nqn)
+    subprocess.run(command, check=True, shell=True, capture_output=False)
+    print("connected to {}".format(uri))
+    time.sleep(1)
+    command = "sudo nvme list -v -o json"
+    discover = json.loads(
+        subprocess.run(
+            command,
+            shell=True,
+            check=True,
+            text=True,
+            capture_output=True).stdout)
+
+    dev = list(
+        filter(
+            lambda d: nqn in d.get("SubsystemNQN"),
+            discover.get("Devices")))
+
+    # we should only have one connection
+    assert len(dev) == 1
+    device = "/dev/{}".format(dev[0].get('Namespaces')[0].get('NameSpace'))
+    return device
+
+
+def nvme_discover(uri):
+    """Discover target."""
+    u = urlparse(uri)
+    port = u.port
+    host = u.hostname
+
+    command = "sudo nvme discover -t tcp -s {0} -a {1}".format(port, host)
+    output = subprocess.run(
+        command,
+        check=True,
+        shell=True,
+        capture_output=True,
+        encoding="utf-8")
+    print(output.stdout)
+    if not u.path[1:] in str(output.stdout):
+        raise ValueError("uri {} is not discovered".format(u.path[1:]))
+
+
+def nvme_disconnect(uri):
+    """Disconnect the given URI on this host."""
+    u = urlparse(uri)
+    nqn = u.path[1:]
+
+    command = "sudo nvme disconnect -n {0}".format(nqn)
+    print(subprocess.run(command, check=True, shell=True, capture_output=True))
+    time.sleep(1)
+
+
+def nvme_read():
+    pass

--- a/test/python/common/volume.py
+++ b/test/python/common/volume.py
@@ -1,0 +1,48 @@
+from common.hdl import MayastorHandle
+from urllib.parse import urlparse
+
+
+class Volume(object):
+    """
+    pool://hostname/pool_name
+
+    The nvmt should be in the form of:
+
+    nvmt://hostname
+    """
+
+    def __init__(self, uuid, nexus_node, pools, size):
+        self.uuid = str(uuid)
+        self.pools = pools
+        self.nexus = nexus_node
+        self.size = size
+
+    def __parse_uri(self, uri):
+        """
+        private function that parses the URI
+        """
+        u = urlparse(uri)
+        return (u.scheme, u.hostname, u.path[1:])
+
+    def __create_replicas(self):
+        """
+        private function that creates the replica and shares it. Note that
+        nvmf is used implicitly here
+
+        """
+        replicas = []
+        for pool in self.pools:
+            scheme, host, pool = self.__parse_uri(pool)
+            assert scheme == "pool"
+            handle = MayastorHandle(host)
+            replicas.append(handle.replica_create(pool, self.uuid, self.size))
+        return replicas
+
+    def create(self) -> str:
+        s, h, p = self.__parse_uri(self.nexus)
+        assert s == "nvmt"
+
+        replicas = [r.uri for r in self.__create_replicas()]
+        handle = MayastorHandle(h)
+        handle.nexus_create(self.uuid, self.size, replicas)
+        return handle.nexus_publish(self.uuid).device_uri

--- a/test/python/conftest.py
+++ b/test/python/conftest.py
@@ -5,8 +5,19 @@ import logging
 import pytest
 from common.hdl import MayastorHandle
 import mayastor_pb2 as pb
+import os
 
 pytest_plugins = ["docker_compose"]
+
+
+@pytest.fixture
+def target_vm():
+    try:
+        return os.environ.get("TARGET_VM")
+    except Exception as e:
+        print("to use this fixture the environ TARGET_VM variable must be set")
+        raise(e)
+
 
 
 @pytest.fixture(scope="module")

--- a/test/python/conftest.py
+++ b/test/python/conftest.py
@@ -1,0 +1,134 @@
+"""Default fixtures that are considered to be reusable."""
+
+import logging
+
+import pytest
+from common.hdl import MayastorHandle
+import mayastor_pb2 as pb
+
+pytest_plugins = ["docker_compose"]
+
+
+@pytest.fixture(scope="module")
+def wait_for_mayastor(docker_project, module_scoped_container_getter):
+    """Fixture to get a reference to mayastor handles."""
+    project = docker_project
+    handles = {}
+    for name in project.service_names:
+        # because we use static networks .get_service() does not work
+        services = module_scoped_container_getter.get(name)
+        ip_v4 = services.get(
+            "NetworkSettings.Networks.python_mayastor_net.IPAddress")
+        handles[name] = MayastorHandle(ip_v4)
+    yield handles
+
+
+@pytest.fixture(scope="module")
+def container_ref(docker_project, module_scoped_container_getter):
+    """Fixture to get handles to mayastor as well as the containers."""
+    project = docker_project
+    containers = {}
+    for name in project.service_names:
+        containers[name] = module_scoped_container_getter.get(name)
+    yield containers
+
+
+@pytest.fixture
+def pool_config():
+    """
+    The idea is this used to obtain the pool types and names that should be
+    created.
+    """
+    pool = {}
+    pool['name'] = "tpool"
+    pool['uri'] = "malloc:///disk0?size_mb=100"
+    return pool
+
+
+@pytest.fixture
+def replica_uuid():
+    """Replica UUID's to be used."""
+    UUID = "0000000-0000-0000-0000-000000000001"
+    size_mb = 64 * 1024 * 1024
+    return (UUID, size_mb)
+
+
+@pytest.fixture
+def nexus_uuid():
+    """Nexus UUID's to be used."""
+    NEXUS_UUID = "3ae73410-6136-4430-a7b5-cbec9fe2d273"
+    size_mb = 64 * 1024 * 1024
+    return (NEXUS_UUID, size_mb)
+
+
+@pytest.fixture
+def create_pools(
+        wait_for_mayastor,
+        container_ref,
+        pool_config):
+    hdls = wait_for_mayastor
+
+    cfg = pool_config
+    pools = []
+
+    pools.append(hdls['ms1'].pool_create(cfg.get('name'),
+                                         cfg.get('uri')))
+
+    pools.append(hdls['ms2'].pool_create(cfg.get('name'),
+                                         cfg.get('uri')))
+
+    for p in pools:
+        assert p.state == pb.POOL_ONLINE
+    yield pools
+    try:
+        hdls['ms1'].pool_destroy(cfg.get('name'))
+        hdls['ms2'].pool_destroy(cfg.get('name'))
+    except Exception:
+        pass
+
+
+@pytest.fixture
+def create_replica(
+        wait_for_mayastor,
+        pool_config,
+        replica_uuid,
+        create_pools):
+    hdls = wait_for_mayastor
+    pools = create_pools
+    replicas = []
+
+    UUID, size_mb = replica_uuid
+
+    replicas.append(hdls['ms1'].replica_create(pools[0].name,
+                                               UUID, size_mb))
+    replicas.append(hdls['ms2'].replica_create(pools[0].name,
+                                               UUID, size_mb))
+
+    yield replicas
+    try:
+        hdls['ms1'].replica_destroy(UUID)
+        hdls['ms2'].replica_destroy(UUID)
+    except Exception as e:
+        logging.debug(e)
+
+
+@pytest.fixture
+def create_nexus(wait_for_mayastor, container_ref, nexus_uuid, create_replica):
+    hdls = wait_for_mayastor
+    replicas = create_replica
+    replicas = [k.uri for k in replicas]
+
+    NEXUS_UUID, size_mb = nexus_uuid
+
+    hdls['ms3'].nexus_create(NEXUS_UUID, 64 * 1024 * 1024, replicas)
+    uri = hdls['ms3'].nexus_publish(NEXUS_UUID)
+
+    assert len(hdls['ms1'].bdev_list().bdevs) == 2
+    assert len(hdls['ms2'].bdev_list().bdevs) == 2
+    assert len(hdls['ms3'].bdev_list().bdevs) == 1
+
+    assert len(hdls['ms1'].pool_list().pools) == 1
+    assert len(hdls['ms2'].pool_list().pools) == 1
+
+    yield uri
+    hdls['ms3'].nexus_destroy(NEXUS_UUID)

--- a/test/python/conftest.py
+++ b/test/python/conftest.py
@@ -133,10 +133,9 @@ def create_nexus(wait_for_mayastor, container_ref, nexus_uuid, create_replica):
 
     hdls['ms3'].nexus_create(NEXUS_UUID, 64 * 1024 * 1024, replicas)
     uri = hdls['ms3'].nexus_publish(NEXUS_UUID)
-
-    assert len(hdls['ms1'].bdev_list().bdevs) == 2
-    assert len(hdls['ms2'].bdev_list().bdevs) == 2
-    assert len(hdls['ms3'].bdev_list().bdevs) == 1
+    assert len(hdls['ms1'].bdev_list()) == 2
+    assert len(hdls['ms2'].bdev_list()) == 2
+    assert len(hdls['ms3'].bdev_list()) == 1
 
     assert len(hdls['ms1'].pool_list().pools) == 1
     assert len(hdls['ms2'].pool_list().pools) == 1

--- a/test/python/docker-compose.yml
+++ b/test/python/docker-compose.yml
@@ -53,6 +53,8 @@ services:
     environment:
         - MY_POD_IP=10.0.0.4
         - RUST_BACKTRACE=full
+        - RUST_LOG=mayastor=trace
+        - NEXUS_DONT_READ_LABELS=true
     command: ${SRCDIR}/target/debug/mayastor -g 0.0.0.0 -l 5,6 -r /tmp/ms3.sock
     networks:
       mayastor_net:

--- a/test/python/docker-compose.yml
+++ b/test/python/docker-compose.yml
@@ -9,7 +9,6 @@ services:
     image: rust:latest
     environment:
         - MY_POD_IP=10.0.0.2
-        - RUST_LOG=mayastor=trace
     command: ${SRCDIR}/target/debug/mayastor -g 0.0.0.0 -l 1,2 -r /tmp/ms1.sock
     networks:
       mayastor_net:
@@ -33,7 +32,6 @@ services:
     image: rust:latest
     environment:
         - MY_POD_IP=10.0.0.3
-        - RUST_LOG=mayastor=trace
     command: ${SRCDIR}/target/debug/mayastor -g 0.0.0.0 -l 3,4 -r /tmp/ms2.sock
     networks:
       mayastor_net:
@@ -53,10 +51,8 @@ services:
     container_name: "ms3"
     image: rust:latest
     environment:
-        - NVME_ADMINQ_POLL_PERIOD_US=10000
         - MY_POD_IP=10.0.0.4
         - RUST_BACKTRACE=full
-        - RUST_LOG=mayastor=trace
     command: ${SRCDIR}/target/debug/mayastor -g 0.0.0.0 -l 5,6 -r /tmp/ms3.sock
     networks:
       mayastor_net:

--- a/test/python/docker-compose.yml
+++ b/test/python/docker-compose.yml
@@ -1,0 +1,80 @@
+#
+# {SRCDIR} should point to your working tree which should be your current pwd
+#
+
+version: '3'
+services:
+  ms1:
+    container_name: "ms1"
+    image: rust:latest
+    environment:
+        - MY_POD_IP=10.0.0.2
+        - RUST_LOG=mayastor=trace
+    command: ${SRCDIR}/target/debug/mayastor -g 0.0.0.0 -l 1,2 -r /tmp/ms1.sock
+    networks:
+      mayastor_net:
+        ipv4_address: 10.0.0.2
+    cap_add:
+      # NUMA related
+      - SYS_ADMIN
+      - SYS_NICE
+      # uring needs mmap
+      - IPC_LOCK
+    security_opt:
+      # we can set this to a JSON file to allow per syscall access
+      - seccomp:unconfined
+    volumes:
+      - ${SRCDIR}:${SRCDIR}
+      - /nix:/nix
+      - /dev/hugepages:/dev/hugepages
+      - /tmp:/tmp
+  ms2:
+    container_name: "ms2"
+    image: rust:latest
+    environment:
+        - MY_POD_IP=10.0.0.3
+        - RUST_LOG=mayastor=trace
+    command: ${SRCDIR}/target/debug/mayastor -g 0.0.0.0 -l 3,4 -r /tmp/ms2.sock
+    networks:
+      mayastor_net:
+        ipv4_address: 10.0.0.3
+    cap_add:
+      - SYS_ADMIN
+      - SYS_NICE
+      - IPC_LOCK
+    security_opt:
+      - seccomp:unconfined
+    volumes:
+      - ${SRCDIR}:${SRCDIR}
+      - /nix:/nix
+      - /dev/hugepages:/dev/hugepages
+      - /tmp:/tmp
+  ms3:
+    container_name: "ms3"
+    image: rust:latest
+    environment:
+        - NVME_ADMINQ_POLL_PERIOD_US=10000
+        - MY_POD_IP=10.0.0.4
+        - RUST_BACKTRACE=full
+        - RUST_LOG=mayastor=trace
+    command: ${SRCDIR}/target/debug/mayastor -g 0.0.0.0 -l 5,6 -r /tmp/ms3.sock
+    networks:
+      mayastor_net:
+        ipv4_address: 10.0.0.4
+    cap_add:
+      - SYS_ADMIN
+      - SYS_NICE
+      - IPC_LOCK
+    security_opt:
+      - seccomp:unconfined
+    volumes:
+      - ${SRCDIR}:${SRCDIR}
+      - /nix:/nix
+      - /dev/hugepages:/dev/hugepages
+      - /tmp:/tmp
+networks:
+  mayastor_net:
+    ipam:
+      driver: default
+      config:
+        - subnet: "10.0.0.0/16"

--- a/test/python/pytest.ini
+++ b/test/python/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-log_level = INFO
-log_cli = true
+log_level = info
+log_cli = false
 
 

--- a/test/python/pytest.ini
+++ b/test/python/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
 log_level = info
-log_cli = false
+log_cli = true
 
 

--- a/test/python/pytest.ini
+++ b/test/python/pytest.ini
@@ -1,5 +1,3 @@
 [pytest]
 log_level = info
 log_cli = true
-
-

--- a/test/python/pytest.ini
+++ b/test/python/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+log_level = INFO
+log_cli = true
+
+

--- a/test/python/requirements.txt
+++ b/test/python/requirements.txt
@@ -1,6 +1,7 @@
 asyncio
-paramiko
+asyncssh
 pytest
 pytest-timeout
 pytest-docker-compose
 pytest-order
+pytest-asyncio

--- a/test/python/requirements.txt
+++ b/test/python/requirements.txt
@@ -1,0 +1,6 @@
+asyncio
+paramiko
+pytest
+pytest-timeout
+pytest-docker-compose
+pytest-order

--- a/test/python/requirements.txt
+++ b/test/python/requirements.txt
@@ -5,3 +5,4 @@ pytest-timeout
 pytest-docker-compose
 pytest-order
 pytest-asyncio
+pytest-variables

--- a/test/python/shell.nix
+++ b/test/python/shell.nix
@@ -1,0 +1,22 @@
+let
+  sources = import ../../nix/sources.nix;
+  pkgs = import sources.nixpkgs {
+    overlays = [
+      (_: _: { inherit sources; })
+      (import ../../nix/mayastor-overlay.nix)
+    ];
+  };
+in
+with pkgs;
+mkShell {
+  buildInputs = [
+    (python3.withPackages (ps: with ps; [ grpcio grpcio-tools ]))
+    python3Packages.virtualenv
+  ];
+  shellHook = ''
+    virtualenv --no-setuptools venv
+    source venv/bin/activate
+    pip install -r requirements.txt
+    python -m grpc_tools.protoc -I `realpath ../../rpc/proto` --python_out=. --grpc_python_out=.  mayastor.proto
+  '';
+}

--- a/test/python/test_multi_nexus.py
+++ b/test/python/test_multi_nexus.py
@@ -1,0 +1,113 @@
+from common.hdl import MayastorHandle
+from common.command import run_cmd
+import pytest
+import uuid as guid
+
+UUID = "0000000-0000-0000-0000-000000000001"
+NEXUS_UUID = "3ae73410-6136-4430-a7b5-cbec9fe2d273"
+
+
+@pytest.fixture(scope="function")
+def create_temp_files(containers):
+    """Create temp files for each run so we start out clean."""
+    for name in containers:
+        run_cmd(f"rm -rf /tmp/{name}.img", True)
+    for name in containers:
+        run_cmd(f"truncate -s 1G /tmp/{name}.img", True)
+
+
+def check_size(prev, current, delta):
+    """Validate that replica creation consumes space on the pool."""
+    before = prev.pools[0].used
+    after = current.pools[0].used
+    assert delta == (before - after) >> 20
+
+
+@pytest.fixture(scope="function")
+def mayastors(docker_project, function_scoped_container_getter):
+    """Fixture to get a reference to mayastor handles."""
+    project = docker_project
+    handles = {}
+    for name in project.service_names:
+        # because we use static networks .get_service() does not work
+        services = function_scoped_container_getter.get(name)
+        ip_v4 = services.get(
+            "NetworkSettings.Networks.python_mayastor_net.IPAddress")
+        handles[name] = MayastorHandle(ip_v4)
+    yield handles
+
+
+@pytest.fixture(scope="function")
+def containers(docker_project, function_scoped_container_getter):
+    """Fixture to get handles to mayastor as well as the containers."""
+    project = docker_project
+    containers = {}
+    for name in project.service_names:
+        containers[name] = function_scoped_container_getter.get(name)
+    yield containers
+
+
+@pytest.fixture
+def create_pool_on_all_nodes(create_temp_files, containers, mayastors):
+    """Create a pool on each node."""
+    uuids = []
+
+    for name, h in mayastors.items():
+        h.pool_create(f"{name}", f"aio:///tmp/{name}.img")
+        # validate we have zero replicas
+        assert len(h.replica_list().replicas) == 0
+
+    for i in range(15):
+        uuid = guid.uuid4()
+        for name, h in mayastors.items():
+            before = h.pool_list()
+            h.replica_create(name, uuid, 64 * 1024 * 1024)
+            after = h.pool_list()
+            check_size(before, after, -64)
+            # ensure our replica count goes up as expected
+            assert len(h.replica_list().replicas) == i + 1
+
+        uuids.append(uuid)
+    return uuids
+
+
+@pytest.mark.parametrize("times", range(2))
+def test_restart(
+        times,
+        create_pool_on_all_nodes,
+        containers,
+        mayastors):
+    """
+    Test that when we create replicas and destroy them the count is as expected
+    At this point we have 3 nodes each with 15 replica's.
+    """
+
+    node = containers.get("ms1")
+    ms1 = mayastors.get("ms1")
+
+    # kill one of the nodes and validate we indeed have 15 replica's
+    node.kill()
+    node.start()
+    # we must reconnect grpc here..
+    ms1.reconnect()
+    # create does import here if found
+    ms1.pool_create("ms1", "aio:///tmp/ms1.img")
+
+    # check the list has 15 replica's
+    replicas = ms1.replica_list().replicas
+    assert 15 == len(replicas)
+
+    # destroy a few
+    for i in range(7):
+        ms1.replica_destroy(replicas[i].uuid)
+
+    # kill and reconnect
+    node.kill()
+    node.start()
+    ms1.reconnect()
+
+    # validate we have 8 replicas left
+    ms1.pool_create("ms1", "aio:///tmp/ms1.img")
+    replicas = ms1.replica_list().replicas
+
+    assert 8 == len(replicas)

--- a/test/python/test_nexus.py
+++ b/test/python/test_nexus.py
@@ -123,7 +123,6 @@ async def test_nexus_2_remote_mirror_kill_one(
         container_ref, wait_for_mayastor, create_nexus):
 
     """
-
     This test does the following steps:
 
         - creates mayastor instances
@@ -150,7 +149,6 @@ async def test_nexus_2_remote_mirror_kill_one(
     uri = create_nexus
 
     dev = await nvme_remote_connect("vixos1", uri)
-
     job = Fio("job1", "rw", dev).build()
 
     # create an event loop polling the async processes for completion

--- a/test/python/test_nexus.py
+++ b/test/python/test_nexus.py
@@ -149,7 +149,7 @@ async def test_nexus_2_remote_mirror_kill_one(
     uri = create_nexus
 
     dev = await nvme_remote_connect("vixos1", uri)
-    job = Fio("job1", "rw", dev).build()
+    job = Fio("job1", "randwrite", dev).build()
 
     # create an event loop polling the async processes for completion
     await asyncio.gather(

--- a/test/python/test_nexus.py
+++ b/test/python/test_nexus.py
@@ -1,0 +1,114 @@
+import logging
+import pytest
+import mayastor_pb2 as pb
+import uuid as guid
+import grpc
+import asyncio
+from common.nvme import nvme_discover, nvme_connect, nvme_disconnect
+from common.volume import Volume
+from common.fio import Fio
+UUID = "0000000-0000-0000-0000-000000000001"
+NEXUS_UUID = "3ae73410-6136-4430-a7b5-cbec9fe2d273"
+
+
+@pytest.mark.skip
+@pytest.fixture
+def destroy_all(wait_for_mayastor):
+    hdls = wait_for_mayastor
+
+    hdls["ms3"].nexus_destroy(NEXUS_UUID)
+
+    hdls["ms1"].replica_destroy(UUID)
+    hdls["ms2"].replica_destroy(UUID)
+
+    hdls["ms1"].pool_destroy("tpool")
+    hdls["ms2"].pool_destroy("tpool")
+
+    hdls["ms1"].replica_destroy(UUID)
+    hdls["ms2"].replica_destroy(UUID)
+    hdls["ms3"].nexus_destroy(NEXUS_UUID)
+
+    hdls["ms1"].pool_destroy("tpool")
+    hdls["ms2"].pool_destroy("tpool")
+
+    assert len(hdls["ms1"].pool_list().pools) == 0
+    assert len(hdls["ms2"].pool_list().pools) == 0
+
+    assert len(hdls["ms1"].bdev_list().bdevs) == 0
+    assert len(hdls["ms2"].bdev_list().bdevs) == 0
+    assert len(hdls["ms3"].bdev_list().bdevs) == 0
+
+
+@pytest.mark.skip
+def test_multi_volume_local(wait_for_mayastor, create_aio_pools):
+    hdls = wait_for_mayastor
+    # contains the replicas
+
+    ms = hdls.get('ms1')
+
+    for i in range(6):
+        uuid = guid.uuid4()
+        replicas = []
+
+        ms.replica_create("tpool", uuid, 8 * 1024 * 1024)
+
+        replicas.append("bdev:///{}".format(uuid))
+        print(ms.nexus_create(uuid, 4 * 1024 * 1024, replicas))
+
+
+@pytest.mark.parametrize("times", range(50))
+@pytest.mark.skip
+def test_create_nexus_with_two_replica(times, create_nexus):
+    nexus, uri, hdls = create_nexus
+    nvme_discover(uri.device_uri)
+    device = nvme_connect(uri.device_uri)
+    nvme_disconnect(uri.device_uri)
+    destroy_all
+
+
+@pytest.mark.skip
+def test_enospace_on_volume(wait_for_mayastor, create_pools):
+    nodes = wait_for_mayastor
+    pools = []
+    uuid = guid.uuid4()
+
+    pools.append(nodes["ms2"].pools_as_uris()[0])
+    pools.append(nodes["ms1"].pools_as_uris()[0])
+    nexus_node = nodes["ms3"].as_target()
+
+    v = Volume(uuid, nexus_node, pools, 100 * 1024 * 1024)
+
+    with pytest.raises(grpc.RpcError, match='RESOURCE_EXHAUSTED'):
+        _ = v.create()
+    print("expected failed")
+
+
+@pytest.mark.timeout(60)
+def test_nexus_2_mirror_kill_one(container_ref, create_nexus):
+    """Kill the given container after sec seconds."""
+    async def kill_after(container, sec):
+        await asyncio.sleep(sec)
+        logging.info(f"killing container {container}")
+        containers.get(container).kill()
+
+    containers = container_ref
+    uri = create_nexus
+    print(uri)
+
+    # XXX this needs to go to VMs
+    nvme_discover(uri)
+    dev = nvme_connect(uri)
+
+    job = Fio("job1", "rw", dev).run()
+
+    kill_ms1 = kill_after("ms1", 5)
+
+    try:
+        loop = asyncio.get_event_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+
+    loop.run_until_complete(asyncio.gather(job, kill_ms1))
+
+    nvme_disconnect(uri)

--- a/test/python/test_nexus_kill_all.py
+++ b/test/python/test_nexus_kill_all.py
@@ -3,34 +3,68 @@
 import logging
 import pytest
 import asyncio
-from common.nvme import nvme_discover, nvme_connect, nvme_disconnect
+from common.nvme import nvme_remote_disconnect, nvme_remote_connect
 from common.fio import Fio
-from common.command import run_cmd_async
+from common.command import run_cmd_async_at
+import mayastor_pb2 as pb
+
+NEXUS_UUID = "3ae73410-6136-4430-a7b5-cbec9fe2d273"
+
+
+async def kill_after(container, sec):
+    """Kill the given container after sec seconds."""
+    await asyncio.sleep(sec)
+    logging.info(f"killing container {container}")
+    container.kill()
 
 
 @pytest.mark.asyncio
-@pytest.mark.xfail
 @pytest.mark.timeout(60)
-def test_nexus_2_mirror_kill_all(container_ref, create_nexus):
-    """Kill the given container after sec seconds."""
-    async def kill_after(container, sec):
-        await asyncio.sleep(sec)
-        logging.info(f"killing container {container}")
-        containers.get(container).kill()
+async def test_nexus_2_remote_mirror_kill_all(
+        container_ref, wait_for_mayastor, create_nexus):
+
+    """
+
+    This test does the following steps:
+
+        - creates mayastor instances
+        - creates pools on mayastor 1 and 2
+        - creates replicas on those pools
+        - creates a nexus on mayastor 3
+        - starts fio on a remote VM (vixos1) for 15 secondsj
+        - kills mayastor 2 after 4 seconds
+        - kills mayastor 1 after 5 seconds
+        - assume the fail with a ChildProcessError due to Fio bailing out
+        - disconnect the VM from mayastor 3 when has failed
+        - removes the nexus from mayastor 3
+    """
 
     containers = container_ref
     uri = create_nexus
 
-    nvme_discover(uri)
-    dev = nvme_connect(uri)
+    dev = await nvme_remote_connect("vixos1", uri)
 
     job = Fio("job1", "rw", dev).build()
-    kill_ms1 = kill_after("ms1", 5)
-    kill_ms2 = kill_after("ms2", 6)
 
     try:
-        await asyncio.gather(run_cmd_async(job), kill_ms1, kill_ms2)
+        # create an event loop polling the async processes for completion
+        await asyncio.gather(
+            run_cmd_async_at("vixos1", job),
+            kill_after(containers.get("ms2"), 4),
+            kill_after(containers.get("ms1"), 5))
     except ChildProcessError:
         pass
+    except Exception as e:
+        # if its not a child processe error fail the test
+        raise(e)
     finally:
-        nvme_disconnect(uri)
+        list = wait_for_mayastor.get("ms3").nexus_list()
+        nexus = next(n for n in list if n.uuid == NEXUS_UUID)
+
+        assert nexus.state == pb.NEXUS_FAULTED
+
+        nexus.children[0].state == pb.CHILD_FAULTED
+        nexus.children[1].state == pb.CHILD_FAULTED
+
+        # disconnect the VM from our target before we shutdown
+        await nvme_remote_disconnect("vixos1", uri)

--- a/test/python/test_nexus_kill_all.py
+++ b/test/python/test_nexus_kill_all.py
@@ -44,7 +44,7 @@ async def test_nexus_2_remote_mirror_kill_all(
 
     dev = await nvme_remote_connect("vixos1", uri)
 
-    job = Fio("job1", "rw", dev).build()
+    job = Fio("job1", "randwrite", dev).build()
 
     try:
         # create an event loop polling the async processes for completion

--- a/test/python/test_nexus_kill_all.py
+++ b/test/python/test_nexus_kill_all.py
@@ -5,8 +5,10 @@ import pytest
 import asyncio
 from common.nvme import nvme_discover, nvme_connect, nvme_disconnect
 from common.fio import Fio
+from common.command import run_cmd_async
 
 
+@pytest.mark.asyncio
 @pytest.mark.xfail
 @pytest.mark.timeout(60)
 def test_nexus_2_mirror_kill_all(container_ref, create_nexus):
@@ -19,22 +21,15 @@ def test_nexus_2_mirror_kill_all(container_ref, create_nexus):
     containers = container_ref
     uri = create_nexus
 
-    # XXX this needs to go to VMs
     nvme_discover(uri)
     dev = nvme_connect(uri)
 
-    job = Fio("job1", "rw", dev).run()
+    job = Fio("job1", "rw", dev).build()
     kill_ms1 = kill_after("ms1", 5)
     kill_ms2 = kill_after("ms2", 6)
 
     try:
-        loop = asyncio.get_event_loop()
-    except RuntimeError:
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-
-    try:
-        loop.run_until_complete(asyncio.gather(job, kill_ms1, kill_ms2))
+        await asyncio.gather(run_cmd_async(job), kill_ms1, kill_ms2)
     except ChildProcessError:
         pass
     finally:

--- a/test/python/test_nexus_kill_all.py
+++ b/test/python/test_nexus_kill_all.py
@@ -1,0 +1,41 @@
+"""Test that will delete all replica's while under load from the nexus."""
+
+import logging
+import pytest
+import asyncio
+from common.nvme import nvme_discover, nvme_connect, nvme_disconnect
+from common.fio import Fio
+
+
+@pytest.mark.xfail
+@pytest.mark.timeout(60)
+def test_nexus_2_mirror_kill_all(container_ref, create_nexus):
+    """Kill the given container after sec seconds."""
+    async def kill_after(container, sec):
+        await asyncio.sleep(sec)
+        logging.info(f"killing container {container}")
+        containers.get(container).kill()
+
+    containers = container_ref
+    uri = create_nexus
+
+    # XXX this needs to go to VMs
+    nvme_discover(uri)
+    dev = nvme_connect(uri)
+
+    job = Fio("job1", "rw", dev).run()
+    kill_ms1 = kill_after("ms1", 5)
+    kill_ms2 = kill_after("ms2", 6)
+
+    try:
+        loop = asyncio.get_event_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+
+    try:
+        loop.run_until_complete(asyncio.gather(job, kill_ms1, kill_ms2))
+    except ChildProcessError:
+        pass
+    finally:
+        nvme_disconnect(uri)


### PR DESCRIPTION
IO errors are now handled differently such that errors on a channel, are
handled on a per-channel basis.

When we are in submission, we simply remove the device from the
channel(s) and retry the IO by resubmitting it into the nexus.

Completion IOs are -- when completed, also retried. For each failed
device, we kick off one retire request which will pause the nexus while
it does so. This prevents any new incoming IO.

