### PR TITLE
fix: missing mod event on immediate creation

### DIFF
--- a/csi/moac/src/volume.ts
+++ b/csi/moac/src/volume.ts
@@ -757,7 +757,7 @@ export class Volume {
         );
       }
     }
-    this.state = VolumeState.Healthy;
+    this._setState(VolumeState.Healthy);
     log.info(`Volume "${this}" with ${this.spec.replicaCount} replica(s) and size ${this.size} was created`);
   }
 

--- a/csi/moac/test/volumes_test.js
+++ b/csi/moac/test/volumes_test.js
@@ -355,7 +355,7 @@ module.exports = function () {
         thin: false,
         share: 'REPLICA_NONE'
       });
-      expect(volEvents).to.have.lengthOf(2);
+      expect(volEvents).to.have.lengthOf(3);
     });
 
     it('should limit the size of created volume', async () => {
@@ -400,7 +400,7 @@ module.exports = function () {
         thin: false,
         share: 'REPLICA_NONE'
       });
-      expect(volEvents).to.have.lengthOf(2);
+      expect(volEvents).to.have.lengthOf(3);
     });
 
     it('should fail if the size is zero', async () => {
@@ -449,7 +449,7 @@ module.exports = function () {
       sinon.assert.notCalled(stub3);
       expect(Object.keys(volume.replicas)).to.have.lengthOf(1);
       expect(Object.values(volume.replicas)[0]).to.equal(replica);
-      expect(volEvents).to.have.lengthOf(2);
+      expect(volEvents).to.have.lengthOf(3);
       expect(volEvents[0].eventType).to.equal('new');
       expect(volEvents[1].eventType).to.equal('mod');
     });
@@ -1989,7 +1989,7 @@ module.exports = function () {
       expect(volume.replicas.node3.uuid).to.equal(UUID);
       expect(volume.state).to.equal('healthy');
 
-      expect(volEvents).to.have.lengthOf(4);
+      expect(volEvents).to.have.lengthOf(5);
     });
 
     it('should publish the volume', async () => {

--- a/mayastor/tests/nvme_device_timeout.rs
+++ b/mayastor/tests/nvme_device_timeout.rs
@@ -38,7 +38,7 @@ struct IoOpCtx {
     handle: Box<dyn BlockDeviceHandle>,
 }
 
-async fn test_io_timeout(action_on_timeout: DeviceTimeoutAction) {
+fn get_config() -> &'static Config {
     Config::get_or_init(|| Config {
         nvme_bdev_opts: NvmeBdevOpts {
             timeout_us: 7_000_000,
@@ -48,7 +48,10 @@ async fn test_io_timeout(action_on_timeout: DeviceTimeoutAction) {
         },
         ..Default::default()
     })
-    .apply();
+}
+
+async fn test_io_timeout(action_on_timeout: DeviceTimeoutAction) {
+    get_config().apply();
 
     let test = Builder::new()
         .name("cargo-test")
@@ -231,16 +234,7 @@ async fn io_timeout_reset() {
 
 #[tokio::test]
 async fn io_timeout_ignore() {
-    Config::get_or_init(|| Config {
-        nvme_bdev_opts: NvmeBdevOpts {
-            timeout_us: 2_000_000,
-            keep_alive_timeout_ms: 5_000,
-            retry_count: 2,
-            ..Default::default()
-        },
-        ..Default::default()
-    })
-    .apply();
+    get_config().apply();
 
     let test = Builder::new()
         .name("cargo-test")


### PR DESCRIPTION
On create the state was being directly set, leading to a missing mod event.
fixes: CAS-948