### PR TITLE
feat(nexus): change create_v2 gRPC to have separate name and uuid

### DIFF
--- a/rpc/proto/mayastor.proto
+++ b/rpc/proto/mayastor.proto
@@ -43,6 +43,7 @@ service Mayastor {
   rpc CreateNexusV2 (CreateNexusV2Request) returns (Nexus) {}
   rpc DestroyNexus (DestroyNexusRequest) returns (Null) {}
   rpc ListNexus (Null) returns (ListNexusReply) {}
+  rpc ListNexusV2 (Null) returns (ListNexusV2Reply) {}
   rpc AddChildNexus (AddChildNexusRequest) returns (Child) {}
   rpc RemoveChildNexus (RemoveChildNexusRequest) returns (Null) {}
   rpc FaultNexusChild (FaultNexusChildRequest) returns (Null) {}
@@ -211,12 +212,13 @@ message CreateNexusRequest {
 }
 
 message CreateNexusV2Request {
-  string uuid = 1; // this UUID will be set in as the UUID
-  uint64 size = 2; // size of the device in bytes
-  uint32 minCntlId = 3;  // minimum NVMe controller ID
-  uint32 maxCntlId = 4;  // maximum NVMe controller ID
-  uint64 resvKey = 5;    // NVMe reservation key for children
-  repeated string children = 6; // uris to the targets we connect to
+  string name = 1; // name of the nexus
+  string uuid = 2; // UUID of the bdev
+  uint64 size = 3; // size of the device in bytes
+  uint32 minCntlId = 4;  // minimum NVMe controller ID
+  uint32 maxCntlId = 5;  // maximum NVMe controller ID
+  uint64 resvKey = 6;    // NVMe reservation key for children
+  repeated string children = 7; // uris to the targets we connect to
 }
 
 // State of the nexus child.
@@ -256,6 +258,23 @@ message Nexus {
 
 message ListNexusReply {
   repeated Nexus nexus_list = 1;
+}
+
+// represents a nexus device
+message NexusV2 {
+  string name = 1;             // name of the nexus
+  string uuid = 2;             // UUID of the bdev
+  uint64 size = 3;             // size of the volume in bytes
+  NexusState state = 4;        // current state of the nexus
+  repeated Child children = 5; // array of children
+  // URI of the device for the volume (missing if not published).
+  // Missing property and empty string are treated the same.
+  string device_uri = 6;
+  uint32 rebuilds = 7;         // total number of rebuild tasks
+}
+
+message ListNexusV2Reply {
+  repeated NexusV2 nexus_list = 1;
 }
 
 message DestroyNexusRequest   {

--- a/test/grpc/test_nexus.js
+++ b/test/grpc/test_nexus.js
@@ -16,6 +16,7 @@ const grpc = require('grpc');
 const common = require('./test_common');
 const enums = require('./grpc_enums');
 const url = require('url');
+const NEXUSNAME = 'nexus0';
 // just some UUID used for nexus ID
 const UUID = 'dbe4d7eb-118a-4d15-b789-a18d9af6ff21';
 const UUID2 = 'dbe4d7eb-118a-4d15-b789-a18d9af6ff22';
@@ -331,9 +332,6 @@ describe('nexus', function () {
     const args = {
       uuid: UUID,
       size: diskSize,
-      minCntlId: 2340,
-      maxCntlId: 2350,
-      resvKey: 0xabcd1234,
       children: [
         'bdev:///Malloc0',
         `aio://${aioFile}?blk_size=4096`,
@@ -342,7 +340,7 @@ describe('nexus', function () {
     };
     if (doUring()) args.children.push(`uring://${uringFile}?blk_size=4096`);
 
-    client.createNexusV2(args, done);
+    client.createNexus(args, done);
   }
 
   it('should create a nexus using all types of replicas', (done) => {
@@ -656,7 +654,7 @@ describe('nexus', function () {
             assert.equal((data[76] & 0x8), 0x8, 'ANA reporting should be enabled');
             // cntlid
             const cntlid = data[79] << 8 | data[78];
-            assert.equal(cntlid, 2340, 'should match expected cntlid');
+            assert.equal(cntlid, 1, 'should match expected cntlid');
           });
           done();
         }
@@ -792,6 +790,7 @@ describe('nexus', function () {
 
     it('should fail to create a nexus with invalid NVMe controller ID range', (done) => {
       const args = {
+        name: NEXUSNAME,
         uuid: UUID,
         size: 131072,
         minCntlId: 0xfff0,
@@ -810,6 +809,7 @@ describe('nexus', function () {
 
     it('should fail to create a nexus with invalid NVMe reservation key', (done) => {
       const args = {
+        name: NEXUSNAME,
         uuid: UUID,
         size: 131072,
         minCntlId: 1,

--- a/test/python/common/hdl.py
+++ b/test/python/common/hdl.py
@@ -115,12 +115,15 @@ class MayastorHandle(object):
             pb.CreateNexusRequest(uuid=str(uuid), size=size, children=children)
         )
 
-    def nexus_create_v2(self, uuid, size, min_cntlid, max_cntlid, resv_key, children):
-        """Create a nexus with the given uuid, size, NVMe controller ID range,
+    def nexus_create_v2(
+        self, name, uuid, size, min_cntlid, max_cntlid, resv_key, children
+    ):
+        """Create a nexus with the given name, uuid, size, NVMe controller ID range,
         and NVMe reservation key for children. The children should be an array
         of nvmf URIs."""
         return self.ms.CreateNexusV2(
             pb.CreateNexusV2Request(
+                name=name,
                 uuid=str(uuid),
                 size=size,
                 minCntlId=min_cntlid,
@@ -148,6 +151,10 @@ class MayastorHandle(object):
     def nexus_list(self):
         """List all the nexus devices."""
         return self.ms.ListNexus(pb.Null()).nexus_list
+
+    def nexus_list_v2(self):
+        """List all the nexus devices, with separate name and uuid."""
+        return self.ms.ListNexusV2(pb.Null()).nexus_list
 
     def nexus_add_replica(self, uuid, uri, norebuild):
         """Add a new replica to the nexus"""


### PR DESCRIPTION
Add a separate name field to the CreateNexusV2 gRPC, which is a
freeform string used directly in the Nexus structure in Rust instead
of being derived from the uuid field by prefixing "nexus-" to it.

Fixes CAS-1007