### PR TITLE
fix(mayastor): add support of uuid and name as separate replica proprties

### DIFF
--- a/mayastor/tests/lvs_pool.rs
+++ b/mayastor/tests/lvs_pool.rs
@@ -123,9 +123,14 @@ async fn lvs_pool_test() {
     ms.spawn(async {
         let pool = Lvs::lookup("tpool").unwrap();
         for i in 0 .. 10 {
-            pool.create_lvol(&format!("vol-{}", i), 8 * 1024 * 1024, true)
-                .await
-                .unwrap();
+            pool.create_lvol(
+                &format!("vol-{}", i),
+                8 * 1024 * 1024,
+                None,
+                true,
+            )
+            .await
+            .unwrap();
         }
 
         assert_eq!(pool.lvols().unwrap().count(), 10);
@@ -146,6 +151,7 @@ async fn lvs_pool_test() {
                 .create_lvol(
                     &format!("pool2-vol-{}", i),
                     8 * 1024 * 1024,
+                    None,
                     false,
                 )
                 .await
@@ -209,7 +215,7 @@ async fn lvs_pool_test() {
     ms.spawn(async {
         let pool = Lvs::lookup("tpool").unwrap();
         let lvol = pool
-            .create_lvol("vol-1", 1024 * 1024 * 8, false)
+            .create_lvol("vol-1", 1024 * 1024 * 8, None, false)
             .await
             .unwrap();
 
@@ -250,16 +256,21 @@ async fn lvs_pool_test() {
         let pool = Lvs::lookup("tpool").unwrap();
 
         for i in 0 .. 10 {
-            pool.create_lvol(&format!("vol-{}", i), 8 * 1024 * 1024, true)
-                .await
-                .unwrap();
+            pool.create_lvol(
+                &format!("vol-{}", i),
+                8 * 1024 * 1024,
+                None,
+                true,
+            )
+            .await
+            .unwrap();
         }
 
         for l in pool.lvols().unwrap() {
             l.share_nvmf(None).await.unwrap();
         }
 
-        pool.create_lvol("notshared", 8 * 1024 * 1024, true)
+        pool.create_lvol("notshared", 8 * 1024 * 1024, None, true)
             .await
             .unwrap();
 

--- a/mayastor/tests/replica_snapshot.rs
+++ b/mayastor/tests/replica_snapshot.rs
@@ -79,7 +79,7 @@ async fn replica_snapshot() {
             .await
             .unwrap();
             let pool = Lvs::lookup(POOL1_NAME).unwrap();
-            pool.create_lvol(UUID1, 64 * 1024 * 1024, true)
+            pool.create_lvol(UUID1, 64 * 1024 * 1024, None, true)
                 .await
                 .unwrap();
             create_nexus(0, &ip0).await;

--- a/rpc/proto/mayastor.proto
+++ b/rpc/proto/mayastor.proto
@@ -29,8 +29,10 @@ service Mayastor {
   // Replica allocates space from storage pool.
 
   rpc CreateReplica (CreateReplicaRequest) returns (Replica) {}
+  rpc CreateReplicaV2 (CreateReplicaRequestV2) returns (ReplicaV2) {}
   rpc DestroyReplica (DestroyReplicaRequest) returns (Null) {}
   rpc ListReplicas (Null) returns (ListReplicasReply) {}
+  rpc ListReplicasV2 (Null) returns (ListReplicasReplyV2) {}
   rpc StatReplicas (Null) returns (StatReplicasReply) {}
   rpc ShareReplica (ShareReplicaRequest) returns (ShareReplicaReply) {}
 
@@ -148,6 +150,15 @@ message CreateReplicaRequest {
   ShareProtocolReplica share = 5;  // protocol to expose the replica over
 }
 
+message CreateReplicaRequestV2 {
+  string name = 1;  // name of the replica
+  string uuid = 2;  // uuid of the replica
+  string pool = 3;  // name of the pool
+  uint64 size = 4;  // size of the replica in bytes
+  bool thin = 5;    // thin provisioning
+  ShareProtocolReplica share = 6;  // protocol to expose the replica over
+}
+
 // Destroy replica arguments.
 message DestroyReplicaRequest {
   string uuid = 1;  // name of the replica
@@ -163,9 +174,25 @@ message Replica {
   string uri = 6;   // uri usable by nexus to access it
 }
 
+// Replica2 properties
+message ReplicaV2 {
+  string name = 1;  // name of the replica
+  string uuid = 2;  // uuid of the replica
+  string pool = 3;  // name of the pool
+  bool thin = 4;    // thin provisioning
+  uint64 size = 5;  // size of the replica in bytes
+  ShareProtocolReplica share = 6;  // protocol used for exposing the replica
+  string uri = 7;   // uri usable by nexus to access it
+}
+
 // List of replicas and their properties.
 message ListReplicasReply {
   repeated Replica replicas = 1;  // list of the replicas
+}
+
+// List of V2 replicas and their properties.
+message ListReplicasReplyV2 {
+  repeated ReplicaV2 replicas = 1;  // list of the replicas
 }
 
 // NOTE: We use struct instead of more suitable map type, because JS protobuf

--- a/test/python/common/hdl.py
+++ b/test/python/common/hdl.py
@@ -100,13 +100,26 @@ class MayastorHandle(object):
             )
         )
 
+    def replica_create_v2(self, pool, name, uuid, size, share=1):
+        """Create a replica on the pool with the specified UUID and size."""
+        return self.ms.CreateReplicaV2(
+            pb.CreateReplicaRequestV2(
+                pool=pool, name=name, uuid=uuid, size=size, thin=False, share=share
+            )
+        )
+
     def replica_destroy(self, uuid):
         """Destroy the replica by the UUID, the pool is resolved within
         mayastor."""
         return self.ms.DestroyReplica(pb.DestroyReplicaRequest(uuid=uuid))
 
     def replica_list(self):
+        """List existing replicas"""
         return self.ms.ListReplicas(pb.Null())
+
+    def replica_list_v2(self):
+        """List existing replicas along with their UUIDs"""
+        return self.ms.ListReplicasV2(pb.Null())
 
     def nexus_create(self, uuid, size, children):
         """Create a nexus with the given uuid and size. The children should

--- a/test/python/features/replica-guid.feature
+++ b/test/python/features/replica-guid.feature
@@ -1,0 +1,18 @@
+Feature: Explicit UUID and name for replicas
+
+    Background:
+      Given a mayastor instance
+      And a data pool created on mayastor instance
+
+    Scenario: create a replica with explicit UUID and name
+      When a new replica is successfully created using UUID and name
+      Then replica block device has the given name and UUID
+      And replica name is returned in the response object to the caller
+
+    Scenario: list replicas created with explicit UUIDs and names
+      When a new replica is successfully created using UUID and name
+      Then both UUID and name should be provided upon replicas enumeration
+
+    Scenario: list replicas created using v1 api
+      When a new replica is successfully created using v1 api
+      Then replica should be successfully enumerated via new replica enumeration api

--- a/test/python/test_replica_uuid.py
+++ b/test/python/test_replica_uuid.py
@@ -1,0 +1,128 @@
+import pytest
+from pytest_bdd import given, scenario, then, when
+from common.mayastor import mayastor_mod
+import mayastor_pb2 as pb
+
+POOL_NAME = "pool0"
+REPLICA_NAME = "replica-4cb9-8097"
+REPLICA_UUID = "45d2fd3e-38f2-42bf-8b5f-acddccf0ff53"
+REPLICA_SIZE = 1024 * 1024 * 16
+
+REPLICA_NAME_V1 = "replica-56e8-443f"
+
+
+@scenario(
+    "features/replica-guid.feature", "create a replica with explicit UUID and name"
+)
+def test_create_replica_with_guid():
+    "Create a replica with explicit UUID and name"
+
+
+@scenario(
+    "features/replica-guid.feature",
+    "list replicas created with explicit UUIDs and names",
+)
+def test_list_replica_with_guid():
+    "List replicas created with explicit UUIDs and names"
+
+
+@scenario(
+    "features/replica-guid.feature",
+    "list replicas created using v1 api",
+)
+def test_list_v1_replicas():
+    "List replicas created using v1 api"
+
+
+@pytest.fixture(scope="module")
+def mayastor_instance(mayastor_mod):
+    yield mayastor_mod["ms0"]
+
+
+@pytest.fixture(scope="module")
+def mayastor_pool(mayastor_instance):
+    pool = mayastor_instance.pool_create(POOL_NAME, "malloc:///disk0?size_mb=64")
+    assert pool.state == pb.POOL_ONLINE
+    yield POOL_NAME
+    try:
+        mayastor_instance.pool_destroy(POOL_NAME)
+    except Exception:
+        pass
+
+
+@given("a mayastor instance")
+def given_instance():
+    pass
+
+
+@given("a data pool created on mayastor instance")
+def given_pool():
+    pass
+
+
+@when("a new replica is successfully created using UUID and name")
+def create_replica(mayastor_instance, mayastor_pool):
+    replica = mayastor_instance.replica_create_v2(
+        mayastor_pool, REPLICA_NAME, REPLICA_UUID, REPLICA_SIZE
+    )
+    assert replica.name == REPLICA_NAME, "Replica name does not match"
+    assert replica.uuid == REPLICA_UUID, "Replica UUID does not match"
+    assert replica.size == REPLICA_SIZE, "Replica size does not match"
+    assert replica.pool == POOL_NAME, "Pool name does not match"
+
+
+@then("replica block device has the given name and UUID")
+def check_replica_device(mayastor_instance):
+    devs = [d for d in mayastor_instance.bdev_list() if d.name == REPLICA_NAME]
+    assert len(devs) == 1, "Replica device not found among Mayastor devices"
+    assert devs[0].uuid == REPLICA_UUID, "UUID for replica device does not match"
+
+    size = devs[0].num_blocks * devs[0].blk_size
+    assert size == REPLICA_SIZE, "Replica device size does not match"
+
+
+@then("both UUID and name should be provided upon replicas enumeration")
+def check_replica_enumeration(mayastor_instance):
+    replicas = [
+        r
+        for r in mayastor_instance.replica_list_v2().replicas
+        if r.name == REPLICA_NAME
+    ]
+    assert len(replicas) == 1, "Replica can not be found by its name"
+
+    replica = replicas[0]
+    assert replica.name == REPLICA_NAME
+    assert replica.uuid == REPLICA_UUID
+    assert replica.size == REPLICA_SIZE
+    assert replica.pool == POOL_NAME
+
+
+@then("replica name is returned in the response object to the caller")
+def check_replica_name():
+    # Already checked upon replica creation.
+    pass
+
+
+@when("a new replica is successfully created using v1 api")
+def create_v1_replica(mayastor_instance, mayastor_pool):
+    replica = mayastor_instance.replica_create(
+        mayastor_pool, REPLICA_NAME_V1, REPLICA_SIZE
+    )
+    assert replica.uuid == REPLICA_NAME_V1, "Replica name does not match"
+    assert replica.size == REPLICA_SIZE, "Replica size does not match"
+
+
+@then("replica should be successfully enumerated via new replica enumeration api")
+def check_v1_replica(mayastor_instance):
+    replicas = [
+        r
+        for r in mayastor_instance.replica_list_v2().replicas
+        if r.name == REPLICA_NAME_V1
+    ]
+    assert len(replicas) == 1, "Replica can not be found by its name"
+
+    replica = replicas[0]
+    assert replica.name == REPLICA_NAME_V1
+    assert replica.size == REPLICA_SIZE
+    assert replica.pool == POOL_NAME, "Pool name does not match"
+    assert replica.uuid != REPLICA_NAME_V1, "Replica UUID was set to replica name"


### PR DESCRIPTION
fix(mayastor): add support of uuid and name as separate replica proprties

Added new gRPC methods to support separately UUID and name for replica
creation and enumeration.

Fixes CAS-1036