### PR TITLE
feat(nexus): serialize gRPC requests

### DIFF
--- a/mayastor/src/grpc/mod.rs
+++ b/mayastor/src/grpc/mod.rs
@@ -4,9 +4,8 @@ use std::{
 };
 
 use futures::{channel::oneshot::Receiver, Future};
-use tonic::{Response, Status};
-
 pub use server::MayastorGrpcServer;
+use tonic::{Response, Status};
 
 use crate::{
     core::{CoreError, Mthread, Reactor},
@@ -40,6 +39,12 @@ mod json_grpc;
 mod mayastor_grpc;
 mod nexus_grpc;
 mod server;
+
+#[async_trait::async_trait]
+/// trait to lock serialize gRPC request outstanding
+pub(crate) trait Serializer<F, R> {
+    async fn locked(&self, f: F) -> R;
+}
 
 pub type GrpcResult<T> = std::result::Result<Response<T>, Status>;
 

--- a/mayastor/src/grpc/server.rs
+++ b/mayastor/src/grpc/server.rs
@@ -1,5 +1,3 @@
-use tonic::transport::Server;
-
 use crate::grpc::{
     bdev_grpc::BdevSvc,
     json_grpc::JsonRpcSvc,
@@ -10,6 +8,8 @@ use rpc::mayastor::{
     json_rpc_server::JsonRpcServer,
     mayastor_server::MayastorServer as MayastorRpcServer,
 };
+use std::time::Duration;
+use tonic::transport::Server;
 
 pub struct MayastorGrpcServer;
 
@@ -20,7 +20,9 @@ impl MayastorGrpcServer {
     ) -> Result<(), ()> {
         info!("gRPC server configured at address {}", endpoint);
         let svc = Server::builder()
-            .add_service(MayastorRpcServer::new(MayastorSvc))
+            .add_service(MayastorRpcServer::new(MayastorSvc::new(
+                Duration::from_millis(4),
+            )))
             .add_service(BdevRpcServer::new(BdevSvc::new()))
             .add_service(JsonRpcServer::new(JsonRpcSvc {
                 rpc_addr,

--- a/test/python/test_null_nexus.py
+++ b/test/python/test_null_nexus.py
@@ -133,11 +133,10 @@ def create_nexus_devices(mayastors, share_null_devs):
     rlist_m2 = mayastors.get('ms2').bdev_list()
 
     assert len(rlist_m0) == len(rlist_m1) == len(rlist_m2)
-    
+
     ms = mayastors.get('ms3')
 
     for uuid in nexus_uuids:
-        time.sleep(0.1)
         ms.nexus_create(uuid,
                         94 * 1024 * 1024,
                         [rlist_m0.pop().share_uri,


### PR DESCRIPTION
gRPC requests are received on the tokio runtime and dispatched to the
reactors by sending it a message. This made us run requests
in parallel which is what we want to avoid.

Additionally, the embedded json-rpc server only checks for incoming
messages every N ms. This change also makes the adopt that model by
holding the lock while it sleeps.

The lock implemented is an RW lock so we can make it more relaxed later
if we need to.