### PR TITLE
fix: remove broken symlink to pool CRD

### DIFF
--- a/deploy/mayastorpoolcrd.yaml
+++ b/deploy/mayastorpoolcrd.yaml
@@ -1,1 +1,0 @@
-../csi/moac/crds/mayastorpool.yaml


### PR DESCRIPTION
It should have been removed when moac was removed from the repo.  We
can live without the link because pool crd is created by moac when it
starts. People who wish to create pools before the moac is fully up
and running can employ different methods (i.e. waiting in loop until
the definition of crd appears or wait until moac liveness probe
confirms that moac has been fully started).