### PR TITLE
chore: add memory and vcpu variables to terraform

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -18,6 +18,8 @@ module "provider" {
   ssh_user  = var.ssh_user
   ssh_key   = var.ssh_key
   num_nodes = var.num_nodes
+  memory = var.memory
+  vcpu = var.vcpu
 
   # libvirt
   image_path         = var.image_path

--- a/terraform/mod/libvirt/main.tf
+++ b/terraform/mod/libvirt/main.tf
@@ -6,6 +6,12 @@ variable "image_path" {
 variable "num_nodes" {
 }
 
+variable "memory" {
+}
+
+variable "vcpu" {
+}
+
 variable "hostname_formatter" {
 }
 
@@ -81,8 +87,8 @@ resource "libvirt_cloudinit_disk" "commoninit" {
 resource "libvirt_domain" "ubuntu-domain" {
   count     = var.num_nodes
   name      = format(var.hostname_formatter, count.index + 1)
-  memory    = 4096
-  vcpu      = 2
+  memory    = var.memory
+  vcpu      = var.vcpu
   autostart = true
 
   cloudinit = libvirt_cloudinit_disk.commoninit[count.index].id

--- a/terraform/mod/lxd/main.tf
+++ b/terraform/mod/lxd/main.tf
@@ -6,6 +6,12 @@ variable "num_nodes" {
   default = 3
 }
 
+variable "memory" {
+}
+
+variable "vcpu" {
+}
+
 resource "lxd_cached_image" "ubuntu" {
   source_remote = "ubuntu"
   source_image  = "bionic/amd64"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -57,6 +57,18 @@ variable "nr_hugepages" {
   default     = "512"
 }
 
+variable "memory" {
+  type        = number
+  default     = 4096
+  description = "Amount of memory (MiB) allocated to each node - only needed for libvirt provider"
+}
+
+variable "vcpu" {
+  type        = number
+  default     = 2
+  description = "Virtual CPUs allocated to each node - only needed for libvirt provider"
+}
+
 variable "modprobe_nvme" {
   type        = string
   description = "modprobe nvme tcp selector for node.sh"


### PR DESCRIPTION
These can be overridden with -var="name=$value" via the cmdline.