### PR TITLE
fix(spdk): restored iscsi initiator module in spdk binary

### DIFF
--- a/spdk-sys/build.sh
+++ b/spdk-sys/build.sh
@@ -12,6 +12,7 @@ rm libspdk.so
 ./configure --enable-debug \
 	--target-arch=nehalem \
 	--without-isal \
+	--with-iscsi-initiator \
 	--with-crypto \
 	--with-uring \
 	--disable-unit-tests \
@@ -26,7 +27,6 @@ find . -type f -name 'libspdk_sock_uring.a' -delete
 find . -type f -name 'libspdk_ut_mock.a' -delete
 find . -type f -name 'libspdk_bdev_ftl.a' -delete
 find . -type f -name 'libspdk_bdev_gpt.a' -delete
-find . -type f -name 'libspdk_bdev_iscsi.a' -delete
 find . -type f -name 'libspdk_bdev_raid.a' -delete
 find . -type f -name 'libspdk_bdev_split.a' -delete
 find . -type f -name 'libspdk_bdev_blobfs.a' -delete


### PR DESCRIPTION
Iscsi initiator module was accidentally removed from spdk build process
in the latest commits, which leads to missing 'delete_iscsi_disk'
function when building custom spdk.
This fix re-adds the removed module to the resulting spdk binary.