### PR TITLE
test(python): add a nexus create/destroy test and update FioSpdk

### DIFF
--- a/test/python/common/fio_spdk.py
+++ b/test/python/common/fio_spdk.py
@@ -1,32 +1,35 @@
-import asyncio
 import os
 import shutil
-from common.command import run_cmd_async
 from urllib.parse import urlparse
 
 
 class FioSpdk(object):
 
-    def __init__(self, name, rw, uri, runtime=15):
+    def __init__(self, name, rw, uris, runtime=15):
         self.name = name
         self.rw = rw
-        u = urlparse(uri)
-        self.host = u.hostname
-        self.port = u.port
-        self.nqn = u.path[1:]
+        if isinstance(uris, str):
+            uris = [uris]
+
+        self.filenames = []
+        for uri in uris:
+            u = urlparse(uri)
+            self.filenames.append(("\'trtype=tcp adrfam=IPv4 traddr={} "
+                                   "trsvcid={} subnqn={} ns=1\'").format(
+                u.hostname, u.port, u.path[1:].replace(":", "\\:")))
+
         self.cmd = shutil.which("fio")
         self.runtime = runtime
 
-    async def run(self):
+    def build(self) -> str:
         spdk_path = os.environ.get('SPDK_PATH')
         if spdk_path is None:
             spdk_path = os.getcwd() + '/../../spdk-sys/spdk/build'
         command = ("sudo LD_PRELOAD={}/fio/spdk_nvme fio --ioengine=spdk "
-                   "--direct=1 --bs=4k --time_based=1 --runtime=15 "
+                   "--direct=1 --bs=4k --time_based=1 --runtime={} "
                    "--thread=1 --rw={} --group_reporting=1 --norandommap=1 "
-                   "--iodepth=64 --name={} --filename=\'trtype=tcp "
-                   "adrfam=IPv4 traddr={} trsvcid={} subnqn={} ns=1\'").format(
-            spdk_path, self.rw, self.name, self.host, self.port,
-            self.nqn.replace(":", "\\:"))
+                   "--iodepth=64 --name={} --filename={}").format(
+            spdk_path, self.runtime, self.rw, self.name,
+            " --filename=".join(map(str, self.filenames)))
 
-        await asyncio.wait_for(run_cmd_async(command), self.runtime + 5)
+        return command

--- a/test/python/common/hdl.py
+++ b/test/python/common/hdl.py
@@ -80,11 +80,11 @@ class MayastorHandle(object):
         """Destroy  the pool."""
         return self.ms.DestroyPool(pb.DestroyPoolRequest(name=name))
 
-    def replica_create(self, pool, uuid, size):
+    def replica_create(self, pool, uuid, size, share=1):
         """Create  a replica on the pool with the specified UUID and size."""
         return self.ms.CreateReplica(
             pb.CreateReplicaRequest(
-                pool=pool, uuid=str(uuid), size=size, thin=False, share=1
+                pool=pool, uuid=str(uuid), size=size, thin=False, share=share
             )
         )
 

--- a/test/python/docker-compose.yml
+++ b/test/python/docker-compose.yml
@@ -79,7 +79,7 @@ services:
         - NVME_KATO_MS=1000
         - RUST_LOG=mayastor=trace
         - NEXUS_DONT_READ_LABELS=true
-    command: ${SRCDIR}/target/debug/mayastor -g 0.0.0.0 -l 11,12,13,14,15 -r /tmp/ms3.sock
+    command: ${SRCDIR}/target/debug/mayastor -g 0.0.0.0 -l 0,7 -r /tmp/ms3.sock
     networks:
       mayastor_net:
         ipv4_address: 10.0.0.5

