### PR TITLE
chore: add additional error

### DIFF
--- a/mayastor/src/bdev/nexus/nexus_bdev.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev.rs
@@ -86,6 +86,8 @@ where
 pub enum Error {
     #[snafu(display("Nexus {} does not exist", name))]
     NexusNotFound { name: String },
+    #[snafu(display("Nexus {} exists and is initialising", name))]
+    NexusInitialising { name: String },
     #[snafu(display("Invalid nexus uuid \"{}\"", uuid))]
     InvalidUuid { uuid: String },
     #[snafu(display("Invalid encryption key"))]
@@ -1063,7 +1065,7 @@ pub async fn nexus_create(
         // FIXME: Instead of error, we return Ok without checking
         // that the children match, which seems wrong.
         if *nexus.state.lock() == NexusState::Init {
-            return Err(Error::NexusNotFound {
+            return Err(Error::NexusInitialising {
                 name: name.to_owned(),
             });
         }

--- a/mayastor/src/bdev/nvmx/controller_inner.rs
+++ b/mayastor/src/bdev/nvmx/controller_inner.rs
@@ -149,13 +149,13 @@ impl TimeoutConfig {
 
     ///
     /// After an IO timeout, we will remove any qpairs associated with
-    /// this controller. This will result into any pending IO (waiting
-    /// for completion) to be aborted. While this is happening, due to the
-    /// nature of the reactor, newly sumbitted to the  qpair we just detached,
-    /// will get an EXIO. However, this will happen only after the qpair is
-    /// disconnected or if the controller is failed. Therefor, we must fall
-    /// thee controller as soon as possible to avoid the need to reset after
-    /// the hot removal.
+    /// this controller. This will result in any pending IO (waiting for
+    /// completion) to be aborted. While this is happening, due to the
+    /// nature of the reactor, newly submitted IOs to the qpair we just
+    /// detached, will get an EXIO. However, this will happen only after the
+    /// qpair is disconnected or if the controller is failed. Therefore, we
+    /// must fail the controller as soon as possible to avoid the need to
+    /// reset after the hot removal.
 
     pub(crate) fn hot_remove(&mut self) {
         // cb invoked when the whole process is done.


### PR DESCRIPTION
Add a NexusInitialising error which is returned when creating a nexus if
a nexus with the same name already exists and is initialising.

Additional changes: minor typo fixes.