### PR TITLE
feat(nexus): allow 2nd nexus to connect to replica

### DIFF
--- a/mayastor/src/bdev/nexus/nexus_child.rs
+++ b/mayastor/src/bdev/nexus/nexus_child.rs
@@ -435,7 +435,7 @@ impl NexusChild {
                 key,
                 0,
                 nvme_reservation_acquire_action::ACQUIRE,
-                nvme_reservation_type::WRITE_EXCLUSIVE,
+                nvme_reservation_type::WRITE_EXCLUSIVE_ALL_REGS,
             )
             .await
         {
@@ -457,7 +457,7 @@ impl NexusChild {
                     key,
                     pkey,
                     nvme_reservation_acquire_action::PREEMPT,
-                    nvme_reservation_type::WRITE_EXCLUSIVE,
+                    nvme_reservation_type::WRITE_EXCLUSIVE_ALL_REGS,
                 )
                 .await?;
                 if let Some((_, hostid)) = self.resv_report(&*hdl).await? {

--- a/test/python/docker-compose.yml
+++ b/test/python/docker-compose.yml
@@ -9,6 +9,7 @@ services:
     image: rust:latest
     environment:
         - MY_POD_IP=10.0.0.2
+        - NEXUS_NVMF_RESV_ENABLE=1
     command: ${SRCDIR}/target/debug/mayastor -g 0.0.0.0 -l 1,2 -r /tmp/ms0.sock
     networks:
       mayastor_net:

--- a/test/python/test_nexus_multipath.py
+++ b/test/python/test_nexus_multipath.py
@@ -1,0 +1,230 @@
+from common.command import run_cmd_async_at, run_cmd_async
+from common.volume import Volume
+from common.hdl import MayastorHandle
+import logging
+import pytest
+import uuid as guid
+import asyncio
+import mayastor_pb2 as pb
+from common.nvme import (
+    nvme_connect,
+    nvme_disconnect,
+    nvme_resv_report,
+)
+
+from common.mayastor import containers_mod, mayastor_mod
+
+
+@pytest.fixture
+def create_nexus(
+    mayastor_mod, nexus_name, nexus_uuid, create_replica, min_cntlid, resv_key
+):
+    """ Create a nexus on ms3 with 2 replicas """
+    hdls = mayastor_mod
+    replicas = create_replica
+    replicas = [k.uri for k in replicas]
+
+    NEXUS_UUID, size_mb = nexus_uuid
+    NEXUS_NAME = nexus_name
+
+    hdls["ms3"].nexus_create_v2(
+        NEXUS_NAME,
+        NEXUS_UUID,
+        size_mb,
+        min_cntlid,
+        min_cntlid + 9,
+        resv_key,
+        replicas,
+    )
+    uri = hdls["ms3"].nexus_publish(NEXUS_NAME)
+    assert len(hdls["ms1"].bdev_list()) == 2
+    assert len(hdls["ms2"].bdev_list()) == 2
+    assert len(hdls["ms3"].bdev_list()) == 1
+
+    assert len(hdls["ms1"].pool_list().pools) == 1
+    assert len(hdls["ms2"].pool_list().pools) == 1
+
+    yield uri
+    hdls["ms3"].nexus_destroy(NEXUS_NAME)
+
+
+@pytest.fixture
+def create_nexus_2(mayastor_mod, nexus_name, nexus_uuid, min_cntlid_2, resv_key_2):
+    """ Create a 2nd nexus on ms0 with the same 2 replicas but with resv_key_2 """
+    hdls = mayastor_mod
+    NEXUS_NAME = nexus_name
+
+    replicas = []
+    list = mayastor_mod.get("ms3").nexus_list_v2()
+    nexus = next(n for n in list if n.name == NEXUS_NAME)
+    replicas.append(nexus.children[0].uri)
+    replicas.append(nexus.children[1].uri)
+
+    NEXUS_UUID, size_mb = nexus_uuid
+
+    hdls["ms0"].nexus_create_v2(
+        NEXUS_NAME,
+        NEXUS_UUID,
+        size_mb,
+        min_cntlid_2,
+        min_cntlid_2 + 9,
+        resv_key_2,
+        replicas,
+    )
+    uri = hdls["ms0"].nexus_publish(NEXUS_NAME)
+    assert len(hdls["ms0"].bdev_list()) == 1
+    assert len(hdls["ms1"].bdev_list()) == 2
+    assert len(hdls["ms2"].bdev_list()) == 2
+    assert len(hdls["ms3"].bdev_list()) == 1
+
+    yield uri
+    hdls["ms0"].nexus_destroy(NEXUS_NAME)
+
+
+@pytest.fixture
+def pool_config():
+    """
+    The idea is this used to obtain the pool types and names that should be
+    created.
+    """
+    pool = {}
+    pool["name"] = "tpool"
+    pool["uri"] = "malloc:///disk0?size_mb=100"
+    return pool
+
+
+@pytest.fixture
+def replica_uuid():
+    """Replica UUID to be used."""
+    UUID = "0000000-0000-0000-0000-000000000001"
+    size_mb = 64 * 1024 * 1024
+    return (UUID, size_mb)
+
+
+@pytest.fixture
+def nexus_name():
+    """Nexus name to be used."""
+    NEXUS_NAME = "nexus0"
+    return NEXUS_NAME
+
+
+@pytest.fixture
+def nexus_uuid():
+    """Nexus UUID to be used."""
+    NEXUS_UUID = "3ae73410-6136-4430-a7b5-cbec9fe2d273"
+    size_mb = 64 * 1024 * 1024
+    return (NEXUS_UUID, size_mb)
+
+
+@pytest.fixture
+def min_cntlid():
+    """NVMe minimum controller ID to be used."""
+    min_cntlid = 50
+    return min_cntlid
+
+
+@pytest.fixture
+def min_cntlid_2():
+    """NVMe minimum controller ID to be used for 2nd nexus."""
+    min_cntlid = 60
+    return min_cntlid
+
+
+@pytest.fixture
+def resv_key():
+    """NVMe reservation key to be used."""
+    resv_key = 0xABCDEF0012345678
+    return resv_key
+
+
+@pytest.fixture
+def resv_key_2():
+    """NVMe reservation key to be used for 2nd nexus."""
+    resv_key = 0x1234567890ABCDEF
+    return resv_key
+
+
+@pytest.fixture
+def create_pools(mayastor_mod, pool_config):
+    hdls = mayastor_mod
+
+    cfg = pool_config
+    pools = []
+
+    pools.append(hdls["ms1"].pool_create(cfg.get("name"), cfg.get("uri")))
+
+    pools.append(hdls["ms2"].pool_create(cfg.get("name"), cfg.get("uri")))
+
+    for p in pools:
+        assert p.state == pb.POOL_ONLINE
+    yield pools
+    try:
+        hdls["ms1"].pool_destroy(cfg.get("name"))
+        hdls["ms2"].pool_destroy(cfg.get("name"))
+    except Exception:
+        pass
+
+
+@pytest.fixture
+def create_replica(mayastor_mod, replica_uuid, create_pools):
+    hdls = mayastor_mod
+    pools = create_pools
+    replicas = []
+
+    UUID, size_mb = replica_uuid
+
+    replicas.append(hdls["ms1"].replica_create(pools[0].name, UUID, size_mb))
+    replicas.append(hdls["ms2"].replica_create(pools[0].name, UUID, size_mb))
+
+    yield replicas
+    try:
+        hdls["ms1"].replica_destroy(UUID)
+        hdls["ms2"].replica_destroy(UUID)
+    except Exception as e:
+        logging.debug(e)
+
+
+@pytest.mark.timeout(60)
+async def test_nexus_multipath(
+    create_nexus,
+    create_nexus_2,
+    nexus_name,
+    nexus_uuid,
+    mayastor_mod,
+    resv_key,
+    resv_key_2,
+):
+    """Create 2 nexuses, each with 2 replicas, with different NVMe reservation keys"""
+
+    uri = create_nexus
+    uri2 = create_nexus_2
+    NEXUS_UUID, _ = nexus_uuid
+    NEXUS_NAME = nexus_name
+    resv_key = resv_key
+    resv_key_2 = resv_key_2
+
+    list = mayastor_mod.get("ms3").nexus_list_v2()
+    nexus = next(n for n in list if n.name == NEXUS_NAME)
+    assert nexus.uuid == NEXUS_UUID
+
+    for c in range(2):
+        child_uri = nexus.children[c].uri
+
+        dev = nvme_connect(child_uri)
+        report = nvme_resv_report(dev)
+
+        assert (
+            report["rtype"] == 5
+        ), "should have write exclusive, all registrants reservation"
+        assert report["regctl"] == 2, "should have 2 registered controllers"
+        assert report["ptpls"] == 0, "should have Persist Through Power Loss State of 0"
+        for i in range(2):
+            assert (
+                report["regctlext"][i]["cntlid"] == 0xFFFF
+            ), "should have dynamic controller ID"
+        assert report["regctlext"][0]["rkey"] == resv_key
+        assert report["regctlext"][1]["rkey"] == resv_key_2
+        assert report["regctlext"][0]["rcsts"] == 1
+        assert report["regctlext"][1]["rcsts"] == 0
+
+        nvme_disconnect(child_uri)


### PR DESCRIPTION
Change the NVMe reservation type to write exclusive, all registrants,
which allows all registrants (any host that registers a key, any key),
write access to the replica. This also treats all registrants as
reservation holders.

Update the existing nexus_resv_acquire cargo test to verify that both
nexuses are registered to the replica's NVMe target. Add a python test
to verify that using the kernel NVMe initiator.

Fixes CAS-973