### PR TITLE
fix: don't readd existing children to the nexus

### DIFF
--- a/csi/moac/src/volume.ts
+++ b/csi/moac/src/volume.ts
@@ -509,11 +509,11 @@ export class Volume {
 
     // pair nexus children with replica objects to get the full picture
     const childReplicaPairs: { ch: Child, r: Replica | undefined }[] = this.nexus.children.map((ch) => {
-      const r = Object.values(this.replicas).find((r) => r.uri === ch.uri);
+      const r = Object.values(replicaSet).find((r) => r.uri === ch.uri);
       return { ch, r };
     });
     // add newly found replicas to the nexus (one by one)
-    const newReplicas = Object.values(this.replicas).filter((r) => {
+    const newReplicas = Object.values(replicaSet).filter((r) => {
       return (!r.isOffline() && !childReplicaPairs.find((pair) => pair.r === r));
     });
     for (let i = 0; i < newReplicas.length; i++) {

--- a/mayastor/src/bdev/loopback.rs
+++ b/mayastor/src/bdev/loopback.rs
@@ -66,9 +66,12 @@ impl CreateDestroy for Loopback {
     type Error = NexusBdevError;
 
     async fn create(&self) -> Result<String, Self::Error> {
-        if let Some(mut bdev) = Bdev::lookup_by_name(&self.name) {
-            if let Some(uuid) = self.uuid {
-                bdev.set_uuid(uuid);
+        if let Some(bdev) = Bdev::lookup_by_name(&self.name) {
+            if self.uuid.is_some() && Some(bdev.uuid()) != self.uuid {
+                return Err(NexusBdevError::BdevWrongUuid {
+                    name: self.get_name(),
+                    uuid: bdev.uuid_as_string(),
+                });
             }
 
             if !bdev.add_alias(&self.alias) {

--- a/mayastor/src/bdev/nexus/nexus_bdev.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev.rs
@@ -183,6 +183,8 @@ pub enum Error {
     },
     #[snafu(display("Child {} of nexus {} not found", child, name))]
     ChildNotFound { child: String, name: String },
+    #[snafu(display("Child {} of nexus {} already exists", child, name))]
+    ChildAlreadyExists { child: String, name: String },
     #[snafu(display("Failed to pause child {} of nexus {}", child, name))]
     PauseChild { child: String, name: String },
     #[snafu(display("Suitable rebuild source for nexus {} not found", name))]

--- a/mayastor/src/bdev/nexus/nexus_bdev_children.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev_children.rs
@@ -163,6 +163,13 @@ impl Nexus {
             }
         };
 
+        if self.child_lookup(&name).is_some() {
+            return Err(Error::ChildAlreadyExists {
+                child: name,
+                name: self.name.to_owned(),
+            });
+        }
+
         let mut child = NexusChild::new(
             uri.to_owned(),
             self.name.clone(),

--- a/mayastor/src/nexus_uri.rs
+++ b/mayastor/src/nexus_uri.rs
@@ -53,6 +53,12 @@ pub enum NexusBdevError {
     // Bdev create/destroy errors
     #[snafu(display("bdev {} already exists", name))]
     BdevExists { name: String },
+    #[snafu(display(
+        "bdev {} already exists with a different uuid: {}",
+        name,
+        uuid
+    ))]
+    BdevWrongUuid { name: String, uuid: String },
     #[snafu(display("bdev {} not found", name))]
     BdevNotFound { name: String },
     #[snafu(display("Invalid parameters for bdev create {}", name))]

--- a/mayastor/tests/nexus_with_local.rs
+++ b/mayastor/tests/nexus_with_local.rs
@@ -119,6 +119,15 @@ async fn nexus_with_local() {
         .await
         .unwrap();
 
+    ms1.mayastor
+        .add_child_nexus(AddChildNexusRequest {
+            uri: format!("bdev:///{}", uuid()),
+            uuid: uuid(),
+            norebuild: false,
+        })
+        .await
+        .expect_err("Should fail to add the same child again");
+
     check_aliases(&mut ms1, true).await;
     ms1.bdev
         .destroy(BdevUri {


### PR DESCRIPTION
fix(moac): use filtered replicaSet

During the volume's fsa, MOAC filters out replicas which are not shared properly but it then
uses the unfiltered list to determine which replicas it should add to a nexus.
This could cause a nexus to have 2 bdev children.
Fix: use the filtered replicaSet

fix: don't add the same loopback device to the nexus

Other device types return an error when we attempt to open them twice.
The loopback's are special cases, because they're already open, eg: we
create a replica and then open the loopback device.
When a loopback device is reopened with a different UUID it ends up
overwriting the existing UUID and returning OK which sounds very bad.
Fix: Fail the open request if the UUID is not the expected one.

Related issue, because opening an existing loopback succeeds it means
that we can add nexus children to the nexus twice.
Fix: Fails NexusAddChild if the child is already part of the nexus!