### PR TITLE
fix(nexus): removing a loopback replica that is already shared

### DIFF
--- a/mayastor/src/core/descriptor.rs
+++ b/mayastor/src/core/descriptor.rs
@@ -68,10 +68,12 @@ impl Descriptor {
         err == 0
     }
 
-    /// unclaim a previously claimed bdev
+    /// unclaim a bdev previously claimed by NEXUS_MODULE
     pub(crate) fn unclaim(&self) {
         unsafe {
-            if !(*self.get_bdev().as_ptr()).internal.claim_module.is_null() {
+            if (*self.get_bdev().as_ptr()).internal.claim_module
+                == NEXUS_MODULE.as_ptr()
+            {
                 spdk_bdev_module_release_bdev(self.get_bdev().as_ptr());
             }
         }

--- a/mayastor/tests/nexus_multipath.rs
+++ b/mayastor/tests/nexus_multipath.rs
@@ -8,6 +8,8 @@ use rpc::mayastor::{
     CreateNexusRequest,
     CreatePoolRequest,
     CreateReplicaRequest,
+    DestroyNexusRequest,
+    Null,
     NvmeAnaState,
     PublishNexusRequest,
     ShareProtocolNexus,
@@ -272,4 +274,24 @@ async fn nexus_multipath() {
         "failed to disconnect from remote replica, {}",
         output_dis2.status
     );
+
+    // destroy nexus on remote node
+    hdls[0]
+        .mayastor
+        .destroy_nexus(DestroyNexusRequest {
+            uuid: UUID.to_string(),
+        })
+        .await
+        .unwrap();
+
+    // verify that the replica is still shared over nvmf
+    assert!(hdls[0]
+        .mayastor
+        .list_replicas(Null {})
+        .await
+        .unwrap()
+        .into_inner()
+        .replicas[0]
+        .uri
+        .contains("nvmf://"));
 }


### PR DESCRIPTION
Removing a loopback replica that is already shared over nvmf should
result in the replica remaining shared over nvmf. NexusChild::close()
calls Descriptor::unclaim() which marks the bdev as unclaimed, causing
the replica to lose its shared state. When the replica is subsequently
destroyed, the nvmf target remains, though with no namespaces, and is
leaked.

Have Descriptor::unclaim() only unclaim a bdev that was claimed by
NEXUS_MODULE. Only test code calls Descriptor::claim().

This issue was always present but could previously only be exposed by
adding a replica over loopback, then sharing that replica over nvmf.
After changes in 347d37a, an already-shared replica could be added as
a local (loopback) child, making it more likely.

Add a cargo test to verify that the loopback replica remains shared
over nvmf after its removal from the nexus.