### PR TITLE
fix(test): io_timeout_reset fails too early

### DIFF
--- a/mayastor/tests/nvme_device_timeout.rs
+++ b/mayastor/tests/nvme_device_timeout.rs
@@ -41,7 +41,7 @@ struct IoOpCtx {
 async fn test_io_timeout(action_on_timeout: DeviceTimeoutAction) {
     Config::get_or_init(|| Config {
         nvme_bdev_opts: NvmeBdevOpts {
-            timeout_us: 2_000_000,
+            timeout_us: 7_000_000,
             keep_alive_timeout_ms: 5_000,
             retry_count: 2,
             ..Default::default()


### PR DESCRIPTION
Depending on timing, if the KeepAlive is triggered before we've submitted the read IO,
the controller could be failed and the IO will fail before getting submitted.
This is likely because we now don't reset and retry to connect and simply fail the controller.
In case of early error check that the error is what we expected for this case.