### PR TITLE
feat: add nvme_core module io_timeout parameter to the csi server

### DIFF
--- a/chart/templates/csi-daemonset.yaml
+++ b/chart/templates/csi-daemonset.yaml
@@ -47,7 +47,8 @@ spec:
         args:
         - "--csi-socket=/csi/csi.sock"
         - "--node-name=$(MY_NODE_NAME)"
-        - "--grpc-endpoint=$(MY_POD_IP):10199"
+        - "--grpc-endpoint=$(MY_POD_IP):10199"{{ if .Values.csi.nvme.io_timeout_enabled }}
+        - "--nvme-core-io-timeout={{ .Values.csi.nvme.io_timeout }}"{{ end }}
         - "-v"
         volumeMounts:
         - name: device

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -11,6 +11,12 @@ mayastorPools:
 # remove when no longer needed.
 moacDebug: false
 
+csi:
+  nvme:
+    # nvme_core module io timeout in seconds
+    io_timeout: "30"
+    io_timeout_enabled: true
+
 nats:
   cluster:
     enabled: false

--- a/csi/src/dev.rs
+++ b/csi/src/dev.rs
@@ -36,7 +36,7 @@ use uuid::Uuid;
 
 mod iscsi;
 mod nbd;
-mod nvmf;
+pub(crate) mod nvmf;
 mod util;
 
 const NVME_NQN_PREFIX: &str = "nqn.2019-05.io.openebs";
@@ -54,6 +54,7 @@ pub trait Attach: Sync + Send {
     ) -> Result<(), DeviceError>;
     async fn attach(&self) -> Result<(), DeviceError>;
     async fn find(&self) -> Result<Option<DeviceName>, DeviceError>;
+    /// Fixup parameters which cannot be set during attach, eg IO timeout
     async fn fixup(&self) -> Result<(), DeviceError>;
 }
 

--- a/csi/src/dev/nvmf.rs
+++ b/csi/src/dev/nvmf.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::HashMap,
     convert::{From, TryFrom},
+    path::Path,
 };
 
 use nvmeadm::{
@@ -233,4 +234,19 @@ impl Detach for NvmfDetach {
     fn devname(&self) -> DeviceName {
         self.name.clone()
     }
+}
+
+/// Set the nvme_core module IO timeout
+/// (note, this is a system-wide parameter)
+pub(crate) fn set_nvmecore_iotimeout(
+    io_timeout_secs: u32,
+) -> Result<(), std::io::Error> {
+    let path = Path::new("/sys/module/nvme_core/parameters");
+    debug!(
+        "Setting nvme_core IO timeout on \"{}\" to {}s",
+        path.to_string_lossy(),
+        io_timeout_secs
+    );
+    sysfs::write_value(&path, "io_timeout", io_timeout_secs)?;
+    Ok(())
 }

--- a/csi/src/server.rs
+++ b/csi/src/server.rs
@@ -137,6 +137,14 @@ async fn main() -> Result<(), String> {
                 .multiple(true)
                 .help("Sets the verbosity level"),
         )
+        .arg(
+            Arg::with_name("nvme-core-io-timeout")
+                .long("nvme-core-io-timeout")
+                .value_name("TIMEOUT")
+                .takes_value(true)
+                .required(false)
+                .help("Sets the global nvme_core module io_timeout, in seconds"),
+        )
         .get_matches();
 
     let node_name = matches.value_of("node-name").unwrap();
@@ -174,6 +182,17 @@ async fn main() -> Result<(), String> {
         });
     }
     builder.init();
+
+    if let Some(nvme_io_timeout_secs) = matches.value_of("nvme_core io_timeout")
+    {
+        let io_timeout_secs: u32 = nvme_io_timeout_secs
+            .parse()
+            .expect("nvme_core io_timeout should be an integer number, representing the timeout in seconds");
+
+        if let Err(error) = dev::nvmf::set_nvmecore_iotimeout(io_timeout_secs) {
+            panic!("Failed to set nvme_core io_timeout: {}", error.to_string());
+        }
+    }
 
     // Remove stale CSI socket from previous instance if there is any
     match fs::remove_file(csi_socket) {

--- a/deploy/csi-daemonset.yaml
+++ b/deploy/csi-daemonset.yaml
@@ -50,6 +50,7 @@ spec:
         - "--csi-socket=/csi/csi.sock"
         - "--node-name=$(MY_NODE_NAME)"
         - "--grpc-endpoint=$(MY_POD_IP):10199"
+        - "--nvme-core-io-timeout=30"
         - "-v"
         volumeMounts:
         - name: device


### PR DESCRIPTION
If this parameter is set, the csi server will set the parameter on startup.
The io_timeout value on the storage class overrides this value and that
should work, but we're not 100% sure that it works for all kernel
versions. This value should cover the cases when the SC value does not
work.

Added a 30s timeout value to the charts. A user may choose to comment
the value out of the yaml to preserve existing settings.