### PR TITLE
test(python): multipath failover scenarios

### DIFF
--- a/test/python/docker-compose.yml
+++ b/test/python/docker-compose.yml
@@ -9,6 +9,7 @@ services:
     image: rust:latest
     environment:
         - MY_POD_IP=10.0.0.2
+        - NEXUS_NVMF_ANA_ENABLE=1
         - NEXUS_NVMF_RESV_ENABLE=1
     command: ${SRCDIR}/target/debug/mayastor -g 0.0.0.0 -l 1,2 -r /tmp/ms0.sock
     networks:


### PR DESCRIPTION
Test destroying a nexus whilst under IO load with 3 paths.
Test making both paths inaccessible whilst under IO load, then restore one path.

Fixes CAS-976, CAS-977, CAS-983