### PR TITLE
fix(moac): volume gets stuck in offline state when doing failover

### DIFF
--- a/csi/moac/src/nats.ts
+++ b/csi/moac/src/nats.ts
@@ -134,7 +134,7 @@ export class MessageBus {
       return;
     }
     log.trace(`"${id}" requested deregistration`);
-    this.registry.removeNode(id);
+    this.registry.disconnectNode(id);
   }
 
   _subscribe () {

--- a/csi/moac/src/node.ts
+++ b/csi/moac/src/node.ts
@@ -102,6 +102,10 @@ export class Node extends events.EventEmitter {
         log.info(
           `mayastor endpoint on node "${this.name}" changed from "${this.endpoint}" to "${endpoint}"`
         );
+        this.emit('node', {
+          eventType: 'mod',
+          object: this
+        });
         this.client.close();
         if (this.syncTimer) {
           clearTimeout(this.syncTimer);
@@ -118,10 +122,11 @@ export class Node extends events.EventEmitter {
 
   // Close the grpc connection
   disconnect() {
+    if (!this.client) return;
     log.info(`mayastor on node "${this.name}" is gone`);
-    assert(this.client);
     this.client.close();
     this.client = null;
+    this.endpoint = null;
     if (this.syncTimer) {
       clearTimeout(this.syncTimer);
       this.syncTimer = null;

--- a/csi/moac/test/nats_test.js
+++ b/csi/moac/test/nats_test.js
@@ -96,6 +96,7 @@ module.exports = function () {
       nc = null;
     }
     stopNats();
+    registry.close();
   });
 
   it('should connect to the nats server', async () => {
@@ -148,9 +149,10 @@ module.exports = function () {
       id: 'v0/deregister',
       data: { id: NODE_NAME }
     })));
+    expect(registry.getNode(NODE_NAME).isSynced());
     await waitUntil(async () => {
-      return !registry.getNode(NODE_NAME);
-    }, 1000, 'node removal');
+      return !registry.getNode(NODE_NAME).isSynced();
+    }, 1000, 'node offline');
   });
 
   it('should disconnect from the nats server', () => {

--- a/csi/moac/test/node_operator_test.js
+++ b/csi/moac/test/node_operator_test.js
@@ -88,8 +88,12 @@ module.exports = function () {
       expect(obj.status).to.equal('unknown');
     });
 
-    it('should not create node resource without grpc endpoint', () => {
-      expect(() => createNodeResource(NAME)).to.throw();
+    // empty endpoint means that the node has unregistered itself
+    it('should create node resource with empty grpc endpoint', () => {
+      const obj = createNodeResource(NAME, '', 'offline');
+      expect(obj.metadata.name).to.equal(NAME);
+      expect(obj.spec.grpcEndpoint).to.equal('');
+      expect(obj.status).to.equal('offline');
     });
   });
 
@@ -173,6 +177,14 @@ module.exports = function () {
       await sleep(EVENT_PROPAGATION_DELAY);
       sinon.assert.calledOnce(addNodeSpy);
       sinon.assert.calledWith(addNodeSpy, NAME, ENDPOINT);
+    });
+
+    it('should not add node to registry if endpoint is empty', async () => {
+      const addNodeSpy = sinon.spy(registry, 'addNode');
+      nodeResource.spec.grpcEndpoint = '';
+      oper.watcher.emit('new', nodeResource);
+      await sleep(EVENT_PROPAGATION_DELAY);
+      sinon.assert.notCalled(addNodeSpy);
     });
 
     it('should remove node from registry upon "del" event', async () => {
@@ -348,6 +360,34 @@ module.exports = function () {
 
       sinon.assert.notCalled(stubs.create);
       sinon.assert.notCalled(stubs.update);
+      sinon.assert.calledOnce(stubs.updateStatus);
+      expect(stubs.updateStatus.args[0][5].metadata.name).to.equal(NAME);
+      expect(stubs.updateStatus.args[0][5].status).to.equal('offline');
+      sinon.assert.notCalled(stubs.delete);
+    });
+
+    it('should update spec and status of the resource upon "mod" node event', async () => {
+      let stubs;
+      const nodeResource = createNodeResource(NAME, ENDPOINT, 'online');
+      mockCache(oper.watcher, (arg) => {
+        stubs = arg;
+        stubs.get.returns(nodeResource);
+      });
+      await oper.start();
+      // give time to registry to install its callbacks
+      await sleep(EVENT_PROPAGATION_DELAY);
+      registry.addNode(NAME, ENDPOINT);
+      await sleep(EVENT_PROPAGATION_DELAY);
+      const node = registry.getNode(NAME);
+      const isSyncedStub = sinon.stub(node, 'isSynced');
+      isSyncedStub.returns(false);
+      node.disconnect();
+      await sleep(EVENT_PROPAGATION_DELAY);
+
+      sinon.assert.notCalled(stubs.create);
+      sinon.assert.calledOnce(stubs.update);
+      expect(stubs.update.args[0][5].metadata.name).to.equal(NAME);
+      expect(stubs.update.args[0][5].spec.grpcEndpoint).to.equal('');
       sinon.assert.calledOnce(stubs.updateStatus);
       expect(stubs.updateStatus.args[0][5].metadata.name).to.equal(NAME);
       expect(stubs.updateStatus.args[0][5].status).to.equal('offline');

--- a/csi/moac/test/node_stub.js
+++ b/csi/moac/test/node_stub.js
@@ -32,12 +32,23 @@ class NodeStub extends Node {
 
   connect (endpoint) {
     this.syncFailed = 0;
+    if (this.endpoint === endpoint) {
+      // nothing changed
+      return;
+    } else if (this.endpoint) {
+      this.emit('node', {
+        eventType: 'mod',
+        object: this
+      });
+    }
     this.endpoint = endpoint;
   }
 
   disconnect () {
     this.syncFailed = this.syncBadLimit + 1;
     this.endpoint = null;
+    this.client = null;
+    this._offline();
   }
 }
 


### PR DESCRIPTION
The problem was that the mayastor unregistered itself and node object
was removed from moac's internal state before all events related to
offlining the node could be processed. One of the previous complaints
about msn records was that they disappear whenever the storage node
is rebooted which is confusing for users. This fix is addressing both
issues at once. Instead of removing the node upon deregistration, it
disconnects the grpc client and switches the node to offline state.
So it stays around along with all other objects that might be on the
node (pools, replicas, nexuses) and events can be processed as
normally. The obvious downside is that users have to remove msn
records manually in case they know that the storage node will never
join the cluster again. But that's just a small inconvenience
compared to what this brings.

A note for insiders. The way how you can tell the difference between
offline node that is unreachable and offline node that unregistered
itself is by looking at grpcEndpoint in msn spec. It will be empty
string for the later.

Resolves: CAS-954