### PR TITLE
chore(mayastor): remove code to create metadata index on "MayaMeta" partition

### DIFF
--- a/mayastor/src/bdev/nexus/nexus_metadata.rs
+++ b/mayastor/src/bdev/nexus/nexus_metadata.rs
@@ -417,9 +417,7 @@ impl NexusMetaData {
     }
 
     /// Get the location of the MetaDataIndex
-    pub(crate) fn get_index_lba(
-        label: &NexusLabel,
-    ) -> Result<u64, MetaDataError> {
+    pub fn get_index_lba(label: &NexusLabel) -> Result<u64, MetaDataError> {
         match label.get_partition("MayaMeta") {
             Some(entry) => Ok(entry.ent_start + 1),
             None => Err(MetaDataError::MissingPartition {
@@ -430,7 +428,7 @@ impl NexusMetaData {
 
     /// Check that a valid MetaDataIndex exists on the MayaMeta partition,
     /// and that it is consistent with the NexusChild object.
-    pub(crate) async fn validate_index(
+    pub async fn validate_index(
         child: &NexusChild,
     ) -> Result<(), MetaDataError> {
         if let Some(index) = NexusMetaData::get_index(child).await? {

--- a/mayastor/tests/nexus_metadata.rs
+++ b/mayastor/tests/nexus_metadata.rs
@@ -150,8 +150,8 @@ async fn read_write_metadata() {
     });
     data.push(object);
 
-    // check if default index was created
-    assert!(NexusMetaData::get_index(&child).await.unwrap().is_some());
+    // check if the offset into the "MayaMeta" partition has been set
+    assert!(child.metadata_index_lba > 0);
 
     // create a (new) index with a capacity of 4
     let now = SystemTime::now();


### PR DESCRIPTION
Do not create a metadata index on the "MayaMeta" partition for persisting
state of each child, as this information is now stored in etcd.