### PR TITLE
fix(iscsi): use correct upstream default for MaxR2TPerConnection

### DIFF
--- a/mayastor/src/subsys/config/opts.rs
+++ b/mayastor/src/subsys/config/opts.rs
@@ -458,7 +458,7 @@ impl Default for IscsiTgtOpts {
             error_recovery_level: 0,
             allow_duplicate_isid: false,
             max_large_data_in_per_connection: 64,
-            max_r2t_per_connection: 64,
+            max_r2t_per_connection: 4,
         }
     }
 }


### PR DESCRIPTION
Upstream SPDK defaults to 4 for MaxR2TPerConnection, not 64, so
"PDU Pool" was 16X larger than it needs to be.

Fixes: 682e802 ("mayastor: Build against SPDK 20.10")