### PR TITLE
fix(grpc): allow UUID as name for CreateNexusV2

### DIFF
--- a/mayastor/src/grpc/nexus_grpc.rs
+++ b/mayastor/src/grpc/nexus_grpc.rs
@@ -115,21 +115,21 @@ pub fn uuid_to_name(uuid: &str) -> Result<String, Error> {
     }
 }
 
-/// Look up a nexus by its uuid prepending "nexus-" prefix, or by name if not
-/// a valid uuid (if created by nexus_create_v2).
+/// Look up a nexus by name first (if created by nexus_create_v2) then by its
+/// uuid prepending "nexus-" prefix.
 /// Return error if nexus not found.
 pub fn nexus_lookup(uuid: &str) -> Result<&mut Nexus, Error> {
-    let name = match uuid_to_name(uuid) {
-        Ok(name) => name,
-        Err(_) => uuid.to_string(),
-    };
-
-    if let Some(nexus) = instances().iter_mut().find(|n| n.name == name) {
+    if let Some(nexus) = instances().iter_mut().find(|n| n.name == uuid) {
         Ok(nexus)
     } else {
-        Err(Error::NexusNotFound {
-            name: uuid.to_owned(),
-        })
+        let name = uuid_to_name(uuid)?;
+        if let Some(nexus) = instances().iter_mut().find(|n| n.name == name) {
+            Ok(nexus)
+        } else {
+            Err(Error::NexusNotFound {
+                name: uuid.to_owned(),
+            })
+        }
     }
 }
 

--- a/test/grpc/test_nexus.js
+++ b/test/grpc/test_nexus.js
@@ -17,6 +17,7 @@ const common = require('./test_common');
 const enums = require('./grpc_enums');
 const url = require('url');
 const NEXUSNAME = 'nexus0';
+const NEXUSUUID = 'dbe4d7eb-118a-4d15-b789-a18d9af6ff20';
 // just some UUID used for nexus ID
 const UUID = 'dbe4d7eb-118a-4d15-b789-a18d9af6ff21';
 const UUID2 = 'dbe4d7eb-118a-4d15-b789-a18d9af6ff22';
@@ -214,6 +215,15 @@ describe('nexus', function () {
   const createNexus = (args) => {
     return new Promise((resolve, reject) => {
       client.createNexus(args, (err, data) => {
+        if (err) return reject(err);
+        resolve(data);
+      });
+    });
+  };
+
+  const createNexusV2 = (args) => {
+    return new Promise((resolve, reject) => {
+      client.createNexusV2(args, (err, data) => {
         if (err) return reject(err);
         resolve(data);
       });
@@ -786,6 +796,22 @@ describe('nexus', function () {
         assert.equal(err.code, grpc.status.INTERNAL);
         done();
       });
+    });
+
+    it('should create v2 and destroy a nexus with UUID as name', async () => {
+      const args = {
+        name: NEXUSUUID,
+        uuid: UUID,
+        size: 32768,
+        minCntlId: 1,
+        maxCntlId: 0xffef,
+        resvKey: 0x12345678,
+        children: [
+          'malloc:///malloc1?size_mb=64'
+        ]
+      };
+      await createNexusV2(args);
+      await destroyNexus({ uuid: NEXUSUUID });
     });
 
     it('should fail to create a nexus with invalid NVMe controller ID range', (done) => {


### PR DESCRIPTION
In nexus_lookup(), search for a nexus with the name as-is first, to
allow UUID-as-name created nexuses to be found, before falling back to
using uuid_to_name() for v1 created Nexuses that have a "nexus-<uuid>"
type name.

Fixes CAS-1021