### PR TITLE
fix: don't succeed volume creation if it failed

### DIFF
--- a/csi/moac/volume.ts
+++ b/csi/moac/volume.ts
@@ -341,6 +341,7 @@ export class Volume {
           grpcCode.INTERNAL,
           `Failed to destroy a replica of ${this}: ${err}`,
         ));
+        return;
       }
       try {
         await this.registry.getPersistentStore().destroyNexus(this.uuid);
@@ -349,6 +350,7 @@ export class Volume {
           grpcCode.INTERNAL,
           `Failed to destroy entry from the persistent store of ${this}: ${err}`,
         ));
+        return;
       }
 
       this._delegatedOpSuccess(DelegatedOp.Destroy);

--- a/csi/moac/volume.ts
+++ b/csi/moac/volume.ts
@@ -176,6 +176,15 @@ export class Volume {
     return this.nexus || undefined;
   }
 
+  // Return whether the volume can still be used and is updatable.
+  isSpecUpdatable (): boolean {
+    return ([
+      VolumeState.Unknown,
+      VolumeState.Pending,
+      VolumeState.Destroyed,
+    ].indexOf(this.state) < 0);
+  }
+
   // Publish the volume. That means, make it accessible through a target.
   //
   // @params nodeId        ID of the node where the volume will be mounted.


### PR DESCRIPTION
fix: don't complete volume destroy until it's done

Don't complete the destroy if the replicas have not been deleted or if
the nexus info entry is not deleted from etcd.

fix: don't succeed volume creation if it failed

When the volume creation fails we attempt to delete the volume. Before
this is complete we leave the volume in limbo and another create could
be tricked into an update, thus completing the CSI call with success.
To avoid this, check that the volume is not pending, unknown or
destroyed before allowing a volume update.

There is still an issue with this logic: if the destroy fails during
creation then nothing else will attempt the destroy again, leaving us
with a destroyed volume in the list, meaning the volume will get
stuck...

