### PR TITLE
fix(moac): volume remains in destroyed state

### DIFF
--- a/csi/moac/src/registry.ts
+++ b/csi/moac/src/registry.ts
@@ -185,7 +185,7 @@ export class Registry extends events.EventEmitter {
     let pools;
 
     if (nodeName) {
-      pools = this.getPools().filter((p) => p.node.name === nodeName);
+      pools = this.getPools().filter((p) => p.node?.name === nodeName);
     } else {
       pools = this.getPools();
     }
@@ -206,6 +206,7 @@ export class Registry extends events.EventEmitter {
     let pools = this.getPools().filter((p) => {
       return (
         p.isAccessible() &&
+        p.node &&
         p.capacity - p.used >= requiredBytes &&
         (mustNodes.length === 0 || mustNodes.indexOf(p.node.name) >= 0)
       );
@@ -215,13 +216,13 @@ export class Registry extends events.EventEmitter {
       // Rule #1: User preference
       if (shouldNodes.length > 0) {
         if (
-          shouldNodes.indexOf(a.node.name) >= 0 &&
-          shouldNodes.indexOf(b.node.name) < 0
+          shouldNodes.indexOf(a.node!.name) >= 0 &&
+          shouldNodes.indexOf(b.node!.name) < 0
         ) {
           return -1;
         } else if (
-          shouldNodes.indexOf(a.node.name) < 0 &&
-          shouldNodes.indexOf(b.node.name) >= 0
+          shouldNodes.indexOf(a.node!.name) < 0 &&
+          shouldNodes.indexOf(b.node!.name) >= 0
         ) {
           return 1;
         }
@@ -250,8 +251,8 @@ export class Registry extends events.EventEmitter {
     // only one pool from each node
     const nodes: Node[] = [];
     pools = pools.filter((p) => {
-      if (nodes.indexOf(p.node) < 0) {
-        nodes.push(p.node);
+      if (nodes.indexOf(p.node!) < 0) {
+        nodes.push(p.node!);
         return true;
       } else {
         return false;

--- a/csi/moac/src/volume.ts
+++ b/csi/moac/src/volume.ts
@@ -1032,7 +1032,8 @@ export class Volume {
     // with the least # of nexuses.
     if (!nexusNode) {
       nexusNode = replicaSet
-        .map((r: Replica) => r.pool!.node)
+        .filter((r: Replica) => !!(r.pool && r.pool.node))
+        .map((r: Replica) => r.pool!.node!)
         .sort((a: Node, b: Node) => a.nexus.length - b.nexus.length)[0];
     }
     assert(nexusNode);
@@ -1047,7 +1048,8 @@ export class Volume {
 
     for (let i = 0; i < replicaSet.length; i++) {
       const replica: Replica = replicaSet[i];
-      const replicaNode: Node = replica.pool!.node;
+      if (replica.pool?.node === undefined) continue;
+      const replicaNode: Node = replica.pool.node;
       let share;
       const local = replicaNode === nexusNode;
       // make sure that replica which is local to the nexus is accessed locally

--- a/csi/moac/test/grpc_client_test.js
+++ b/csi/moac/test/grpc_client_test.js
@@ -3,7 +3,6 @@
 'use strict';
 
 const expect = require('chai').expect;
-const grpc = require('@grpc/grpc-js');
 const { MayastorServer } = require('./mayastor_mock');
 const { GrpcClient, grpcCode } = require('../dist/grpc_client');
 const { shouldFailWith } = require('./utils');
@@ -15,12 +14,7 @@ module.exports = function () {
   let srv;
   let client;
 
-  // start a fake mayastor server and initialize the client
-  before(() => {
-    client = new GrpcClient(MS_ENDPOINT);
-  });
-
-  beforeEach((done) => {
+  function startServer (replyDelay, done) {
     if (!srv) {
       const pools = [
         {
@@ -31,53 +25,120 @@ module.exports = function () {
           used: 4
         }
       ];
-      srv = new MayastorServer(MS_ENDPOINT, pools);
+      srv = new MayastorServer(MS_ENDPOINT, pools, [], [], replyDelay);
       srv.start(done);
     } else {
       done();
     }
-  });
+  }
 
-  after(() => {
-    if (client) client.close();
-    if (srv) srv.stop();
-    client = null;
-    srv = null;
-  });
-
-  it('should provide grpc status codes', () => {
-    expect(grpcCode.NOT_FOUND).to.equal(5);
-    expect(grpcCode.INTERNAL).to.equal(13);
-  });
-
-  it('should call a grpc method', async () => {
-    const res = await client.call('listPools', {});
-    expect(res.pools).to.have.lengthOf(1);
-    expect(res.pools[0].name).to.equal('pool');
-  });
-
-  it('should throw if grpc method fails', async () => {
-    await shouldFailWith(grpc.status.NOT_FOUND, async () => {
-      await client.call('removeChildNexus', { uuid: UUID, uri: 'bdev://bbb' });
-    });
-  });
-
-  it('should throw if unable to connect to the server', async () => {
-    srv.stop();
-    srv = null;
-    // 1 = CANCELLED received
-    await shouldFailWith(1, async () => {
-      await client.call('destroyPool', { name: 'unknown-pool' });
-    });
-  });
-
-  it('should release the client after close', async () => {
-    client.close();
-    try {
-      await client.call('listPools', {});
-    } catch (err) {
-      return;
+  function stopServer () {
+    if (srv) {
+      srv.stop();
+      srv = null;
     }
-    throw new Error('Expected to throw error');
+  }
+
+  function createClient (timeout) {
+    client = new GrpcClient(MS_ENDPOINT, timeout);
+  }
+
+  function destroyClient () {
+    if (client) {
+      client.close();
+      client = null;
+    }
+  }
+
+  describe('server without delay', () => {
+    before((done) => {
+      createClient();
+      startServer(undefined, done);
+    });
+
+    after(() => {
+      destroyClient();
+      stopServer();
+    });
+
+    it('should provide grpc status codes', () => {
+      expect(grpcCode.NOT_FOUND).to.equal(5);
+      expect(grpcCode.INTERNAL).to.equal(13);
+    });
+
+    it('should call a grpc method', async () => {
+      const res = await client.call('listPools', {});
+      expect(res.pools).to.have.lengthOf(1);
+      expect(res.pools[0].name).to.equal('pool');
+    });
+
+    it('should throw if grpc method fails', async () => {
+      await shouldFailWith(
+        grpcCode.NOT_FOUND,
+        () => client.call('removeChildNexus', { uuid: UUID, uri: 'bdev://bbb' })
+      );
+    });
+
+    // This must come after other tests using the server because it closes it.
+    it('should throw if the server with connected client shuts down', async () => {
+      stopServer();
+      await shouldFailWith(
+        grpcCode.CANCELLED,
+        () => client.call('destroyPool', { name: 'unknown-pool' })
+      );
+    });
+
+    // This must be the last test here because it closes the client handle.
+    it('should release the client after close', async () => {
+      client.close();
+      try {
+        await client.call('listPools', {});
+      } catch (err) {
+        return;
+      }
+      throw new Error('Expected to throw error');
+    });
+  });
+
+  describe('server with delayed replies', () => {
+    const delayMs = 20;
+
+    before((done) => {
+      startServer(delayMs, done);
+    });
+
+    after(() => {
+      stopServer();
+    });
+
+    afterEach(destroyClient);
+
+    it('should honor timeout set for the grpc call', async () => {
+      createClient();
+      await shouldFailWith(
+        grpcCode.DEADLINE_EXCEEDED,
+        () => client.call('listPools', {}, delayMs / 2)
+      );
+    });
+
+    it('should honor the default timeout set for the grpc client', async () => {
+      createClient(delayMs / 2);
+      await shouldFailWith(
+        grpcCode.DEADLINE_EXCEEDED,
+        () => client.call('listPools', {})
+      );
+    });
+  });
+
+  describe('no server', () => {
+    before(() => createClient());
+    after(destroyClient);
+
+    it('should throw if unable to connect to the server', async () => {
+      await shouldFailWith(
+        grpcCode.UNAVAILABLE,
+        () => client.call('destroyPool', { name: 'unknown-pool' })
+      );
+    });
   });
 };

--- a/csi/moac/test/pool_test.js
+++ b/csi/moac/test/pool_test.js
@@ -172,7 +172,7 @@ module.exports = function () {
         expect(ev.eventType).to.equal('del');
         expect(ev.object).to.equal(pool);
         setTimeout(() => {
-          expect(pool.node).to.be.null;
+          expect(pool.node).to.be.undefined;
           done();
         }, 0);
       });


### PR DESCRIPTION
For some reason which is out of scope of this PR, mayastor fails to
send a reply to grpc request issued by moac. That makes the whole
life-cycle of the volume stuck until the moac is restarted. It's
a general problem pertaining to all grpc operations. We need to
set a timeout on all grpc requests to prevent this from happening.

The default timeout for all grpc calls is 15s now. The destroy
replica call with timeout of 1 hour being exception because it is
known to be slow when the replica is large.

This might trigger new bugs in mayastor as some operations might
be resent now. It is a question of how mayastor will handle a new
request while the old one is still in the progress. We will fix
those as we discover them. This could have happened even before.
It's just that likelyhood has increased now.

Resolves: CAS-896