### PR TITLE
feat(nvmx): allow configurable extended host ID

### DIFF
--- a/mayastor/src/bdev/nvmx/controller.rs
+++ b/mayastor/src/bdev/nvmx/controller.rs
@@ -1003,6 +1003,7 @@ pub(crate) mod options {
         admin_timeout_ms: Option<u32>,
         disable_error_logging: Option<bool>,
         fabrics_connect_timeout_us: Option<u64>,
+        ext_host_id: Option<[u8; 16]>,
         host_nqn: Option<String>,
         keep_alive_timeout_ms: Option<u32>,
         transport_retry_count: Option<u8>,
@@ -1038,6 +1039,11 @@ pub(crate) mod options {
             self
         }
 
+        pub fn with_ext_host_id(mut self, ext_host_id: [u8; 16]) -> Self {
+            self.ext_host_id = Some(ext_host_id);
+            self
+        }
+
         pub fn with_hostnqn<T: Into<String>>(mut self, host_nqn: T) -> Self {
             self.host_nqn = Some(host_nqn.into());
             self
@@ -1061,6 +1067,10 @@ pub(crate) mod options {
 
             if let Some(timeout_ms) = self.keep_alive_timeout_ms {
                 opts.0.keep_alive_timeout_ms = timeout_ms;
+            }
+
+            if let Some(ext_host_id) = self.ext_host_id {
+                opts.0.extended_host_id = ext_host_id;
             }
 
             if let Some(host_nqn) = self.host_nqn {

--- a/mayastor/tests/nexus_multipath.rs
+++ b/mayastor/tests/nexus_multipath.rs
@@ -22,6 +22,7 @@ use common::{compose::Builder, MayastorTest};
 static POOL_NAME: &str = "tpool";
 static UUID: &str = "cdc2a7db-3ac3-403a-af80-7fadc1581c47";
 static HOSTNQN: &str = "nqn.2019-05.io.openebs";
+static HOSTID0: &str = "53b35ce9-8e71-49a9-ab9b-cba7c5670fad";
 
 fn nvme_connect(target_addr: &str, nqn: &str) {
     let status = Command::new("nvme")
@@ -310,6 +311,7 @@ async fn nexus_multipath() {
 /// that the write exclusive reservation has been acquired by the new nexus.
 async fn nexus_resv_acquire() {
     std::env::set_var("NEXUS_NVMF_RESV_ENABLE", "1");
+    std::env::set_var("MAYASTOR_NVMF_HOSTID", HOSTID0);
     let test = Builder::new()
         .name("nexus_resv_acquire_test")
         .network("10.1.0.0/16")
@@ -395,6 +397,11 @@ async fn nexus_resv_acquire() {
     assert_eq!(
         v["regctlext"][0]["rcsts"], 1,
         "should have reservation status as reserved"
+    );
+    assert_eq!(
+        v["regctlext"][0]["hostid"].as_str().unwrap(),
+        HOSTID0.to_string().replace("-", ""),
+        "should match host ID of NVMe client"
     );
     assert_eq!(
         v["regctlext"][0]["rkey"], 0x12345678,


### PR DESCRIPTION
Allow the MAYASTOR_NVMF_HOSTID environment variable to override the
default randomly generated 128-bit extended host identifier used by
the nvmx NVMf client with an optionally-hyphenated UUID string.

Overriding that also overrides the host NQN as SPDK usually derives
the host NQN from the host ID, unless the host NQN has also been
overridden.

Extend the NVMe reservation acquire test to verify that the host
adding the child has indeed acquired the write exclusive reservation.

Fixes CAS-856