### PR TITLE
fix(build): ship mayastor-csi in container

### DIFF
--- a/nix/pkgs/mayastor/cargo-package.nix
+++ b/nix/pkgs/mayastor/cargo-package.nix
@@ -83,7 +83,7 @@ let
 in
 {
   release = rustPlatform.buildRustPackage (buildProps // {
-    cargoBuildFlags = "--bin mayastor --bin mayastor-client";
+    cargoBuildFlags = "--bin mayastor --bin mayastor-client --bin mayastor-csi";
     buildType = "release";
     buildInputs = buildProps.buildInputs ++ [ libspdk ];
     SPDK_PATH = "${libspdk}";


### PR DESCRIPTION
All the containers in fact use the same images. So the CSI agent should
actually be part of that.