### PR TITLE
fix(pytest): update setup.sh to reflect new location of mayadata.proto

### DIFF
--- a/test/python/README.md
+++ b/test/python/README.md
@@ -53,7 +53,7 @@ Not all packages are available on nix, so one extra step is needed if you run
 nix.
 
 ```shell
-python -m grpc_tools.protoc --proto_path=`realpath rpc/proto` --python_out=test/python --grpc_python_out=test/python mayastor.proto
+python -m grpc_tools.protoc --proto_path=`realpath rpc/mayastor-api/protobuf` --python_out=test/python --grpc_python_out=test/python mayastor.proto
 python -m grpc_tools.protoc --proto_path=`realpath csi/proto` --python_out=test/python --grpc_python_out=test/python csi.proto
 virtualenv --no-setuptools test/python/venv
 source test/python/venv/bin/activate

--- a/test/python/setup.sh
+++ b/test/python/setup.sh
@@ -10,7 +10,7 @@ fi
 
 cd "$SRCDIR"
 
-python -m grpc_tools.protoc --proto_path=rpc/proto --grpc_python_out=test/python --python_out=test/python mayastor.proto
+python -m grpc_tools.protoc --proto_path=rpc/mayastor-api/protobuf --grpc_python_out=test/python --python_out=test/python mayastor.proto
 python -m grpc_tools.protoc --proto_path=csi/proto --grpc_python_out=test/python --python_out=test/python csi.proto
 
 virtualenv --no-setuptools test/python/venv


### PR DESCRIPTION
This change allows the python tests to to be configured and run manually.
In order to run them in CI will require changes to the Jenkins pipeline
to include  submodules in the checkout.