### PR TITLE
chore(build): rust-overlay and container image

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,9 +46,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.41"
+version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15af2628f6890fe2609a3b91bef4c83450512802e59489f9c1cb1fa5df064a61"
+checksum = "595d3cfa7a60d4555cb5067b99f07142a08ea778de5cf993f7b75c7d8fabc486"
 
 [[package]]
 name = "assert_matches"
@@ -397,9 +397,9 @@ checksum = "631ae5198c9be5e753e5cc215e1bd73c2b466a3565173db433f52bb9d3e66dba"
 
 [[package]]
 name = "cc"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a72c244c1ff497a746a7e1fb3d14bd08420ecda70c8f25c7112f2781652d787"
+checksum = "e70cc2f62c6ce1868963827bd677764c62d07c3d9a3e1fb1177ee1a9ab199eb2"
 
 [[package]]
 name = "cexpr"
@@ -960,9 +960,9 @@ dependencies = [
 
 [[package]]
 name = "etcd-client"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06da8620f9398a2f5d24a38d77baee793a270d6bbd1c41418e3e59775b6700bd"
+checksum = "3b6f21058de2d25f5b16afc7a42c07da13b0cced7707bf88557d9e09f62e23b7"
 dependencies = [
  "http",
  "prost",
@@ -1332,9 +1332,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.9"
+version = "0.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07d6baa1b441335f3ce5098ac421fb6547c46dda735ca1bc6d0153c838f9dd83"
+checksum = "7728a72c4c7d72665fde02204bcbd93b247721025b222ef78606f14513e0fd03"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1396,9 +1396,9 @@ dependencies = [
 
 [[package]]
 name = "instant"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
+checksum = "bee0328b1209d157ef001c94dd85b4f8f64139adb0eac2659f4b08382b2f474d"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -1485,9 +1485,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.97"
+version = "0.2.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12b8adadd720df158f4d70dfe7ccc6adb0472d7c55ca83445f6a5ab3e36f8fb6"
+checksum = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790"
 
 [[package]]
 name = "libloading"
@@ -2668,9 +2668,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "structopt"
-version = "0.3.21"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5277acd7ee46e63e5168a80734c9f6ee81b1367a7d8772a2d765df2a3705d28c"
+checksum = "69b041cdcb67226aca307e6e7be44c8806423d83e018bd662360a93dabce4d71"
 dependencies = [
  "clap",
  "lazy_static",
@@ -2679,9 +2679,9 @@ dependencies = [
 
 [[package]]
 name = "structopt-derive"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ba9cdfda491b814720b6b06e0cac513d922fc407582032e8706e9f137976f90"
+checksum = "7813934aecf5f51a54775e00068c237de98489463968231a51746bbbc03f9c10"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -2710,9 +2710,9 @@ dependencies = [
 
 [[package]]
 name = "subtle"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
+checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "subtle-encoding"
@@ -2747,9 +2747,9 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.12.4"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
+checksum = "474aaa926faa1603c40b7885a9eaea29b444d1cb2850cb7c0e37bb1a4182f4fa"
 dependencies = [
  "proc-macro2 1.0.27",
  "quote 1.0.9",
@@ -2806,18 +2806,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa6f76457f59514c7eeb4e59d891395fab0b2fd1d40723ae737d64153392e9c6"
+checksum = "93119e4feac1cbe6c798c34d3a53ea0026b0b1de6a120deef895137c0529bfe2"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a36768c0fbf1bb15eca10defa29526bda730a2376c2ab4393ccfa16fb1a318d"
+checksum = "060d69a0afe7796bf42e9e2ff91f5ee691fb15c53d38b4b62a9a53eb23164745"
 dependencies = [
  "proc-macro2 1.0.27",
  "quote 1.0.9",
@@ -2860,9 +2860,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "570c2eb13b3ab38208130eccd41be92520388791207fde783bda7c1e8ace28d4"
+checksum = "98c8b05dc14c75ea83d63dd391100353789f5f24b8b3866542a5e85c8be8e985"
 dependencies = [
  "autocfg",
  "bytes",
@@ -2880,9 +2880,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c49e3df43841dafb86046472506755d8501c5615673955f6aa17181125d13c37"
+checksum = "54473be61f4ebe4efd09cec9bd5d16fa51d70ea0192213d754d2d500457db110"
 dependencies = [
  "proc-macro2 1.0.27",
  "quote 1.0.9",
@@ -2891,9 +2891,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8864d706fdb3cc0843a49647ac892720dac98a6eeb818b77190592cf4994066"
+checksum = "7b2f3f698253f03119ac0102beaa64f67a67e08074d03a22d18784104543727f"
 dependencies = [
  "futures-core",
  "pin-project-lite",

--- a/mayastor/src/bdev/nexus/nexus_bdev.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev.rs
@@ -212,7 +212,7 @@ pub enum Error {
         child,
         name,
     ))]
-    CreateRebuildError {
+    CreateRebuild {
         source: RebuildError,
         child: String,
         name: String,
@@ -242,7 +242,7 @@ pub enum Error {
         job,
         name,
     ))]
-    RebuildOperationError {
+    RebuildOperation {
         job: String,
         name: String,
         source: RebuildError,
@@ -273,9 +273,9 @@ pub enum Error {
     #[snafu(display("Failed to create snapshot on nexus {}", name))]
     FailedCreateSnapshot { name: String, source: CoreError },
     #[snafu(display("NVMf subsystem error: {}", e))]
-    SubsysNvmfError { e: String },
+    SubsysNvmf { e: String },
     #[snafu(display("failed to pause {} current state {:?}", name, state))]
-    PauseError {
+    Pause {
         state: NexusPauseState,
         name: String,
     },
@@ -283,7 +283,7 @@ pub enum Error {
 
 impl From<NvmfError> for Error {
     fn from(error: NvmfError) -> Self {
-        Error::SubsysNvmfError {
+        Error::SubsysNvmf {
             e: error.to_string(),
         }
     }
@@ -849,7 +849,7 @@ impl Nexus {
 
             // we must pause again, schedule pause operation
             Err(NexusPauseState::Unpausing) => {
-                return Err(Error::PauseError {
+                return Err(Error::Pause {
                     state: NexusPauseState::Unpausing,
                     name: self.name.clone(),
                 });

--- a/mayastor/src/bdev/nexus/nexus_bdev_rebuild.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev_rebuild.rs
@@ -12,11 +12,11 @@ use crate::{
         nexus::{
             nexus_bdev::{
                 nexus_lookup,
-                CreateRebuildError,
+                CreateRebuild,
                 Error,
                 Nexus,
                 RebuildJobNotFound,
-                RebuildOperationError,
+                RebuildOperation,
                 RemoveRebuildJob,
             },
             nexus_channel::DrEvent,
@@ -86,7 +86,7 @@ impl Nexus {
                 });
             },
         )
-        .context(CreateRebuildError {
+        .context(CreateRebuild {
             child: name.to_owned(),
             name: self.name.clone(),
         })?;
@@ -101,7 +101,7 @@ impl Nexus {
         // rebuilt ranges in sync with the other children.
         self.reconfigure(DrEvent::ChildRebuild).await;
 
-        job.as_client().start().context(RebuildOperationError {
+        job.as_client().start().context(RebuildOperation {
             job: name.to_owned(),
             name: self.name.clone(),
         })
@@ -128,7 +128,7 @@ impl Nexus {
     /// Stop a rebuild job in the background
     pub async fn stop_rebuild(&self, name: &str) -> Result<(), Error> {
         match self.get_rebuild_job(name) {
-            Ok(rj) => rj.as_client().stop().context(RebuildOperationError {
+            Ok(rj) => rj.as_client().stop().context(RebuildOperation {
                 job: name.to_owned(),
                 name: self.name.clone(),
             }),
@@ -141,7 +141,7 @@ impl Nexus {
     /// Pause a rebuild job in the background
     pub async fn pause_rebuild(&mut self, name: &str) -> Result<(), Error> {
         let rj = self.get_rebuild_job(name)?.as_client();
-        rj.pause().context(RebuildOperationError {
+        rj.pause().context(RebuildOperation {
             job: name.to_owned(),
             name: self.name.clone(),
         })
@@ -150,7 +150,7 @@ impl Nexus {
     /// Resume a rebuild job in the background
     pub async fn resume_rebuild(&mut self, name: &str) -> Result<(), Error> {
         let rj = self.get_rebuild_job(name)?.as_client();
-        rj.resume().context(RebuildOperationError {
+        rj.resume().context(RebuildOperation {
             job: name.to_owned(),
             name: self.name.clone(),
         })

--- a/mayastor/src/bdev/nexus/nexus_channel.rs
+++ b/mayastor/src/bdev/nexus/nexus_channel.rs
@@ -68,6 +68,7 @@ impl ReconfigureCtx {
 }
 
 #[derive(Debug)]
+#[allow(clippy::enum_variant_names)]
 /// Dynamic Reconfiguration Events occur when a child is added or removed
 pub enum DrEvent {
     /// Child offline reconfiguration event
@@ -289,20 +290,15 @@ impl NexusChannel {
     pub extern "C" fn reconfigure(
         device: *mut c_void,
         ctx: Box<ReconfigureCtx>,
-        event: &DrEvent,
+        _event: &DrEvent,
     ) {
-        match event {
-            DrEvent::ChildOffline
-            | DrEvent::ChildRemove
-            | DrEvent::ChildFault
-            | DrEvent::ChildRebuild => unsafe {
-                spdk_for_each_channel(
-                    device,
-                    Some(NexusChannel::refresh_io_channels),
-                    Box::into_raw(ctx).cast(),
-                    Some(Self::reconfigure_completed),
-                );
-            },
+        unsafe {
+            spdk_for_each_channel(
+                device,
+                Some(NexusChannel::refresh_io_channels),
+                Box::into_raw(ctx).cast(),
+                Some(Self::reconfigure_completed),
+            );
         }
     }
 

--- a/mayastor/src/bdev/nvmx/controller.rs
+++ b/mayastor/src/bdev/nvmx/controller.rs
@@ -263,7 +263,7 @@ impl<'a> NvmeController<'a> {
         if !ns_active {
             self
                 .state_machine
-                .transition(Faulted(ControllerFailureReason::NamespaceInitFailed))
+                .transition(Faulted(ControllerFailureReason::NamespaceInit))
                 .expect("failed to fault controller in response to ns enumeration failure");
         }
 
@@ -379,7 +379,7 @@ impl<'a> NvmeController<'a> {
             error!("{} failed to shutdown I/O channels, rc = {}. Shutdown aborted.", ctx.name, result);
             controller
                 .state_machine
-                .transition(Faulted(ControllerFailureReason::ShutdownFailed))
+                .transition(Faulted(ControllerFailureReason::Shutdown))
                 .expect("failed to transition controller to Faulted state");
             return;
         }
@@ -544,7 +544,7 @@ impl<'a> NvmeController<'a> {
                 // shutdown might be in place.
                 let _ = controller.state_machine.transition_checked(
                     Running,
-                    Faulted(ControllerFailureReason::ResetFailed),
+                    Faulted(ControllerFailureReason::Reset),
                 );
             }
 

--- a/mayastor/src/bdev/nvmx/controller_state.rs
+++ b/mayastor/src/bdev/nvmx/controller_state.rs
@@ -14,9 +14,9 @@ pub enum NvmeControllerState {
 }
 #[derive(Debug, PartialEq, Copy, Clone)]
 pub enum ControllerFailureReason {
-    ResetFailed,
-    ShutdownFailed,
-    NamespaceInitFailed,
+    Reset,
+    Shutdown,
+    NamespaceInit,
 }
 
 impl ToString for NvmeControllerState {

--- a/mayastor/src/bin/mayastor-client/context.rs
+++ b/mayastor/src/bin/mayastor-client/context.rs
@@ -30,7 +30,7 @@ pub enum Error {
         backtrace: Backtrace,
     },
     #[snafu(display("Invalid output format: {}", format))]
-    OutputFormatError { format: String },
+    OutputFormatInvalid { format: String },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -46,7 +46,7 @@ impl FromStr for OutputFormat {
         match s.to_lowercase().as_str() {
             "json" => Ok(Self::Json),
             "default" => Ok(Self::Default),
-            s => Err(Error::OutputFormatError {
+            s => Err(Error::OutputFormatInvalid {
                 format: s.to_string(),
             }),
         }
@@ -102,7 +102,7 @@ impl Context {
         }
 
         let output = matches.value_of("output").ok_or_else(|| {
-            Error::OutputFormatError {
+            Error::OutputFormatInvalid {
                 format: "<none>".to_string(),
             }
         })?;

--- a/nix/lib/rust.nix
+++ b/nix/lib/rust.nix
@@ -1,8 +1,9 @@
 { sources ? import ../sources.nix }:
 let
-  pkgs = import sources.nixpkgs { overlays = [ (import sources.nixpkgs-mozilla) ]; };
+  pkgs =
+    import sources.nixpkgs { overlays = [ (import sources.rust-overlay) ]; };
 in
-rec {
-  nightly = pkgs.rustChannelOf { channel = "nightly"; date = "2021-04-19"; };
-  stable = pkgs.rustChannelOf { channel = "stable"; };
+with pkgs; rec  {
+  nightly = rust-bin.nightly."2021-06-22".default;
+  stable = rust-bin.stable.latest.default;
 }

--- a/nix/pkgs/images/default.nix
+++ b/nix/pkgs/images/default.nix
@@ -22,7 +22,7 @@
 let
   versionDrv = import ../../lib/version.nix { inherit lib stdenv git; };
   version = builtins.readFile "${versionDrv}";
-  env = lib.makeBinPath [ busybox xfsprogs e2fsprogs utillinux ];
+  env = lib.makeBinPath [ "/" busybox xfsprogs e2fsprogs utillinux ];
 
   # common props for all mayastor images
   mayastorImageProps = {
@@ -65,21 +65,20 @@ let
     #!${stdenv.shell}
     chroot /host /usr/bin/env -i PATH="/sbin:/bin:/usr/bin" iscsiadm "$@"
   '';
+
+  mctl = writeScriptBin "mctl" ''
+    /bin/mayastor-client "$@"
+  '';
 in
 {
   mayastor = dockerTools.buildImage (mayastorImageProps // {
     name = "mayadata/mayastor";
-    contents = [ busybox mayastor ];
+    contents = [ busybox mayastor mctl ];
   });
 
   mayastor-dev = dockerTools.buildImage (mayastorImageProps // {
     name = "mayadata/mayastor-dev";
     contents = [ busybox mayastor-dev ];
-  });
-
-  mayastor-adhoc = dockerTools.buildImage (mayastorImageProps // {
-    name = "mayadata/mayastor-adhoc";
-    contents = [ busybox mayastor-adhoc ];
   });
 
   # The algorithm for placing packages into the layers is not optimal.

--- a/nix/pkgs/mayastor/cargo-package.nix
+++ b/nix/pkgs/mayastor/cargo-package.nix
@@ -26,8 +26,8 @@
 let
   channel = import ../../lib/rust.nix { inherit sources; };
   rustPlatform = makeRustPlatform {
-    rustc = channel.stable.rust;
-    cargo = channel.stable.cargo;
+    rustc = channel.stable;
+    cargo = channel.stable;
   };
   whitelistSource = src: allowedPrefixes:
     builtins.filterSource
@@ -83,6 +83,7 @@ let
 in
 {
   release = rustPlatform.buildRustPackage (buildProps // {
+    cargoBuildFlags = "--bin mayastor --bin mayastor-client";
     buildType = "release";
     buildInputs = buildProps.buildInputs ++ [ libspdk ];
     SPDK_PATH = "${libspdk}";
@@ -92,30 +93,4 @@ in
     buildInputs = buildProps.buildInputs ++ [ libspdk-dev ];
     SPDK_PATH = "${libspdk-dev}";
   });
-  # this is for an image that does not do a build of mayastor
-  adhoc = stdenv.mkDerivation {
-    name = "mayastor-adhoc";
-    inherit version;
-    src = [
-      ../../../target/debug/mayastor
-      ../../../target/debug/mayastor-csi
-      ../../../target/debug/mayastor-client
-      ../../../target/debug/jsonrpc
-    ];
-
-    buildInputs =
-      [ libaio libspdk-dev liburing libudev openssl xfsprogs e2fsprogs ];
-
-    unpackPhase = ''
-      for srcFile in $src; do
-         cp $srcFile $(stripHash $srcFile)
-      done
-    '';
-    dontBuild = true;
-    dontConfigure = true;
-    installPhase = ''
-      mkdir -p $out/bin
-      install * $out/bin
-    '';
-  };
 }

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -35,16 +35,16 @@
         "url": "https://github.com/NixOS/nixpkgs/archive/3600a82711987ac1267a96fd97974437b69f6806.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
-    "nixpkgs-mozilla": {
+    "rust-overlay": {
         "branch": "master",
-        "description": "mozilla related nixpkgs (extends nixos/nixpkgs repo)",
-        "homepage": "https://github.com/mozilla/nixpkgs-mozilla",
-        "owner": "mozilla",
-        "repo": "nixpkgs-mozilla",
-        "rev": "3f3fba4e2066f28a1ad7ac60e86a688a92eb5b5f",
-        "sha256": "1mrj89gzrzhci4lssvzmmk31l715cddp7l39favnfs1qaijly814",
+        "description": "Pure and reproducible nix overlay for binary distributed rust toolchains",
+        "homepage": "",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "aa5f9c64c8865966b36726787721d6dc9f4948b5",
+        "sha256": "0pzaiqx4k43i3vfc74d25ins4k5zvwadqmijakkfpl4l5qr30sc6",
         "type": "tarball",
-        "url": "https://github.com/mozilla/nixpkgs-mozilla/archive/3f3fba4e2066f28a1ad7ac60e86a688a92eb5b5f.tar.gz",
+        "url": "https://github.com/oxalica/rust-overlay/archive/aa5f9c64c8865966b36726787721d6dc9f4948b5.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/shell.nix
+++ b/shell.nix
@@ -18,7 +18,7 @@ let
     (ps: with ps; [ virtualenv grpcio grpcio-tools asyncssh black ]);
 in
 mkShell {
-
+  name = "mayastor-dev-shell";
   # fortify does not work with -O0 which is used by spdk when --enable-debug
   hardeningDisable = [ "fortify" ];
   buildInputs = [
@@ -27,15 +27,10 @@ mkShell {
     docker
     docker-compose
     e2fsprogs
-    envsubst # for e2e tests
     etcd
     fio
     gdb
     git
-    go
-    gptfdisk
-    kind
-    kubectl
     kubernetes-helm
     libaio
     libiscsi
@@ -46,19 +41,17 @@ mkShell {
     nats-server
     ninja
     nodejs-16_x
-    numactl
     nvme-cli
-    nvmet-cli
     openssl
     pkg-config
     pre-commit
     procps
-    python3
     pytest_inputs
+    python3
     utillinux
     xfsprogs
   ] ++ (if (nospdk) then [ libspdk-dev.buildInputs ] else [ libspdk-dev ])
-  ++ pkgs.lib.optional (!norust) channel.nightly.rust;
+  ++ pkgs.lib.optional (!norust) channel.nightly;
 
   LIBCLANG_PATH = mayastor.LIBCLANG_PATH;
   PROTOC = mayastor.PROTOC;

--- a/shell.nix
+++ b/shell.nix
@@ -42,6 +42,7 @@ mkShell {
     ninja
     nodejs-16_x
     nvme-cli
+    numactl
     openssl
     pkg-config
     pre-commit


### PR DESCRIPTION
This removes the test binaries from the container image as they are not needed.
Also, add /bin to PATH and wrap mayastor-client to mctl.

Lastly, the mozilla-overlay isn't very flexible to use. Switch to a
more flexible overlay which, for example, does not take forever to copy
HTML files when building images.

The second commit bumps cargo deps.