--- a/test/python/test_nexus_create_destroy.py
+++ b/test/python/test_nexus_create_destroy.py
@@ -1,0 +1,121 @@
+from common.hdl import MayastorHandle
+import logging
+import pytest
+import uuid as guid
+import grpc
+import mayastor_pb2 as pb
+
+
+@pytest.fixture
+def pool_config():
+    pool = {}
+    pool['name'] = "tpool"
+    pool['uri'] = "malloc:///disk0?size_mb=100"
+    return pool
+
+
+@pytest.fixture(scope="module")
+def containers(docker_project, module_scoped_container_getter):
+    project = docker_project
+    containers = {}
+    for name in project.service_names:
+        containers[name] = module_scoped_container_getter.get(name)
+    yield containers
+
+
+@pytest.fixture(scope="module")
+def wait_for_mayastor(docker_project, module_scoped_container_getter):
+    project = docker_project
+    handles = {}
+    for name in project.service_names:
+        # because we use static networks .get_service() does not work
+        services = module_scoped_container_getter.get(name)
+        ip_v4 = services.get(
+            "NetworkSettings.Networks.python_mayastor_net.IPAddress")
+        handles[name] = MayastorHandle(ip_v4)
+    yield handles
+
+
+@pytest.fixture
+def replica_uuid():
+    UUID = "0000000-0000-0000-0000-000000000001"
+    size_mb = 64 * 1024 * 1024
+    return (UUID, size_mb)
+
+
+@pytest.fixture
+def nexus_uuid():
+    NEXUS_UUID = "3ae73410-6136-4430-a7b5-cbec9fe2d273"
+    size_mb = 64 * 1024 * 1024
+    return (NEXUS_UUID, size_mb)
+
+
+@pytest.fixture
+def create_pools(
+        wait_for_mayastor,
+        containers,
+        pool_config):
+    hdls = wait_for_mayastor
+
+    cfg = pool_config
+    pools = []
+
+    pools.append(hdls['ms1'].pool_create(cfg.get('name'),
+                                         cfg.get('uri')))
+
+    pools.append(hdls['ms2'].pool_create(cfg.get('name'),
+                                         cfg.get('uri')))
+
+    pools.append(hdls['ms3'].pool_create(cfg.get('name'),
+                                         cfg.get('uri')))
+
+    for p in pools:
+        assert p.state == pb.POOL_ONLINE
+    yield pools
+
+
+@pytest.fixture
+def create_replica(
+        wait_for_mayastor,
+        pool_config,
+        replica_uuid,
+        create_pools):
+    hdls = wait_for_mayastor
+    pools = create_pools
+    replicas = []
+
+    UUID, size_mb = replica_uuid
+
+    replicas.append(hdls['ms1'].replica_create(pools[0].name,
+                                               UUID, size_mb))
+    replicas.append(hdls['ms2'].replica_create(pools[0].name,
+                                               UUID, size_mb))
+    replicas.append(hdls['ms3'].replica_create(pools[0].name,
+                                               UUID, size_mb, 0))
+
+    yield replicas
+
+
+@pytest.mark.timeout(60)
+def test_nexus_create_destroy(wait_for_mayastor, nexus_uuid, create_replica):
+    replicas = create_replica
+    replicas = [k.uri for k in replicas]
+
+    hdls = wait_for_mayastor
+
+    NEXUS_UUID, size_mb = nexus_uuid
+
+    assert len(hdls['ms1'].bdev_list()) == 2
+    assert len(hdls['ms2'].bdev_list()) == 2
+    assert len(hdls['ms3'].bdev_list()) == 2
+    assert len(hdls['ms1'].pool_list().pools) == 1
+    assert len(hdls['ms2'].pool_list().pools) == 1
+    assert len(hdls['ms3'].pool_list().pools) == 1
+
+    for i in range(10):
+        hdls['ms3'].nexus_create(NEXUS_UUID, 64 * 1024 * 1024, replicas)
+        assert len(hdls['ms3'].nexus_list()) == 1
+        assert len(hdls['ms3'].bdev_list()) == 3
+        hdls['ms3'].nexus_destroy(NEXUS_UUID)
+        assert len(hdls['ms3'].nexus_list()) == 0
+        assert len(hdls['ms3'].bdev_list()) == 2


### PR DESCRIPTION
Fix docker-compose config so that container ms3 starts on a system
with only 8 cores.

Add a new test that creates 2 replicas shared over nvmf, 1 as
loopback. Create a nexus with all 3 replicas, then destroy the nexus,
for 10 repetitions.

Update the FioSpdk class to match the interface of Fio so that it
supports multiple filenames and add copies of existing Fio tests that
use FioSpdk instead, which removes the requirement for another VM.