### PR TITLE
feat: build against SPDK 21.07

### DIFF
--- a/mayastor/src/bdev/aio.rs
+++ b/mayastor/src/bdev/aio.rs
@@ -124,6 +124,7 @@ impl CreateDestroy for Aio {
     async fn destroy(self: Box<Self>) -> Result<(), Self::Error> {
         match Bdev::lookup_by_name(&self.name) {
             Some(bdev) => {
+                bdev.remove_alias(&self.alias);
                 let (sender, receiver) = oneshot::channel::<ErrnoResult<()>>();
                 unsafe {
                     bdev_aio_delete(

--- a/mayastor/src/bdev/malloc.rs
+++ b/mayastor/src/bdev/malloc.rs
@@ -187,6 +187,7 @@ impl CreateDestroy for Malloc {
 
     async fn destroy(self: Box<Self>) -> Result<(), Self::Error> {
         if let Some(bdev) = Bdev::lookup_by_name(&self.name) {
+            bdev.remove_alias(&self.alias);
             let (s, r) = oneshot::channel::<ErrnoResult<()>>();
 
             unsafe {

--- a/mayastor/src/bdev/nexus/nexus_share.rs
+++ b/mayastor/src/bdev/nexus/nexus_share.rs
@@ -90,6 +90,10 @@ impl Share for Nexus {
     fn bdev_uri(&self) -> Option<String> {
         self.bdev.bdev_uri()
     }
+
+    fn bdev_uri_original(&self) -> Option<String> {
+        self.bdev.bdev_uri_original()
+    }
 }
 
 impl From<&NexusTarget> for ShareProtocolNexus {

--- a/mayastor/src/bdev/null.rs
+++ b/mayastor/src/bdev/null.rs
@@ -185,6 +185,7 @@ impl CreateDestroy for Null {
 
     async fn destroy(self: Box<Self>) -> Result<(), Self::Error> {
         if let Some(bdev) = Bdev::lookup_by_name(&self.name) {
+            bdev.remove_alias(&self.alias);
             let (s, r) = oneshot::channel::<ErrnoResult<()>>();
             unsafe {
                 spdk_sys::bdev_null_delete(

--- a/mayastor/src/bdev/nvme.rs
+++ b/mayastor/src/bdev/nvme.rs
@@ -126,7 +126,8 @@ impl CreateDestroy for NVMe {
     }
 
     async fn destroy(self: Box<Self>) -> Result<(), Self::Error> {
-        if let Some(_bdev) = Bdev::lookup_by_name(&self.get_name()) {
+        if let Some(bdev) = Bdev::lookup_by_name(&self.get_name()) {
+            bdev.remove_alias(&self.url.to_string());
             let errno = unsafe {
                 bdev_nvme_delete(
                     self.name.clone().into_cstring().as_ptr(),

--- a/mayastor/src/bdev/nvmf.rs
+++ b/mayastor/src/bdev/nvmf.rs
@@ -231,7 +231,8 @@ impl CreateDestroy for Nvmf {
     /// Destroy the given NVMF bdev
     async fn destroy(self: Box<Self>) -> Result<(), Self::Error> {
         match Bdev::lookup_by_name(&self.get_name()) {
-            Some(_) => {
+            Some(bdev) => {
+                bdev.remove_alias(&self.alias);
                 let cname = CString::new(self.name.clone()).unwrap();
 
                 let errno = unsafe {

--- a/mayastor/src/bdev/nvmx/controller_inner.rs
+++ b/mayastor/src/bdev/nvmx/controller_inner.rs
@@ -464,6 +464,7 @@ impl<'a> NvmeController<'a> {
             spdk_nvme_ctrlr_register_timeout_callback(
                 self.ctrlr_as_ptr(),
                 device_defaults.timeout_us,
+                device_defaults.timeout_us,
                 Some(NvmeController::io_timeout_handler),
                 self.timeout_config.as_ptr().cast(),
             );

--- a/mayastor/src/bdev/uring.rs
+++ b/mayastor/src/bdev/uring.rs
@@ -114,6 +114,7 @@ impl CreateDestroy for Uring {
     async fn destroy(self: Box<Self>) -> Result<(), Self::Error> {
         match Bdev::lookup_by_name(&self.name) {
             Some(bdev) => {
+                bdev.remove_alias(&self.alias);
                 let (sender, receiver) = oneshot::channel::<ErrnoResult<()>>();
                 unsafe {
                     delete_uring_bdev(

--- a/mayastor/src/core/bdev.rs
+++ b/mayastor/src/core/bdev.rs
@@ -347,7 +347,7 @@ impl Bdev {
         let mut ent_ptr = head.tqh_first;
         while !ent_ptr.is_null() {
             let ent = unsafe { &*ent_ptr };
-            let alias = unsafe { CStr::from_ptr(ent.alias) };
+            let alias = unsafe { CStr::from_ptr(ent.alias.name) };
             aliases.push(alias.to_str().unwrap().to_string());
             ent_ptr = ent.tailq.tqe_next;
         }

--- a/mayastor/src/core/bdev.rs
+++ b/mayastor/src/core/bdev.rs
@@ -143,6 +143,18 @@ impl Share for Bdev {
         }
         None
     }
+
+    /// return the URI that was used to construct the bdev, without uuid
+    fn bdev_uri_original(&self) -> Option<String> {
+        for alias in self.aliases().iter() {
+            if let Ok(uri) = url::Url::parse(alias) {
+                if self == uri {
+                    return Some(uri.to_string());
+                }
+            }
+        }
+        None
+    }
 }
 
 impl Bdev {

--- a/mayastor/src/core/share.rs
+++ b/mayastor/src/core/share.rs
@@ -55,4 +55,5 @@ pub trait Share: std::fmt::Debug {
     fn shared(&self) -> Option<Protocol>;
     fn share_uri(&self) -> Option<String>;
     fn bdev_uri(&self) -> Option<String>;
+    fn bdev_uri_original(&self) -> Option<String>;
 }

--- a/mayastor/src/core/thread.rs
+++ b/mayastor/src/core/thread.rs
@@ -9,6 +9,8 @@ use spdk_sys::{
     spdk_thread_destroy,
     spdk_thread_exit,
     spdk_thread_get_by_id,
+    spdk_thread_get_id,
+    spdk_thread_get_name,
     spdk_thread_is_exited,
     spdk_thread_poll,
     spdk_thread_send_msg,
@@ -65,7 +67,7 @@ impl Mthread {
     }
 
     pub fn id(&self) -> u64 {
-        unsafe { (self.0.as_ref()).id }
+        unsafe { spdk_thread_get_id(self.0.as_ptr()) }
     }
     ///
     /// # Note
@@ -104,7 +106,7 @@ impl Mthread {
 
     pub fn name(&self) -> &str {
         unsafe {
-            std::ffi::CStr::from_ptr(&self.0.as_ref().name[0])
+            std::ffi::CStr::from_ptr(spdk_thread_get_name(self.0.as_ptr()))
                 .to_str()
                 .unwrap()
         }

--- a/mayastor/src/lvs/lvol.rs
+++ b/mayastor/src/lvs/lvol.rs
@@ -174,6 +174,10 @@ impl Share for Lvol {
     fn bdev_uri(&self) -> Option<String> {
         None
     }
+
+    fn bdev_uri_original(&self) -> Option<String> {
+        None
+    }
 }
 
 impl Lvol {

--- a/mayastor/src/lvs/lvs_pool.rs
+++ b/mayastor/src/lvs/lvs_pool.rs
@@ -404,7 +404,7 @@ impl Lvs {
             })?;
 
         info!("pool {} exported successfully", pool);
-        bdev_destroy(&base_bdev.bdev_uri().unwrap())
+        bdev_destroy(&base_bdev.bdev_uri_original().unwrap())
             .await
             .map_err(|e| Error::Destroy {
                 source: e,
@@ -478,7 +478,7 @@ impl Lvs {
 
         info!("pool {} destroyed successfully", pool);
 
-        bdev_destroy(&base_bdev.bdev_uri().unwrap())
+        bdev_destroy(&base_bdev.bdev_uri_original().unwrap())
             .await
             .map_err(|e| Error::Destroy {
                 source: e,

--- a/mayastor/src/subsys/config/opts.rs
+++ b/mayastor/src/subsys/config/opts.rs
@@ -551,6 +551,8 @@ pub struct PosixSocketOpts {
     recv_buf_size: u32,
     send_buf_size: u32,
     enable_recv_pipe: bool,
+    /// deprecated, use use enable_zerocopy_send_server or
+    /// enable_zerocopy_send_client instead
     enable_zero_copy_send: bool,
     enable_quickack: bool,
     enable_placement_id: u32,
@@ -564,7 +566,7 @@ impl Default for PosixSocketOpts {
             recv_buf_size: try_from_env("SOCK_RECV_BUF_SIZE", 2097152),
             send_buf_size: try_from_env("SOCK_SEND_BUF_SIZE", 2097152),
             enable_recv_pipe: try_from_env("SOCK_ENABLE_RECV_PIPE", true),
-            enable_zero_copy_send: try_from_env("SOCK_ZERO_COPY_SEND", true),
+            enable_zero_copy_send: true,
             enable_quickack: try_from_env("SOCK_ENABLE_QUICKACK", true),
             enable_placement_id: try_from_env("SOCK_ENABLE_PLACEMENT_ID", 0),
             enable_zerocopy_send_server: try_from_env(
@@ -573,7 +575,7 @@ impl Default for PosixSocketOpts {
             ),
             enable_zerocopy_send_client: try_from_env(
                 "SOCK_ZEROCOPY_SEND_CLIENT",
-                true,
+                false,
             ),
         }
     }

--- a/mayastor/tests/nexus_multipath.rs
+++ b/mayastor/tests/nexus_multipath.rs
@@ -456,7 +456,8 @@ async fn nexus_resv_acquire() {
         "should have dynamic controller ID"
     );
     assert_eq!(
-        v2["regctlext"][1]["rcsts"], 0,
+        v2["regctlext"][1]["rcsts"].as_u64().unwrap() & 0x1,
+        0,
         "should have reservation status as not reserved"
     );
     assert_eq!(

--- a/nix/pkgs/libspdk/default.nix
+++ b/nix/pkgs/libspdk/default.nix
@@ -36,13 +36,13 @@
 let
   # Derivation attributes for production version of libspdk
   drvAttrs = rec {
-    version = "21.04-34af5c5fd07c10e432b3b878ade69e36571e1b67";
+    version = "21.07-4a58029";
 
     src = fetchFromGitHub {
       owner = "openebs";
       repo = "spdk";
-      rev = "34af5c5fd07c10e432b3b878ade69e36571e1b67";
-      sha256 = "bC0plqdOB8Ynjh6u6qaQugyPUI7kvGcxI17QwBakXe4=";
+      rev = "4a5802936d06b03e300759d72a7f4dd0e6a7adb9";
+      sha256 = "0mi86rwm5v0yal5w69ykhxc4hdmmzcrb750yanbdzgb4lpcpi7g3";
       #sha256 = lib.fakeSha256;
       fetchSubmodules = true;
     };
@@ -73,6 +73,7 @@ let
       ncurses
       numactl
       openssl
+      (python3.withPackages (ps: with ps; [ pyelftools ]))
       zlib
     ];
 

--- a/scripts/check-coredumps.sh
+++ b/scripts/check-coredumps.sh
@@ -53,7 +53,7 @@ fi
 # Iterate over new coredumps and print a summary and stack for each
 echo "Looking for new coredumps ..."
 echo
-coredump_pids=$(coredumpctl list --quiet --no-legend --since="$since" | awk '{ print $5 }')
+coredump_pids=$(coredumpctl list --quiet --no-legend --since="$since" | grep -v "sshd$" | awk '{ print $5 }')
 coredump_count=0
 for pid in $coredump_pids; do
   coredump_count=$((coredump_count + 1))

--- a/spdk-sys/wrapper.h
+++ b/spdk-sys/wrapper.h
@@ -32,8 +32,10 @@
 #include <spdk/uuid.h>
 #include <spdk/version.h>
 #include <spdk_internal/event.h>
+#include <spdk_internal/init.h>
 #include <spdk_internal/thread.h>
 #include <spdk_internal/lvolstore.h>
+#include <thread/thread_internal.h>
 
 #include "logwrapper.h"
 #include "nvme_helper.h"

--- a/test/python/test_nexus_multipath.py
+++ b/test/python/test_nexus_multipath.py
@@ -308,8 +308,8 @@ def test_nexus_multipath(
             ), "should have dynamic controller ID"
         assert report["regctlext"][0]["rkey"] == resv_key
         assert report["regctlext"][1]["rkey"] == resv_key_2
-        assert report["regctlext"][0]["rcsts"] == 1
-        assert report["regctlext"][1]["rcsts"] == 0
+        assert (report["regctlext"][0]["rcsts"] & 0x1) == 1
+        assert (report["regctlext"][1]["rcsts"] & 0x1) == 0
 
         nvme_disconnect(child_uri)
 


### PR DESCRIPTION
Build mayastor against SPDK 21.07. This fixes heap corruption when a 
nexus is unpublished or destroyed whilst an NVMe client is still 
connected to it.

The upgrade required fixes to leaked bdev aliases and corrects the use
of spdk_nvme_probe_poll_async().

Fixed CAS-1042, CAS-1056.