### PR TITLE
ci(fix): remove the need to specify cargosha256

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,12 +94,11 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "1.4.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bbfd5cf2794b1e908ea8457e6c45f8f8f1f6ec5f74617bf4662623f47503c3b"
+checksum = "a811e6a479f2439f0c04038796b5cfb3d2ad56c230e0f2d3f7b04d68cfee607b"
 dependencies = [
  "concurrent-queue",
- "fastrand",
  "futures-lite",
  "libc",
  "log",
@@ -123,13 +122,12 @@ dependencies = [
 
 [[package]]
 name = "async-net"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69b0a74e7f70af3c8cf1aa539edbd044795706659ac52b78a71dc1a205ecefdf"
+checksum = "5373304df79b9b4395068fb080369ec7178608827306ce4d081cba51cac551df"
 dependencies = [
  "async-io",
  "blocking",
- "fastrand",
  "futures-lite",
 ]
 
@@ -295,24 +293,6 @@ name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
-
-[[package]]
-name = "blkid"
-version = "0.2.1"
-source = "git+https://github.com/openebs/blkid?branch=blkid-sys#3dc458b001fffeaa4525296b838d1aafd51a7c33"
-dependencies = [
- "blkid-sys",
- "err-derive",
- "libc",
-]
-
-[[package]]
-name = "blkid-sys"
-version = "0.1.4"
-source = "git+https://github.com/openebs/blkid?branch=blkid-sys#3dc458b001fffeaa4525296b838d1aafd51a7c33"
-dependencies = [
- "bindgen",
-]
 
 [[package]]
 name = "block-buffer"
@@ -537,9 +517,9 @@ checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
 
 [[package]]
 name = "cpufeatures"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed00c67cb5d0a7d64a44f6ad2668db7e7530311dd53ea79bcd4fb022c64911c8"
+checksum = "66c99696f6c9dd7f35d486b9d04d7e6e202aa3e8c40d553f2fdf5e7e0c6a71ef"
 dependencies = [
  "libc",
 ]
@@ -637,9 +617,9 @@ version = "0.2.0"
 dependencies = [
  "async-stream",
  "async-trait",
- "blkid",
  "chrono",
  "clap",
+ "devinfo",
  "env_logger",
  "failure",
  "futures",
@@ -802,6 +782,7 @@ dependencies = [
 name = "devinfo"
 version = "0.1.0"
 dependencies = [
+ "bindgen",
  "snafu",
  "udev",
  "url",
@@ -1056,7 +1037,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a50045aa8931ae01afbc5d72439e8f57f326becb8c70d07dfc816778eff3d167"
 dependencies = [
- "rand 0.8.3",
+ "rand 0.8.4",
  "users",
 ]
 
@@ -1264,7 +1245,8 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 [[package]]
 name = "h2"
 version = "0.3.3"
-source = "git+https://github.com/openebs/h2?branch=v0.3.3#64033595cbf9211e670481c519a9c0ac7691891e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "825343c4eef0b63f541f8903f395dc5beb362a979b5799a84062527ef1e37726"
 dependencies = [
  "bytes",
  "fnv",
@@ -1281,9 +1263,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.9.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
 name = "heck"
@@ -1296,9 +1278,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
@@ -1405,9 +1387,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.6.2"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824845a0bf897a9042383849b02c1bc219c2383772efcd5c6f9766fa4b81aef3"
+checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -1554,10 +1536,11 @@ dependencies = [
 
 [[package]]
 name = "loopdev"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac9e35cfb6646d67059f2ca8913a90e6c60633053c103df423975297f33d6fcc"
+checksum = "405bbb859905dabfc115e83d5271aeb3bb64aefbd5e6d213f17a40e1d5468485"
 dependencies = [
+ "bindgen",
  "errno",
  "libc",
 ]
@@ -1731,9 +1714,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.7.11"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf80d3e903b34e0bd7282b218398aec54e082c840d9baf8339e0080a0c542956"
+checksum = "8c2bdb6314ec10835cd3293dd268473a835c02b7b352e788be788b3c6ca6bb16"
 dependencies = [
  "libc",
  "log",
@@ -1945,7 +1928,8 @@ dependencies = [
 [[package]]
 name = "partition-identity"
 version = "0.2.8"
-source = "git+https://github.com/openebs/partition-identity.git#0111c030aa82d4dbb1f234a9939ba86535775d36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec13ba9a0eec5c10a89f6ec1b6e9e2ef7d29b810d771355abbd1c43cae003ed6"
 dependencies = [
  "err-derive",
 ]
@@ -1994,9 +1978,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc0e1f259c92177c30a4c9d177246edd0a3568b25756a977d0632cf8fa37e905"
+checksum = "8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443"
 
 [[package]]
 name = "pin-utils"
@@ -2012,14 +1996,14 @@ checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
 
 [[package]]
 name = "polling"
-version = "2.0.3"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fc12d774e799ee9ebae13f4076ca003b40d18a11ac0f3641e6f899618580b7b"
+checksum = "92341d779fa34ea8437ef4d82d440d5e1ce3f3ff7f824aa64424cd481f9a1f25"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "log",
- "wepoll-sys",
+ "wepoll-ffi",
  "winapi",
 ]
 
@@ -2186,14 +2170,14 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
+checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
- "rand_core 0.6.2",
- "rand_hc 0.3.0",
+ "rand_core 0.6.3",
+ "rand_hc 0.3.1",
 ]
 
 [[package]]
@@ -2213,7 +2197,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.2",
+ "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -2227,9 +2211,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
  "getrandom 0.2.3",
 ]
@@ -2245,18 +2229,18 @@ dependencies = [
 
 [[package]]
 name = "rand_hc"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
+checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
 dependencies = [
- "rand_core 0.6.2",
+ "rand_core 0.6.3",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "742739e41cd49414de871ea5e549afb7e2a3ac77b589bcbebe8c82fab37147fc"
+checksum = "5ab49abadf3f9e1c4bc499e8845e152ad87d2ad2d30371841171169e9d75feee"
 dependencies = [
  "bitflags",
 ]
@@ -2347,9 +2331,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "410f7acf3cb3a44527c5d9546bad4bf4e6c460915d5f9f2fc524498bfe8f70ce"
+checksum = "dead70b0b5e03e9c814bcb6b01e03e68f7c57a80aa48c72ec92152ab3e818d49"
 
 [[package]]
 name = "rustc-hash"
@@ -2488,9 +2472,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "1.9.2"
+version = "1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e3132bd01cfb74aac8b1b10083ad1f38dbf756df3176d5e63dd91e3f62a87f5"
+checksum = "1ad9fdbb69badc8916db738c25efd04f0a65297d26c2f8de4b62e57b8c12bc72"
 dependencies = [
  "rustversion",
  "serde",
@@ -2592,9 +2576,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f0242b8e50dd9accdd56170e94ca1ebd223b098eb9c83539a6e367d0f36ae68"
+checksum = "c19772be3c4dd2ceaacf03cb41d5885f2a02c4d8804884918e3a258480803335"
 
 [[package]]
 name = "slab"
@@ -2797,7 +2781,7 @@ checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "rand 0.8.3",
+ "rand 0.8.4",
  "redox_syscall",
  "remove_dir_all",
  "winapi",
@@ -2877,9 +2861,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.6.1"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a38d31d7831c6ed7aad00aa4c12d9375fd225a6dd77da1d25b707346319a975"
+checksum = "5fb2ed024293bb19f7a5dc54fe83bf86532a44c12a2bb8ba40d64a4509395ca2"
 dependencies = [
  "autocfg",
  "bytes",
@@ -2991,7 +2975,7 @@ dependencies = [
  "futures-util",
  "indexmap",
  "pin-project",
- "rand 0.8.3",
+ "rand 0.8.4",
  "slab",
  "tokio",
  "tokio-stream",
@@ -3079,9 +3063,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa5553bf0883ba7c9cbe493b085c29926bd41b66afc31ff72cf17ff4fb60dcd5"
+checksum = "ab69019741fca4d98be3c62d2b75254528b5432233fd8a4d2739fec20278de48"
 dependencies = [
  "ansi_term 0.12.1",
  "chrono",
@@ -3142,9 +3126,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.7.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0d2e7be6ae3a5fa87eed5fb451aff96f2573d2694942e40543ae0bbe19c796"
+checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
 
 [[package]]
 name = "unicode-width"
@@ -3316,10 +3300,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wepoll-sys"
-version = "3.0.1"
+name = "wepoll-ffi"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fcb14dea929042224824779fbc82d9fab8d2e6d3cbc0ac404de8edf489e77ff"
+checksum = "d743fdedc5c64377b5fc2bc036b01c7fd642205a0d96356034ae3404d49eb7fb"
 dependencies = [
  "cc",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1245,8 +1245,7 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 [[package]]
 name = "h2"
 version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "825343c4eef0b63f541f8903f395dc5beb362a979b5799a84062527ef1e37726"
+source = "git+https://github.com/openebs/h2?rev=0.3.3#64033595cbf9211e670481c519a9c0ac7691891e"
 dependencies = [
  "bytes",
  "fnv",
@@ -2861,9 +2860,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.7.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fb2ed024293bb19f7a5dc54fe83bf86532a44c12a2bb8ba40d64a4509395ca2"
+checksum = "570c2eb13b3ab38208130eccd41be92520388791207fde783bda7c1e8ace28d4"
 dependencies = [
  "autocfg",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,4 @@
 [patch.crates-io]
-partition-identity = { git = "https://github.com/openebs/partition-identity.git" }
-h2 = { git = "https://github.com/openebs/h2", branch = "v0.3.3"}
 
 [profile.dev]
 panic = "abort"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [patch.crates-io]
+h2 = { git = "https://github.com/openebs/h2",  rev = "0.3.3"}
 
 [profile.dev]
 panic = "abort"

--- a/csi/Cargo.toml
+++ b/csi/Cargo.toml
@@ -42,8 +42,5 @@ udev = "0.6"
 url = "2.1.1"
 uuid = { version = "0.8", features = ["v4"] }
 which = "3.1.1"
-
-[dependencies.blkid]
-branch = "blkid-sys"
-git = "https://github.com/openebs/blkid"
+devinfo = { path = "../devinfo"}
 

--- a/csi/Cargo.toml
+++ b/csi/Cargo.toml
@@ -11,7 +11,6 @@ path = "src/server.rs"
 [build-dependencies]
 tonic-build = "0.4"
 prost-build = "0.7"
-
 [dependencies]
 async-trait = "0.1.36"
 async-stream = "0.3.0"

--- a/csi/src/filesystem_vol.rs
+++ b/csi/src/filesystem_vol.rs
@@ -129,13 +129,13 @@ pub async fn unstage_fs_volume(
 
     if let Some(mount) = mount::find_mount(None, Some(fs_staging_path)) {
         debug!(
-            "Unstaging filesystem volume {}, unmounting device {} from {}",
+            "Unstaging filesystem volume {}, unmounting device {:?} from {}",
             volume_id, mount.source, fs_staging_path
         );
         if let Err(error) = mount::filesystem_unmount(fs_staging_path) {
             return Err(failure!(
                     Code::Internal,
-                    "Failed to unstage volume {}: failed to unmount device {} from {}: {}",
+                    "Failed to unstage volume {}: failed to unmount device {:?} from {}: {}",
                     volume_id,
                     mount.source,
                     fs_staging_path,

--- a/csi/src/format.rs
+++ b/csi/src/format.rs
@@ -2,7 +2,7 @@
 
 use std::process::Command;
 
-use blkid::probe::Probe;
+use devinfo::blkid::probe::Probe;
 
 pub(crate) async fn prepare_device(
     device: &str,

--- a/csi/src/mount.rs
+++ b/csi/src/mount.rs
@@ -2,7 +2,7 @@
 
 use std::{collections::HashSet, io::Error};
 
-use proc_mounts::MountIter;
+use devinfo::mountinfo::{MountInfo, MountIter};
 use sys_mount::{unmount, FilesystemType, Mount, MountFlags, UnmountFlags};
 
 // Simple trait for checking if the readonly (ro) option
@@ -24,32 +24,12 @@ impl ReadOnly for &str {
     }
 }
 
-// Information about a mounted filesystem.
-#[derive(Debug)]
-pub struct MountInfo {
-    pub source: String,
-    pub dest: String,
-    pub fstype: String,
-    pub options: Vec<String>,
-}
-
-impl From<proc_mounts::MountInfo> for MountInfo {
-    fn from(mount: proc_mounts::MountInfo) -> MountInfo {
-        MountInfo {
-            source: mount.source.to_string_lossy().to_string(),
-            dest: mount.dest.to_string_lossy().to_string(),
-            fstype: mount.fstype,
-            options: mount.options,
-        }
-    }
-}
-
 /// Return mountinfo matching source and/or destination.
 pub fn find_mount(
     source: Option<&str>,
     target: Option<&str>,
 ) -> Option<MountInfo> {
-    let mut found: Option<proc_mounts::MountInfo> = None;
+    let mut found: Option<MountInfo> = None;
 
     for mount in MountIter::new().unwrap().flatten() {
         if let Some(value) = source {

--- a/csi/src/nodeplugin_svc.rs
+++ b/csi/src/nodeplugin_svc.rs
@@ -54,7 +54,8 @@ async fn fsfreeze(
     {
         let device_path = device.devname();
         if let Some(mnt) = mount::find_mount(Some(&device_path), None) {
-            let args = [freeze_op, &mnt.dest];
+            let dest = mnt.dest.display().to_string();
+            let args = [freeze_op, &dest];
             let output =
                 Command::new(FSFREEZE).args(&args).output().await.context(
                     IoError {

--- a/devinfo/Cargo.toml
+++ b/devinfo/Cargo.toml
@@ -4,9 +4,10 @@ version = "0.1.0"
 authors = ["Jeffry Molanus <jeffry.molanus@gmail.com>"]
 edition = "2018"
 
-
 [dependencies]
 snafu = "0.6"
 udev = "0.6"
 url = "2.1"
 uuid = { version = "0.8", features = ["v4"] }
+[build-dependencies]
+bindgen = "0.58"

--- a/devinfo/build.rs
+++ b/devinfo/build.rs
@@ -1,0 +1,15 @@
+use std::{env, path::PathBuf};
+fn main() {
+    let bindings = bindgen::Builder::default()
+        .header("wrapper.h")
+        .allowlist_function("^blkid.*")
+        .generate()
+        .expect("Unable to generate bindings");
+
+    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+    bindings
+        .write_to_file(out_path.join("libblkid.rs"))
+        .expect("failed to generate bindings");
+
+    println!("cargo:rustc-link-lib=blkid");
+}

--- a/devinfo/src/blkid/mod.rs
+++ b/devinfo/src/blkid/mod.rs
@@ -1,0 +1,42 @@
+pub mod partition;
+pub mod probe;
+use crate::DevInfoError;
+
+include!(concat!(env!("OUT_DIR"), "/libblkid.rs"));
+pub(crate) trait CResult: Copy {
+    fn is_error(self) -> bool;
+}
+
+impl CResult for i32 {
+    fn is_error(self) -> bool {
+        self < 0
+    }
+}
+
+impl CResult for i64 {
+    fn is_error(self) -> bool {
+        self < 0
+    }
+}
+
+impl<T> CResult for *const T {
+    fn is_error(self) -> bool {
+        self.is_null()
+    }
+}
+
+impl<T> CResult for *mut T {
+    fn is_error(self) -> bool {
+        self.is_null()
+    }
+}
+
+pub(crate) fn to_result<T: CResult>(result: T) -> Result<T, DevInfoError> {
+    if result.is_error() {
+        return Err(DevInfoError::Io {
+            source: std::io::Error::last_os_error(),
+        });
+    }
+
+    Ok(result)
+}

--- a/devinfo/src/blkid/partition.rs
+++ b/devinfo/src/blkid/partition.rs
@@ -1,0 +1,77 @@
+use crate::{
+    blkid::{
+        blkid_partition,
+        blkid_partition_get_name,
+        blkid_partition_get_type_string,
+        blkid_partition_get_uuid,
+        blkid_partlist,
+        blkid_partlist_get_partition,
+        blkid_partlist_get_partition_by_partno,
+        blkid_partlist_numof_partitions,
+        to_result,
+    },
+    DevInfoError,
+};
+use std::{ffi::CStr, os::raw::c_int};
+pub struct Partition(pub(crate) blkid_partition);
+
+impl Partition {
+    pub fn get_name(&self) -> Option<String> {
+        let ptr = unsafe { blkid_partition_get_name(self.0) };
+        if ptr.is_null() {
+            return None;
+        }
+
+        Some(unsafe { CStr::from_ptr(ptr) }.to_string_lossy().to_string())
+    }
+
+    pub fn get_type_string(&self) -> Option<String> {
+        let ptr = unsafe { blkid_partition_get_type_string(self.0) };
+        if ptr.is_null() {
+            return None;
+        }
+
+        Some(unsafe { CStr::from_ptr(ptr) }.to_string_lossy().to_string())
+    }
+
+    pub fn get_uuid(&self) -> Option<String> {
+        let ptr = unsafe { blkid_partition_get_uuid(self.0) };
+        if ptr.is_null() {
+            return None;
+        }
+
+        Some(unsafe { CStr::from_ptr(ptr) }.to_string_lossy().to_string())
+    }
+}
+
+pub struct PartList(pub(crate) blkid_partlist);
+
+impl PartList {
+    pub fn get_partition(&self, partition: i32) -> Option<Partition> {
+        if let Ok(p) = to_result(unsafe {
+            blkid_partlist_get_partition(self.0, partition as c_int)
+        }) {
+            return Some(Partition(p));
+        }
+        {
+            None
+        }
+    }
+
+    pub fn get_partition_by_partno(&self, partition: i32) -> Option<Partition> {
+        if let Ok(p) = to_result(unsafe {
+            blkid_partlist_get_partition_by_partno(self.0, partition as c_int)
+        }) {
+            return Some(Partition(p));
+        }
+        {
+            None
+        }
+    }
+
+    pub fn numof_partitions(&self) -> Result<u32, DevInfoError> {
+        unsafe {
+            to_result(blkid_partlist_numof_partitions(self.0)).map(|v| v as u32)
+        }
+    }
+}

--- a/devinfo/src/blkid/probe.rs
+++ b/devinfo/src/blkid/probe.rs
@@ -1,0 +1,87 @@
+use crate::blkid::{
+    blkid_do_probe,
+    blkid_do_safeprobe,
+    blkid_free_probe,
+    blkid_new_probe,
+    blkid_new_probe_from_filename,
+    blkid_probe,
+    blkid_probe_has_value,
+    blkid_probe_lookup_value,
+};
+use std::{
+    ffi::{CStr, CString},
+    path::Path,
+};
+
+use crate::blkid::to_result;
+pub struct Probe(blkid_probe);
+use crate::DevInfoError;
+
+impl Probe {
+    pub fn new() -> Result<Probe, DevInfoError> {
+        unsafe { Ok(Probe(to_result(blkid_new_probe())?)) }
+    }
+
+    pub fn new_from_filename<P: AsRef<Path>>(
+        path: P,
+    ) -> Result<Probe, DevInfoError> {
+        let path =
+            CString::new(path.as_ref().as_os_str().to_string_lossy().as_ref())
+                .expect("provided path contained null bytes");
+
+        unsafe {
+            Ok(Probe(to_result(blkid_new_probe_from_filename(
+                path.as_ptr(),
+            ))?))
+        }
+    }
+
+    pub fn do_probe(&self) -> Result<bool, DevInfoError> {
+        unsafe { to_result(blkid_do_probe(self.0)).map(|v| v == 1) }
+    }
+
+    pub fn do_safe_probe(&self) -> Result<i32, DevInfoError> {
+        unsafe { to_result(blkid_do_safeprobe(self.0)) }
+    }
+
+    /// Fetch a value by name.
+    pub fn lookup_value(self, name: &str) -> Result<String, DevInfoError> {
+        let name = CString::new(name).unwrap();
+        let data_ptr = std::ptr::null_mut();
+        let mut len = 0;
+        unsafe {
+            to_result::<i32>(blkid_probe_lookup_value(
+                self.0,
+                name.as_ptr(),
+                data_ptr,
+                &mut len,
+            ))?;
+            Ok(CStr::from_ptr(data_ptr.cast())
+                .to_string_lossy()
+                .to_string())
+        }
+    }
+
+    /// Returns `true` if the value exists.
+    pub fn has_value(&self, name: &str) -> Result<bool, DevInfoError> {
+        let name =
+            CString::new(name).expect("provided path contained null bytes");
+
+        unsafe {
+            to_result(blkid_probe_has_value(self.0, name.as_ptr()))
+                .map(|v| v == 1)
+        }
+    }
+}
+
+impl Drop for Probe {
+    fn drop(&mut self) {
+        if self.0.is_null() {
+            // No cleanup needed
+            return;
+        }
+        unsafe {
+            blkid_free_probe(self.0);
+        }
+    }
+}

--- a/devinfo/src/lib.rs
+++ b/devinfo/src/lib.rs
@@ -3,7 +3,11 @@
 pub use block_device::BlkDev;
 mod block_device;
 use snafu::Snafu;
+pub mod mountinfo;
+pub mod partition;
 
+#[allow(non_camel_case_types)]
+pub mod blkid;
 #[derive(Debug, Snafu)]
 pub enum DevInfoError {
     #[snafu(display("Device {} not found", path))]
@@ -16,6 +20,10 @@ pub enum DevInfoError {
     NotSupported { value: String },
     #[snafu(display("udev internal error {}", value))]
     Udev { value: String },
+    #[snafu(display("I/O error: {}", source))]
+    Io { source: std::io::Error },
+    #[snafu(display("non-UTF8 string"))]
+    InvalidStr,
 }
 
 #[test]

--- a/devinfo/src/mountinfo/mod.rs
+++ b/devinfo/src/mountinfo/mod.rs
@@ -1,0 +1,213 @@
+use crate::partition::PartitionID;
+use std::{
+    ffi::OsString,
+    fmt::{self, Display, Formatter},
+    fs::File,
+    io::{self, BufRead, BufReader, Error, ErrorKind},
+    os::unix::prelude::OsStringExt,
+    path::{Path, PathBuf},
+    str::FromStr,
+};
+#[derive(Debug, Default, Clone, Hash, Eq, PartialEq)]
+pub struct MountInfo {
+    pub source: PathBuf,
+    pub dest: PathBuf,
+    pub fstype: String,
+    pub options: Vec<String>,
+}
+
+impl Display for MountInfo {
+    fn fmt(&self, fmt: &mut Formatter) -> fmt::Result {
+        write!(
+            fmt,
+            "{} {} {} {}",
+            self.source.display(),
+            self.dest.display(),
+            self.fstype,
+            if self.options.is_empty() {
+                "defaults".into()
+            } else {
+                self.options.join(",")
+            },
+        )
+    }
+}
+
+impl FromStr for MountInfo {
+    type Err = io::Error;
+
+    fn from_str(line: &str) -> Result<Self, Self::Err> {
+        let mut parts = line.split_whitespace();
+
+        fn map_err(why: &'static str) -> io::Error {
+            Error::new(ErrorKind::InvalidData, why)
+        }
+
+        let source = parts.next().ok_or_else(|| map_err("missing source"))?;
+        let dest = parts.next().ok_or_else(|| map_err("missing dest"))?;
+        let fstype = parts.next().ok_or_else(|| map_err("missing type"))?;
+        let options = parts.next().ok_or_else(|| map_err("missing options"))?;
+
+        let _dump = parts.next().map_or(Ok(0), |value| {
+            value
+                .parse::<i32>()
+                .map_err(|_| map_err("dump value is not a number"))
+        })?;
+
+        let _pass = parts.next().map_or(Ok(0), |value| {
+            value
+                .parse::<i32>()
+                .map_err(|_| map_err("pass value is not a number"))
+        })?;
+
+        let path = Self::parse_value(source)?;
+        let path = path
+            .to_str()
+            .ok_or_else(|| map_err("non-utf8 paths are unsupported"))?;
+
+        let source = if path.starts_with("/dev/disk/by-") {
+            Self::fetch_from_disk_by_path(path)?
+        } else {
+            PathBuf::from(path)
+        };
+
+        let path = Self::parse_value(dest)?;
+        let path = path
+            .to_str()
+            .ok_or_else(|| map_err("non-utf8 paths are unsupported"))?;
+
+        let dest = PathBuf::from(path);
+
+        Ok(MountInfo {
+            source,
+            dest,
+            fstype: fstype.to_owned(),
+            options: options.split(',').map(String::from).collect(),
+        })
+    }
+}
+
+impl MountInfo {
+    /// Attempt to parse a `/proc/mounts`-like line.
+
+    fn fetch_from_disk_by_path(path: &str) -> io::Result<PathBuf> {
+        PartitionID::from_disk_by_path(path)
+            .map_err(|why| {
+                Error::new(ErrorKind::InvalidData, format!("{}: {}", path, why))
+            })?
+            .get_device_path()
+            .ok_or_else(|| {
+                Error::new(
+                    ErrorKind::NotFound,
+                    format!("device path for {} was not found", path),
+                )
+            })
+    }
+
+    fn parse_value(value: &str) -> io::Result<OsString> {
+        let mut ret = Vec::new();
+
+        let mut bytes = value.bytes();
+        while let Some(b) = bytes.next() {
+            match b {
+                b'\\' => {
+                    let mut code = 0;
+                    for _i in 0 .. 3 {
+                        if let Some(b) = bytes.next() {
+                            code *= 8;
+                            code += u32::from_str_radix(
+                                &(b as char).to_string(),
+                                8,
+                            )
+                            .map_err(|err| Error::new(ErrorKind::Other, err))?;
+                        } else {
+                            return Err(Error::new(
+                                ErrorKind::Other,
+                                "truncated octal code",
+                            ));
+                        }
+                    }
+                    ret.push(code as u8);
+                }
+                _ => {
+                    ret.push(b);
+                }
+            }
+        }
+
+        Ok(OsString::from_vec(ret))
+    }
+}
+
+/// Iteratively parse the `/proc/mounts` file.
+pub struct MountIter<R> {
+    file: R,
+    buffer: String,
+}
+
+impl MountIter<BufReader<File>> {
+    pub fn new() -> io::Result<Self> {
+        Self::new_from_file("/proc/mounts")
+    }
+
+    /// Read mounts from any mount-tab-like file.
+    pub fn new_from_file<P: AsRef<Path>>(path: P) -> io::Result<Self> {
+        Ok(Self::new_from_reader(BufReader::new(File::open(path)?)))
+    }
+}
+
+impl<R: BufRead> MountIter<R> {
+    /// Read mounts from any in-memory buffer.
+    pub fn new_from_reader(readable: R) -> Self {
+        Self {
+            file: readable,
+            buffer: String::with_capacity(512),
+        }
+    }
+
+    /// Iterator-based variant of `source_mounted_at`.
+    ///
+    /// Returns true if the `source` is mounted at the given `dest`.
+    ///
+    /// Due to iterative parsing of the mount file, an error may be returned.
+    pub fn source_mounted_at<D: AsRef<Path>, P: AsRef<Path>>(
+        source: D,
+        path: P,
+    ) -> io::Result<bool> {
+        let source = source.as_ref();
+        let path = path.as_ref();
+
+        let mut is_found = false;
+
+        let mounts = MountIter::new()?;
+        for mount in mounts {
+            let mount = mount?;
+            if mount.source == source {
+                is_found = mount.dest == path;
+                break;
+            }
+        }
+
+        Ok(is_found)
+    }
+}
+
+impl<R: BufRead> Iterator for MountIter<R> {
+    type Item = io::Result<MountInfo>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            self.buffer.clear();
+            match self.file.read_line(&mut self.buffer) {
+                Ok(read) if read == 0 => return None,
+                Ok(_) => {
+                    let line = self.buffer.trim_start();
+                    if !(line.starts_with('#') || line.is_empty()) {
+                        return Some(MountInfo::from_str(line));
+                    }
+                }
+                Err(why) => return Some(Err(why)),
+            }
+        }
+    }
+}

--- a/devinfo/src/partition/mod.rs
+++ b/devinfo/src/partition/mod.rs
@@ -1,0 +1,330 @@
+use self::PartitionSource::{Path as SourcePath, *};
+use std::{
+    borrow::Cow,
+    fmt::{self, Display, Formatter},
+    fs,
+    io::{Error, ErrorKind},
+    path::{Path, PathBuf},
+    str::FromStr,
+};
+
+/// Describes a partition identity.
+///
+/// A device path may be recovered from this.
+///
+/// # Notes
+///
+/// This is a struct instead of an enum to make access to the `id` string
+/// easier for situations where the variant does not need to be checked.
+#[derive(Clone, Debug, Hash, Eq, PartialEq)]
+pub struct PartitionID {
+    pub variant: PartitionSource,
+    pub id: String,
+}
+
+impl PartitionID {
+    /// Construct a new `PartitionID` as the given source.
+    pub fn new(variant: PartitionSource, id: String) -> Self {
+        Self {
+            variant,
+            id,
+        }
+    }
+
+    /// Construct a new `PartitionID` as a `ID` source.
+    pub fn new_id(id: String) -> Self {
+        Self::new(ID, id)
+    }
+
+    /// Construct a new `PartitionID` as a `Label` source.
+    pub fn new_label(id: String) -> Self {
+        Self::new(Label, id)
+    }
+
+    /// Construct a new `PartitionID` as a `UUID` source.
+    pub fn new_uuid(id: String) -> Self {
+        Self::new(UUID, id)
+    }
+
+    /// Construct a new `PartitionID` as a `PartLabel` source.
+    pub fn new_partlabel(id: String) -> Self {
+        Self::new(PartLabel, id)
+    }
+
+    /// Construct a new `PartitionID` as a `PartUUID` source.
+    pub fn new_partuuid(id: String) -> Self {
+        Self::new(PartUUID, id)
+    }
+
+    /// Construct a new `PartitionID` as a `Path` source.
+    pub fn new_path(id: String) -> Self {
+        Self::new(SourcePath, id)
+    }
+
+    /// Find the device path of this ID.
+    pub fn get_device_path(&self) -> Option<PathBuf> {
+        if self.variant == PartitionSource::Path && self.id.starts_with('/') {
+            Some(PathBuf::from(&self.id))
+        } else {
+            from_id(&self.id, &self.variant.disk_by_path())
+        }
+    }
+
+    /// Find the given source ID of the device at the given path.
+    pub fn get_source<P: AsRef<Path>>(
+        variant: PartitionSource,
+        path: P,
+    ) -> Option<Self> {
+        Some(Self {
+            variant,
+            id: find_id(path.as_ref(), &variant.disk_by_path())?,
+        })
+    }
+
+    /// Find the UUID of the device at the given path.
+    pub fn get_uuid<P: AsRef<Path>>(path: P) -> Option<Self> {
+        Self::get_source(UUID, path)
+    }
+
+    /// Find the PARTUUID of the device at the given path.
+    pub fn get_partuuid<P: AsRef<Path>>(path: P) -> Option<Self> {
+        Self::get_source(PartUUID, path)
+    }
+
+    /// Fetch a partition ID by a `/dev/disk/by-` path.
+    pub fn from_disk_by_path<S: AsRef<str>>(path: S) -> Result<Self, Error> {
+        let path = path.as_ref();
+
+        let path = if let Some(path) = path.strip_prefix("/dev/disk/by-") {
+            path
+        } else {
+            return Err(Error::new(ErrorKind::NotFound, path));
+        };
+
+        let id = if let Some(id) = path.strip_prefix("id/") {
+            Self::new(ID, id.into())
+        } else if let Some(path) = path.strip_prefix("label/") {
+            Self::new(Label, path.into())
+        } else if let Some(path) = path.strip_prefix("partlabel/") {
+            Self::new(PartLabel, path.into())
+        } else if let Some(path) = path.strip_prefix("partuuid/") {
+            Self::new(PartUUID, path.into())
+        } else if let Some(path) = path.strip_prefix("path/") {
+            Self::new(PartUUID, path.into())
+        } else if let Some(path) = path.strip_prefix("uuid/") {
+            Self::new(PartUUID, path.into())
+        } else {
+            return Err(Error::new(ErrorKind::InvalidData, path));
+        };
+
+        Ok(id)
+    }
+}
+
+impl Display for PartitionID {
+    fn fmt(&self, fmt: &mut Formatter) -> fmt::Result {
+        if let PartitionSource::Path = self.variant {
+            write!(fmt, "{}", self.id)
+        } else {
+            write!(fmt, "{}={}", <&'static str>::from(self.variant), self.id)
+        }
+    }
+}
+
+impl FromStr for PartitionID {
+    type Err = Error;
+
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        if let Some(s) = input.strip_prefix('/') {
+            Ok(PartitionID {
+                variant: SourcePath,
+                id: s.to_owned(),
+            })
+        } else if let Some(s) = input.strip_prefix("ID=") {
+            Ok(PartitionID {
+                variant: ID,
+                id: s.to_owned(),
+            })
+        } else if let Some(s) = input.strip_prefix("LABEL=") {
+            Ok(PartitionID {
+                variant: Label,
+                id: s.to_owned(),
+            })
+        } else if let Some(s) = input.strip_prefix("PARTLABEL=") {
+            Ok(PartitionID {
+                variant: PartLabel,
+                id: s.to_owned(),
+            })
+        } else if let Some(s) = input.strip_prefix("PARTUUID=") {
+            Ok(PartitionID {
+                variant: PartUUID,
+                id: s.to_owned(),
+            })
+        } else if let Some(s) = input.strip_prefix("UUID=") {
+            Ok(PartitionID {
+                variant: UUID,
+                id: s.to_owned(),
+            })
+        } else {
+            Err(Error::new(ErrorKind::InvalidData, input))
+        }
+    }
+}
+
+/// Describes the type of partition identity.
+#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
+pub enum PartitionSource {
+    ID,
+    Label,
+    PartLabel,
+    PartUUID,
+    Path,
+    UUID,
+}
+
+impl Display for PartitionSource {
+    fn fmt(&self, fmt: &mut Formatter) -> fmt::Result {
+        write!(fmt, "{}", <&'static str>::from(*self))
+    }
+}
+
+impl From<PartitionSource> for &'static str {
+    fn from(pid: PartitionSource) -> &'static str {
+        match pid {
+            PartitionSource::ID => "ID",
+            PartitionSource::Label => "LABEL",
+            PartitionSource::PartLabel => "PARTLABEL",
+            PartitionSource::PartUUID => "PARTUUID",
+            PartitionSource::Path => "PATH",
+            PartitionSource::UUID => "UUID",
+        }
+    }
+}
+
+impl PartitionSource {
+    fn disk_by_path(self) -> PathBuf {
+        PathBuf::from(
+            ["/dev/disk/by-", &<&'static str>::from(self).to_lowercase()]
+                .concat(),
+        )
+    }
+}
+
+/// A collection of all discoverable identifiers for a partition.
+#[derive(Debug, Default, Clone, Hash, PartialEq)]
+pub struct PartitionIdentifiers {
+    pub id: Option<String>,
+    pub label: Option<String>,
+    pub part_label: Option<String>,
+    pub part_uuid: Option<String>,
+    pub path: Option<String>,
+    pub uuid: Option<String>,
+}
+
+impl PartitionIdentifiers {
+    /// Fetches all discoverable identifiers for a partition by the path to that
+    /// partition.
+    pub fn from_path<P: AsRef<Path>>(path: P) -> PartitionIdentifiers {
+        let path = path.as_ref();
+
+        PartitionIdentifiers {
+            path: PartitionID::get_source(SourcePath, path).map(|id| id.id),
+            id: PartitionID::get_source(ID, path).map(|id| id.id),
+            label: PartitionID::get_source(Label, path).map(|id| id.id),
+            part_label: PartitionID::get_source(PartLabel, path)
+                .map(|id| id.id),
+            part_uuid: PartitionID::get_source(PartUUID, path).map(|id| id.id),
+            uuid: PartitionID::get_source(UUID, path).map(|id| id.id),
+        }
+    }
+
+    /// Checks if the given identity matches one of the available identifiers.
+    pub fn matches(&self, id: &PartitionID) -> bool {
+        match id.variant {
+            ID => self.id.as_ref().map_or(false, |s| &id.id == s),
+            Label => self.label.as_ref().map_or(false, |s| &id.id == s),
+            PartLabel => {
+                self.part_label.as_ref().map_or(false, |s| &id.id == s)
+            }
+            PartUUID => self.part_uuid.as_ref().map_or(false, |s| &id.id == s),
+            SourcePath => self.path.as_ref().map_or(false, |s| &id.id == s),
+            UUID => self.uuid.as_ref().map_or(false, |s| &id.id == s),
+        }
+    }
+}
+
+fn attempt<T, F: FnMut() -> Option<T>>(
+    attempts: u8,
+    wait: u64,
+    mut func: F,
+) -> Option<T> {
+    let mut tried = 0;
+    let mut result;
+
+    loop {
+        result = func();
+        if result.is_none() && tried != attempts {
+            ::std::thread::sleep(::std::time::Duration::from_millis(wait));
+            tried += 1;
+        } else {
+            return result;
+        }
+    }
+}
+
+fn canonicalize(path: &Path) -> Cow<'_, Path> {
+    // NOTE: It seems that the kernel may intermittently error.
+    match attempt::<PathBuf, _>(10, 1, || path.canonicalize().ok()) {
+        Some(path) => Cow::Owned(path),
+        None => Cow::Borrowed(path),
+    }
+}
+
+/// Attempts to find the ID from the given path.
+fn find_id(path: &Path, uuid_dir: &Path) -> Option<String> {
+    // NOTE: It seems that the kernel may sometimes intermittently skip
+    // directories.
+    attempt(10, 1, move || {
+        let dir = uuid_dir.read_dir().ok()?;
+        find_id_(path, dir)
+    })
+}
+
+fn from_id(uuid: &str, uuid_dir: &Path) -> Option<PathBuf> {
+    // NOTE: It seems that the kernel may sometimes intermittently skip
+    // directories.
+    attempt(10, 1, move || {
+        let dir = uuid_dir.read_dir().ok()?;
+        from_id_(uuid, dir)
+    })
+}
+
+fn find_id_(path: &Path, uuid_dir: fs::ReadDir) -> Option<String> {
+    let path = canonicalize(path);
+    for uuid_entry in uuid_dir.filter_map(|entry| entry.ok()) {
+        let uuid_path = uuid_entry.path();
+        let uuid_path = canonicalize(&uuid_path);
+        if uuid_path == path {
+            if let Some(uuid_entry) = uuid_entry.file_name().to_str() {
+                return Some(uuid_entry.into());
+            }
+        }
+    }
+
+    None
+}
+
+fn from_id_(uuid: &str, uuid_dir: fs::ReadDir) -> Option<PathBuf> {
+    for uuid_entry in uuid_dir.filter_map(|entry| entry.ok()) {
+        let uuid_entry = uuid_entry.path();
+        if let Some(name) = uuid_entry.file_name() {
+            if name == uuid {
+                if let Ok(uuid_entry) = uuid_entry.canonicalize() {
+                    return Some(uuid_entry);
+                }
+            }
+        }
+    }
+
+    None
+}

--- a/devinfo/wrapper.h
+++ b/devinfo/wrapper.h
@@ -1,0 +1,1 @@
+#include <blkid/blkid.h>

--- a/mayastor/src/logger.rs
+++ b/mayastor/src/logger.rs
@@ -161,13 +161,12 @@ where
         } else {
             Style::new()
         };
-
         let scope = self
             .span
             .and_then(|id| self.context.span(id))
             .or_else(|| self.context.lookup_current())
             .into_iter()
-            .flat_map(|span| span.from_root().chain(std::iter::once(span)));
+            .flat_map(|span| span.scope().from_root());
 
         for span in scope {
             write!(f, ":{}", bold.paint(span.metadata().name()))?;

--- a/nix/pkgs/mayastor/cargo-package.nix
+++ b/nix/pkgs/mayastor/cargo-package.nix
@@ -1,7 +1,28 @@
-{ stdenv, clang_11, dockerTools, e2fsprogs, lib, libaio, libspdk, libspdk-dev
-, libudev, liburing, makeRustPlatform, numactl, openssl, pkg-config, protobuf
-, sources, xfsprogs, utillinux, llvmPackages_11, targetPackages, buildPackages
-, targetPlatform, version, cargoBuildFlags ? [ ] }:
+{ stdenv
+, clang_11
+, dockerTools
+, e2fsprogs
+, lib
+, libaio
+, libspdk
+, libspdk-dev
+, libudev
+, liburing
+, makeRustPlatform
+, numactl
+, openssl
+, pkg-config
+, protobuf
+, sources
+, xfsprogs
+, utillinux
+, llvmPackages_11
+, targetPackages
+, buildPackages
+, targetPlatform
+, version
+, cargoBuildFlags ? [ ]
+}:
 let
   channel = import ../../lib/rust.nix { inherit sources; };
   rustPlatform = makeRustPlatform {
@@ -9,10 +30,12 @@ let
     cargo = channel.stable.cargo;
   };
   whitelistSource = src: allowedPrefixes:
-    builtins.filterSource (path: type:
-      lib.any
-      (allowedPrefix: lib.hasPrefix (toString (src + "/${allowedPrefix}")) path)
-      allowedPrefixes) src;
+    builtins.filterSource
+      (path: type:
+        lib.any
+          (allowedPrefix: lib.hasPrefix (toString (src + "/${allowedPrefix}")) path)
+          allowedPrefixes)
+      src;
   src_list = [
     ".git"
     "Cargo.lock"
@@ -50,12 +73,15 @@ let
     ];
     cargoLock = {
       lockFile = ../../../Cargo.lock;
-      outputHashes = { };
+      outputHashes = {
+        "h2-0.3.3" = "sha256-Y4AaBj10ZOutI37sVRY4yVUYmVWj5dwPbPhBhPWHNiQ=";
+      };
     };
     doCheck = false;
     meta = { platforms = lib.platforms.linux; };
   };
-in {
+in
+{
   release = rustPlatform.buildRustPackage (buildProps // {
     buildType = "release";
     buildInputs = buildProps.buildInputs ++ [ libspdk ];

--- a/test/grpc/test_csi.js
+++ b/test/grpc/test_csi.js
@@ -335,7 +335,6 @@ describe('csi', function () {
     });
   });
 
-  csiProtocolTest('NBD', enums.NEXUS_NBD, 10000);
   csiProtocolTest('iSCSI', enums.NEXUS_ISCSI, 120000);
   csiProtocolTest('NVMF', enums.NEXUS_NVMF, 120000);
 });


### PR DESCRIPTION
By not pulling in dependencies from git directly we can get rid of the
need to calculate the sha and use nix builtins.

The git dependencies we used where:

 - h2 (to fix a k8s issue)
 - partition_id
 - blkid

 The changes to h2 are perhaps not needed anymore as the newer k8s
 clients should have the issue of authority IDs fixed.

 To get around the partition and blkid dependencies, I've implemented
 the required pieces myself basing it those crates which are not
 actively maintained.