### PR TITLE
feat(yaml): enable mayastor trace for some images

### DIFF
--- a/chart/develop/values.yaml
+++ b/chart/develop/values.yaml
@@ -15,3 +15,4 @@ etcd:
   persistence:
     enabled: false
 
+mayastorLogLevel: debug

--- a/chart/release/values.yaml
+++ b/chart/release/values.yaml
@@ -16,3 +16,4 @@ etcd:
   persistence:
     enabled: false
 
+mayastorLogLevel: info

--- a/chart/templates/mayastor-daemonset.yaml
+++ b/chart/templates/mayastor-daemonset.yaml
@@ -34,6 +34,8 @@ spec:
         image: {{ include "mayastorImagesPrefix" . }}mayadata/mayastor:{{ .Values.mayastorImagesTag }}
         imagePullPolicy: {{ .Values.mayastorImagePullPolicy }}
         env:
+        - name: RUST_LOG
+          value: mayastor={{ .Values.mayastorLogLevel }}
         - name: MY_NODE_NAME
           valueFrom:
             fieldRef:

--- a/chart/test/values.yaml
+++ b/chart/test/values.yaml
@@ -16,3 +16,4 @@ etcd:
   persistence:
     enabled: false
 
+mayastorLogLevel: debug


### PR DESCRIPTION
Enable RUST_LOG=trace for develop and test images, avoid on release
images.

Does it make sense? Should help in cases when errors are not easily repeatable.