### PR TITLE
feat(cli): cli command for nvme controller statistics

### DIFF
--- a/mayastor/src/grpc/mayastor_grpc.rs
+++ b/mayastor/src/grpc/mayastor_grpc.rs
@@ -16,7 +16,7 @@ use crate::{
     },
     core::{Bdev, BlockDeviceIoStats, CoreError, Protocol, Share},
     grpc::{
-        controller_grpc::list_controllers,
+        controller_grpc::{controller_stats, list_controllers},
         nexus_grpc::{
             nexus_add_child,
             nexus_destroy,
@@ -1014,5 +1014,12 @@ impl mayastor_server::Mayastor for MayastorSvc {
         _request: Request<Null>,
     ) -> GrpcResult<ListNvmeControllersReply> {
         list_controllers().await
+    }
+
+    async fn stat_nvme_controllers(
+        &self,
+        _request: Request<Null>,
+    ) -> GrpcResult<StatNvmeControllersReply> {
+        controller_stats().await
     }
 }

--- a/rpc/proto/mayastor.proto
+++ b/rpc/proto/mayastor.proto
@@ -78,6 +78,7 @@ service Mayastor {
 
   // NVMe controllers
   rpc ListNvmeControllers (Null) returns (ListNvmeControllersReply) {}
+  rpc StatNvmeControllers (Null) returns (StatNvmeControllersReply) {}
 }
 
 // Means no arguments or no return value.
@@ -491,6 +492,24 @@ message NvmeController {
 
 message ListNvmeControllersReply {
   repeated NvmeController controllers = 1;
+}
+
+message NvmeControllerIoStats {
+  uint64 num_read_ops = 1;
+  uint64 num_write_ops = 2;
+  uint64 bytes_read = 3;
+  uint64 bytes_written = 4;
+  uint64 num_unmap_ops = 5;
+  uint64 bytes_unmapped = 6;
+}
+
+message NvmeControllerStats {
+  string name = 1;                 // NVMe controller name
+  NvmeControllerIoStats stats = 2; // Controller I/O statistics
+}
+
+message StatNvmeControllersReply {
+  repeated NvmeControllerStats controllers = 1;
 }
 
 // SPDK json-rpc proxy service

--- a/test/python/README.md
+++ b/test/python/README.md
@@ -53,7 +53,7 @@ Not all packages are available on nix, so one extra step is needed if you run
 nix.
 
 ```shell
-python -m grpc_tools.protoc -i `realpath ../../rpc/proto` --python_out=test/python --grpc_python_out=test/python mayastor.proto
+python -m grpc_tools.protoc -I `realpath ./rpc/proto` --python_out=test/python --grpc_python_out=test/python mayastor.proto
 virtualenv --no-setuptools test/python/venv
 source test/python/venv/bin/activate
 pip install -r test/python/requirements.txt

--- a/test/python/common/hdl.py
+++ b/test/python/common/hdl.py
@@ -47,6 +47,9 @@ class MayastorHandle(object):
     def close(self):
         self.__del__()
 
+    def ip_address(self):
+        return self.ip_v4
+
     def as_target(self) -> str:
         """Returns this node as scheme which is used to designate this node to
         be used as the node where the nexus shall be created on."""
@@ -128,8 +131,18 @@ class MayastorHandle(object):
         return self.ms.UnpublishNexus(pb.UnpublishNexusRequest(uuid=str(uuid)))
 
     def nexus_list(self):
-        """List all the  the nexus devices."""
+        """List all the nexus devices."""
         return self.ms.ListNexus(pb.Null()).nexus_list
+
+    def nexus_add_replica(self, uuid, uri, norebuild):
+        """Add a new replica to the nexus"""
+        return self.ms.AddChildNexus(
+            pb.AddChildNexusRequest(uuid=uuid, uri=uri, norebuild=norebuild)
+        )
+
+    def nexus_remove_replica(self, uuid, uri):
+        """Add a new replica to the nexus"""
+        return self.ms.RemoveChildNexus(pb.RemoveChildNexusRequest(uuid=uuid, uri=uri))
 
     def bdev_list(self):
         """ "List all bdevs found within the system."""

--- a/test/python/common/msclient.py
+++ b/test/python/common/msclient.py
@@ -1,0 +1,73 @@
+import os
+import subprocess
+import json
+from common.util import mayastor_target_dir
+
+
+class MayastorClient:
+    """Abstraction around Mayastor command line client, which allows
+    flexible client configuration and supports parsing of command output
+    depending on requested output mode.
+    In order to invoke mayastor CLI just perform a call operation against
+    a MayastorClient instance, passing all the commands via function arguments:
+        mscli = get_msclient()
+        mscli("controller", "list")
+    """
+
+    def __init__(self, path, cfg):
+        assert path, "CLI command path must be provided"
+        self.path = path
+        self.verbose = cfg.get("verbose", False)
+        self.url = cfg.get("url", None)
+        self.quiet = cfg.get("quiet", False)
+        self.output = cfg.get("output", "default")
+
+    def __call__(self, *args):
+        cmd = [self.path, "-o", self.output]
+
+        if self.quiet:
+            cmd.append("-q")
+        if self.verbose:
+            cmd.append("-v")
+        if self.url:
+            cmd += ["-b", self.url]
+
+        cmd += list(args)
+
+        output = subprocess.check_output(cmd, shell=False)
+        output = output.decode("utf-8")
+
+        if self.output == "json":
+            output = json.loads(output)
+
+        return output
+
+    def with_url(self, url):
+        """Set URL of the Mayastor."""
+        self.url = url
+        return self
+
+    def with_json_output(self):
+        """Set JSON output mode."""
+        self.output = "json"
+        return self
+
+    def with_default_output(self):
+        """Set default output mode (non-JSON)."""
+        self.output = "default"
+        return self
+
+    def with_verbose(self, verbose):
+        """Request verbose output."""
+        self.verbose = verbose
+        return self
+
+
+def get_msclient(cfg=None):
+    """Instantiate mayastor CLI object based on user config."""
+    # Check that CLI binary exists.
+    p = "%s/mayastor-client" % mayastor_target_dir()
+    if not os.path.isfile(p):
+        raise FileNotFoundError("No Mayastor CLI command available")
+
+    return MayastorClient(p, {} if cfg is None else cfg)

--- a/test/python/common/util.py
+++ b/test/python/common/util.py
@@ -1,0 +1,13 @@
+import os
+
+
+def mayastor_target_dir():
+    """Get Mayastor target directory (absolute path) based on evironment variable SRCDIR.
+    Raise exception if no Mayastor root is configured.
+    """
+    if "SRCDIR" not in os.environ:
+        raise Exception("SRCDIR environment variable not defined")
+
+    # For now assume only Debug builds, but we might want to consider using
+    # a variable to access Release binaries too.
+    return "%s/target/debug" % os.environ["SRCDIR"]

--- a/test/python/test_cli_controller.py
+++ b/test/python/test_cli_controller.py
@@ -1,0 +1,148 @@
+import pytest
+from common.mayastor import containers_mod, mayastor_mod
+from common.msclient import get_msclient
+import mayastor_pb2 as pb
+import uuid
+from urllib.parse import urlparse
+from common.command import run_cmd_async
+from common.fio_spdk import FioSpdk
+
+
+POOL_NAME = "pool1"
+NEXUS_GUID = "9febdeb9-cb33-4166-a89d-254b810ba34a"
+
+
+@pytest.fixture
+def create_replicas(mayastor_mod):
+    ms1 = mayastor_mod.get("ms1")
+    ms2 = mayastor_mod.get("ms2")
+
+    replicas = []
+
+    for m in (ms1, ms2):
+        p = m.pool_create(POOL_NAME, "malloc:///disk0?size_mb=100")
+        assert p.state == pb.POOL_ONLINE
+        r = m.replica_create(POOL_NAME, str(uuid.uuid4()), 32 * 1024 * 1024)
+        replicas.append(r.uri)
+    yield replicas
+    try:
+        for m in (ms1, ms2):
+            m.pool_destroy(POOL_NAME)
+    except Exception:
+        pass
+
+
+@pytest.fixture
+def create_nexus(mayastor_mod, create_replicas):
+    ms3 = mayastor_mod.get("ms3")
+    ms3.nexus_create(NEXUS_GUID, 32 * 1024 * 1024, create_replicas)
+    uri = ms3.nexus_publish(NEXUS_GUID)
+    yield uri
+    ms3.nexus_destroy(NEXUS_GUID)
+
+
+def assure_controllers(mscli, replicas):
+    """Check that target mayastor contains all the given controllers."""
+    output = mscli("controller", "list")
+    assert len(output["controllers"]) == len(replicas)
+    names = [c["name"] for c in output["controllers"]]
+
+    for r in replicas:
+        c = ctrl_name_from_uri(r)
+        assert c in names, "Controller for replica %s not found" % c
+
+
+def ctrl_name_from_uri(uri):
+    """Form controller name from the full replica URL."""
+    u = urlparse(uri)
+    return "%s%sn1" % (u.netloc, u.path)
+
+
+@pytest.mark.asyncio
+async def test_controller_list(create_replicas, create_nexus, mayastor_mod):
+    replica1 = mayastor_mod.get("ms1")
+    replica2 = mayastor_mod.get("ms2")
+    replicas = [replica1, replica2]
+    nexus = mayastor_mod.get("ms3")
+    mscli = get_msclient().with_json_output()
+
+    # Should not see any controllers on replica instances.
+    for r in replicas:
+        output = mscli.with_url(r.ip_address())("controller", "list")
+        assert len(output["controllers"]) == 0
+
+    # Should see exactly 2 controllers on the nexus instance.
+    mscli.with_url(nexus.ip_address())
+    assure_controllers(mscli, create_replicas)
+
+    # Should not see a controller for the removed replica.
+    nexus.nexus_remove_replica(NEXUS_GUID, create_replicas[0])
+    assure_controllers(mscli, create_replicas[1:])
+
+    # Should see controller for the newly added replica.
+    nexus.nexus_add_replica(NEXUS_GUID, create_replicas[0], True)
+    assure_controllers(mscli, create_replicas)
+
+
+@pytest.mark.asyncio
+async def test_controller_stats(
+    create_replicas, create_nexus, mayastor_mod, containers_mod
+):
+    nexus = mayastor_mod.get("ms3")
+    mscli = get_msclient().with_json_output().with_url(nexus.ip_address())
+
+    # Should see exactly 2 controllers on the nexus instance.
+    assure_controllers(mscli, create_replicas)
+
+    # Check that stats exist for all controllers and are initially empty.
+    output = mscli("controller", "stats")
+    assert len(output["controllers"]) == len(create_replicas)
+    names = [c["name"] for c in output["controllers"]]
+
+    for r in create_replicas:
+        c = ctrl_name_from_uri(r)
+        assert c in names, "Controller for replica %s not found" % c
+
+    for s in output["controllers"]:
+        stats = s["stats"]
+        for n in stats.keys():
+            assert stats[n] == 0, "Stat %s is not zero for a new controller" % n
+
+    # Issue I/O to replicas and make sure stats reflect that.
+    job = FioSpdk("job1", "readwrite", create_nexus, runtime=5).build()
+    await run_cmd_async(job)
+
+    target_stats = ["num_read_ops", "num_write_ops", "bytes_read", "bytes_written"]
+    cached_stats = {"num_write_ops": 0, "bytes_written": 0}
+
+    output = mscli("controller", "stats")
+    assert len(output["controllers"]) == 2
+    for c in output["controllers"]:
+        stats = c["stats"]
+
+        # Make sure all related I/O stats are counted.
+        for s in target_stats:
+            assert stats[s] > 0, "I/O stat %s is zero after active I/O operations" % s
+
+        # Make sure IOPS and number of bytes are sane (fio uses 4k block).
+        assert (
+            stats["bytes_read"] == stats["num_read_ops"] * 4096
+        ), "Read IOPs don't match number of bytes"
+        assert (
+            stats["bytes_written"] == stats["num_write_ops"] * 4096
+        ), "Write IOPs don't match number of bytes"
+
+        # Check that write-related stats are equal for all controllers in the same nexus
+        # and make sure all unrelated stats remained untouched.
+        for s in stats.keys():
+            if s in cached_stats:
+                # Cache I/O stat to check across all controllers against the same value.
+                if cached_stats[s] == 0:
+                    cached_stats[s] = stats[s]
+                else:
+                    # I/O stats for all controllers in a nexus must be equal.
+                    assert cached_stats[s] == stats[s], (
+                        "I/O statistics %s for replicas mismatch" % s
+                    )
+            elif s not in target_stats:
+                assert stats[s] == 0, "Unrelated I/O stat %s got impacted by I/O" % s


### PR DESCRIPTION
This commit introduces a new CLI command for obtaining I/O statistics for
NVMe controllers: 'controller stats'.
Also implemented a test helper for exposing mayastor CLI to Python BDD tests
in a handy manner.

Implements CAS-950