### PR TITLE
fix(nexus): handle IO errors per channel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,24 +4,24 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.14.1"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55f82cfe485775d02112886f4169bde0c5894d75e79ead7eafe7e40a25e45f7"
+checksum = "03345e98af8f3d786b6d9f656ccfa6ac316d954e92bc4841f0bba20789d5fb5a"
 dependencies = [
  "gimli",
 ]
 
 [[package]]
 name = "adler"
-version = "0.2.3"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.15"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
 dependencies = [
  "memchr",
 ]
@@ -46,9 +46,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afddf7f520a80dbf76e6f50a35bca42a2331ef227a28b3b6dc5c2e2338d114b1"
+checksum = "28b2cd92db5cbd74e8e5028f7e27dd7aa3090e89e4f2a197cc7c8dfb69c7063b"
 
 [[package]]
 name = "assert_matches"
@@ -69,16 +69,16 @@ dependencies = [
 
 [[package]]
 name = "async-executor"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb877970c7b440ead138f6321a3b5395d6061183af779340b65e20c0fede9146"
+checksum = "871f9bb5e0a22eeb7e8cf16641feb87c9dc67032ccf8ff49e772eb9941d3a965"
 dependencies = [
  "async-task",
  "concurrent-queue",
  "fastrand",
  "futures-lite",
  "once_cell",
- "vec-arena",
+ "slab",
 ]
 
 [[package]]
@@ -94,38 +94,38 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "1.3.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9315f8f07556761c3e48fec2e6b276004acf426e6dc068b2c2251854d65ee0fd"
+checksum = "4bbfd5cf2794b1e908ea8457e6c45f8f8f1f6ec5f74617bf4662623f47503c3b"
 dependencies = [
  "concurrent-queue",
  "fastrand",
  "futures-lite",
  "libc",
  "log",
- "nb-connect",
  "once_cell",
  "parking",
  "polling",
- "vec-arena",
+ "slab",
+ "socket2",
  "waker-fn",
  "winapi",
 ]
 
 [[package]]
 name = "async-lock"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1996609732bde4a9988bc42125f55f2af5f3c36370e27c778d5191a4a1b63bfb"
+checksum = "e6a8ea61bf9947a1007c5cada31e647dbc77b103c679858150003ba697ea798b"
 dependencies = [
  "event-listener",
 ]
 
 [[package]]
 name = "async-net"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06de475c85affe184648202401d7622afb32f0f74e02192857d0201a16defbe5"
+checksum = "69b0a74e7f70af3c8cf1aa539edbd044795706659ac52b78a71dc1a205ecefdf"
 dependencies = [
  "async-io",
  "blocking",
@@ -135,17 +135,18 @@ dependencies = [
 
 [[package]]
 name = "async-process"
-version = "1.0.2"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef37b86e2fa961bae5a4d212708ea0154f904ce31d1a4a7f47e1bbc33a0c040b"
+checksum = "a8f38756dd9ac84671c428afbf7c9f7495feff9ec5b0710f17100098e5b354ac"
 dependencies = [
  "async-io",
  "blocking",
  "cfg-if 1.0.0",
  "event-listener",
  "futures-lite",
+ "libc",
  "once_cell",
- "signal-hook 0.3.4",
+ "signal-hook 0.3.8",
  "winapi",
 ]
 
@@ -162,9 +163,9 @@ dependencies = [
 
 [[package]]
 name = "async-stream"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3670df70cbc01729f901f94c887814b3c68db038aad1329a418bae178bc5295c"
+checksum = "171374e7e3b2504e0e5236e3b59260560f9fe94bfe9ac39ba5e4e929c5590625"
 dependencies = [
  "async-stream-impl",
  "futures-core",
@@ -172,9 +173,9 @@ dependencies = [
 
 [[package]]
 name = "async-stream-impl"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3548b8efc9f8e8a5a0a2808c5bd8451a9031b9e5b879a79590304ae928b0a70"
+checksum = "648ed8c8d2ce5409ccd57453d9d1b214b342a0d69376a6feda1fd6cae3299308"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -189,9 +190,9 @@ checksum = "e91831deabf0d6d7ec49552e489aed63b7456a7a3c46cff62adad428110b0af0"
 
 [[package]]
 name = "async-trait"
-version = "0.1.42"
+version = "0.1.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d3a45e77e34375a7923b1e8febb049bb011f064714a8e17a1a616fef01da13d"
+checksum = "0b98e84bbb4cbcdd97da190ba0c58a1bb0de2c1fdf67d159e192ed766aeca722"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -223,11 +224,12 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "backtrace"
-version = "0.3.56"
+version = "0.3.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d117600f438b1707d4e4ae15d3595657288f8235a0eb593e80ecc98ab34e1bc"
+checksum = "4717cfcbfaa661a0fd48f8453951837ae7e8f81e481fbb136e3202d72805a744"
 dependencies = [
  "addr2line",
+ "cc",
  "cfg-if 1.0.0",
  "libc",
  "miniz_oxide",
@@ -249,20 +251,19 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "base64-url"
-version = "1.4.8"
+version = "1.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8a7558a139be0909d407d70873248681e70bac73595c3ded9dba98a625c8acb"
+checksum = "44265cf903f576fcaa1c2f23b32ec2dadaa8ec9d6b7c6212704d72a417bfbeef"
 dependencies = [
  "base64 0.13.0",
 ]
 
 [[package]]
 name = "bincode"
-version = "1.3.1"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f30d3a39baa26f9651f17b375061f3233dde33424a8b72b0dbe93a68a0bc896d"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
- "byteorder",
  "serde",
 ]
 
@@ -380,9 +381,9 @@ dependencies = [
 
 [[package]]
 name = "build_const"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39092a32794787acd8525ee150305ff051b0aa6cc2abaf193924f5ab05425f39"
+checksum = "b4ae4235e6dac0694637c763029ecea1a2ec9e4e06ec2729bd21ba4d9c863eb7"
 
 [[package]]
 name = "bumpalo"
@@ -398,9 +399,9 @@ checksum = "415301c9de11005d4b92193c0eb7ac7adc37e5a49e0ac9bed0a42343512744b8"
 
 [[package]]
 name = "byteorder"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae44d1a3d5a19df61dd0c8beb138458ac2a53a7ac09eba97d55592540004306b"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
@@ -416,9 +417,9 @@ checksum = "631ae5198c9be5e753e5cc215e1bd73c2b466a3565173db433f52bb9d3e66dba"
 
 [[package]]
 name = "cc"
-version = "1.0.66"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c0496836a84f8d0495758516b8621a622beb77c0fed418570e50764093ced48"
+checksum = "4a72c244c1ff497a746a7e1fb3d14bd08420ecda70c8f25c7112f2781652d787"
 
 [[package]]
 name = "cexpr"
@@ -457,9 +458,9 @@ dependencies = [
 
 [[package]]
 name = "clang-sys"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cb92721cb37482245ed88428f72253ce422b3b4ee169c70a0642521bb5db4cc"
+checksum = "853eda514c284c2287f4bf20ae614f8781f40a81d32ecda6e91449304dfe077c"
 dependencies = [
  "glob",
  "libc",
@@ -535,10 +536,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
 
 [[package]]
-name = "cpuid-bool"
-version = "0.1.2"
+name = "cpufeatures"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
+checksum = "ed00c67cb5d0a7d64a44f6ad2668db7e7530311dd53ea79bcd4fb022c64911c8"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "crc"
@@ -676,9 +680,9 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "3.0.2"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f627126b946c25a4638eec0ea634fc52506dea98db118aae985118ce7c3d723f"
+checksum = "639891fde0dbea823fc3d798a0fdf9d2f9440a42d64a78ab3488b0ca025117b3"
 dependencies = [
  "byteorder",
  "digest",
@@ -689,9 +693,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.12.0"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11947000d710ff98138229f633039982f0fef2d9a3f546c21d610fee5f8631d5"
+checksum = "5f2c43f534ea4b0b049015d00269734195e6d3f0f6635cb692251aca6f9f8b3c"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -699,9 +703,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.12.0"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae53b4d9cc89c40314ccf2bf9e6ff1eb19c31e3434542445a41893dbf041aec2"
+checksum = "8e91455b86830a1c21799d94524df0845183fa55bafd9aa137b01c7d1065fa36"
 dependencies = [
  "fnv",
  "ident_case",
@@ -713,9 +717,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.12.0"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9cd9ac4d50d023af5e710cae1501afb063efcd917bd3fc026e8ed6493cc9755"
+checksum = "29b5acf0dea37a7f66f7b25d2c5e93fd46f8f6968b1a5d7a3e02e97768afc95a"
 dependencies = [
  "darling_core",
  "quote",
@@ -730,19 +734,18 @@ checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
 
 [[package]]
 name = "derive_builder"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ef25735c9f0d0c547d2794701600c94abf030ecb740fad1673fa64461f3573"
+checksum = "d13202debe11181040ae9063d739fa32cfcaaebe2275fe387703460ae2365b30"
 dependencies = [
- "derive_builder_core",
  "derive_builder_macro",
 ]
 
 [[package]]
 name = "derive_builder_core"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3150f1e84602847b99d3eeb702487fc364f7d6c94f634e944a68fdbaea09e457"
+checksum = "66e616858f6187ed828df7c64a6d71720d83767a7f19740b2d1b6fe6327b36e5"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -752,9 +755,9 @@ dependencies = [
 
 [[package]]
 name = "derive_builder_macro"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca1008bddefdc08d1e734aeb27b94f384390af261b4d1a8fb51fe19c577f05c"
+checksum = "58a94ace95092c5acb1e97a7e846b310cfbd499652f72297da7493f618a98d73"
 dependencies = [
  "derive_builder_core",
  "syn",
@@ -802,9 +805,9 @@ dependencies = [
 
 [[package]]
 name = "dns-lookup"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "093d88961fd18c4ecacb8c80cd0b356463ba941ba11e0e01f9cf5271380b79dc"
+checksum = "eb4c5ce3a7034c5eb66720bb16e9ac820e01b29032ddc06dd0fe47072acf7454"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -820,9 +823,9 @@ checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "dtoa"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d7ed2934d741c6b37e33e3832298e8850b53fd2d2bea03873375596c7cea4e"
+checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
 
 [[package]]
 name = "dyn-clonable"
@@ -853,9 +856,9 @@ checksum = "ee2626afccd7561a06cf1367e2950c4718ea04565e20fb5029b6c7d8ad09abcf"
 
 [[package]]
 name = "ed25519"
-version = "1.0.3"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37c66a534cbb46ab4ea03477eae19d5c22c01da8258030280b7bd9d8433fb6ef"
+checksum = "8d0860415b12243916284c67a9be413e044ee6668247b99ba26d94b2bc06c8f6"
 dependencies = [
  "signature",
 ]
@@ -983,9 +986,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca5faf057445ce5c9d4329e382b2ce7ca38550ef3b73a5348362d5f24e0c7fe3"
+checksum = "77b705829d1e87f762c2df6da140b26af5839e1033aa84aa5f56bb688e4e1bdb"
 dependencies = [
  "instant",
 ]
@@ -1014,19 +1017,19 @@ dependencies = [
 
 [[package]]
 name = "fsio"
-version = "0.1.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1fd087255f739f4f1aeea69f11b72f8080e9c2e7645cd06955dad4a178a49e3"
+checksum = "a50045aa8931ae01afbc5d72439e8f57f326becb8c70d07dfc816778eff3d167"
 dependencies = [
- "rand 0.7.3",
+ "rand 0.8.3",
  "users",
 ]
 
 [[package]]
 name = "futures"
-version = "0.3.12"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da9052a1a50244d8d5aa9bf55cbc2fb6f357c86cc52e46c62ed390a7180cf150"
+checksum = "0e7e43a803dae2fa37c1f6a8fe121e1f7bf9548b4dfc0522a42f34145dadfc27"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1039,9 +1042,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.12"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2d31b7ec7efab6eefc7c57233bb10b847986139d88cc2f5a02a1ae6871a1846"
+checksum = "e682a68b29a882df0545c143dc3646daefe80ba479bcdede94d5a703de2871e2"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1049,15 +1052,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.12"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79e5145dde8da7d1b3892dad07a9c98fc04bc39892b1ecc9692cf53e2b780a65"
+checksum = "0402f765d8a89a26043b889b26ce3c4679d268fa6bb22cd7c6aad98340e179d1"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.12"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9e59fdc009a4b3096bf94f740a0f2424c082521f20a9b08c5c07c48d90fd9b9"
+checksum = "badaa6a909fac9e7236d0620a2f57f7664640c56575b71a7552fbd68deafab79"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1066,9 +1069,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.12"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28be053525281ad8259d47e4de5de657b25e7bac113458555bb4b70bc6870500"
+checksum = "acc499defb3b348f8d8f3f66415835a9131856ff7714bf10dadfc4ec4bdb29a1"
 
 [[package]]
 name = "futures-lite"
@@ -1087,10 +1090,11 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.12"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c287d25add322d9f9abdcdc5927ca398917996600182178774032e9f8258fedd"
+checksum = "a4c40298486cdf52cc00cd6d6987892ba502c7656a16a4192a9992b1ccedd121"
 dependencies = [
+ "autocfg",
  "proc-macro-hack",
  "proc-macro2",
  "quote",
@@ -1099,25 +1103,23 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.12"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf5c69029bda2e743fddd0582d1083951d65cc9539aebf8812f36c3491342d6"
+checksum = "a57bead0ceff0d6dde8f465ecd96c9338121bb7717d3e7b108059531870c4282"
 
 [[package]]
 name = "futures-task"
-version = "0.3.12"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13de07eb8ea81ae445aca7b69f5f7bf15d7bf4912d8ca37d6645c77ae8a58d86"
-dependencies = [
- "once_cell",
-]
+checksum = "8a16bef9fc1a4dddb5bee51c989e3fbba26569cbb0e31f5b303c184e3dd33dae"
 
 [[package]]
 name = "futures-util"
-version = "0.3.12"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "632a8cd0f2a4b3fdea1657f08bde063848c3bd00f9bbf6e256b8be78802e624b"
+checksum = "feb5c238d27e2bf94ffdfd27b2c29e3df4a68c4193bb6427384259e2bf191967"
 dependencies = [
+ "autocfg",
  "futures-channel",
  "futures-core",
  "futures-io",
@@ -1161,20 +1163,20 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
+checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
+ "wasi 0.10.2+wasi-snapshot-preview1",
 ]
 
 [[package]]
 name = "gimli"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6503fe142514ca4799d4c26297c4248239fe8838d827db6bd6065c6ed29a6ce"
+checksum = "0e4075386626662786ddb0ec9081e7c7eeb1ba31951f447ca780ef9f5d568189"
 
 [[package]]
 name = "git-version"
@@ -1206,8 +1208,8 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "h2"
-version = "0.3.1"
-source = "git+https://github.com/openebs/h2?branch=bump-authority-workaround#c4d0b9925c354c6a7d0681f8e886abfdea459ca5"
+version = "0.3.3"
+source = "git+https://github.com/openebs/h2?branch=v0.3.3#64033595cbf9211e670481c519a9c0ac7691891e"
 dependencies = [
  "bytes",
  "fnv",
@@ -1248,9 +1250,9 @@ dependencies = [
 
 [[package]]
 name = "hex"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
@@ -1265,25 +1267,26 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2861bd27ee074e5ee891e8b539837a9430012e249d7f0ca2d795650f579c1994"
+checksum = "60daa14be0e0786db0f03a9e57cb404c9d756eed2b6c62b9ea98ec5743ec75a9"
 dependencies = [
  "bytes",
  "http",
+ "pin-project-lite",
 ]
 
 [[package]]
 name = "httparse"
-version = "1.3.5"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "615caabe2c3160b313d52ccc905335f4ed5f10881dd63dc5699d47e90be85691"
+checksum = "f3a87b616e37e93c22fb19bcd386f02f3af5ea98a25670ad0fce773de23c5e68"
 
 [[package]]
 name = "httpdate"
-version = "0.3.2"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
+checksum = "6456b8a6c8f33fee7d958fcd1b60d55b11940a79e63ae87013e6d22e26034440"
 
 [[package]]
 name = "humantime"
@@ -1293,9 +1296,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.4"
+version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8e946c2b1349055e0b72ae281b238baf1a3ea7307c7e9f9d64673bdd9c26ac7"
+checksum = "d3f71a7eea53a3f8257a7b4795373ff886397178cd634430ea94e12d7fe4fe34"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1336,9 +1339,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89829a5d69c23d348314a7ac337fe39173b61149a9864deabd260983aed48c21"
+checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
 dependencies = [
  "matches",
  "unicode-bidi",
@@ -1347,9 +1350,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.6.1"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb1fa934250de4de8aef298d81c729a7d33d8c239daa3a7575e6b92bfc7313b"
+checksum = "824845a0bf897a9042383849b02c1bc219c2383772efcd5c6f9766fa4b81aef3"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -1406,9 +1409,9 @@ checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "js-sys"
-version = "0.3.47"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cfb73131c35423a367daf8cbd24100af0d077668c8c2943f0e7dd775fef0f65"
+checksum = "83bdfbace3a0e81a4253f73b49e960b053e396a11012cbd49b9b74d6a2b67062"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1446,15 +1449,15 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.86"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7282d924be3275cec7f6756ff4121987bc6481325397dde6ba3e7802b1a8b1c"
+checksum = "789da6d93f1b866ffe175afc5322a4d76c038605a1c3319bb57b06967ca98a36"
 
 [[package]]
 name = "libloading"
-version = "0.6.7"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "351a32417a12d5f7e82c368a66781e307834dae04c6ce0cd4456d52989229883"
+checksum = "6f84d96438c15fcd6c3f244c8fce01d1e2b9c6b5623e9c711dc9286d8fc92d6a"
 dependencies = [
  "cfg-if 1.0.0",
  "winapi",
@@ -1478,9 +1481,9 @@ checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 
 [[package]]
 name = "lock_api"
-version = "0.4.2"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd96ffd135b2fd7b973ac026d28085defbe8983df057ced3eb4f2130b0831312"
+checksum = "0382880606dff6d15c9476c416d18690b72742aa7b605bb6dd6ec9030fbf07eb"
 dependencies = [
  "scopeguard",
 ]
@@ -1557,6 +1560,7 @@ dependencies = [
  "nix",
  "nvmeadm",
  "once_cell",
+ "parking_lot",
  "pin-utils",
  "proc-mounts",
  "prost",
@@ -1624,9 +1628,9 @@ checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"
-version = "2.3.4"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
+checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
 
 [[package]]
 name = "memoffset"
@@ -1661,9 +1665,9 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f2d26ec3309788e423cfbf68ad1800f061638098d76a83681af979dc4eda19d"
+checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
 dependencies = [
  "adler",
  "autocfg",
@@ -1671,9 +1675,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.7.9"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5dede4e2065b3842b8b0af444119f3aa331cc7cc2dd20388bfb0f5d5a38823a"
+checksum = "cf80d3e903b34e0bd7282b218398aec54e082c840d9baf8339e0080a0c542956"
 dependencies = [
  "libc",
  "log",
@@ -1684,19 +1688,18 @@ dependencies = [
 
 [[package]]
 name = "miow"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a33c1b55807fbed163481b5ba66db4b2fa6cde694a5027be10fb724206c5897"
+checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
 dependencies = [
- "socket2",
  "winapi",
 ]
 
 [[package]]
 name = "multimap"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1255076139a83bb467426e7f8d0134968a8118844faa755985e077cf31850333"
+checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
 name = "nats"
@@ -1722,16 +1725,6 @@ dependencies = [
  "once_cell",
  "regex",
  "rustls-native-certs",
-]
-
-[[package]]
-name = "nb-connect"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670361df1bc2399ee1ff50406a0d422587dd3bb0da596e1978fe8e05dabddf4f"
-dependencies = [
- "libc",
- "socket2",
 ]
 
 [[package]]
@@ -1837,15 +1830,15 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9a7ab5d64814df0fe4a4b5ead45ed6c5f181ee3ff04ba344313a6c80446c5d4"
+checksum = "1a5b3dd1c072ee7963717671d1ca129f1048fda25edea6b752bfc71ac8854170"
 
 [[package]]
 name = "once_cell"
-version = "1.6.0"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ad167a2f54e832b82dbe003a046280dceffe5227b5f79e08e363a29638cfddd"
+checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
 
 [[package]]
 name = "opaque-debug"
@@ -1855,9 +1848,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
+checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
 
 [[package]]
 name = "parking"
@@ -1922,18 +1915,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.0.5"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96fa8ebb90271c4477f144354485b8068bd8f6b78b428b01ba892ca26caf0b63"
+checksum = "c7509cc106041c40a4518d2af7a61530e1eed0e6285296a3d8c5472806ccc4a4"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.5"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758669ae3558c6f74bd2a18b41f7ac0b5a195aea6639d6a9b5e5d1ad5ba24c0b"
+checksum = "48c950132583b500556b1efd71d45b319029f2b71518d979fcc208e16b42426f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1960,11 +1953,11 @@ checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
 
 [[package]]
 name = "polling"
-version = "2.0.2"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2a7bc6b2a29e632e45451c941832803a18cce6781db04de8a04696cdca8bde4"
+checksum = "4fc12d774e799ee9ebae13f4076ca003b40d18a11ac0f3641e6f899618580b7b"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "libc",
  "log",
  "wepoll-sys",
@@ -2015,9 +2008,9 @@ checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.24"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
+checksum = "f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038"
 dependencies = [
  "unicode-xid",
 ]
@@ -2057,7 +2050,7 @@ dependencies = [
  "prost",
  "prost-types",
  "tempfile",
- "which 4.0.2",
+ "which 4.1.0",
 ]
 
 [[package]]
@@ -2152,7 +2145,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
 dependencies = [
- "getrandom 0.2.2",
+ "getrandom 0.2.3",
 ]
 
 [[package]]
@@ -2175,9 +2168,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.5"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94341e4e44e24f6b591b59e47a8a027df12e008d73fd5672dbea9cc22f4507d9"
+checksum = "742739e41cd49414de871ea5e549afb7e2a3ac77b589bcbebe8c82fab37147fc"
 dependencies = [
  "bitflags",
 ]
@@ -2188,20 +2181,19 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
 dependencies = [
- "getrandom 0.2.2",
+ "getrandom 0.2.3",
  "redox_syscall",
 ]
 
 [[package]]
 name = "regex"
-version = "1.4.3"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9251239e129e16308e70d853559389de218ac275b515068abc96829d05b948a"
+checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
 dependencies = [
  "aho-corasick",
  "memchr",
  "regex-syntax",
- "thread_local",
 ]
 
 [[package]]
@@ -2216,9 +2208,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.22"
+version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5eb417147ba9860a96cfe72a0b93bf88fee1744b5636ec99ab20c1aa9376581"
+checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
 name = "remove_dir_all"
@@ -2261,18 +2253,18 @@ dependencies = [
 
 [[package]]
 name = "run_script"
-version = "0.6.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8e8fc35067815a04a35fe2144361e1257b0f1041f0d413664f38e44d1a73cb4"
+checksum = "7fa4becc694242c537d43695743701f362b43c42cb11a3d44c8a01eb0cd18ded"
 dependencies = [
  "fsio",
 ]
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e3bad0ee36814ca07d7968269dd4b7ec89ec2da10c4bb613928d3077083c232"
+checksum = "410f7acf3cb3a44527c5d9546bad4bf4e6c460915d5f9f2fc524498bfe8f70ce"
 
 [[package]]
 name = "rustc-hash"
@@ -2307,9 +2299,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb5d2a036dc6d2d8fd16fde3498b04306e29bd193bf306a57427019b823d5acd"
+checksum = "61b3909d758bb75c79f23d4736fac9433868679d3ad2ea7a61e3c25cfda9a088"
 
 [[package]]
 name = "ryu"
@@ -2335,9 +2327,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "sct"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3042af939fca8c3453b7af0f1c66e533a15a86169e39de2657310ade8f98d3c"
+checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
 dependencies = [
  "ring",
  "untrusted",
@@ -2368,18 +2360,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.123"
+version = "1.0.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92d5161132722baa40d802cc70b15262b98258453e85e5d1d365c757c73869ae"
+checksum = "ec7505abeacaec74ae4778d9d9328fe5a5d04253220a85c4ee022239fc996d03"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.123"
+version = "1.0.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9391c295d64fc0abb2c556bad848f33cb8296276b1ad2677d1ae1ace4f258f31"
+checksum = "963a7dbc9895aeac7ac90e74f34a5d5261828f79df35cbed41e10189d3804d43"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2388,9 +2380,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.62"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea1c6153794552ea7cf7cf63b1231a25de00ec90db326ba6264440fa08e31486"
+checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
 dependencies = [
  "itoa",
  "ryu",
@@ -2411,10 +2403,11 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "1.6.4"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b44be9227e214a0420707c9ca74c2d4991d9955bae9415a8f93f05cebf561be5"
+checksum = "edeeaecd5445109b937a3a335dc52780ca7779c4b4b7374cc6340dedfe44cfca"
 dependencies = [
+ "rustversion",
  "serde",
  "serde_with_macros",
 ]
@@ -2445,13 +2438,13 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.9.3"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa827a14b29ab7f44778d14a88d3cb76e949c45083f7dbfa507d0cb699dc12de"
+checksum = "b362ae5752fd2137731f9fa25fd4d9058af34666ca1966fb969119cc35719f12"
 dependencies = [
  "block-buffer",
  "cfg-if 1.0.0",
- "cpuid-bool",
+ "cpufeatures",
  "digest",
  "opaque-debug",
 ]
@@ -2483,9 +2476,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook"
-version = "0.3.4"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "780f5e3fe0c66f67197236097d89de1e86216f1f6fdeaf47c442f854ab46c240"
+checksum = "ef33d6d0cd06e0840fba9985aab098c147e67e05cee14d412d3345ed14ff30ac"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -2520,9 +2513,9 @@ checksum = "0f0242b8e50dd9accdd56170e94ca1ebd223b098eb9c83539a6e367d0f36ae68"
 
 [[package]]
 name = "slab"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
+checksum = "f173ac3d1a7e3b28003f40de0b5ce7fe2710f9b9dc3fc38664cebee46b3b6527"
 
 [[package]]
 name = "smallvec"
@@ -2571,11 +2564,10 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.3.19"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "122e570113d28d773067fab24266b66753f6ea915758651696b6e35e49f88d6e"
+checksum = "9e3dfc207c526015c632472a77be09cf1b6e46866581aecae5cc38fb4235dea2"
 dependencies = [
- "cfg-if 1.0.0",
  "libc",
  "winapi",
 ]
@@ -2665,9 +2657,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.60"
+version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c700597eca8a5a762beb35753ef6b94df201c81cca676604f547495a0d7f0081"
+checksum = "a1e8cdbefb79a9a5a65e0db8b47b723ee907b7c7f8496c76a1770b5c310bab82"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2735,18 +2727,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0f4a65597094d4483ddaed134f409b2cb7c1beccf25201a9f73c719254fa98e"
+checksum = "fa6f76457f59514c7eeb4e59d891395fab0b2fd1d40723ae737d64153392e9c6"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7765189610d8241a44529806d6fd1f2e0a08734313a35d5b3a556f92b381f3c0"
+checksum = "8a36768c0fbf1bb15eca10defa29526bda730a2376c2ab4393ccfa16fb1a318d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2764,20 +2756,19 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.44"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi",
 ]
 
 [[package]]
 name = "tinyvec"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317cca572a0e89c3ce0ca1f1bdc9369547fe318a683418e42ac8f59d14701023"
+checksum = "5b5220f05bb7de7f3f53c7c065e1199b3172696fe2db9f9c4d8ad9b4ee74c342"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -2790,9 +2781,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83f0c8e7c0addab50b663055baf787d0af7f413a46e6e7fb9559a4e4db7137a5"
+checksum = "bd3076b5c8cc18138b8f8814895c11eb4de37114a5d127bafdc5e55798ceef37"
 dependencies = [
  "autocfg",
  "bytes",
@@ -2810,9 +2801,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf7b11a536f46a809a8a9f0bb4237020f70ecbf115b842360afb127ea2fda57"
+checksum = "c49e3df43841dafb86046472506755d8501c5615673955f6aa17181125d13c37"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2821,9 +2812,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e177a5d8c3bf36de9ebe6d58537d8879e964332f93fb3339e43f618c81361af0"
+checksum = "f8864d706fdb3cc0843a49647ac892720dac98a6eeb818b77190592cf4994066"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -2832,9 +2823,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.6.4"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec31e5cc6b46e653cf57762f36f71d5e6386391d88a72fd6db4508f8f676fb29"
+checksum = "1caa0b0c8d94a049db56b5acf8cba99dc0623aab1b26d5b5f5e2d945846b3592"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2919,9 +2910,9 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.24"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f77d3842f76ca899ff2dbcf231c5c65813dea431301d6eb686279c15c4464f12"
+checksum = "09adeb8c97449311ccd28a427f96fb563e7fd31aabf994189879d9da2394b89d"
 dependencies = [
  "cfg-if 1.0.0",
  "log",
@@ -2932,9 +2923,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.13"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8a9bd1db7706f2373a190b0d067146caa39350c486f3d455b0e33b431f94c07"
+checksum = "c42e6fa53307c8a17e4ccd4dc81cf5ec38db9209f59b222210375b54ee40d1e2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2943,9 +2934,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50de3927f93d202783f4513cda820ab47ef17f624b03c096e86ef00c67e6b5f"
+checksum = "a9ff14f98b1a4b289c6248a023c1c2fa1491062964e9fed67ab29c4e4da4a052"
 dependencies = [
  "lazy_static",
 ]
@@ -2962,9 +2953,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-log"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e0f8c7178e13481ff6765bd169b33e8d554c5d2bbede5e32c356194be02b9b9"
+checksum = "a6923477a48e41c1951f1999ef8bb5a3023eb723ceadafe78ffb65dc366761e3"
 dependencies = [
  "lazy_static",
  "log",
@@ -2983,9 +2974,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.15"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1fa8f0c8f4c594e4fc9debc1990deab13238077271ba84dd853d54902ee3401"
+checksum = "aa5553bf0883ba7c9cbe493b085c29926bd41b66afc31ff72cf17ff4fb60dcd5"
 dependencies = [
  "ansi_term 0.12.1",
  "chrono",
@@ -3011,9 +3002,9 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "typenum"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
+checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
 
 [[package]]
 name = "udev"
@@ -3028,9 +3019,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
+checksum = "eeb8be209bb1c96b7c177c7420d26e04eccacb0eeae6b980e35fcb74678107e0"
 dependencies = [
  "matches",
 ]
@@ -3058,9 +3049,9 @@ checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
+checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "untrusted"
@@ -3070,9 +3061,9 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "url"
-version = "2.2.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ccd964113622c8e9322cfac19eb1004a07e636c545f325da085d5cdde6f1f8b"
+checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -3082,9 +3073,9 @@ dependencies = [
 
 [[package]]
 name = "users"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa4227e95324a443c9fcb06e03d4d85e91aabe9a5a02aa818688b6918b6af486"
+checksum = "24cc0f6d6f267b73e5a2cadf007ba8f9bc39c6a6f9666f8cf25ea809a153b032"
 dependencies = [
  "libc",
  "log",
@@ -3096,14 +3087,8 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
- "getrandom 0.2.2",
+ "getrandom 0.2.3",
 ]
-
-[[package]]
-name = "vec-arena"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eafc1b9b2dfc6f5529177b62cf806484db55b32dc7c9658a118e11bbeb33061d"
 
 [[package]]
 name = "vec_map"
@@ -3113,9 +3098,9 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
+checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
 name = "waker-fn"
@@ -3141,15 +3126,15 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
+version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.70"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55c0f7123de74f0dab9b7d00fd614e7b19349cd1e2f5252bbe9b1754b59433be"
+checksum = "d54ee1d4ed486f78874278e63e4069fc1ab9f6a18ca492076ffb90c5eb2997fd"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen-macro",
@@ -3157,9 +3142,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.70"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bc45447f0d4573f3d65720f636bbcc3dd6ce920ed704670118650bcd47764c7"
+checksum = "3b33f6a0694ccfea53d94db8b2ed1c3a8a4c86dd936b13b9f0a15ec4a451b900"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -3172,9 +3157,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.70"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b8853882eef39593ad4174dd26fc9865a64e84026d223f63bb2c42affcbba2c"
+checksum = "088169ca61430fe1e58b8096c24975251700e7b1f6fd91cc9d59b04fb9b18bd4"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3182,9 +3167,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.70"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4133b5e7f2a531fa413b3a1695e925038a05a71cf67e87dafa295cb645a01385"
+checksum = "be2241542ff3d9f241f5e2cb6dd09b37efe786df8851c54957683a49f0987a97"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3195,15 +3180,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.70"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd4945e4943ae02d15c13962b38a5b1e81eadd4b71214eee75af64a4d6a4fd64"
+checksum = "d7cff876b8f18eed75a66cf49b65e7f967cb354a7aa16003fb55dbfd25b44b4f"
 
 [[package]]
 name = "web-sys"
-version = "0.3.47"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c40dc691fc48003eba817c38da7113c15698142da971298003cac3ef175680b3"
+checksum = "e828417b379f3df7111d3a2a9e5753706cae29c41f7c4029ee9fd77f3e09e582"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3240,12 +3225,12 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "4.0.2"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87c14ef7e1b8b8ecfc75d5eca37949410046e66f15d185c01d70824f1f8111ef"
+checksum = "b55551e42cbdf2ce2bedd2203d0cc08dba002c27510f86dab6d0ce304cba3dfe"
 dependencies = [
+ "either",
  "libc",
- "thiserror",
 ]
 
 [[package]]
@@ -3290,18 +3275,18 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81a974bcdd357f0dca4d41677db03436324d45a4c9ed2d0b873a5a360ce41c36"
+checksum = "4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3f369ddb18862aba61aa49bf31e74d29f0f162dec753063200e1dc084345d16"
+checksum = "a2c1e130bebaeab2f23886bf9acbaca14b092408c452543c857f66399cd6dab1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [patch.crates-io]
 partition-identity = { git = "https://github.com/openebs/partition-identity.git" }
-h2 = { git = "https://github.com/openebs/h2", branch = "bump-authority-workaround"}
+h2 = { git = "https://github.com/openebs/h2", branch = "v0.3.3"}
 
 [profile.dev]
 panic = "abort"

--- a/mayastor/Cargo.toml
+++ b/mayastor/Cargo.toml
@@ -86,6 +86,8 @@ smol = "1.0.0"
 dns-lookup = "1.0.4"
 mbus_api = { path = "../mbus-api" }
 etcd-client = "0.6.3"
+parking_lot = {version = "0.11.1" }
+
 
 [dependencies.rpc]
 path = "../rpc"

--- a/mayastor/src/bdev/dev.rs
+++ b/mayastor/src/bdev/dev.rs
@@ -45,17 +45,14 @@ impl Uri {
         })?;
 
         match url.scheme() {
-            // backend NVMF target - fairly unstable (as of Linux 5.2)
-            "nvmf" => Ok(Box::new(nvmx::NvmfDeviceTemplate::try_from(&url)?)),
-            "malloc" => Ok(Box::new(malloc::Malloc::try_from(&url)?)),
             "aio" => Ok(Box::new(aio::Aio::try_from(&url)?)),
             "bdev" => Ok(Box::new(loopback::Loopback::try_from(&url)?)),
-            "null" => Ok(Box::new(null::Null::try_from(&url)?)),
-            "loopback" => Ok(Box::new(loopback::Loopback::try_from(&url)?)),
             "iscsi" => Ok(Box::new(iscsi::Iscsi::try_from(&url)?)),
+            "loopback" => Ok(Box::new(loopback::Loopback::try_from(&url)?)),
+            "malloc" => Ok(Box::new(malloc::Malloc::try_from(&url)?)),
+            "null" => Ok(Box::new(null::Null::try_from(&url)?)),
+            "nvmf" => Ok(Box::new(nvmx::NvmfDeviceTemplate::try_from(&url)?)),
             "pcie" => Ok(Box::new(nvme::NVMe::try_from(&url)?)),
-
-            // also for testing - requires Linux 5.1 or higher
             "uring" => Ok(Box::new(uring::Uring::try_from(&url)?)),
 
             scheme => Err(NexusBdevError::UriSchemeUnsupported {
@@ -94,17 +91,14 @@ pub fn device_lookup(name: &str) -> Option<Box<dyn BlockDevice>> {
     nvmx::lookup_by_name(name).or_else(|| SpdkBlockDevice::lookup_by_name(name))
 }
 
-#[instrument]
 pub async fn device_create(uri: &str) -> Result<String, NexusBdevError> {
     Uri::parse(uri)?.create().await
 }
 
-#[instrument]
 pub async fn device_destroy(uri: &str) -> Result<(), NexusBdevError> {
     Uri::parse(uri)?.destroy().await
 }
 
-#[instrument]
 pub fn device_open(
     name: &str,
     read_write: bool,

--- a/mayastor/src/bdev/nexus/nexus_bdev.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev.rs
@@ -11,13 +11,12 @@ use std::{
     ptr::NonNull,
 };
 
+use crossbeam::atomic::AtomicCell;
 use futures::{channel::oneshot, future::join_all};
 use nix::errno::Errno;
 use serde::Serialize;
 use snafu::{ResultExt, Snafu};
 use tonic::{Code, Status};
-
-use crate::core::IoDevice;
 
 use rpc::mayastor::NvmeAnaState;
 use spdk_sys::{spdk_bdev, spdk_bdev_register, spdk_bdev_unregister};
@@ -39,7 +38,16 @@ use crate::{
             nexus_persistence::{NexusInfo, PersistOp},
         },
     },
-    core::{Bdev, CoreError, Cores, IoType, Protocol, Reactor, Share},
+    core::{
+        Bdev,
+        CoreError,
+        Cores,
+        IoDevice,
+        IoType,
+        Protocol,
+        Reactor,
+        Share,
+    },
     ffihelper::errno_result_from_i32,
     nexus_uri::{bdev_destroy, NexusBdevError},
     rebuild::RebuildError,
@@ -244,6 +252,11 @@ pub enum Error {
     FailedCreateSnapshot { name: String, source: CoreError },
     #[snafu(display("NVMf subsystem error: {}", e))]
     SubsysNvmfError { e: String },
+    #[snafu(display("failed to pause {} current state {:?}", name, state))]
+    PauseError {
+        state: NexusPauseState,
+        name: String,
+    },
 }
 
 impl From<NvmfError> for Error {
@@ -306,8 +319,8 @@ pub enum NexusTarget {
     NexusIscsiTarget,
     NexusNvmfTarget,
 }
-#[derive(Debug, Eq, PartialEq)]
-enum NexusPauseState {
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum NexusPauseState {
     Unpaused,
     Pausing,
     Paused,
@@ -330,7 +343,7 @@ pub struct Nexus {
     /// raw pointer to bdev (to destruct it later using Box::from_raw())
     bdev_raw: *mut spdk_bdev,
     /// represents the current state of the Nexus
-    pub(crate) state: std::sync::Mutex<NexusState>,
+    pub state: parking_lot::Mutex<NexusState>,
     /// the offset in num blocks where the data partition starts
     pub data_ent_offset: u64,
     /// the handle to be used when sharing the nexus, this allows for the bdev
@@ -341,7 +354,7 @@ pub struct Nexus {
     /// Nexus I/O device.
     pub io_device: Option<IoDevice>,
     /// Nexus pause counter to allow concurrent pause/resume.
-    pause_state: NexusPauseState,
+    pause_state: AtomicCell<NexusPauseState>,
     pause_waiters: Vec<oneshot::Sender<i32>>,
     /// information saved to a persistent store
     pub nexus_info: futures::lock::Mutex<NexusInfo>,
@@ -368,6 +381,8 @@ pub enum NexusState {
     Closed,
     /// open
     Open,
+    /// reconfiguring internal IO channels
+    Reconfiguring,
 }
 
 impl ToString for NexusState {
@@ -376,6 +391,7 @@ impl ToString for NexusState {
             NexusState::Init => "init",
             NexusState::Closed => "closed",
             NexusState::Open => "open",
+            NexusState::Reconfiguring => "reconfiguring",
         }
         .parse()
         .unwrap()
@@ -405,41 +421,21 @@ impl Drop for Nexus {
 }
 
 struct UpdateFailFastCtx {
-    increment: bool,
     sender: oneshot::Sender<bool>,
     nexus: String,
+    child: Option<String>,
 }
 
 fn update_failfast_cb(
     channel: &mut NexusChannelInner,
     ctx: &mut UpdateFailFastCtx,
 ) -> i32 {
-    let old_value = channel.fail_fast;
-
-    if ctx.increment {
-        channel.fail_fast = channel
-            .fail_fast
-            .checked_add(1)
-            .expect("Fail-fast counter overflow");
-    } else {
-        channel.fail_fast = channel
-            .fail_fast
-            .checked_sub(1)
-            .expect("Fail-fast counter underflow");
-    }
-    info!(
-        "{}: fail-fast counter transition: {} -> {}",
-        ctx.nexus, old_value, channel.fail_fast
-    );
+    ctx.child.as_ref().map(|child| channel.remove_child(child));
+    debug!(?ctx.nexus, ?ctx.child, "removed from channel");
     0
 }
 
-fn update_failfast_done(status: i32, ctx: UpdateFailFastCtx) {
-    info!(
-        "{}: Fail-fast counter update completed, increment={}, status={}",
-        ctx.nexus, ctx.increment, status
-    );
-
+fn update_failfast_done(_status: i32, ctx: UpdateFailFastCtx) {
     ctx.sender.send(true).expect("Receiver disappeared");
 }
 
@@ -467,14 +463,14 @@ impl Nexus {
             child_count: 0,
             children: Vec::new(),
             bdev: Bdev::from(&*b as *const _ as *mut spdk_bdev),
-            state: std::sync::Mutex::new(NexusState::Init),
+            state: parking_lot::Mutex::new(NexusState::Init),
             bdev_raw: Box::into_raw(b),
             data_ent_offset: 0,
             share_handle: None,
             size,
             nexus_target: None,
             io_device: None,
-            pause_state: NexusPauseState::Unpaused,
+            pause_state: AtomicCell::new(NexusPauseState::Unpaused),
             pause_waiters: Vec::new(),
             nexus_info: futures::lock::Mutex::new(Default::default()),
         });
@@ -530,7 +526,7 @@ impl Nexus {
             "{} Transitioned state from {:?} to {:?}",
             self.name, self.state, state
         );
-        *self.state.lock().unwrap() = state;
+        *self.state.lock() = state;
         state
     }
     /// returns the size in bytes of the nexus instance
@@ -600,7 +596,7 @@ impl Nexus {
     pub(crate) fn destruct(&mut self) -> NexusState {
         // a closed operation might already be in progress calling unregister
         // will trip an assertion within the external libraries
-        if *self.state.lock().unwrap() == NexusState::Closed {
+        if *self.state.lock() == NexusState::Closed {
             trace!("{}: already closed", self.name);
             return NexusState::Closed;
         }
@@ -695,11 +691,11 @@ impl Nexus {
     }
 
     /// Resume IO to the bdev.
-    /// Note: in order to handle cuncurrent resumes properly, this function must
+    /// Note: in order to handle concurrent resumes properly, this function must
     /// be called only from the master core.
-    pub(crate) async fn resume(&mut self) -> Result<(), Error> {
+    pub async fn resume(&mut self) -> Result<(), Error> {
         assert_eq!(Cores::current(), Cores::first());
-        assert_eq!(self.pause_state, NexusPauseState::Paused);
+        assert_eq!(self.pause_state.load(), NexusPauseState::Paused);
 
         info!(
             "{} resuming nexus, waiters: {}",
@@ -710,7 +706,7 @@ impl Nexus {
         if let Some(Protocol::Nvmf) = self.shared() {
             if self.pause_waiters.is_empty() {
                 if let Some(subsystem) = NvmfSubsystem::nqn_lookup(&self.name) {
-                    self.pause_state = NexusPauseState::Unpausing;
+                    self.pause_state.store(NexusPauseState::Unpausing);
                     subsystem.resume().await.unwrap();
                     // The trickiest case: a new waiter appeared during nexus
                     // unpausing. By the agreement we keep
@@ -722,7 +718,7 @@ impl Nexus {
                             self.name,
                         );
                         subsystem.pause().await.unwrap();
-                        self.pause_state = NexusPauseState::Paused;
+                        self.pause_state.store(NexusPauseState::Paused);
                     }
                 }
             }
@@ -733,7 +729,7 @@ impl Nexus {
             let s = self.pause_waiters.pop().unwrap();
             s.send(0).expect("Nexus pause waiter disappeared");
         } else {
-            self.pause_state = NexusPauseState::Unpaused;
+            self.pause_state.store(NexusPauseState::Unpaused);
         }
 
         Ok(())
@@ -744,17 +740,25 @@ impl Nexus {
     /// In case concurrent pause requests take place, the other callers
     /// will wait till the nexus is resumed and will continue execution
     /// with the nexus paused once they are awakened via resume().
-    /// Note: in order to handle cuncurrent pauses properly, this function must
+    /// Note: in order to handle concurrent pauses properly, this function must
     /// be called only from the master core.
-    pub(crate) async fn pause(&mut self) -> Result<(), Error> {
+    pub async fn pause(&mut self) -> Result<(), Error> {
         assert_eq!(Cores::current(), Cores::first());
 
-        match self.pause_state {
-            // Pause nexus if its unpaused.
-            NexusPauseState::Unpaused => {
-                self.pause_state = NexusPauseState::Pausing;
+        let state = self
+            .pause_state
+            .compare_exchange(
+                NexusPauseState::Unpaused,
+                NexusPauseState::Pausing,
+            )
+            .map_err(|e| Error::PauseError {
+                state: e,
+                name: self.name.clone(),
+            })?;
 
-                info!("{} pausing nexus", self.name);
+        match state {
+            // Pause nexus if it is in the unpaused state.
+            NexusPauseState::Unpaused => {
                 if let Some(Protocol::Nvmf) = self.shared() {
                     if let Some(subsystem) =
                         NvmfSubsystem::nqn_lookup(&self.name)
@@ -772,22 +776,24 @@ impl Nexus {
                         );
                     }
                 }
-                self.pause_state = NexusPauseState::Paused;
-                info!("{} nexus paused", self.name);
+                self.pause_state
+                    .compare_exchange(
+                        NexusPauseState::Pausing,
+                        NexusPauseState::Paused,
+                    )
+                    .unwrap();
             }
-            // Wait till the pauser unpauses the nexus.
             _ => {
-                info!(
+                debug!(
                     "{} concurrent subsystem pause detected, yielding at state: {:?}",
                     self.name, self.pause_state,
                 );
 
                 let (s, r) = oneshot::channel::<i32>();
                 self.pause_waiters.push(s);
-
                 r.await.expect("Nexus pause sender disappeared");
-                info!("{} pause is granted", self.name,);
-                assert_eq!(self.pause_state, NexusPauseState::Paused);
+                debug!("{} pause is granted", self.name,);
+                assert_eq!(self.pause_state.load(), NexusPauseState::Paused);
             }
         }
 
@@ -796,13 +802,19 @@ impl Nexus {
 
     // Abort all active I/O for target child and set I/O fail-fast flag
     // for the child.
-    async fn update_failfast(&self, increment: bool) -> Result<(), Error> {
+
+    #[allow(dead_code)]
+    async fn update_failfast(
+        &self,
+        increment: bool,
+        child: Option<String>,
+    ) -> Result<(), Error> {
         let (sender, r) = oneshot::channel::<bool>();
 
         let ctx = UpdateFailFastCtx {
             sender,
-            increment,
             nexus: self.name.clone(),
+            child,
         };
 
         let io_device = self.io_device.as_ref().expect("Nexus not opened");
@@ -820,12 +832,57 @@ impl Nexus {
         Ok(())
     }
 
-    pub(crate) async fn set_failfast(&self) -> Result<(), Error> {
-        self.update_failfast(true).await
+    async fn child_retire_for_each_channel(
+        &self,
+        child: Option<String>,
+    ) -> Result<(), Error> {
+        let (sender, r) = oneshot::channel::<bool>();
+
+        let ctx = UpdateFailFastCtx {
+            sender,
+            nexus: self.name.clone(),
+            child,
+        };
+
+        if let Some(io_device) = self.io_device.as_ref() {
+            io_device.traverse_io_channels(
+                update_failfast_cb,
+                update_failfast_done,
+                NexusChannel::inner_from_channel,
+                ctx,
+            );
+
+            debug!(?self, "all channels retired");
+            r.await.expect("update failfast sender already dropped");
+        }
+
+        Ok(())
     }
 
-    pub(crate) async fn clear_failfast(&self) -> Result<(), Error> {
-        self.update_failfast(false).await
+    pub async fn child_retire(&mut self, name: String) -> Result<(), Error> {
+        self.child_retire_for_each_channel(Some(name.clone()))
+            .await?;
+        debug!(?self, "PAUSE");
+        self.pause().await?;
+        debug!(?self, "UNPAUSE");
+        if let Some(child) = self.child_lookup(&name) {
+            self.persist(PersistOp::Update((
+                child.name.clone(),
+                child.state(),
+            )))
+            .await;
+        }
+        self.resume().await
+    }
+
+    #[allow(dead_code)]
+    pub async fn set_failfast(&self) -> Result<(), Error> {
+        self.update_failfast(true, None).await
+    }
+
+    #[allow(dead_code)]
+    pub async fn clear_failfast(&self) -> Result<(), Error> {
+        self.update_failfast(false, None).await
     }
 
     /// get ANA state of the NVMe subsystem
@@ -869,7 +926,7 @@ impl Nexus {
     /// creation. Once this function is called, the device is visible and can
     /// be used for IO.
     pub(crate) async fn register(&mut self) -> Result<(), Error> {
-        assert_eq!(*self.state.lock().unwrap(), NexusState::Init);
+        assert_eq!(*self.state.lock(), NexusState::Init);
 
         let io_device = IoDevice::new::<NexusChannel>(
             NonNull::new(self.as_ptr()).unwrap(),
@@ -947,10 +1004,10 @@ impl Nexus {
     /// No child is online so the nexus is faulted
     /// This may be made more configurable in the future
     pub fn status(&self) -> NexusStatus {
-        match *self.state.lock().unwrap() {
+        match *self.state.lock() {
             NexusState::Init => NexusStatus::Degraded,
             NexusState::Closed => NexusStatus::Faulted,
-            NexusState::Open => {
+            NexusState::Open | NexusState::Reconfiguring => {
                 if self
                     .children
                     .iter()

--- a/mayastor/src/bdev/nexus/nexus_bdev_children.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev_children.rs
@@ -56,7 +56,7 @@ impl Nexus {
     /// register children with the nexus, only allowed during the nexus init
     /// phase
     pub fn register_children(&mut self, dev_name: &[String]) {
-        assert_eq!(*self.state.lock().unwrap(), NexusState::Init);
+        assert_eq!(*self.state.lock(), NexusState::Init);
         self.child_count = dev_name.len() as u32;
         dev_name
             .iter()
@@ -77,7 +77,7 @@ impl Nexus {
         &mut self,
         uri: &str,
     ) -> Result<(), NexusBdevError> {
-        assert_eq!(*self.state.lock().unwrap(), NexusState::Init);
+        assert_eq!(*self.state.lock(), NexusState::Init);
         let name = device_create(&uri).await?;
         self.children.push(NexusChild::new(
             uri.to_string(),

--- a/mayastor/src/bdev/nexus/nexus_child.rs
+++ b/mayastor/src/bdev/nexus/nexus_child.rs
@@ -174,14 +174,7 @@ impl Debug for NexusChild {
 impl Display for NexusChild {
     fn fmt(&self, f: &mut Formatter) -> Result<(), std::fmt::Error> {
         match &self.device {
-            Some(dev) => writeln!(
-                f,
-                "{}: {:?}, blk_cnt: {}, blk_size: {}",
-                self.name,
-                self.state(),
-                dev.num_blocks(),
-                dev.block_len(),
-            ),
+            Some(_dev) => writeln!(f, "{}: {:?}", self.name, self.state(),),
             None => writeln!(f, "{}: state {:?}", self.name, self.state()),
         }
     }
@@ -537,7 +530,7 @@ impl NexusChild {
     }
 
     /// destroy the child device
-    pub(crate) async fn destroy(&self) -> Result<(), NexusBdevError> {
+    pub async fn destroy(&self) -> Result<(), NexusBdevError> {
         if self.device.is_some() {
             self.set_state(ChildState::Destroying);
             info!("{} destroying underlying block device", self.name);

--- a/mayastor/src/bdev/nexus/nexus_fn_table.rs
+++ b/mayastor/src/bdev/nexus/nexus_fn_table.rs
@@ -103,6 +103,7 @@ impl NexusFnTable {
     /// Main entry point to submit IO to the underlying children this uses
     /// callbacks rather than futures and closures for performance reasons.
     /// This function is not called when the IO is re-submitted (see below).
+    #[no_mangle]
     pub extern "C" fn io_submit(
         channel: *mut spdk_io_channel,
         io: *mut spdk_bdev_io,

--- a/mayastor/src/bdev/nexus/nexus_io.rs
+++ b/mayastor/src/bdev/nexus/nexus_io.rs
@@ -13,14 +13,11 @@ use crate::{
     bdev::{
         nexus::{
             nexus_bdev::NEXUS_PRODUCT_ID,
-            nexus_channel::{DrEvent, NexusChannel, NexusChannelInner},
-            nexus_persistence::PersistOp,
+            nexus_channel::{NexusChannel, NexusChannelInner},
         },
         nexus_lookup,
-        ChildState,
         Nexus,
         NexusStatus,
-        Reason,
     },
     core::{
         Bio,
@@ -82,36 +79,27 @@ impl From<*mut spdk_bdev_io> for NexusBio {
     }
 }
 
+impl NexusBio {
+    fn as_ptr(&self) -> *mut spdk_bdev_io {
+        self.0.as_ptr()
+    }
+}
+
 #[derive(Debug)]
 #[repr(C)]
 pub struct NioCtx {
+    /// number of IO's submitted. Nexus IO's may never be freed until this
+    /// counter drops to zero.
     in_flight: u8,
-    num_ok: u8,
+    /// intermediate status of the IO
     status: IoStatus,
+    /// a reference to  our channel
     channel: NonNull<spdk_io_channel>,
-    core: u32,
-}
-
-#[derive(Debug, Clone)]
-#[repr(C)]
-enum Disposition {
-    /// All IOs are completed, and the final status of the IO should be set to
-    /// the enum variant
-    Complete(IoStatus),
-    /// IOs are still in flight status of the last IO that failed
-    Flying(IoStatus),
-    /// retire the current child
-    Retire(IoStatus),
+    /// the IO must fail regardless of when it completes
+    must_fail: bool,
 }
 
 pub(crate) fn nexus_submit_io(mut io: NexusBio) {
-    // Fail-fast all incoming I/O if the flag is set.
-    let inner = io.inner_channel();
-    if inner.fail_fast > 0 {
-        io.fail();
-        return;
-    }
-
     if let Err(_e) = match io.cmd() {
         IoType::Read => io.readv(),
         // these IOs are submitted to all the underlying children
@@ -136,12 +124,7 @@ pub(crate) fn nexus_submit_io(mut io: NexusBio) {
             })
         }
     } {
-        // TODO: Displaying a message in response to every
-        // submission error might result in log files flooded with
-        // zillions of similar error messages for faulted nexuses.
-        // Need to rethink the approach for error notifications here.
-
-        // error!(?e, ?io, "Error during IO submission");
+        //trace!(?e, ?io, "Error during IO submission");
     }
 }
 
@@ -154,16 +137,14 @@ impl NexusBio {
     ) -> Self {
         let mut bio = NexusBio::from(io);
         let ctx = bio.ctx_as_mut();
-        // for verification purposes when retiring a child
-        ctx.core = Cores::current();
         ctx.channel = NonNull::new(channel).unwrap();
         ctx.status = IoStatus::Pending;
         ctx.in_flight = 0;
-        ctx.num_ok = 0;
+        ctx.must_fail = false;
         bio
     }
 
-    /// invoked when a nexus Io completes
+    /// invoked when a nexus IO completes
     fn child_completion(
         device: &dyn BlockDevice,
         status: IoCompletionStatus,
@@ -175,66 +156,14 @@ impl NexusBio {
 
     #[inline(always)]
     /// a mutable reference to the IO context
-    fn ctx_as_mut(&mut self) -> &mut NioCtx {
+    pub fn ctx_as_mut(&mut self) -> &mut NioCtx {
         self.specific_as_mut::<NioCtx>()
     }
 
     #[inline(always)]
     /// immutable reference to the IO context
-    fn ctx(&self) -> &NioCtx {
+    pub fn ctx(&self) -> &NioCtx {
         self.specific::<NioCtx>()
-    }
-
-    /// Determine what to do with the IO if anything. In principle, it's the
-    /// same way any other IO is completed but, it wrapped by the
-    /// disposition. The general approach is if we return Disposition::
-    /// Retire(IoStatus::Success) it means that we retire the current child and
-    /// then, return mark the IO successful.
-    fn disposition(&mut self, success: bool) -> Disposition {
-        let ctx = self.ctx_as_mut();
-        match ctx.status {
-            // all child IO's completed, complete the parent IO
-            IoStatus::Pending if ctx.in_flight == 0 => {
-                Disposition::Complete(IoStatus::Success)
-            }
-            // some child IO has completed, but not all
-            IoStatus::Pending if ctx.in_flight != 0 => {
-                Disposition::Flying(IoStatus::Success)
-            }
-
-            // Other IO are still inflight we encountered an error, retire this
-            // child.
-            IoStatus::Failed if ctx.in_flight != 0 => {
-                Disposition::Retire(IoStatus::Pending)
-            }
-
-            // this IO failed, but we have seen successfully IO's for the parent
-            // already retire it
-            IoStatus::Failed if ctx.num_ok != 0 && ctx.in_flight == 0 => {
-                // Do not retire the current device if the error was triggered
-                // by I/Os on other replicas.
-                if success {
-                    Disposition::Complete(IoStatus::Failed)
-                } else {
-                    Disposition::Retire(IoStatus::Failed)
-                }
-            }
-
-            // ALL io's have failed
-            IoStatus::Failed if ctx.num_ok == 0 && ctx.in_flight == 0 => {
-                Disposition::Retire(IoStatus::Failed)
-            }
-            // all IOs that where partially submitted completed, no bubble up
-            // the ENOMEM to the upper layer we do not care if the
-            // IO failed or complete, the whole IO must be resubmitted
-            IoStatus::NoMemory if ctx.in_flight == 0 => {
-                Disposition::Complete(IoStatus::NoMemory)
-            }
-            _ => {
-                error!("{:?}", ctx);
-                Disposition::Complete(IoStatus::Failed)
-            }
-        }
     }
 
     /// returns the type of command for this IO
@@ -250,95 +179,61 @@ impl NexusBio {
         status: IoCompletionStatus,
     ) {
         let success = status == IoCompletionStatus::Success;
-        // If the IO failed it is possible that completion callback is
-        // called from a different core.
-        if success {
-            assert_eq!(self.ctx().core, Cores::current());
-        }
 
-        // decrement the counter of in flight IO
         self.ctx_as_mut().in_flight -= 1;
 
-        // record the state of at least one of the IO's.
         if success {
-            self.ctx_as_mut().num_ok += 1;
+            self.ok_checked();
         } else {
+            // IO failure, mark the IO failed and take the child out
+            error!(
+                ?self,
+                "{} IO completion failed: {:?}",
+                child.device_name(),
+                self.ctx()
+            );
             self.ctx_as_mut().status = IoStatus::Failed;
+            self.ctx_as_mut().must_fail = true;
+            self.handle_failure(child, status);
         }
+    }
 
-        match self.disposition(success) {
-            // the happy path, all is good
-            Disposition::Complete(IoStatus::Success) => {
-                // Check if the operation has to be explicitly failed still.
-                if self.inner_channel().fail_fast > 0 {
-                    error!(
-                        "{} failing the {:?} operation due to fail-fast request",
-                        child.device_name(),
-                        self.cmd(),
-                    );
-                    self.fail()
-                } else {
-                    self.ok()
-                }
-            }
-            // All of IO's have failed but all remaining in flights completed
-            // now as well depending on the error we can attempt to
-            // do a retry.
-            Disposition::Complete(IoStatus::Failed) => self.fail(),
-
-            // IOs were submitted before we bumped into ENOMEM. The IO has
-            // now completed, so we can finally report back to the
-            // callee that we encountered ENOMEM during submission
-            Disposition::Complete(IoStatus::NoMemory) => self.no_mem(),
-
-            // We can mark the IO as success but before we do we need to retire
-            // this child. This typically would only match when the last IO
-            // has failed i.e [ok,ok,fail]
-            Disposition::Retire(IoStatus::Success) => {
-                let device_name = child.device_name();
-                //assert!(!success);
-                error!(
-                    ?self,
-                    ?device_name,
-                    "{}:{}",
-                    Cores::current(),
-                    "last child IO failed completion"
-                );
-
-                self.try_retire(child, status);
+    /// Complete the IO marking at as successfully when all child IO's have been
+    /// accounted for. Failing to account for all child IO's will result in
+    /// a lockup.
+    #[inline]
+    fn ok_checked(&mut self) {
+        if self.ctx().in_flight == 0 {
+            if self.ctx().must_fail {
+                //warn!(?self, "resubmitted due to must_fail");
+                self.retry_checked();
+                //self.fail();
+            } else {
                 self.ok();
             }
+        }
+    }
 
-            // IO still in flight (pending) fail this IO and continue by setting
-            // the parent status back to pending for example [ok,
-            // fail, pending]
-            Disposition::Retire(IoStatus::Pending) => {
-                let device_name = child.device_name();
+    /// Complete the IO marking it as failed.
+    #[inline]
+    pub fn fail_checked(&mut self) {
+        if self.ctx().in_flight == 0 {
+            self.fail();
+        }
+    }
 
-                error!(
-                    ?self,
-                    ?device_name,
-                    "{}:{}",
-                    Cores::current(),
-                    "child IO completion failed"
-                );
-                self.try_retire(child, status);
-                // more IO is pending ensure we set the proper context state
-                self.ctx_as_mut().status = IoStatus::Pending;
-            }
-
-            Disposition::Retire(IoStatus::Failed) => {
-                //assert_eq!(success, false);
-                error!(
-                    ?self,
-                    "{}:{}",
-                    Cores::current(),
-                    "last child IO failed completion"
-                );
-                self.try_retire(child, status);
-                self.fail();
-            }
-            _ => {}
+    /// retry this IO when all other IOs have completed
+    #[inline]
+    pub fn retry_checked(&mut self) {
+        if self.ctx().in_flight == 0 {
+            let bio = unsafe {
+                Self::nexus_bio_setup(
+                    self.ctx().channel.as_ptr(),
+                    self.as_ptr(),
+                )
+            };
+            debug!(?self, "resubmitting IO");
+            nexus_submit_io(bio);
         }
     }
 
@@ -357,12 +252,13 @@ impl NexusBio {
     }
 
     /// helper routine to get a channel to read from
+    #[inline]
     fn read_channel_at_index(&self, i: usize) -> &dyn BlockDeviceHandle {
         &*self.inner_channel().readers[i]
     }
 
     /// submit a read operation to one of the children of this nexus
-    #[inline(always)]
+    #[inline]
     fn submit_read(
         &self,
         hdl: &dyn BlockDeviceHandle,
@@ -377,47 +273,43 @@ impl NexusBio {
         )
     }
 
+    /// submit a read operation
     fn do_readv(&mut self) -> Result<(), CoreError> {
         let inner = self.inner_channel();
 
-        // Upon buffer allocation we might have been rescheduled, so check
-        // the fail-fast flag once more.
-        if inner.fail_fast > 0 {
-            self.fail();
-            return Err(CoreError::ReadDispatch {
-                source: Errno::ENXIO,
-                offset: self.offset(),
-                len: self.num_blocks(),
-            });
-        }
-
         if let Some(i) = inner.child_select() {
             let hdl = self.read_channel_at_index(i);
-            let r = self.submit_read(hdl).map_err(|e| {
-                self.fail();
-                e
-            });
+            let r = self.submit_read(hdl);
 
             if r.is_err() {
                 // Such a situation can happen when there is no active I/O in
                 // the queues, but error on qpair is observed
                 // due to network timeout, which initiates
                 // controller reset. During controller reset all
-                // I/O channels are deinitialized, so no I/O
+                // I/O channels are de-initialized, so no I/O
                 // submission is possible (spdk returns -6/ENXIO), so we have to
                 // start device retire.
                 // TODO: ENOMEM and ENXIO should be handled differently and
                 // device should not be retired in case of ENOMEM.
-                info!(
-                    "{} initiating retire in response to READ submission error",
-                    hdl.get_device().device_name(),
-                );
-                self.do_retire(hdl.get_device().device_name());
+
+                let device = hdl.get_device().device_name();
+                trace!(
+                    "(core: {} thread: {}): read IO to {} submission failed with error {:?}",
+                    Cores::current(), Mthread::current().unwrap().name(), device, r);
+                let must_retire = inner.fault_child(&device);
+                if must_retire {
+                    self.do_retire(device);
+                }
+
+                self.fail();
             } else {
-                self.ctx_as_mut().in_flight += 1;
+                self.ctx_as_mut().in_flight = 1;
             }
             r
         } else {
+            trace!(
+                "(core: {} thread: {}): read IO submission failed no children available",
+                Cores::current(), Mthread::current().unwrap().name());
             self.fail();
             Err(CoreError::NoDevicesAvailable {})
         }
@@ -431,11 +323,15 @@ impl NexusBio {
         let mut bio = NexusBio::from(io);
 
         if !success {
-            error!("Failed to get io buffer for io");
+            trace!(
+                "(core: {} thread: {}): get_buf() failed",
+                Cores::current(),
+                Mthread::current().unwrap().name()
+            );
             bio.no_mem();
-        } else if let Err(e) = bio.do_readv() {
-            error!("Failed to submit I/O after iovec allocation: {:?}", e,);
         }
+
+        let _ = bio.do_readv();
     }
 
     /// submit read IO to some child
@@ -454,7 +350,7 @@ impl NexusBio {
         }
     }
 
-    #[inline(always)]
+    #[inline]
     fn submit_write(
         &self,
         hdl: &dyn BlockDeviceHandle,
@@ -469,7 +365,7 @@ impl NexusBio {
         )
     }
 
-    #[inline(always)]
+    #[inline]
     fn submit_unmap(
         &self,
         hdl: &dyn BlockDeviceHandle,
@@ -482,7 +378,7 @@ impl NexusBio {
         )
     }
 
-    #[inline(always)]
+    #[inline]
     fn submit_write_zeroes(
         &self,
         hdl: &dyn BlockDeviceHandle,
@@ -495,7 +391,7 @@ impl NexusBio {
         )
     }
 
-    #[inline(always)]
+    #[inline]
     fn submit_reset(
         &self,
         hdl: &dyn BlockDeviceHandle,
@@ -510,62 +406,63 @@ impl NexusBio {
     /// be submitted to all the underlying children.
     fn submit_all(&mut self) -> Result<(), CoreError> {
         let mut inflight = 0;
-        let mut status = IoStatus::Pending;
         // Name of the device which experiences I/O submission failures.
         let mut failed_device = None;
 
-        let cmd = self.cmd();
         let result = self.inner_channel().writers.iter().try_for_each(|h| {
-            match cmd {
-                IoType::Write => self.submit_write(&**h),
-                IoType::Unmap => self.submit_unmap(&**h),
-                IoType::WriteZeros => self.submit_write_zeroes(&**h),
-                IoType::Reset => self.submit_reset(&**h),
+            match self.cmd() {
+                IoType::Write => self.submit_write(h.as_ref()),
+                IoType::Unmap => self.submit_unmap(h.as_ref()),
+                IoType::WriteZeros => self.submit_write_zeroes(h.as_ref()),
+                IoType::Reset => self.submit_reset(h.as_ref()),
                 // we should never reach here, if we do it is a bug.
                 _ => unreachable!(),
             }
-            .map(|_| {
-                inflight += 1;
-            })
-            .map_err(|se| {
-                status = IoStatus::Failed;
-                error!(
-                    "IO submission failed with error {:?}, I/Os submitted: {}",
-                    se, inflight
-                );
+                .map(|_| {
+                    inflight += 1;
+                })
+                .map_err(|se| {
+                    error!(
+                        "(core: {} thread: {}): IO submission failed with error {:?}, I/Os submitted: {}",
+                        Cores::current(), Mthread::current().unwrap().name(), se, inflight
+                    );
 
-                // Record the name of the device for immediat retire.
-                failed_device = Some(h.get_device().device_name());
-                se
-            })
+                    // Record the name of the device for immediate retire.
+                    failed_device = Some(h.get_device().device_name());
+                    se
+                })
         });
 
         // Submission errors can also trigger device retire.
         // Such a situation can happen when there is no active I/O in the
         // queues, but error on qpair is observed due to network
         // timeout, which initiates controller reset. During controller
-        // reset all I/O channels are deinitialized, so no I/O
+        // reset all I/O channels are de-initialized, so no I/O
         // submission is possible (spdk returns -6/ENXIO), so we have to
         // start device retire.
         // TODO: ENOMEM and ENXIO should be handled differently and
         // device should not be retired in case of ENOMEM.
         if result.is_err() {
             let device = failed_device.unwrap();
-            info!(
-                "{}: retiring device in response to submission error={:?}",
-                device, result,
-            );
-            self.do_retire(device);
+            // set the IO as failed in the submission stage.
+            self.ctx_as_mut().must_fail = true;
+            if self.inner_channel().remove_child(&device) {
+                self.do_retire(device);
+            }
         }
 
+        // partial submission
         if inflight != 0 {
+            // An error was experienced during submission. Some IO however, has
+            // been submitted successfully prior to the error condition.
             self.ctx_as_mut().in_flight = inflight;
-            self.ctx_as_mut().status = status;
-        } else {
-            // if no IO was submitted at all, we can fail the IO now.
-            // TODO: Support of IoStatus::NoMemory in ENOMEM-related errors.
-            self.fail();
+            self.ctx_as_mut().status = IoStatus::Success;
+            self.ok_checked();
+            return result;
         }
+
+        self.fail_checked();
+
         result
     }
 
@@ -576,114 +473,72 @@ impl NexusBio {
         ));
     }
 
-    fn try_retire(
+    fn handle_failure(
         &mut self,
         child: &dyn BlockDevice,
         status: IoCompletionStatus,
     ) {
-        trace!(?status);
+        // We have experienced a failure on one of the child devices. We need to
+        // ensure we do not submit more IOs to this child. We do not
+        // need to tell other cores about this because
+        // they will experience the same errors on their own channels, and
+        // handle it on their own.
+        //
+        // We differentiate between errors in the submission and completion.
+        // When we have a completion error, it typically means that the
+        // child has lost the connection to the nexus. In order for
+        // outstanding IO to complete, the IO's to that child must be aborted.
+        // The abortion is implicit when removing the device.
 
-        if let IoCompletionStatus::NvmeError(nvme_status) = status {
-            if nvme_status
-                == NvmeCommandStatus::GenericCommandStatus(
-                    GenericStatusCode::InvalidOpcode,
+        if matches!(
+            status,
+            IoCompletionStatus::NvmeError(
+                NvmeCommandStatus::GenericCommandStatus(
+                    GenericStatusCode::InvalidOpcode
                 )
-            {
-                info!(
-                        "Device {} experienced invalid opcode error: retiring skipped",
-                        child.device_name()
-                    );
-                return;
-            }
+            )
+        ) {
+            debug!(
+                "Device {} experienced invalid opcode error: retiring skipped",
+                child.device_name()
+            );
+            return;
         }
-        info!("{} try_retire() called", child.device_name());
-        self.do_retire(child.device_name());
+
+        let retry = matches!(
+            status,
+            IoCompletionStatus::NvmeError(
+                NvmeCommandStatus::GenericCommandStatus(
+                    GenericStatusCode::AbortedSubmissionQueueDeleted
+                )
+            )
+        );
+
+        let child = child.device_name();
+        // check if this child needs to be retired
+        let needs_retire = self.inner_channel().fault_child(&child);
+        // The child state was not faulted yet, so this is the first IO
+        // to this child for which we encountered an error.
+        if needs_retire {
+            self.do_retire(child);
+        }
+
+        // if the IO was failed because of retire, resubmit the IO
+        if retry {
+            return self.ok_checked();
+        }
+
+        self.fail_checked();
     }
 
     /// Retire a child for this nexus.
     async fn child_retire(nexus: String, device: String) {
-        match nexus_lookup(&nexus) {
-            Some(nexus) => {
-                // Narrow nexus child scope to not interfere with mutually
-                // borrowed nexus object.
-                let child_state = {
-                    if let Some(child) = nexus.child_lookup(&device) {
-                        let current_state = child.state.compare_and_swap(
-                            ChildState::Open,
-                            ChildState::Faulted(Reason::IoError),
-                        );
-                        Some(current_state)
-                    } else {
-                        None
-                    }
-                };
+        if let Some(nexus) = nexus_lookup(&nexus) {
+            warn!(?nexus, ?device, "retiring child");
 
-                match child_state {
-                    None => {
-                        debug!(
-                            "{} does not belong (anymore) to nexus {}",
-                            device, nexus
-                        );
-                    }
-                    Some(current_state) => {
-                        if current_state == ChildState::Open {
-                            warn!(
-                                "core {} thread {:?}, faulting child {}",
-                                Cores::current(),
-                                Mthread::current(),
-                                device,
-                            );
-
-                            // Pausing a nexus acts like entering a critical
-                            // section,
-                            // allowing only one retire request to run at a
-                            // time, which prevents
-                            // inconsistency in reading/updating nexus
-                            // configuration.
-                            nexus.pause().await.unwrap();
-                            nexus.set_failfast().await.unwrap();
-                            nexus.reconfigure(DrEvent::ChildFault).await;
-
-                            // Lookup child once more and finally remove it.
-                            match nexus.child_lookup(&device) {
-                                Some(child) => {
-                                    nexus
-                                        .persist(PersistOp::Update((
-                                            child.name.clone(),
-                                            child.state(),
-                                        )))
-                                        .await;
-                                    // TODO: an error can occur here if a
-                                    // separate task,
-                                    // e.g. grpc request is also deleting the
-                                    // child.
-                                    if let Err(err) = child.destroy().await {
-                                        error!(
-                                            "{}: destroying child {} failed {}",
-                                            nexus, child, err
-                                        );
-                                    }
-                                }
-                                None => {
-                                    warn!(
-                                        "{} no longer belongs to nexus {}, skipping child removal",
-                                        device, nexus
-                                    );
-                                }
-                            }
-
-                            nexus.clear_failfast().await.unwrap();
-                            nexus.resume().await.unwrap();
-
-                            if nexus.status() == NexusStatus::Faulted {
-                                error!(":{} has no children left... ", nexus);
-                            }
-                        }
-                    }
-                }
-            }
-            None => {
-                debug!("{} Nexus does not exist anymore", nexus);
+            nexus.child_retire(device).await.unwrap();
+            if matches!(nexus.status(), NexusStatus::Faulted) {
+                warn!(?nexus, "no children left");
             }
         }
     }

--- a/mayastor/src/bdev/nvmx/channel.rs
+++ b/mayastor/src/bdev/nvmx/channel.rs
@@ -10,7 +10,6 @@ use spdk_sys::{
     spdk_nvme_ctrlr_disconnect_io_qpair,
     spdk_nvme_ctrlr_free_io_qpair,
     spdk_nvme_ctrlr_get_default_io_qpair_opts,
-    spdk_nvme_ctrlr_reconnect_io_qpair,
     spdk_nvme_io_qpair_opts,
     spdk_nvme_poll_group,
     spdk_nvme_poll_group_add,
@@ -65,6 +64,49 @@ impl<'a> NvmeIoChannel<'a> {
         }
     }
 }
+
+#[derive(Debug, Serialize, Clone, Copy, PartialEq, PartialOrd)]
+pub enum QPairState {
+    Disconnected,
+    Disconnecting,
+    Connecting,
+    Connected,
+    Enabling,
+    Enabled,
+    Destroying,
+}
+
+impl From<u8> for QPairState {
+    fn from(u: u8) -> Self {
+        match u {
+            0 => Self::Disconnected,
+            1 => Self::Disconnecting,
+            2 => Self::Connecting,
+            3 => Self::Connected,
+            4 => Self::Enabling,
+            5 => Self::Enabled,
+            6 => Self::Destroying,
+            _ => panic!("qpair in a unknown state"),
+        }
+    }
+}
+
+impl ToString for QPairState {
+    fn to_string(&self) -> String {
+        match *self {
+            QPairState::Disconnected => "Disconnected",
+            QPairState::Disconnecting => "Disconnecting",
+            QPairState::Connecting => "Connecting",
+            QPairState::Connected => "Connected",
+            QPairState::Enabling => "Enabling",
+            QPairState::Enabled => "Enabled",
+            QPairState::Destroying => "Destroying",
+        }
+        .parse()
+        .unwrap()
+    }
+}
+
 pub struct IoQpair {
     qpair: NonNull<spdk_nvme_qpair>,
     ctrlr_handle: SpdkNvmeController,
@@ -176,31 +218,40 @@ impl PollGroup {
 impl Drop for PollGroup {
     fn drop(&mut self) {
         debug!("dropping poll group {:p}", self.0.as_ptr());
-        unsafe { spdk_nvme_poll_group_destroy(self.0.as_ptr()) };
+        let rc = unsafe { spdk_nvme_poll_group_destroy(self.0.as_ptr()) };
+        if rc < 0 {
+            error!("Error on poll group destroy: {}", rc);
+        }
         debug!("poll group {:p} successfully dropped", self.0.as_ptr());
     }
 }
 
+/// spdk_nvme_ctrlr_free_io_qpair() calls disconnected. So we can either
+/// a. NOT call disconnect here
+///     and have SPDK disconnect it.
+/// b. set the ptr to null, as SPDK checks if the ptr is NULL. However, that
+/// breaks    the contract with NonNull<T>
 impl Drop for IoQpair {
     fn drop(&mut self) {
         let qpair = self.qpair.as_ptr();
 
-        debug!(?qpair, "dropping qpair");
         unsafe {
             nvme_qpair_abort_reqs(qpair, 1);
             debug!(?qpair, "I/O requests successfully aborted,");
             spdk_nvme_ctrlr_disconnect_io_qpair(qpair);
             debug!(?qpair, "qpair successfully disconnected,");
             spdk_nvme_ctrlr_free_io_qpair(qpair);
+            debug!(?qpair, "qpair successfully freed,");
         }
+
         debug!(?qpair, "qpair successfully dropped,");
     }
 }
 
 pub struct NvmeIoChannelInner<'a> {
+    pub qpair: Option<IoQpair>,
     poll_group: PollGroup,
     poller: poller::Poller<'a>,
-    pub qpair: Option<IoQpair>,
     io_stats_controller: IoStatsController,
     pub device: Box<dyn BlockDevice>,
     num_pending_ios: u64,
@@ -225,7 +276,7 @@ impl NvmeIoChannelInner<'_> {
         if self.qpair.is_some() {
             // Remove qpair and trigger its deallocation via drop().
             let qpair = self.qpair.take().unwrap();
-            info!(
+            debug!(
                 "dropping qpair {:p} ({} I/O requests pending)",
                 qpair.as_ptr(),
                 self.num_pending_ios
@@ -389,17 +440,20 @@ impl IoStatsController {
 pub struct NvmeControllerIoChannel(NonNull<spdk_io_channel>);
 
 extern "C" fn disconnected_qpair_cb(
-    qpair: *mut spdk_nvme_qpair,
-    _ctx: *mut c_void,
+    _qpair: *mut spdk_nvme_qpair,
+    ctx: *mut c_void,
 ) {
-    warn!(?qpair, "NVMe qpair disconnected");
+    let inner = NvmeIoChannel::from_raw(ctx).inner_mut();
 
-    // Currently, just try to reconnect indefinitely. If we are doing a
-    // reset, the reset will reconnect a qpair, and we will stop getting a
-    // callback for this one.
-    unsafe {
-        spdk_nvme_ctrlr_reconnect_io_qpair(qpair);
+    if let Some(ref qpair) = inner.qpair {
+        unsafe {
+            nvme_qpair_abort_reqs(qpair.as_ptr(), 1);
+        }
     }
+
+    //warn!(?qpair, "NVMe qpair disconnected");
+    // shutdown the channel such that pending IO if any, gets aborted.
+    //inner.shutdown();
 }
 
 extern "C" fn nvme_poll(ctx: *mut c_void) -> i32 {
@@ -435,7 +489,7 @@ impl NvmeControllerIoChannel {
         };
 
         let (cname, controller, block_size) = {
-            let controller = carc.lock().expect("lock error");
+            let controller = carc.lock();
             // Make sure controller is available.
             if controller.get_state() != NvmeControllerState::Running {
                 error!(
@@ -527,7 +581,7 @@ impl NvmeControllerIoChannel {
         });
 
         nvme_channel.inner = Box::into_raw(inner);
-        info!(?cname, ?ctx, "I/O channel successfully initialized");
+        debug!(?cname, ?ctx, "I/O channel successfully initialized");
         0
     }
 

--- a/mayastor/src/bdev/nvmx/controller_inner.rs
+++ b/mayastor/src/bdev/nvmx/controller_inner.rs
@@ -58,7 +58,7 @@ impl TryFrom<u32> for DeviceTimeoutAction {
 /// This is done to prevent the storm of reset requests in response to
 /// frequent I/O errors in a controller (including errors while processing
 /// admin queue completions).
-const MAX_RESET_ATTEMPTS: u32 = 5;
+const MAX_RESET_ATTEMPTS: u32 = 1;
 
 /// Time to wait till reset attempts can be recharged to maximum
 /// after all current reset attempts have been used.
@@ -154,7 +154,7 @@ impl TimeoutConfig {
             self.reset_attempts -= 1;
 
             if let Some(c) = NVME_CONTROLLERS.lookup_by_name(&self.name) {
-                let mut c = c.lock().expect("controller lock poisoned");
+                let mut c = c.lock();
                 if let Err(e) = c.reset(
                     TimeoutConfig::reset_cb,
                     self as *mut TimeoutConfig as *mut c_void,

--- a/mayastor/src/bdev/nvmx/handle.rs
+++ b/mayastor/src/bdev/nvmx/handle.rs
@@ -757,7 +757,7 @@ impl BlockDeviceHandle for NvmeDeviceHandle {
                 name: self.name.to_string(),
             },
         )?;
-        let mut controller = controller.lock().expect("lock poisoned");
+        let mut controller = controller.lock();
 
         let ctx = Box::new(ResetCtx {
             cb,

--- a/mayastor/src/bdev/nvmx/mod.rs
+++ b/mayastor/src/bdev/nvmx/mod.rs
@@ -1,10 +1,7 @@
-use std::{
-    collections::HashMap,
-    fmt::Display,
-    sync::{Arc, Mutex, RwLock, RwLockReadGuard, RwLockWriteGuard},
-};
+use std::{collections::HashMap, fmt::Display, sync::Arc};
 
 use once_cell::sync::Lazy;
+use parking_lot::{Mutex, RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 pub use channel::{NvmeControllerIoChannel, NvmeIoChannel, NvmeIoChannelInner};
 pub use controller::NvmeController;
@@ -39,13 +36,13 @@ impl<'a> NVMeCtlrList<'a> {
     fn write_lock(
         &self,
     ) -> RwLockWriteGuard<HashMap<String, Arc<Mutex<NvmeController<'a>>>>> {
-        self.entries.write().expect("rwlock poisoned")
+        self.entries.write()
     }
 
     fn read_lock(
         &self,
     ) -> RwLockReadGuard<HashMap<String, Arc<Mutex<NvmeController<'a>>>>> {
-        self.entries.read().expect("rwlock poisoned")
+        self.entries.read()
     }
 
     /// lookup a NVMe controller
@@ -73,7 +70,7 @@ impl<'a> NVMeCtlrList<'a> {
 
         // Remove 'controller name -> controller' mapping.
         let e = entries.remove(&name.to_string()).unwrap();
-        let controller = e.lock().unwrap();
+        let controller = e.lock();
 
         // Remove 'controller id->controller' mapping. This will remove the last
         // reference as causes the controller to be dropped.

--- a/mayastor/src/bin/mayastor.rs
+++ b/mayastor/src/bin/mayastor.rs
@@ -1,18 +1,22 @@
 #[macro_use]
 extern crate tracing;
+
+use std::path::Path;
+
 use futures::future::FutureExt;
+use structopt::StructOpt;
+
 use mayastor::{
     bdev::util::uring,
     core::{runtime, MayastorCliArgs, MayastorEnvironment, Mthread, Reactors},
     grpc,
     logger,
+    persistent_store::PersistentStore,
     subsys,
+    subsys::Registration,
 };
-use std::path::Path;
-use structopt::StructOpt;
-mayastor::CPS_INIT!();
-use mayastor::{persistent_store::PersistentStore, subsys::Registration};
 
+mayastor::CPS_INIT!();
 fn start_tokio_runtime(args: &MayastorCliArgs) {
     let grpc_address = grpc::endpoint(args.grpc_endpoint.clone());
     let rpc_address = args.rpc_address.clone();

--- a/mayastor/src/core/bio.rs
+++ b/mayastor/src/core/bio.rs
@@ -172,6 +172,7 @@ impl Bio {
     #[inline]
     pub(crate) fn fail(&self) {
         unsafe {
+            trace!(?self, "failed");
             spdk_bdev_io_complete(self.0.as_ptr(), IoStatus::Failed.into())
         }
     }

--- a/mayastor/src/core/channel.rs
+++ b/mayastor/src/core/channel.rs
@@ -6,7 +6,6 @@ use std::{
 use spdk_sys::{spdk_io_channel, spdk_put_io_channel};
 use std::ptr::NonNull;
 
-#[derive(Clone)]
 pub struct IoChannel(NonNull<spdk_io_channel>);
 
 impl From<*mut spdk_io_channel> for IoChannel {

--- a/mayastor/src/core/io_device.rs
+++ b/mayastor/src/core/io_device.rs
@@ -1,5 +1,6 @@
 use std::{os::raw::c_void, ptr::NonNull};
 
+use crate::ffihelper::IntoCString;
 use spdk_sys::{
     spdk_for_each_channel,
     spdk_for_each_channel_continue,
@@ -10,7 +11,6 @@ use spdk_sys::{
     spdk_io_device_register,
     spdk_io_device_unregister,
 };
-
 #[derive(Debug)]
 pub struct IoDevice(NonNull<c_void>);
 
@@ -28,13 +28,14 @@ impl IoDevice {
         create_cb: Option<IoDeviceCreateCb>,
         destroy_cb: Option<IoDeviceDestroyCb>,
     ) -> Self {
+        let cname = name.into_cstring();
         unsafe {
             spdk_io_device_register(
                 devptr.as_ptr(),
                 create_cb,
                 destroy_cb,
                 std::mem::size_of::<C>() as u32,
-                name.as_ptr() as *const i8,
+                cname.as_ptr(),
             )
         }
 

--- a/mayastor/src/core/thread.rs
+++ b/mayastor/src/core/thread.rs
@@ -146,7 +146,7 @@ impl Mthread {
     /// send the given thread 'msg' in xPDK speak.
     pub fn msg<F, T>(&self, t: T, f: F)
     where
-        F: FnMut(T),
+        F: FnOnce(T),
         T: std::fmt::Debug + 'static,
     {
         // context structure which is passed to the callback as argument
@@ -158,10 +158,10 @@ impl Mthread {
         // helper routine to unpack the closure and its arguments
         extern "C" fn trampoline<F, T>(arg: *mut c_void)
         where
-            F: FnMut(T),
+            F: FnOnce(T),
             T: 'static + std::fmt::Debug,
         {
-            let mut ctx = unsafe { Box::from_raw(arg as *mut Ctx<F, T>) };
+            let ctx = unsafe { Box::from_raw(arg as *mut Ctx<F, T>) };
             (ctx.closure)(ctx.args);
         }
 

--- a/mayastor/src/grpc/bdev_grpc.rs
+++ b/mayastor/src/grpc/bdev_grpc.rs
@@ -39,7 +39,19 @@ impl From<Bdev> for RpcBdev {
 }
 
 #[derive(Debug)]
-pub struct BdevSvc;
+pub struct BdevSvc {}
+
+impl BdevSvc {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl Default for BdevSvc {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 #[tonic::async_trait]
 impl BdevRpc for BdevSvc {

--- a/mayastor/src/grpc/mayastor_grpc.rs
+++ b/mayastor/src/grpc/mayastor_grpc.rs
@@ -46,7 +46,7 @@ impl From<LvsError> for Status {
             LvsError::Import {
                 ..
             } => Status::invalid_argument(e.to_string()),
-            LvsError::Create {
+            LvsError::RepCreate {
                 source, ..
             } => {
                 if source == Errno::ENOSPC {
@@ -422,8 +422,7 @@ impl mayastor_server::Mayastor for MayastorSvc {
                 nexus_list: instances()
                     .iter()
                     .filter(|n| {
-                        n.state.lock().unwrap().deref()
-                            != &nexus_bdev::NexusState::Init
+                        n.state.lock().deref() != &nexus_bdev::NexusState::Init
                     })
                     .map(|n| n.to_grpc())
                     .collect::<Vec<_>>(),

--- a/mayastor/src/grpc/server.rs
+++ b/mayastor/src/grpc/server.rs
@@ -21,7 +21,7 @@ impl MayastorGrpcServer {
         info!("gRPC server configured at address {}", endpoint);
         let svc = Server::builder()
             .add_service(MayastorRpcServer::new(MayastorSvc))
-            .add_service(BdevRpcServer::new(BdevSvc))
+            .add_service(BdevRpcServer::new(BdevSvc::new()))
             .add_service(JsonRpcServer::new(JsonRpcSvc {
                 rpc_addr,
             }))

--- a/mayastor/src/lvs/error.rs
+++ b/mayastor/src/lvs/error.rs
@@ -9,8 +9,8 @@ pub enum Error {
     #[snafu(display("failed to import pool {}", name))]
     Import { source: Errno, name: String },
 
-    #[snafu(display("failed to create pool {}", name))]
-    Create { source: Errno, name: String },
+    #[snafu(display("errno: {} failed to create pool {}", source, name))]
+    PoolCreate { source: Errno, name: String },
 
     #[snafu(display("failed to export pool {}", name))]
     Export { source: Errno, name: String },
@@ -26,13 +26,13 @@ pub enum Error {
         name: String,
     },
 
-    #[snafu(display("errno {}: {}", source.to_string(), msg))]
+    #[snafu(display("errno {}: {}", source, msg))]
     Invalid { source: Errno, msg: String },
 
     #[snafu(display("lvol exists {}", name))]
     RepExists { source: Errno, name: String },
 
-    #[snafu(display("failed to create lvol {}", name))]
+    #[snafu(display("errno: {} failed to create lvol {}", source, name))]
     RepCreate { source: Errno, name: String },
 
     #[snafu(display("failed to destroy lvol {}", name))]

--- a/mayastor/src/lvs/lvs_pool.rs
+++ b/mayastor/src/lvs/lvs_pool.rs
@@ -259,7 +259,7 @@ impl Lvs {
                 cb_arg(sender),
             )
         }
-        .to_result(|e| Error::Create {
+        .to_result(|e| Error::PoolCreate {
             source: Errno::from_i32(e),
             name: name.to_string(),
         })?;
@@ -267,7 +267,7 @@ impl Lvs {
         receiver
             .await
             .expect("Cancellation is not supported")
-            .map_err(|err| Error::Create {
+            .map_err(|err| Error::PoolCreate {
                 source: err,
                 name: name.to_string(),
             })?;
@@ -277,7 +277,7 @@ impl Lvs {
                 info!("The pool '{}' has been created on {}", name, bdev);
                 Ok(pool)
             }
-            None => Err(Error::Create {
+            None => Err(Error::PoolCreate {
                 source: Errno::ENOENT,
                 name: name.to_string(),
             }),
@@ -322,7 +322,7 @@ impl Lvs {
             return if pool.base_bdev().name() == parsed.get_name() {
                 Ok(pool)
             } else {
-                Err(Error::Create {
+                Err(Error::PoolCreate {
                     source: Errno::EEXIST,
                     name: args.name.clone(),
                 })

--- a/mayastor/src/subsys/config/opts.rs
+++ b/mayastor/src/subsys/config/opts.rs
@@ -178,15 +178,15 @@ where
 impl Default for NvmfTcpTransportOpts {
     fn default() -> Self {
         Self {
-            max_queue_depth: try_from_env("NVMF_TCP_MAX_QUEUE_DEPTH", 64),
+            max_queue_depth: try_from_env("NVMF_TCP_MAX_QUEUE_DEPTH", 32),
             in_capsule_data_size: 4096,
             max_io_size: 131_072,
             io_unit_size: 131_072,
-            max_qpairs_per_ctrl: 128,
+            max_qpairs_per_ctrl: 32,
             num_shared_buf: try_from_env("NVMF_TCP_NUM_SHARED_BUF", 2048),
             buf_cache_size: try_from_env("NVMF_TCP_BUF_CACHE_SIZE", 64),
             dif_insert_or_strip: false,
-            max_aq_depth: 128,
+            max_aq_depth: 32,
             abort_timeout_sec: 1,
         }
     }
@@ -268,16 +268,16 @@ impl Default for NvmeBdevOpts {
     fn default() -> Self {
         Self {
             action_on_timeout: SPDK_BDEV_NVME_TIMEOUT_ACTION_ABORT,
-            timeout_us: try_from_env("NVME_TIMEOUT_US", 30_000_000),
-            keep_alive_timeout_ms: try_from_env("NVME_KATO_MS", 10_000),
-            retry_count: try_from_env("NVME_RETRY_COUNT", 3),
+            timeout_us: try_from_env("NVME_TIMEOUT_US", 5_000_000),
+            keep_alive_timeout_ms: try_from_env("NVME_KATO_MS", 0),
+            retry_count: try_from_env("NVME_RETRY_COUNT", 0),
             arbitration_burst: 0,
             low_priority_weight: 0,
             medium_priority_weight: 0,
             high_priority_weight: 0,
             nvme_adminq_poll_period_us: try_from_env(
                 "NVME_ADMINQ_POLL_PERIOD_US",
-                0,
+                1_000,
             ),
             nvme_ioq_poll_period_us: try_from_env("NVME_IOQ_POLL_PERIOD_US", 0),
             io_queue_requests: 0,

--- a/nix/mayastor-overlay.nix
+++ b/nix/mayastor-overlay.nix
@@ -1,4 +1,5 @@
 self: super: {
+  fio = super.callPackage ./pkgs/fio { };
   libiscsi = super.callPackage ./pkgs/libiscsi { };
   nvmet-cli = super.callPackage ./pkgs/nvmet-cli { };
   libspdk = (super.callPackage ./pkgs/libspdk { }).release;

--- a/nix/pkgs/fio/default.nix
+++ b/nix/pkgs/fio/default.nix
@@ -1,0 +1,55 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, makeWrapper
+, libaio
+, python3
+, zlib
+, withGnuplot ? false
+, gnuplot ? null
+}:
+
+stdenv.mkDerivation rec {
+  pname = "fio";
+  version = "3.26";
+
+  src = fetchFromGitHub {
+    owner = "axboe";
+    repo = "fio";
+    rev = "fio-${version}";
+    sha256 = "sha256-/Si0McndJ6Xp3ifDr+BStv89LmZyAgof95QkHGT8MGQ=";
+  };
+
+  buildInputs = [ python3 zlib ]
+    ++ lib.optional (!stdenv.isDarwin) libaio;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  strictDeps = true;
+
+  enableParallelBuilding = true;
+
+  postPatch = ''
+    substituteInPlace Makefile \
+      --replace "mandir = /usr/share/man" "mandir = \$(prefix)/man" \
+      --replace "sharedir = /usr/share/fio" "sharedir = \$(prefix)/share/fio"
+    substituteInPlace tools/plot/fio2gnuplot --replace /usr/share/fio $out/share/fio
+  '';
+
+  preInstall = ''
+    mkdir -p $out/include
+    cp -p --parents $(find . -name "*.h") $out/include
+  '';
+
+  postInstall = lib.optionalString withGnuplot ''
+    wrapProgram $out/bin/fio2gnuplot \
+      --prefix PATH : ${lib.makeBinPath [ gnuplot ]}
+  '';
+
+  meta = with lib; {
+    description = "Flexible IO Tester - an IO benchmark tool";
+    homepage = "https://git.kernel.dk/cgit/fio/";
+    license = licenses.gpl2;
+    platforms = platforms.unix;
+  };
+}

--- a/nix/pkgs/libspdk/default.nix
+++ b/nix/pkgs/libspdk/default.nix
@@ -14,6 +14,7 @@
 , libexecinfo
 , nasm
 , cmake
+, fio
 , ninja
 , jansson
 , meson
@@ -28,13 +29,14 @@
 , buildPlatform
 , buildPackages
 , llvmPackages_11
+, pkgs
 , gcc
 , zlib
 }:
 let
   # Derivation attributes for production version of libspdk
   drvAttrs = rec {
-    version = "21.01";
+    version = "21.01-3f85fb5";
 
     src = fetchFromGitHub {
       owner = "openebs";
@@ -57,6 +59,7 @@ let
 
     buildInputs = [
       binutils
+      fio
       libtool
       libaio
       libiscsi
@@ -92,9 +95,9 @@ let
       "--without-isal"
       "--with-iscsi-initiator"
       "--with-uring"
-      "--disable-examples"
       "--disable-unit-tests"
       "--disable-tests"
+      "--with-fio=${pkgs.fio}/include"
     ];
 
     enableParallelBuilding = true;
@@ -130,6 +133,7 @@ let
     installPhase = ''
       mkdir -p $out/lib
       mkdir $out/bin
+      mkdir $out/fio
 
       pushd include
       find . -type f -name "*.h" -exec install -D "{}" $out/include/{} \;
@@ -149,6 +153,8 @@ let
 
       echo $(find $out -type f -name '*.a*' -delete)
       find . -executable -type f -name 'bdevperf' -exec install -D "{}" $out/bin \;
+
+      cp build/fio/spdk_* $out/fio
     '';
   };
 in

--- a/nix/pkgs/mayastor/cargo-package.nix
+++ b/nix/pkgs/mayastor/cargo-package.nix
@@ -57,7 +57,7 @@ let
   buildProps = rec {
     name = "mayastor";
     #cargoSha256 = "0000000000000000000000000000000000000000000000000000";
-    cargoSha256 = "1zm5bs7af9m7j2i4aamkh9rvg2xfxr13mgk26sdzahf9zisi9wqk";
+    cargoSha256 = "0j24k64qkrws3z680n56dv6v7bzsg8kmcqmdli6fl1rxwg50vxll";
     inherit version cargoBuildFlags;
     src = whitelistSource ../../../. src_list;
     LIBCLANG_PATH = "${llvmPackages.libclang}/lib";

--- a/shell.nix
+++ b/shell.nix
@@ -38,7 +38,6 @@ mkShell {
     kubernetes-helm
     libaio
     libiscsi
-    libiscsi
     libudev
     liburing
     llvmPackages.libclang

--- a/spdk-sys/build.sh
+++ b/spdk-sys/build.sh
@@ -15,7 +15,8 @@ rm libspdk.so
 	--with-iscsi-initiator \
 	--with-crypto \
 	--with-uring \
-	--enable-unit-tests
+	--enable-unit-tests \
+	--with-fio=$(which fio | sed s';bin/fio;include;')
 
 make -j $(nproc)
 

--- a/test/python/README.md
+++ b/test/python/README.md
@@ -1,0 +1,63 @@
+# Purpose
+To test things in containers but on the same host, we have the composer library in Rust.
+This works pretty well but has the downside that if you want to add something to
+that test, you have to recompile the tests all the time, and you can not leave the
+containers running when the test fails without modifying the tests either. This is
+because those tests are part of our CI/CD pipeline, so we must clean them up.
+
+Additionally, when working on the data plane and you want to test, let us say,
+"child retire" logic. It can be rather a pain to do that manually, even when
+scripted. To fill this cap, we can use pytest, which can a far richer than bash
+scripts - and it can leverage docker-compose.  Upside is that the test suites
+can run with -- or without starting the containers.
+
+So all in all, the purpose is to create reproducible tests/environments.
+
+For example, I can start my containers and run:
+```
+docker-compose up
+pytest nexus.py --docker-compose-no-build --use-running-containers
+```
+This allows me to see the logs in real-time, and on failure, figure out why it
+failed and so forth.
+
+Without the extra arguments however, the test suite will create and destroy
+the containers
+
+# Setup
+
+Depending on the used OS/distro of choice you will need to install some
+python packages. To make it easier. You can also use virtual environments.
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+```
+
+Install python packages:
+
+
+```bash
+pip install -r requirements.txt
+```
+
+# Protobuf
+
+`shell.nix` contains a few python3 packages in particular for proto generation.
+From within the `rpc/proto` run:
+
+```bash
+python -m grpc_tools.protoc -I . --proto_path=. --python_out=. --grpc_python_out=. mayastor.proto
+```
+
+And copy them (yes -- on the TODO list) over when they where updated, such that:
+
+```bash
+docker-compose.yml  mayastor_pb2_grpc.py  mayastor_pb2.py  nexus.py  README.md  requirements.txt
+```
+
+# TODO:
+ [ ] fix proto generation
+ [ ] create test suite layout such that the tests fixtures can be re-used
+ [ ] create test that run fio, do "create 110" volumes etc type like tests
+ [ ] ...

--- a/test/python/README.md
+++ b/test/python/README.md
@@ -22,39 +22,11 @@ This allows me to see the logs in real-time, and on failure, figure out why it
 failed and so forth.
 
 Without the extra arguments however, the test suite will create and destroy
-the containers
+the containers automatically. This is done by making use of the pytest fixtures
 
 # Setup
 
-Depending on the used OS/distro of choice you will need to install some
-python packages. To make it easier. You can also use virtual environments.
-
-```bash
-python3 -m venv .venv
-source .venv/bin/activate
-```
-
-Install python packages:
-
-
-```bash
-pip install -r requirements.txt
-```
-
-# Protobuf
-
-`shell.nix` contains a few python3 packages in particular for proto generation.
-From within the `rpc/proto` run:
-
-```bash
-python -m grpc_tools.protoc -I . --proto_path=. --python_out=. --grpc_python_out=. mayastor.proto
-```
-
-And copy them (yes -- on the TODO list) over when they where updated, such that:
-
-```bash
-docker-compose.yml  mayastor_pb2_grpc.py  mayastor_pb2.py  nexus.py  README.md  requirements.txt
-```
+`nix-shell` and have fun.
 
 # TODO:
  [ ] fix proto generation

--- a/test/python/common/command.py
+++ b/test/python/common/command.py
@@ -1,0 +1,34 @@
+import asyncio
+from collections import namedtuple
+
+CommandReturn = namedtuple("CommandReturn", "returncode stdout stderr")
+
+
+async def run_cmd_async(cmd):
+    proc = await asyncio.create_subprocess_shell(
+        cmd,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE)
+    stdout, stderr = await proc.communicate()
+
+    output_message = f"\n[{proc.pid}] Command:\n{cmd}"
+    # Append stdout/stderr to the output message
+    if stdout.decode() != "":
+        output_message += f"\n[{proc.pid}] stdout:\n{stdout.decode()}"
+    if stderr.decode() != "":
+        output_message += f"\n[{proc.pid}] stderr:\n{stderr.decode()}"
+
+    # If a non-zero return code was thrown, raise an exception
+    if proc.returncode != 0:
+        output_message += \
+            f"\nReturned error code: {proc.returncode}"
+
+        if stderr.decode() != "":
+            output_message += \
+                f"\nstderr:\n{stderr.decode()}"
+        raise ChildProcessError(output_message)
+
+    return CommandReturn(
+        proc.returncode,
+        stdout.decode(),
+        stderr.decode())

--- a/test/python/common/command.py
+++ b/test/python/common/command.py
@@ -1,7 +1,12 @@
 import asyncio
 from collections import namedtuple
 import asyncssh
+import subprocess
 CommandReturn = namedtuple("CommandReturn", "returncode stdout stderr")
+
+
+def run_cmd(cmd, check=True):
+    subprocess.run(cmd, shell=True, check=check)
 
 
 async def run_cmd_async(cmd):
@@ -40,7 +45,7 @@ async def run_cmd_async_at(host, cmd):
     async with asyncssh.connect(host) as conn:
         result = await conn.run(cmd, check=False)
 
-        output_message = f"Command:\n {host}:{cmd}"
+        output_message = f"Command: {host}:{cmd}\n"
         # Append stdout/stderr to the output message
         if result.stdout != "":
             output_message += f"\nstdout:\n{result.stdout}"

--- a/test/python/common/fio.py
+++ b/test/python/common/fio.py
@@ -15,10 +15,18 @@ class Fio(object):
         self.runtime = runtime
 
     def build(self) -> str:
+        if isinstance(self.device, str):
+            devs = [self.device]
+        else:
+            devs = self.device
+
         command = ("sudo fio --ioengine=linuxaio --direct=1 --bs=4k "
                    "--time_based=1 --rw={} "
                    "--group_reporting=1 --norandommap=1 --iodepth=64 "
-                   "--runtime={} --name={} --filename={}").format(
-            self.rw, self.runtime, self.name, self.device)
+                   "--runtime={} --name={} --filename={}").format(self.rw,
+                                                       self.runtime,
+                                                       self.name,
+                                                       " --filename=".join(map(str,
+                                                                               devs)))
 
         return command

--- a/test/python/common/fio.py
+++ b/test/python/common/fio.py
@@ -1,8 +1,7 @@
-import sys
-import subprocess
 import shutil
 from common.command import run_cmd_async
 import asyncio
+
 
 class Fio(object):
 
@@ -15,11 +14,11 @@ class Fio(object):
         self.success = {}
         self.runtime = runtime
 
-    async def run(self):
+    def build(self) -> str:
         command = ("sudo fio --ioengine=linuxaio --direct=1 --bs=4k "
                    "--time_based=1 --rw={} "
                    "--group_reporting=1 --norandommap=1 --iodepth=64 "
                    "--runtime={} --name={} --filename={}").format(
             self.rw, self.runtime, self.name, self.device)
 
-        await asyncio.wait_for(run_cmd_async(command), self.runtime + 5)
+        return command

--- a/test/python/common/fio.py
+++ b/test/python/common/fio.py
@@ -1,0 +1,25 @@
+import sys
+import subprocess
+import shutil
+from common.command import run_cmd_async
+import asyncio
+
+class Fio(object):
+
+    def __init__(self, name, rw, device, runtime=15):
+        self.name = name
+        self.rw = rw
+        self.device = device
+        self.cmd = shutil.which("fio")
+        self.output = {}
+        self.success = {}
+        self.runtime = runtime
+
+    async def run(self):
+        command = ("sudo fio --ioengine=linuxaio --direct=1 --bs=4k "
+                   "--time_based=1 --rw={} "
+                   "--group_reporting=1 --norandommap=1 --iodepth=64 "
+                   "--runtime={} --name={} --filename={}").format(
+            self.rw, self.runtime, self.name, self.device)
+
+        await asyncio.wait_for(run_cmd_async(command), self.runtime + 5)

--- a/test/python/common/fio_spdk.py
+++ b/test/python/common/fio_spdk.py
@@ -1,0 +1,31 @@
+import asyncio
+import os
+import shutil
+from common.command import run_cmd_async
+from urllib.parse import urlparse
+
+class FioSpdk(object):
+
+    def __init__(self, name, rw, uri, runtime=15):
+        self.name = name
+        self.rw = rw
+        u = urlparse(uri)
+        self.host = u.hostname
+        self.port = u.port
+        self.nqn = u.path[1:]
+        self.cmd = shutil.which("fio")
+        self.runtime = runtime
+
+    async def run(self):
+        spdk_path = os.environ.get('SPDK_PATH')
+        if spdk_path == None:
+            spdk_path = os.getcwd() + '/../../spdk-sys/spdk/build'
+        command = ("sudo LD_PRELOAD={}/fio/spdk_nvme fio --ioengine=spdk "
+                   "--direct=1 --bs=4k --time_based=1 --runtime=15 "
+                   "--thread=1 --rw={} --group_reporting=1 --norandommap=1 "
+                   "--iodepth=64 --name={} --filename=\'trtype=tcp "
+                   "adrfam=IPv4 traddr={} trsvcid={} subnqn={} ns=1\'").format(
+            spdk_path, self.rw, self.name, self.host, self.port,
+            self.nqn.replace(":", "\\:"))
+
+        await asyncio.wait_for(run_cmd_async(command), self.runtime + 5)

--- a/test/python/common/fio_spdk.py
+++ b/test/python/common/fio_spdk.py
@@ -4,6 +4,7 @@ import shutil
 from common.command import run_cmd_async
 from urllib.parse import urlparse
 
+
 class FioSpdk(object):
 
     def __init__(self, name, rw, uri, runtime=15):
@@ -18,7 +19,7 @@ class FioSpdk(object):
 
     async def run(self):
         spdk_path = os.environ.get('SPDK_PATH')
-        if spdk_path == None:
+        if spdk_path is None:
             spdk_path = os.getcwd() + '/../../spdk-sys/spdk/build'
         command = ("sudo LD_PRELOAD={}/fio/spdk_nvme fio --ioengine=spdk "
                    "--direct=1 --bs=4k --time_based=1 --runtime=15 "

--- a/test/python/common/hdl.py
+++ b/test/python/common/hdl.py
@@ -1,0 +1,110 @@
+"""Common code that represents a mayastor handle."""
+import mayastor_pb2 as pb
+import grpc
+import mayastor_pb2_grpc as rpc
+
+pytest_plugins = ["docker_compose"]
+
+
+class MayastorHandle(object):
+    """Mayastor gRPC handle."""
+
+    def __init__(self, ip_v4):
+        """Init."""
+        self.ip_v4 = ip_v4
+        self.channel = grpc.insecure_channel(("%s:10124") % self.ip_v4)
+        self.bdev = rpc.BdevRpcStub(self.channel)
+        self.ms = rpc.MayastorStub(self.channel)
+        self.bdev_list()
+        self.pool_list()
+
+    def __del__(self):
+        del self.channel
+
+    def close(self):
+        self.__del__()
+
+    def as_target(self) -> str:
+        """Returns this node as scheme which is used to designate this node to
+        be used as the node where the nexus shall be created on."""
+        node = "nvmt://{0}".format(self.ip_v4)
+        return node
+
+    def bdev_create(self, uri):
+        """create the bdev using the specific URI where URI can be one of the
+        following supported schemes:
+
+            nvmf://
+            aio://
+            uring://
+            malloc://
+
+        Note that we do not check the URI schemes, as this should be done in
+        mayastor as this is for testing, we do not want to prevent parsing
+        invalid schemes."""
+
+        return self.bdev.Create(pb.BdevUri(uri=uri)).uri
+
+    def pool_create(self, name, bdev):
+        """Create a pool with given name on this node using the bdev as the
+        backend device. The bdev is implicitly created."""
+
+        disks = []
+        disks.append(bdev)
+        return self.ms.CreatePool(pb.CreatePoolRequest(name=name, disks=disks))
+
+    def pool_destroy(self, name):
+        """Destroy  the pool."""
+        return self.ms.DestroyPool(pb.DestroyPoolRequest(name=name))
+
+    def replica_create(self, pool, uuid, size):
+        """Create  a replica on the pool with the specified UUID and size."""
+        return self.ms.CreateReplica(
+            pb.CreateReplicaRequest(
+                pool=pool, uuid=str(uuid), size=size, thin=False, share=1
+            )
+        )
+
+    def replica_destroy(self, uuid):
+        """Destroy the replica by the UUID, the pool is resolved within
+        mayastor."""
+        return self.ms.DestroyReplica(pb.DestroyReplicaRequest(uuid=uuid))
+
+    def nexus_create(self, uuid, size, children):
+        """Create a nexus with the given uuid and size. The children are
+        should be an array of nvmf URIs."""
+        return self.ms.CreateNexus(
+            pb.CreateNexusRequest(uuid=str(uuid), size=size, children=children)
+        )
+
+    def nexus_destroy(self, uuid):
+        """Destroy the nexus."""
+        return self.ms.DestroyNexus(pb.DestroyNexusRequest(uuid=uuid))
+
+    def nexus_publish(self, uuid):
+        """Publish the nexus. this is the same as bdev_share() but is not used
+        by the control plane."""
+        return self.ms.PublishNexus(
+            pb.PublishNexusRequest(
+                uuid=uuid, key="", share=1)).device_uri
+
+    def nexus_unpublish(self, uuid):
+        """Unpublish the nexus."""
+        return self.ms.UnpublishNexus(pb.UnpublishNexusRequest(uuid=uuid))
+
+    def bdev_list(self):
+        """"List all bdevs found within the system."""
+        return self.bdev.List(pb.Null(), wait_for_ready=True)
+
+    def pool_list(self):
+        """Only list pools"""
+        return self.ms.ListPools(pb.Null(), wait_for_ready=True)
+
+    def pools_as_uris(self):
+        """Return a list of pools as found on the system."""
+        uris = []
+        pools = self.ms.ListPools(pb.Null(), wait_for_ready=True)
+        for p in pools.pools:
+            uri = "pool://{0}/{1}".format(self.ip_v4, p.name)
+            uris.append(uri)
+        return uris

--- a/test/python/common/nvme.py
+++ b/test/python/common/nvme.py
@@ -2,20 +2,69 @@ from urllib.parse import urlparse
 import subprocess
 import time
 import json
+from common.command import run_cmd_async_at
 
 
-def nvme_connect(uri):
+async def nvme_remote_connect(remote, uri):
     """Connect to the remote nvmf target on this host."""
     u = urlparse(uri)
     port = u.port
     host = u.hostname
     nqn = u.path[1:]
-    uuid = nqn.split("nexus-")
+
+    command = "sudo nvme connect -t tcp -s {0} -a {1} -n {2}".format(
+        port, host, nqn)
+
+    await run_cmd_async_at(remote, command)
+    time.sleep(1)
+    command = "sudo nvme list -v -o json"
+
+    discover = await run_cmd_async_at(remote, command)
+    discover = json.loads(discover.stdout)
+
+    dev = list(
+        filter(
+            lambda d: nqn in d.get("SubsystemNQN"),
+            discover.get("Devices")))
+
+    # we should only have one connection
+    assert len(dev) == 1
+    dev_path = dev[0].get('Controllers')[0].get(
+        'Namespaces')[0].get('NameSpace')
+
+    return f"/dev/{dev_path}"
+
+
+async def nvme_remote_disconnect(remote, uri):
+    """Disconnect the given URI on this host."""
+    u = urlparse(uri)
+    nqn = u.path[1:]
+
+    command = "sudo nvme disconnect -n {0}".format(nqn)
+    await run_cmd_async_at(remote, command)
+
+
+async def nvme_remote_discover(remote, uri):
+    """Discover target."""
+    u = urlparse(uri)
+    port = u.port
+    host = u.hostname
+
+    command = "sudo nvme discover -t tcp -s {0} -a {1}".format(port, host)
+    output = await run_cmd_async_at(remote, command).stdout
+    if not u.path[1:] in str(output.stdout):
+        raise ValueError("uri {} is not discovered".format(u.path[1:]))
+
+
+def nvme_connect(uri):
+    u = urlparse(uri)
+    port = u.port
+    host = u.hostname
+    nqn = u.path[1:]
 
     command = "sudo nvme connect -t tcp -s {0} -a {1} -n {2}".format(
         port, host, nqn)
     subprocess.run(command, check=True, shell=True, capture_output=False)
-    print("connected to {}".format(uri))
     time.sleep(1)
     command = "sudo nvme list -v -o json"
     discover = json.loads(
@@ -50,7 +99,6 @@ def nvme_discover(uri):
         shell=True,
         capture_output=True,
         encoding="utf-8")
-    print(output.stdout)
     if not u.path[1:] in str(output.stdout):
         raise ValueError("uri {} is not discovered".format(u.path[1:]))
 
@@ -61,9 +109,4 @@ def nvme_disconnect(uri):
     nqn = u.path[1:]
 
     command = "sudo nvme disconnect -n {0}".format(nqn)
-    print(subprocess.run(command, check=True, shell=True, capture_output=True))
-    time.sleep(1)
-
-
-def nvme_read():
-    pass
+    subprocess.run(command, check=True, shell=True, capture_output=True)

--- a/test/python/common/nvme.py
+++ b/test/python/common/nvme.py
@@ -1,0 +1,69 @@
+from urllib.parse import urlparse
+import subprocess
+import time
+import json
+
+
+def nvme_connect(uri):
+    """Connect to the remote nvmf target on this host."""
+    u = urlparse(uri)
+    port = u.port
+    host = u.hostname
+    nqn = u.path[1:]
+    uuid = nqn.split("nexus-")
+
+    command = "sudo nvme connect -t tcp -s {0} -a {1} -n {2}".format(
+        port, host, nqn)
+    subprocess.run(command, check=True, shell=True, capture_output=False)
+    print("connected to {}".format(uri))
+    time.sleep(1)
+    command = "sudo nvme list -v -o json"
+    discover = json.loads(
+        subprocess.run(
+            command,
+            shell=True,
+            check=True,
+            text=True,
+            capture_output=True).stdout)
+
+    dev = list(
+        filter(
+            lambda d: nqn in d.get("SubsystemNQN"),
+            discover.get("Devices")))
+
+    # we should only have one connection
+    assert len(dev) == 1
+    device = "/dev/{}".format(dev[0].get('Namespaces')[0].get('NameSpace'))
+    return device
+
+
+def nvme_discover(uri):
+    """Discover target."""
+    u = urlparse(uri)
+    port = u.port
+    host = u.hostname
+
+    command = "sudo nvme discover -t tcp -s {0} -a {1}".format(port, host)
+    output = subprocess.run(
+        command,
+        check=True,
+        shell=True,
+        capture_output=True,
+        encoding="utf-8")
+    print(output.stdout)
+    if not u.path[1:] in str(output.stdout):
+        raise ValueError("uri {} is not discovered".format(u.path[1:]))
+
+
+def nvme_disconnect(uri):
+    """Disconnect the given URI on this host."""
+    u = urlparse(uri)
+    nqn = u.path[1:]
+
+    command = "sudo nvme disconnect -n {0}".format(nqn)
+    print(subprocess.run(command, check=True, shell=True, capture_output=True))
+    time.sleep(1)
+
+
+def nvme_read():
+    pass

--- a/test/python/common/volume.py
+++ b/test/python/common/volume.py
@@ -1,0 +1,48 @@
+from common.hdl import MayastorHandle
+from urllib.parse import urlparse
+
+
+class Volume(object):
+    """
+    pool://hostname/pool_name
+
+    The nvmt should be in the form of:
+
+    nvmt://hostname
+    """
+
+    def __init__(self, uuid, nexus_node, pools, size):
+        self.uuid = str(uuid)
+        self.pools = pools
+        self.nexus = nexus_node
+        self.size = size
+
+    def __parse_uri(self, uri):
+        """
+        private function that parses the URI
+        """
+        u = urlparse(uri)
+        return (u.scheme, u.hostname, u.path[1:])
+
+    def __create_replicas(self):
+        """
+        private function that creates the replica and shares it. Note that
+        nvmf is used implicitly here
+
+        """
+        replicas = []
+        for pool in self.pools:
+            scheme, host, pool = self.__parse_uri(pool)
+            assert scheme == "pool"
+            handle = MayastorHandle(host)
+            replicas.append(handle.replica_create(pool, self.uuid, self.size))
+        return replicas
+
+    def create(self) -> str:
+        s, h, p = self.__parse_uri(self.nexus)
+        assert s == "nvmt"
+
+        replicas = [r.uri for r in self.__create_replicas()]
+        handle = MayastorHandle(h)
+        handle.nexus_create(self.uuid, self.size, replicas)
+        return handle.nexus_publish(self.uuid).device_uri

--- a/test/python/conftest.py
+++ b/test/python/conftest.py
@@ -1,134 +1,59 @@
-"""Default fixtures that are considered to be reusable."""
+"""Default fixtures that are considered to be reusable. These are all function scoped."""
 
 import logging
 
 import pytest
 from common.hdl import MayastorHandle
 import mayastor_pb2 as pb
+import os
 
 pytest_plugins = ["docker_compose"]
 
 
-@pytest.fixture(scope="module")
-def wait_for_mayastor(docker_project, module_scoped_container_getter):
-    """Fixture to get a reference to mayastor handles."""
+@pytest.fixture
+def target_vm():
+    try:
+        return os.environ.get("TARGET_VM")
+    except Exception as e:
+        print("the environment variable TARGET_VM must be set to a valid host")
+        raise(e)
+
+
+@pytest.fixture(scope="function")
+def create_temp_files(containers):
+    """Create temp files for each run so we start out clean."""
+    for name in containers:
+        run_cmd(f"rm -rf /tmp/{name}.img", True)
+    for name in containers:
+        run_cmd(f"truncate -s 1G /tmp/{name}.img", True)
+
+
+def check_size(prev, current, delta):
+    """Validate that replica creation consumes space on the pool."""
+    before = prev.pools[0].used
+    after = current.pools[0].used
+    assert delta == (before - after) >> 20
+
+
+@pytest.fixture(scope="function")
+def mayastors(docker_project, function_scoped_container_getter):
+    """Fixture to get a reference to mayastor gRPC handles."""
     project = docker_project
     handles = {}
     for name in project.service_names:
         # because we use static networks .get_service() does not work
-        services = module_scoped_container_getter.get(name)
+        services = function_scoped_container_getter.get(name)
         ip_v4 = services.get(
             "NetworkSettings.Networks.python_mayastor_net.IPAddress")
         handles[name] = MayastorHandle(ip_v4)
     yield handles
 
 
-@pytest.fixture(scope="module")
-def container_ref(docker_project, module_scoped_container_getter):
+@pytest.fixture(scope="function")
+def containers(docker_project, function_scoped_container_getter):
     """Fixture to get handles to mayastor as well as the containers."""
     project = docker_project
     containers = {}
     for name in project.service_names:
-        containers[name] = module_scoped_container_getter.get(name)
+        containers[name] = function_scoped_container_getter.get(name)
     yield containers
-
-
-@pytest.fixture
-def pool_config():
-    """
-    The idea is this used to obtain the pool types and names that should be
-    created.
-    """
-    pool = {}
-    pool['name'] = "tpool"
-    pool['uri'] = "malloc:///disk0?size_mb=100"
-    return pool
-
-
-@pytest.fixture
-def replica_uuid():
-    """Replica UUID's to be used."""
-    UUID = "0000000-0000-0000-0000-000000000001"
-    size_mb = 64 * 1024 * 1024
-    return (UUID, size_mb)
-
-
-@pytest.fixture
-def nexus_uuid():
-    """Nexus UUID's to be used."""
-    NEXUS_UUID = "3ae73410-6136-4430-a7b5-cbec9fe2d273"
-    size_mb = 64 * 1024 * 1024
-    return (NEXUS_UUID, size_mb)
-
-
-@pytest.fixture
-def create_pools(
-        wait_for_mayastor,
-        container_ref,
-        pool_config):
-    hdls = wait_for_mayastor
-
-    cfg = pool_config
-    pools = []
-
-    pools.append(hdls['ms1'].pool_create(cfg.get('name'),
-                                         cfg.get('uri')))
-
-    pools.append(hdls['ms2'].pool_create(cfg.get('name'),
-                                         cfg.get('uri')))
-
-    for p in pools:
-        assert p.state == pb.POOL_ONLINE
-    yield pools
-    try:
-        hdls['ms1'].pool_destroy(cfg.get('name'))
-        hdls['ms2'].pool_destroy(cfg.get('name'))
-    except Exception:
-        pass
-
-
-@pytest.fixture
-def create_replica(
-        wait_for_mayastor,
-        pool_config,
-        replica_uuid,
-        create_pools):
-    hdls = wait_for_mayastor
-    pools = create_pools
-    replicas = []
-
-    UUID, size_mb = replica_uuid
-
-    replicas.append(hdls['ms1'].replica_create(pools[0].name,
-                                               UUID, size_mb))
-    replicas.append(hdls['ms2'].replica_create(pools[0].name,
-                                               UUID, size_mb))
-
-    yield replicas
-    try:
-        hdls['ms1'].replica_destroy(UUID)
-        hdls['ms2'].replica_destroy(UUID)
-    except Exception as e:
-        logging.debug(e)
-
-
-@pytest.fixture
-def create_nexus(wait_for_mayastor, container_ref, nexus_uuid, create_replica):
-    hdls = wait_for_mayastor
-    replicas = create_replica
-    replicas = [k.uri for k in replicas]
-
-    NEXUS_UUID, size_mb = nexus_uuid
-
-    hdls['ms3'].nexus_create(NEXUS_UUID, 64 * 1024 * 1024, replicas)
-    uri = hdls['ms3'].nexus_publish(NEXUS_UUID)
-
-    assert len(hdls['ms1'].bdev_list().bdevs) == 2
-    assert len(hdls['ms2'].bdev_list().bdevs) == 2
-    assert len(hdls['ms3'].bdev_list().bdevs) == 1
-
-    assert len(hdls['ms1'].pool_list().pools) == 1
-    assert len(hdls['ms2'].pool_list().pools) == 1
-
-    yield uri
-    hdls['ms3'].nexus_destroy(NEXUS_UUID)

--- a/test/python/conftest.py
+++ b/test/python/conftest.py
@@ -1,0 +1,134 @@
+"""Default fixtures that are considered to be reusable."""
+
+import logging
+
+import pytest
+from common.hdl import MayastorHandle
+import mayastor_pb2 as pb
+
+pytest_plugins = ["docker_compose"]
+
+
+@pytest.fixture(scope="module")
+def wait_for_mayastor(docker_project, module_scoped_container_getter):
+    """Fixture to get a reference to mayastor handles."""
+    project = docker_project
+    handles = {}
+    for name in project.service_names:
+        # because we use static networks .get_service() does not work
+        services = module_scoped_container_getter.get(name)
+        ip_v4 = services.get(
+            "NetworkSettings.Networks.python_mayastor_net.IPAddress")
+        handles[name] = MayastorHandle(ip_v4)
+    yield handles
+
+
+@pytest.fixture(scope="module")
+def container_ref(docker_project, module_scoped_container_getter):
+    """Fixture to get handles to mayastor as well as the containers."""
+    project = docker_project
+    containers = {}
+    for name in project.service_names:
+        containers[name] = module_scoped_container_getter.get(name)
+    yield containers
+
+
+@pytest.fixture
+def pool_config():
+    """
+    The idea is this used to obtain the pool types and names that should be
+    created.
+    """
+    pool = {}
+    pool['name'] = "tpool"
+    pool['uri'] = "malloc:///disk0?size_mb=100"
+    return pool
+
+
+@pytest.fixture
+def replica_uuid():
+    """Replica UUID's to be used."""
+    UUID = "0000000-0000-0000-0000-000000000001"
+    size_mb = 64 * 1024 * 1024
+    return (UUID, size_mb)
+
+
+@pytest.fixture
+def nexus_uuid():
+    """Nexus UUID's to be used."""
+    NEXUS_UUID = "3ae73410-6136-4430-a7b5-cbec9fe2d273"
+    size_mb = 64 * 1024 * 1024
+    return (NEXUS_UUID, size_mb)
+
+
+@pytest.fixture
+def create_pools(
+        wait_for_mayastor,
+        container_ref,
+        pool_config):
+    hdls = wait_for_mayastor
+
+    cfg = pool_config
+    pools = []
+
+    pools.append(hdls['ms1'].pool_create(cfg.get('name'),
+                                         cfg.get('uri')))
+
+    pools.append(hdls['ms2'].pool_create(cfg.get('name'),
+                                         cfg.get('uri')))
+
+    for p in pools:
+        assert p.state == pb.POOL_ONLINE
+    yield pools
+    try:
+        hdls['ms1'].pool_destroy(cfg.get('name'))
+        hdls['ms2'].pool_destroy(cfg.get('name'))
+    except Exception:
+        pass
+
+
+@pytest.fixture
+def create_replica(
+        wait_for_mayastor,
+        pool_config,
+        replica_uuid,
+        create_pools):
+    hdls = wait_for_mayastor
+    pools = create_pools
+    replicas = []
+
+    UUID, size_mb = replica_uuid
+
+    replicas.append(hdls['ms1'].replica_create(pools[0].name,
+                                               UUID, size_mb))
+    replicas.append(hdls['ms2'].replica_create(pools[0].name,
+                                               UUID, size_mb))
+
+    yield replicas
+    try:
+        hdls['ms1'].replica_destroy(UUID)
+        hdls['ms2'].replica_destroy(UUID)
+    except Exception as e:
+        logging.debug(e)
+
+
+@pytest.fixture
+def create_nexus(wait_for_mayastor, container_ref, nexus_uuid, create_replica):
+    hdls = wait_for_mayastor
+    replicas = create_replica
+    replicas = [k.uri for k in replicas]
+
+    NEXUS_UUID, size_mb = nexus_uuid
+
+    hdls['ms3'].nexus_create(NEXUS_UUID, 64 * 1024 * 1024, replicas)
+    uri = hdls['ms3'].nexus_publish(NEXUS_UUID)
+
+    assert len(hdls['ms1'].bdev_list().bdevs) == 2
+    assert len(hdls['ms2'].bdev_list().bdevs) == 2
+    assert len(hdls['ms3'].bdev_list().bdevs) == 1
+
+    assert len(hdls['ms1'].pool_list().pools) == 1
+    assert len(hdls['ms2'].pool_list().pools) == 1
+
+    yield uri
+    hdls['ms3'].nexus_destroy(NEXUS_UUID)

--- a/test/python/docker-compose.yml
+++ b/test/python/docker-compose.yml
@@ -4,16 +4,38 @@
 
 version: '3'
 services:
+  ms0:
+    container_name: "ms0"
+    image: rust:latest
+    environment:
+        - MY_POD_IP=10.0.0.2
+    command: ${SRCDIR}/target/debug/mayastor -g 0.0.0.0 -l 1,2 -r /tmp/ms0.sock
+    networks:
+      mayastor_net:
+        ipv4_address: 10.0.0.2
+    cap_add:
+      # NUMA related
+      - SYS_ADMIN
+      - SYS_NICE
+      # uring needs mmap
+      - IPC_LOCK
+    security_opt:
+      # we can set this to a JSON file to allow per syscall access
+      - seccomp:unconfined
+    volumes:
+      - ${SRCDIR}:${SRCDIR}
+      - /nix:/nix
+      - /dev/hugepages:/dev/hugepages
+      - /tmp:/tmp
   ms1:
     container_name: "ms1"
     image: rust:latest
     environment:
-        - MY_POD_IP=10.0.0.2
-        - RUST_LOG=mayastor=trace
-    command: ${SRCDIR}/target/debug/mayastor -g 0.0.0.0 -l 1,2 -r /tmp/ms1.sock
+        - MY_POD_IP=10.0.0.3
+    command: ${SRCDIR}/target/debug/mayastor -g 0.0.0.0 -l 3,4 -r /tmp/ms1.sock
     networks:
       mayastor_net:
-        ipv4_address: 10.0.0.2
+        ipv4_address: 10.0.0.3
     cap_add:
       # NUMA related
       - SYS_ADMIN
@@ -32,12 +54,11 @@ services:
     container_name: "ms2"
     image: rust:latest
     environment:
-        - MY_POD_IP=10.0.0.3
-        - RUST_LOG=mayastor=trace
-    command: ${SRCDIR}/target/debug/mayastor -g 0.0.0.0 -l 3,4 -r /tmp/ms2.sock
+        - MY_POD_IP=10.0.0.4
+    command: ${SRCDIR}/target/debug/mayastor -g 0.0.0.0 -l 5,6 -r /tmp/ms2.sock
     networks:
       mayastor_net:
-        ipv4_address: 10.0.0.3
+        ipv4_address: 10.0.0.4
     cap_add:
       - SYS_ADMIN
       - SYS_NICE
@@ -53,14 +74,14 @@ services:
     container_name: "ms3"
     image: rust:latest
     environment:
-        - NVME_ADMINQ_POLL_PERIOD_US=10000
-        - MY_POD_IP=10.0.0.4
+        - MY_POD_IP=10.0.0.5
         - RUST_BACKTRACE=full
-        - RUST_LOG=mayastor=trace
-    command: ${SRCDIR}/target/debug/mayastor -g 0.0.0.0 -l 5,6 -r /tmp/ms3.sock
+        - RUST_LOG=mayastor=DEBUG
+        - NEXUS_DONT_READ_LABELS=true
+    command: ${SRCDIR}/target/debug/mayastor -g 0.0.0.0 -l 11,12,13,14,15 -r /tmp/ms3.sock
     networks:
       mayastor_net:
-        ipv4_address: 10.0.0.4
+        ipv4_address: 10.0.0.5
     cap_add:
       - SYS_ADMIN
       - SYS_NICE

--- a/test/python/docker-compose.yml
+++ b/test/python/docker-compose.yml
@@ -1,0 +1,80 @@
+#
+# {SRCDIR} should point to your working tree which should be your current pwd
+#
+
+version: '3'
+services:
+  ms1:
+    container_name: "ms1"
+    image: rust:latest
+    environment:
+        - MY_POD_IP=10.0.0.2
+        - RUST_LOG=mayastor=trace
+    command: ${SRCDIR}/target/debug/mayastor -g 0.0.0.0 -l 1,2 -r /tmp/ms1.sock
+    networks:
+      mayastor_net:
+        ipv4_address: 10.0.0.2
+    cap_add:
+      # NUMA related
+      - SYS_ADMIN
+      - SYS_NICE
+      # uring needs mmap
+      - IPC_LOCK
+    security_opt:
+      # we can set this to a JSON file to allow per syscall access
+      - seccomp:unconfined
+    volumes:
+      - ${SRCDIR}:${SRCDIR}
+      - /nix:/nix
+      - /dev/hugepages:/dev/hugepages
+      - /tmp:/tmp
+  ms2:
+    container_name: "ms2"
+    image: rust:latest
+    environment:
+        - MY_POD_IP=10.0.0.3
+        - RUST_LOG=mayastor=trace
+    command: ${SRCDIR}/target/debug/mayastor -g 0.0.0.0 -l 3,4 -r /tmp/ms2.sock
+    networks:
+      mayastor_net:
+        ipv4_address: 10.0.0.3
+    cap_add:
+      - SYS_ADMIN
+      - SYS_NICE
+      - IPC_LOCK
+    security_opt:
+      - seccomp:unconfined
+    volumes:
+      - ${SRCDIR}:${SRCDIR}
+      - /nix:/nix
+      - /dev/hugepages:/dev/hugepages
+      - /tmp:/tmp
+  ms3:
+    container_name: "ms3"
+    image: rust:latest
+    environment:
+        - NVME_ADMINQ_POLL_PERIOD_US=10000
+        - MY_POD_IP=10.0.0.4
+        - RUST_BACKTRACE=full
+        - RUST_LOG=mayastor=trace
+    command: ${SRCDIR}/target/debug/mayastor -g 0.0.0.0 -l 5,6 -r /tmp/ms3.sock
+    networks:
+      mayastor_net:
+        ipv4_address: 10.0.0.4
+    cap_add:
+      - SYS_ADMIN
+      - SYS_NICE
+      - IPC_LOCK
+    security_opt:
+      - seccomp:unconfined
+    volumes:
+      - ${SRCDIR}:${SRCDIR}
+      - /nix:/nix
+      - /dev/hugepages:/dev/hugepages
+      - /tmp:/tmp
+networks:
+  mayastor_net:
+    ipam:
+      driver: default
+      config:
+        - subnet: "10.0.0.0/16"

--- a/test/python/pytest.ini
+++ b/test/python/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-log_level = INFO
-log_cli = true
+log_level = info
+log_cli = false
 
 

--- a/test/python/pytest.ini
+++ b/test/python/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+log_level = INFO
+log_cli = true
+
+

--- a/test/python/pytest.ini
+++ b/test/python/pytest.ini
@@ -1,5 +1,3 @@
 [pytest]
-log_level = info
-log_cli = false
-
-
+log_level = error
+log_cli = true

--- a/test/python/requirements.txt
+++ b/test/python/requirements.txt
@@ -1,6 +1,7 @@
 asyncio
-paramiko
+asyncssh
 pytest
 pytest-timeout
 pytest-docker-compose
 pytest-order
+pytest-asyncio

--- a/test/python/requirements.txt
+++ b/test/python/requirements.txt
@@ -1,0 +1,6 @@
+asyncio
+paramiko
+pytest
+pytest-timeout
+pytest-docker-compose
+pytest-order

--- a/test/python/requirements.txt
+++ b/test/python/requirements.txt
@@ -5,3 +5,4 @@ pytest-timeout
 pytest-docker-compose
 pytest-order
 pytest-asyncio
+pytest-variables

--- a/test/python/shell.nix
+++ b/test/python/shell.nix
@@ -1,0 +1,22 @@
+let
+  sources = import ../../nix/sources.nix;
+  pkgs = import sources.nixpkgs {
+    overlays = [
+      (_: _: { inherit sources; })
+      (import ../../nix/mayastor-overlay.nix)
+    ];
+  };
+in
+with pkgs;
+mkShell {
+  buildInputs = [
+    (python3.withPackages (ps: with ps; [ grpcio grpcio-tools ]))
+    python3Packages.virtualenv
+  ];
+  shellHook = ''
+    virtualenv --no-setuptools venv
+    source venv/bin/activate
+    pip install -r requirements.txt
+    python -m grpc_tools.protoc -I `realpath ../../rpc/proto` --python_out=. --grpc_python_out=.  mayastor.proto
+  '';
+}

--- a/test/python/test_multi_nexus.py
+++ b/test/python/test_multi_nexus.py
@@ -1,0 +1,157 @@
+from common.hdl import MayastorHandle
+from common.command import run_cmd, run_cmd_async_at
+from common.nvme import nvme_remote_connect, nvme_remote_disconnect
+from common.fio import Fio
+import pytest
+import asyncio
+import uuid as guid
+
+UUID = "0000000-0000-0000-0000-000000000001"
+NEXUS_UUID = "3ae73410-6136-4430-a7b5-cbec9fe2d273"
+
+
+@pytest.fixture(scope="function")
+def create_temp_files(containers):
+    """Create temp files for each run so we start out clean."""
+    for name in containers:
+        run_cmd(f"rm -rf /tmp/{name}.img", True)
+    for name in containers:
+        run_cmd(f"truncate -s 2G /tmp/{name}.img", True)
+
+
+def check_size(prev, current, delta):
+    """Validate that replica creation consumes space on the pool."""
+    before = prev.pools[0].used
+    after = current.pools[0].used
+    assert delta == (before - after) >> 20
+
+
+@pytest.fixture(scope="function")
+def mayastors(docker_project, function_scoped_container_getter):
+    """Fixture to get a reference to mayastor handles."""
+    project = docker_project
+    handles = {}
+    for name in project.service_names:
+        # because we use static networks .get_service() does not work
+        services = function_scoped_container_getter.get(name)
+        ip_v4 = services.get(
+            "NetworkSettings.Networks.python_mayastor_net.IPAddress")
+        handles[name] = MayastorHandle(ip_v4)
+    yield handles
+
+
+@pytest.fixture(scope="function")
+def containers(docker_project, function_scoped_container_getter):
+    """Fixture to get handles to mayastor as well as the containers."""
+    project = docker_project
+    containers = {}
+    for name in project.service_names:
+        containers[name] = function_scoped_container_getter.get(name)
+    yield containers
+
+
+@pytest.fixture
+def create_pool_on_all_nodes(create_temp_files, containers, mayastors):
+    """Create a pool on each node."""
+    uuids = []
+
+    for name, h in mayastors.items():
+        h.pool_create(f"{name}", f"aio:///tmp/{name}.img")
+        # validate we have zero replicas
+        assert len(h.replica_list().replicas) == 0
+
+    for i in range(30):
+        uuid = guid.uuid4()
+        for name, h in mayastors.items():
+            before = h.pool_list()
+            h.replica_create(name, uuid, 64 * 1024 * 1024)
+            after = h.pool_list()
+            check_size(before, after, -64)
+            # ensure our replica count goes up as expected
+            assert len(h.replica_list().replicas) == i + 1
+
+        uuids.append(uuid)
+    return uuids
+
+
+@pytest.mark.skip
+@pytest.mark.parametrize("times", range(2))
+def test_restart(
+        times,
+        create_pool_on_all_nodes,
+        containers,
+        mayastors):
+    """
+    Test that when we create replicas and destroy them the count is as expected
+    At this point we have 3 nodes each with 15 replica's.
+    """
+
+    node = containers.get("ms1")
+    ms1 = mayastors.get("ms1")
+
+    # kill one of the nodes and validate we indeed have 15 replica's
+    node.kill()
+    node.start()
+    # we must reconnect grpc here..
+    ms1.reconnect()
+    # create does import here if found
+    ms1.pool_create("ms1", "aio:///tmp/ms1.img")
+
+    # check the list has 15 replica's
+    replicas = ms1.replica_list().replicas
+    assert 15 == len(replicas)
+
+    # destroy a few
+    for i in range(7):
+        ms1.replica_destroy(replicas[i].uuid)
+
+    # kill and reconnect
+    node.kill()
+    node.start()
+    ms1.reconnect()
+
+    # validate we have 8 replicas left
+    ms1.pool_create("ms1", "aio:///tmp/ms1.img")
+    replicas = ms1.replica_list().replicas
+
+    assert 8 == len(replicas)
+
+
+async def kill_after(container, sec):
+    """Kill the given container after sec seconds."""
+    await asyncio.sleep(sec)
+    container.kill()
+
+
+@pytest.mark.asyncio
+async def test_multiple(create_pool_on_all_nodes,
+                        containers,
+                        mayastors,
+                        target_vm):
+
+    ms1 = mayastors.get('ms1')
+    rlist_m2 = mayastors.get('ms2').replica_list().replicas
+    rlist_m3 = mayastors.get('ms3').replica_list().replicas
+    nexus_list = []
+    to_kill = containers.get("ms3")
+
+    devs = []
+
+    for i in range(30):
+        uuid = guid.uuid4()
+        ms1.nexus_create(uuid, 60 * 1024 * 1024,
+                         [rlist_m2.pop().uri, rlist_m3.pop().uri])
+        nexus_list.append(ms1.nexus_publish(uuid))
+
+    for nexus in nexus_list:
+        dev = await nvme_remote_connect(target_vm, nexus)
+        devs.append(dev)
+
+    fio_cmd = Fio(f"job-{dev}", "randwrite", devs).build()
+
+    await asyncio.gather(run_cmd_async_at(target_vm, fio_cmd),
+                         kill_after(to_kill, 3),
+                         )
+
+    for nexus in nexus_list:
+        dev = await nvme_remote_disconnect(target_vm, nexus)

--- a/test/python/test_nexus.py
+++ b/test/python/test_nexus.py
@@ -1,11 +1,13 @@
 from common.command import run_cmd_async_at, run_cmd_async
 from common.fio import Fio
 from common.volume import Volume
+from common.hdl import MayastorHandle
 import logging
 import pytest
 import uuid as guid
 import grpc
 import asyncio
+import mayastor_pb2 as pb
 from common.nvme import (
     nvme_discover,
     nvme_connect,
@@ -13,8 +15,127 @@ from common.nvme import (
     nvme_remote_connect,
     nvme_remote_disconnect)
 
-UUID = "0000000-0000-0000-0000-000000000001"
-NEXUS_UUID = "3ae73410-6136-4430-a7b5-cbec9fe2d273"
+@pytest.fixture
+def create_nexus(wait_for_mayastor, containers, nexus_uuid, create_replica):
+    hdls = wait_for_mayastor
+    replicas = create_replica
+    replicas = [k.uri for k in replicas]
+
+    NEXUS_UUID, size_mb = nexus_uuid
+
+    hdls['ms3'].nexus_create(NEXUS_UUID, 64 * 1024 * 1024, replicas)
+    uri = hdls['ms3'].nexus_publish(NEXUS_UUID)
+    assert len(hdls['ms1'].bdev_list()) == 2
+    assert len(hdls['ms2'].bdev_list()) == 2
+    assert len(hdls['ms3'].bdev_list()) == 1
+
+    assert len(hdls['ms1'].pool_list().pools) == 1
+    assert len(hdls['ms2'].pool_list().pools) == 1
+
+    yield uri
+    hdls['ms3'].nexus_destroy(NEXUS_UUID)
+
+@pytest.fixture
+def pool_config():
+    """
+    The idea is this used to obtain the pool types and names that should be
+    created.
+    """
+    pool = {}
+    pool['name'] = "tpool"
+    pool['uri'] = "malloc:///disk0?size_mb=100"
+    return pool
+
+
+@pytest.fixture(scope="module")
+def containers(docker_project, module_scoped_container_getter):
+    """Fixture to get handles to mayastor as well as the containers."""
+    project = docker_project
+    containers = {}
+    for name in project.service_names:
+        containers[name] = module_scoped_container_getter.get(name)
+    yield containers
+
+
+@pytest.fixture(scope="module")
+def wait_for_mayastor(docker_project, module_scoped_container_getter):
+    """Fixture to get a reference to mayastor gRPC handles"""
+    project = docker_project
+    handles = {}
+    for name in project.service_names:
+        # because we use static networks .get_service() does not work
+        services = module_scoped_container_getter.get(name)
+        ip_v4 = services.get(
+            "NetworkSettings.Networks.python_mayastor_net.IPAddress")
+        handles[name] = MayastorHandle(ip_v4)
+    yield handles
+
+
+@pytest.fixture
+def replica_uuid():
+    """Replica UUID's to be used."""
+    UUID = "0000000-0000-0000-0000-000000000001"
+    size_mb = 64 * 1024 * 1024
+    return (UUID, size_mb)
+
+
+@pytest.fixture
+def nexus_uuid():
+    """Nexus UUID's to be used."""
+    NEXUS_UUID = "3ae73410-6136-4430-a7b5-cbec9fe2d273"
+    size_mb = 64 * 1024 * 1024
+    return (NEXUS_UUID, size_mb)
+
+
+@pytest.fixture
+def create_pools(
+        wait_for_mayastor,
+        containers,
+        pool_config):
+    hdls = wait_for_mayastor
+
+    cfg = pool_config
+    pools = []
+
+    pools.append(hdls['ms1'].pool_create(cfg.get('name'),
+                                         cfg.get('uri')))
+
+    pools.append(hdls['ms2'].pool_create(cfg.get('name'),
+                                         cfg.get('uri')))
+
+    for p in pools:
+        assert p.state == pb.POOL_ONLINE
+    yield pools
+    try:
+        hdls['ms1'].pool_destroy(cfg.get('name'))
+        hdls['ms2'].pool_destroy(cfg.get('name'))
+    except Exception:
+        pass
+
+
+@pytest.fixture
+def create_replica(
+        wait_for_mayastor,
+        pool_config,
+        replica_uuid,
+        create_pools):
+    hdls = wait_for_mayastor
+    pools = create_pools
+    replicas = []
+
+    UUID, size_mb = replica_uuid
+
+    replicas.append(hdls['ms1'].replica_create(pools[0].name,
+                                               UUID, size_mb))
+    replicas.append(hdls['ms2'].replica_create(pools[0].name,
+                                               UUID, size_mb))
+
+    yield replicas
+    try:
+        hdls['ms1'].replica_destroy(UUID)
+        hdls['ms2'].replica_destroy(UUID)
+    except Exception as e:
+        logging.debug(e)
 
 
 @pytest.mark.skip
@@ -46,7 +167,7 @@ def destroy_all(wait_for_mayastor):
 
 
 @pytest.mark.skip
-def test_multi_volume_local(wait_for_mayastor, create_aio_pools):
+def test_multi_volume_local(wait_for_mayastor, create_pools):
     hdls = wait_for_mayastor
     # contains the replicas
 
@@ -99,9 +220,9 @@ async def kill_after(container, sec):
 @pytest.mark.skip
 @pytest.mark.asyncio
 @pytest.mark.timeout(60)
-async def test_nexus_2_mirror_kill_one(container_ref, create_nexus):
+async def test_nexus_2_mirror_kill_one(containers, create_nexus):
 
-    to_kill = container_ref.get("ms2")
+    to_kill = containers.get("ms2")
     uri = create_nexus
 
     nvme_discover(uri)
@@ -113,26 +234,48 @@ async def test_nexus_2_mirror_kill_one(container_ref, create_nexus):
     nvme_disconnect(uri)
 
 
-# @pytest.mark.skip
 @pytest.mark.asyncio
 @pytest.mark.timeout(60)
-async def test_nexus_2_remote_mirror_kill_one(
-        container_ref, create_nexus):
+async def test_nexus_2_remote_mirror_kill_one(target_vm,
+                                              containers, nexus_uuid, wait_for_mayastor, create_nexus):
 
-    containers = container_ref
+    """
+    This test does the following steps:
+
+        - creates mayastor instances
+        - creates pools on mayastor 1 and 2
+        - creates replicas on those pools
+        - creates a nexus on mayastor 3
+        - starts fio on a remote VM (vixos1) for 15 secondsj
+        - kills mayastor 2 after 4 seconds
+        - assume the test to succeed
+        - disconnect the VM from mayastor 3 when FIO completes
+        - removes the nexus from mayastor 3
+        - removes the replicas but as mayastor 2 is down, will swallow errors
+        - removes the pool
+
+    The bulk of this is done by reusing fixtures those fitures are not as
+    generic as one might like at this point so look/determine if you need them
+    to begin with.
+
+    By yielding from fixtures, after the tests the function is resumed where
+    yield is called.
+    """
+
     uri = create_nexus
+    NEXUS_UUID, size_mb = nexus_uuid
+    dev = await nvme_remote_connect(target_vm, uri)
+    job = Fio("job1", "randwrite", dev).build()
 
-    dev = await nvme_remote_connect("vixos1", uri)
+    # create an event loop polling the async processes for completion
+    await asyncio.gather(
+        run_cmd_async_at(target_vm, job),
+        kill_after(containers.get("ms2"), 4))
 
-    job = Fio("job1", "rw", dev).build()
-    try:
-        await asyncio.gather(
-            run_cmd_async_at("vixos1", job),
-            kill_after(containers.get("ms1"), 5),
-            kill_after(containers.get("ms2"), 4)
-        )
-    except Exception:
-        # expect failure
-        pass
-    finally:
-        await nvme_remote_disconnect("vixos1", uri)
+    list = wait_for_mayastor.get("ms3").nexus_list()
+    nexus = next(n for n in list if n.uuid == NEXUS_UUID)
+    assert nexus.state == pb.NEXUS_DEGRADED
+    nexus.children[1].state == pb.CHILD_FAULTED
+
+    # disconnect the VM from our target before we shutdown
+    await nvme_remote_disconnect(target_vm, uri)

--- a/test/python/test_nexus.py
+++ b/test/python/test_nexus.py
@@ -1,0 +1,114 @@
+import logging
+import pytest
+import mayastor_pb2 as pb
+import uuid as guid
+import grpc
+import asyncio
+from common.nvme import nvme_discover, nvme_connect, nvme_disconnect
+from common.volume import Volume
+from common.fio import Fio
+UUID = "0000000-0000-0000-0000-000000000001"
+NEXUS_UUID = "3ae73410-6136-4430-a7b5-cbec9fe2d273"
+
+
+@pytest.mark.skip
+@pytest.fixture
+def destroy_all(wait_for_mayastor):
+    hdls = wait_for_mayastor
+
+    hdls["ms3"].nexus_destroy(NEXUS_UUID)
+
+    hdls["ms1"].replica_destroy(UUID)
+    hdls["ms2"].replica_destroy(UUID)
+
+    hdls["ms1"].pool_destroy("tpool")
+    hdls["ms2"].pool_destroy("tpool")
+
+    hdls["ms1"].replica_destroy(UUID)
+    hdls["ms2"].replica_destroy(UUID)
+    hdls["ms3"].nexus_destroy(NEXUS_UUID)
+
+    hdls["ms1"].pool_destroy("tpool")
+    hdls["ms2"].pool_destroy("tpool")
+
+    assert len(hdls["ms1"].pool_list().pools) == 0
+    assert len(hdls["ms2"].pool_list().pools) == 0
+
+    assert len(hdls["ms1"].bdev_list().bdevs) == 0
+    assert len(hdls["ms2"].bdev_list().bdevs) == 0
+    assert len(hdls["ms3"].bdev_list().bdevs) == 0
+
+
+@pytest.mark.skip
+def test_multi_volume_local(wait_for_mayastor, create_aio_pools):
+    hdls = wait_for_mayastor
+    # contains the replicas
+
+    ms = hdls.get('ms1')
+
+    for i in range(6):
+        uuid = guid.uuid4()
+        replicas = []
+
+        ms.replica_create("tpool", uuid, 8 * 1024 * 1024)
+
+        replicas.append("bdev:///{}".format(uuid))
+        print(ms.nexus_create(uuid, 4 * 1024 * 1024, replicas))
+
+
+@pytest.mark.parametrize("times", range(50))
+@pytest.mark.skip
+def test_create_nexus_with_two_replica(times, create_nexus):
+    nexus, uri, hdls = create_nexus
+    nvme_discover(uri.device_uri)
+    device = nvme_connect(uri.device_uri)
+    nvme_disconnect(uri.device_uri)
+    destroy_all
+
+
+@pytest.mark.skip
+def test_enospace_on_volume(wait_for_mayastor, create_pools):
+    nodes = wait_for_mayastor
+    pools = []
+    uuid = guid.uuid4()
+
+    pools.append(nodes["ms2"].pools_as_uris()[0])
+    pools.append(nodes["ms1"].pools_as_uris()[0])
+    nexus_node = nodes["ms3"].as_target()
+
+    v = Volume(uuid, nexus_node, pools, 100 * 1024 * 1024)
+
+    with pytest.raises(grpc.RpcError, match='RESOURCE_EXHAUSTED'):
+        _ = v.create()
+    print("expected failed")
+
+
+@pytest.mark.timeout(60)
+def test_nexus_2_mirror_kill_one(container_ref, create_nexus):
+    """Kill the given container after sec seconds."""
+    async def kill_after(container, sec):
+        await asyncio.sleep(sec)
+        logging.info(f"killing container {container}")
+        containers.get(container).kill()
+
+    containers = container_ref
+    uri = create_nexus
+    print(uri)
+
+    # XXX this needs to go to VMs
+    nvme_discover(uri)
+    dev = nvme_connect(uri)
+
+    job = Fio("job1", "rw", dev).run()
+
+    kill_ms1 = kill_after("ms1", 5)
+
+    try:
+        loop = asyncio.get_event_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+
+    loop.run_until_complete(asyncio.gather(job, kill_ms1))
+
+    nvme_disconnect(uri)

--- a/test/python/test_nexus_kill_all.py
+++ b/test/python/test_nexus_kill_all.py
@@ -3,34 +3,68 @@
 import logging
 import pytest
 import asyncio
-from common.nvme import nvme_discover, nvme_connect, nvme_disconnect
+from common.nvme import nvme_remote_disconnect, nvme_remote_connect
 from common.fio import Fio
-from common.command import run_cmd_async
+from common.command import run_cmd_async_at
+import mayastor_pb2 as pb
+
+NEXUS_UUID = "3ae73410-6136-4430-a7b5-cbec9fe2d273"
+
+
+async def kill_after(container, sec):
+    """Kill the given container after sec seconds."""
+    await asyncio.sleep(sec)
+    logging.info(f"killing container {container}")
+    container.kill()
 
 
 @pytest.mark.asyncio
-@pytest.mark.xfail
 @pytest.mark.timeout(60)
-def test_nexus_2_mirror_kill_all(container_ref, create_nexus):
-    """Kill the given container after sec seconds."""
-    async def kill_after(container, sec):
-        await asyncio.sleep(sec)
-        logging.info(f"killing container {container}")
-        containers.get(container).kill()
+async def test_nexus_2_remote_mirror_kill_all(
+        container_ref, wait_for_mayastor, create_nexus):
+
+    """
+
+    This test does the following steps:
+
+        - creates mayastor instances
+        - creates pools on mayastor 1 and 2
+        - creates replicas on those pools
+        - creates a nexus on mayastor 3
+        - starts fio on a remote VM (vixos1) for 15 secondsj
+        - kills mayastor 2 after 4 seconds
+        - kills mayastor 1 after 5 seconds
+        - assume the fail with a ChildProcessError due to Fio bailing out
+        - disconnect the VM from mayastor 3 when has failed
+        - removes the nexus from mayastor 3
+    """
 
     containers = container_ref
     uri = create_nexus
 
-    nvme_discover(uri)
-    dev = nvme_connect(uri)
+    dev = await nvme_remote_connect("vixos1", uri)
 
-    job = Fio("job1", "rw", dev).build()
-    kill_ms1 = kill_after("ms1", 5)
-    kill_ms2 = kill_after("ms2", 6)
+    job = Fio("job1", "randwrite", dev).build()
 
     try:
-        await asyncio.gather(run_cmd_async(job), kill_ms1, kill_ms2)
+        # create an event loop polling the async processes for completion
+        await asyncio.gather(
+            run_cmd_async_at("vixos1", job),
+            kill_after(containers.get("ms2"), 4),
+            kill_after(containers.get("ms1"), 5))
     except ChildProcessError:
         pass
+    except Exception as e:
+        # if its not a child processe error fail the test
+        raise(e)
     finally:
-        nvme_disconnect(uri)
+        list = wait_for_mayastor.get("ms3").nexus_list()
+        nexus = next(n for n in list if n.uuid == NEXUS_UUID)
+
+        assert nexus.state == pb.NEXUS_FAULTED
+
+        nexus.children[0].state == pb.CHILD_FAULTED
+        nexus.children[1].state == pb.CHILD_FAULTED
+
+        # disconnect the VM from our target before we shutdown
+        await nvme_remote_disconnect("vixos1", uri)

--- a/test/python/test_nexus_kill_all.py
+++ b/test/python/test_nexus_kill_all.py
@@ -5,8 +5,10 @@ import pytest
 import asyncio
 from common.nvme import nvme_discover, nvme_connect, nvme_disconnect
 from common.fio import Fio
+from common.command import run_cmd_async
 
 
+@pytest.mark.asyncio
 @pytest.mark.xfail
 @pytest.mark.timeout(60)
 def test_nexus_2_mirror_kill_all(container_ref, create_nexus):
@@ -19,22 +21,15 @@ def test_nexus_2_mirror_kill_all(container_ref, create_nexus):
     containers = container_ref
     uri = create_nexus
 
-    # XXX this needs to go to VMs
     nvme_discover(uri)
     dev = nvme_connect(uri)
 
-    job = Fio("job1", "rw", dev).run()
+    job = Fio("job1", "rw", dev).build()
     kill_ms1 = kill_after("ms1", 5)
     kill_ms2 = kill_after("ms2", 6)
 
     try:
-        loop = asyncio.get_event_loop()
-    except RuntimeError:
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-
-    try:
-        loop.run_until_complete(asyncio.gather(job, kill_ms1, kill_ms2))
+        await asyncio.gather(run_cmd_async(job), kill_ms1, kill_ms2)
     except ChildProcessError:
         pass
     finally:

--- a/test/python/test_nexus_kill_all.py
+++ b/test/python/test_nexus_kill_all.py
@@ -1,0 +1,41 @@
+"""Test that will delete all replica's while under load from the nexus."""
+
+import logging
+import pytest
+import asyncio
+from common.nvme import nvme_discover, nvme_connect, nvme_disconnect
+from common.fio import Fio
+
+
+@pytest.mark.xfail
+@pytest.mark.timeout(60)
+def test_nexus_2_mirror_kill_all(container_ref, create_nexus):
+    """Kill the given container after sec seconds."""
+    async def kill_after(container, sec):
+        await asyncio.sleep(sec)
+        logging.info(f"killing container {container}")
+        containers.get(container).kill()
+
+    containers = container_ref
+    uri = create_nexus
+
+    # XXX this needs to go to VMs
+    nvme_discover(uri)
+    dev = nvme_connect(uri)
+
+    job = Fio("job1", "rw", dev).run()
+    kill_ms1 = kill_after("ms1", 5)
+    kill_ms2 = kill_after("ms2", 6)
+
+    try:
+        loop = asyncio.get_event_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+
+    try:
+        loop.run_until_complete(asyncio.gather(job, kill_ms1, kill_ms2))
+    except ChildProcessError:
+        pass
+    finally:
+        nvme_disconnect(uri)

--- a/test/python/test_null_nexus.py
+++ b/test/python/test_null_nexus.py
@@ -1,0 +1,214 @@
+from common.hdl import MayastorHandle
+from common.command import run_cmd, run_cmd_async_at
+from common.nvme import nvme_remote_connect, nvme_remote_disconnect
+from common.fio import Fio
+import pytest
+import asyncio
+import uuid as guid
+import time
+import mayastor_pb2 as pb
+import random
+# Reusing nexus UUIDs to avoid the need to disconnect between tests
+nexus_uuids = [
+    "78c0e836-ef26-47c2-a136-2a99b538a9a8",
+    "fc2bd1bf-301c-46e7-92e7-71e7a062e2dd",
+    "1edc6a04-74b0-450e-b953-14237a6795de",
+    "70bb42e6-4924-4079-a755-3798015e1319",
+    "9aae12d7-48dd-4fa6-a554-c4d278a9386a",
+    "af8107b6-2a9b-4097-9676-7a0941ba9bf9",
+    "7fde42a4-758b-466e-9755-825328131f67",
+    "6956b466-7491-4b8f-9a97-731bf7c9fd9c",
+    "c5fa226d-b1c7-4102-83b3-7f69ff1b311b",
+    "0cc74b98-fcd9-4a95-93ea-7c921d56c8cc",
+    "460758a4-d87f-4738-8666-cd07c23077db",
+    "63c567c9-75a6-466f-940e-a4ec5163794d",
+    "e425b05c-0730-4c10-8d01-77a2a65b4016",
+    "38d73fea-6f69-4a80-8959-2e2705be0f52",
+    "7eae6f7c-a52a-4689-b591-9642a094b4cc",
+    "52978839-8813-4c38-8665-42a78eeab499",
+    "8dccd362-b0fa-473d-abd3-b9c4d2a95f48",
+    "41dd24c4-8d20-4ee7-b52d-45dfcd580c52",
+    "9d879d46-8f71-4520-8eac-2b749c76adb8",
+    "d53cf04b-032d-412d-822a-e6b8b308bc52",
+    "da6247ab-6c28-429b-8848-c290ee474a81",
+    "71e9aab8-a350-4768-ab56-a2c66fda4e80",
+    "2241726a-487f-4852-8735-ddf849c92145",
+    "dbbbd8d4-96a4-45ae-9403-9dd43e34db6d",
+    "51ceb351-f864-43fc-bf31-3e36f75d8e86",
+    "7f90415a-29b3-41cd-9918-2d35b3b66056",
+    "f594f29c-b227-46a7-b4a6-486243c9f500",
+    "563b91ab-7ffd-44fc-aead-c551e280587a",
+    "8616f575-bcc9-490e-9524-9e6e7d9c76cc",
+    "817d4ca0-1f52-40de-b3d2-e59ce28b05ee",
+    "0a1103de-c466-4f77-88ca-521044b18483",
+    "ef6ff58b-0307-43df-bb87-9db0d06c1818",
+    "615c6fbb-90c1-46d6-b47c-6436a023953d",
+    "201e80b9-9389-4013-ab3c-b85b40d0cb56",
+    "e392187b-657f-4b4b-a249-cae27b7a5ba5",
+    "19e34f44-ff93-437d-9c11-31adfc974d64",
+    "b9542cb0-12e9-4b32-9cab-3b476161e1c6",
+    "3db3bfb9-0453-48bf-bb57-bd51b35e7f77",
+    "10e1f9e8-4cb2-4a79-a3d4-2b6314b58ba7",
+    "5ab8188a-e622-4965-b558-3355a5ceb285",
+    "063e2338-c42a-4aee-b4ed-b97a6c3bdc2b",
+    "94b03db5-14d7-4668-a952-e71160a658fc",
+    "4d03a0bc-645c-45ce-8d5e-a9ca584dfcb0",
+    "1a038ddb-fb0d-45b3-a46c-bdd57030af9e",
+    "89eecdef-4dc7-4228-8794-7139f15bf966",
+    "67369dd2-9c6a-49f8-b7bb-32ecba8698f2",
+    "f57cc434-d00c-4fee-b85f-56126403bf31",
+    "f9458cf7-8a12-487c-88f2-19c89e1d60c5",
+    "a33aca3e-fa5f-4477-b945-78616316ffb0",
+    "965329ba-24c1-4de7-b988-5a0baa376e66",
+    "453adc9f-501e-4d03-8810-990b747296e3",
+    "3a95e49d-afaa-4f3f-871a-4ec96ab86380",
+    "710450f3-266a-462a-abc0-bd3cdf235568",
+    "619b8ec8-2098-47fc-a55c-0a4048687163",
+    "9e3ae3ee-ddfe-4d81-93c0-9c62737d96fb",
+    "bc320f97-3a1f-4c6f-a2ee-936bfb5f293c",
+    "e5e271a8-d099-4cf4-8035-1f1672b6b16e",
+    "0fae6293-57b6-4135-b7dc-317b210d89b6",
+    "b8debec5-ea8e-4063-bba9-630bd108752f",
+    "cab0e91e-4e27-4820-a734-06c0bcd3f6ae",
+    "4986c804-64e9-4fb9-93ce-8ad6ca0cd3b2",
+    "5604d2cd-8ba6-4322-900a-31396168b72c",
+    "1affafb6-2089-45b5-8938-e40de8f89381",
+    "1fc64e79-9875-4136-b312-9f5df02d7c93",
+    "7fe16343-40dd-4bb5-bc63-9021be0cafb7",
+    "d24ad88e-b4ed-4ca5-91a0-b7afbc99744a",
+    "65889c75-7b2b-40a6-bfec-7bd9db64d20a",
+    "f60c9d96-360c-4b50-a1a8-f3fce87e24d7",
+    "4b6dc95f-1fb2-47f5-9746-e0e3970cbbb3",
+    "b37eb168-6430-44f8-8242-d1e0110bc71e",
+    "e34264f2-c999-4a3e-b2af-53b0c4f45095",
+    "157e6489-a96c-4e8c-8843-928c89529fff",
+    "efcbca04-8b0b-4a48-b3f2-e644a732d16d",
+    "238e35f2-9baa-4540-8fbd-ee46d2eca2cc",
+    "2f7e6ffb-47d5-485e-9166-1d455f2ec824",
+    "f75099a7-8600-4e4e-8332-1d045b6b85e1",
+    "2323b974-420c-40f7-8296-a28c4bc6b64e",
+    "31e7dab5-dbcb-4c33-999f-0e6779dad480",
+    "5221023d-6a15-4eeb-bf82-b770fcf8576d",
+    "51eee369-d85f-4097-ab93-419d31c2205f",
+    "3beaf7e5-a70e-4687-a28f-f9c8ff9364d8",
+    "c80d88bb-b1ca-454f-b793-19b00b141479",
+    "fda3e343-1f29-4e4d-8e56-6dd77fe28838",
+    "298a065a-1571-434e-a8cd-7464890595be",
+    "64540a85-4260-4469-81be-fac0e831a0ad",
+    "1fc17318-cec1-40cd-86d4-f498ce3342a4",
+    "30096c80-6e35-4c3f-910b-99b4190b79e1",
+    "4451d707-39d9-4174-b7ea-8dcfc4c408d4",
+    "dbc05fa6-bd30-4e0d-997b-6f8cb8854141",
+    "4ce06ba7-9074-445d-b97b-d665f065d60e",
+    "80115d98-b7df-4ed2-8fd8-7c7464143ce4",
+    "aa7142fc-b6c3-4499-98a2-5f424912d107",
+    "8adf8819-c3eb-43ce-ad11-04e0d22dfb52",
+    "a21b7d6e-354e-4d2d-b75f-b5782dcef385",
+    "b7ac8c80-8dfa-4314-8d76-6a57f87ad32f",
+    "2b15ccf1-6ee2-4c7d-9286-5133b0b57844",
+    "f443ce61-8ba8-4490-8bf9-8c1c443a0aa2",
+    "73025002-8582-48f4-8e32-d9866e8d97d2",
+    "6eb21022-4a99-4dd8-b76f-f2715378253b",
+    "f0e074af-2f97-4c67-bac8-f29f409b9db2",
+]
+
+
+def check_nexus_state(ms, state=pb.NEXUS_ONLINE):
+    nl = ms.nexus_list()
+    for nexus in nl:
+        assert nexus.state == state
+        for child in nexus.children:
+            assert child.state == pb.CHILD_ONLINE
+
+
+def destroy_nexus(ms, list):
+    for uuid in list:
+        ms.nexus_destroy(uuid)
+
+@pytest.fixture
+def create_nexus_devices(mayastors, share_null_devs):
+
+    rlist_m0 = mayastors.get('ms0').bdev_list()
+    rlist_m1 = mayastors.get('ms1').bdev_list()
+    rlist_m2 = mayastors.get('ms2').bdev_list()
+
+    assert len(rlist_m0) == len(rlist_m1) == len(rlist_m2)
+    
+    ms = mayastors.get('ms3')
+
+    for uuid in nexus_uuids:
+        time.sleep(0.1)
+        ms.nexus_create(uuid,
+                        94 * 1024 * 1024,
+                        [rlist_m0.pop().share_uri,
+                         rlist_m1.pop().share_uri,
+                         rlist_m2.pop().share_uri])
+
+    for uuid in nexus_uuids:
+        ms.nexus_publish(uuid)
+
+    assert len(ms.nexus_list()) == len(nexus_uuids)
+
+
+@pytest.fixture
+def create_null_devs(mayastors):
+    for node in ['ms0', 'ms1', 'ms2']:
+        ms = mayastors.get(node)
+
+        for i in range(len(nexus_uuids)):
+            ms.bdev_create(f"null:///null{i}?blk_size=512&size_mb=100")
+    yield
+#    for node in ['ms0', 'ms1', 'ms2']:
+#        ms = mayastors.get(node)
+#        names = ms.bdev_list()
+#        for n in names:
+#            ms.bdev_destroy((n.uri))
+#
+
+@pytest.fixture
+def share_null_devs(mayastors, create_null_devs):
+
+    for node in ['ms0', 'ms1', 'ms2']:
+        ms = mayastors.get(node)
+        names = ms.bdev_list()
+        for n in names:
+            ms.bdev_share((n.name))
+
+    yield
+
+#    for node in ['ms0', 'ms1', 'ms2']:
+#        ms = mayastors.get(node)
+#        names = ms.bdev_list()
+#        for n in names:
+#            ms.bdev_unshare((n.name))
+#
+
+async def kill_after(container, sec):
+    """Kill the given container after sec seconds."""
+    await asyncio.sleep(sec)
+    container.kill()
+
+
+def test_null_nexus(create_nexus_devices,
+                          containers,
+                          mayastors,
+                          target_vm):
+
+    ms = mayastors.get('ms3')
+    check_nexus_state(ms)
+#    destroy_nexus(ms, nexus_uuids)
+
+@pytest.mark.skip
+def test_kill_one_by_one(create_nexus_devices, containers, mayastors):
+
+    ms = mayastors.get('ms3')
+
+    check_nexus_state(ms)
+    nodes = ['ms0', 'ms1', 'ms2'];
+    random.shuffle(nodes)
+
+
+    for ms in nodes:
+        ms.kill()
+
+    check_nexus_state(ms, state=pb.NEXUS_FAULTED)


### PR DESCRIPTION
IO errors are now handled differently such that errors on a channel, are
    handled on a per channel basis.

When we are in submission, we simply remove the device from the
channel(s) and retry the IO by resubmitting it into the nexus.

Completion IOs are,  when completed, also retried. For each failed
device, we kick off one retire request which will pause the nexus.  This
prevents any new incoming IO, giving us the time to persist data if any.

Before we can pasue the nexus, all requests in the qpairs must be
completed. As the channel is removed from the nexus its io channels,
queued IO to the child will be aborted.

This has been tested with 400 volumes in total. The script used are part
of the commit. They test purely the data and gRPC parts.  Added to that,
kudos to @tiagolobocastro for helping out debugging an issue that I,
locally, could not reproduce.