### PR TITLE
test(e2e): support for coverage builds

### DIFF
--- a/chart/templates/csi-daemonset.yaml
+++ b/chart/templates/csi-daemonset.yaml
@@ -28,7 +28,7 @@ spec:
       # the same.
       containers:
       - name: mayastor-csi
-        image: {{ include "mayastorImagesPrefix" . }}mayadata/mayastor-csi:{{ .Values.mayastorImagesTag }}
+        image: {{ include "mayastorImagesPrefix" . }}mayadata/mayastor:{{ .Values.mayastorImagesTag }}
         imagePullPolicy: {{ .Values.mayastorImagePullPolicy }}
         # we need privileged because we mount filesystems and use mknod
         securityContext:
@@ -44,12 +44,16 @@ spec:
               fieldPath: status.podIP
         - name: RUST_BACKTRACE
           value: "1"
+        - name: LLVM_PROFILE_FILE
+          value: /var/local/mayastor-csi/mayastor-csi.profraw
         args:
         - "--csi-socket=/csi/csi.sock"
         - "--node-name=$(MY_NODE_NAME)"
         - "--grpc-endpoint=$(MY_POD_IP):10199"{{ if .Values.csi.nvme.io_timeout_enabled }}
         - "--nvme-core-io-timeout={{ .Values.csi.nvme.io_timeout }}"{{ end }}
         - "-v"
+        command:
+        - mayastor-csi
         volumeMounts:
         - name: device
           mountPath: /dev
@@ -61,6 +65,8 @@ spec:
           mountPath: /host
         - name: plugin-dir
           mountPath: /csi
+        - name: coverage
+          mountPath: /var/local/mayastor-csi
         - name: kubelet-dir
           mountPath: /var/lib/kubelet
           mountPropagation: "Bidirectional"
@@ -122,3 +128,7 @@ spec:
         hostPath:
           path: /var/lib/kubelet
           type: Directory
+      - name: coverage
+        hostPath:
+          path: /var/local/mayastor-csi
+          type: DirectoryOrCreate

--- a/chart/templates/mayastor-daemonset.yaml
+++ b/chart/templates/mayastor-daemonset.yaml
@@ -44,6 +44,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: LLVM_PROFILE_FILE
+          value: /var/local/mayastor/mayastor.profraw
         args:
         # The -l argument accepts cpu-list. Indexing starts at zero.
         # For example -l 1,2,10-20 means use core 1, 2, 10 to 20.
@@ -56,6 +58,8 @@ spec:
         - "-P/var/local/mayastor/pools.yaml"
         - "-l{{ include "mayastorCpuSpec" . }}"
         - "-pmayastor-etcd"
+        command:
+        - mayastor
         securityContext:
           privileged: true
         volumeMounts:

--- a/nix/mayastor-overlay.nix
+++ b/nix/mayastor-overlay.nix
@@ -8,6 +8,7 @@ self: super: {
   mayastor = (super.callPackage ./pkgs/mayastor { }).release;
   mayastor-adhoc = (super.callPackage ./pkgs/mayastor { }).adhoc;
   mayastor-dev = (super.callPackage ./pkgs/mayastor { }).debug;
+  mayastor-cov = (super.callPackage ./pkgs/mayastor { }).cov;
   mkContainerEnv = super.callPackage ./lib/mkContainerEnv.nix { };
   ms-buildenv = super.callPackage ./pkgs/ms-buildenv { };
   nvmet-cli = super.callPackage ./pkgs/nvmet-cli { };

--- a/nix/pkgs/images/default.nix
+++ b/nix/pkgs/images/default.nix
@@ -13,6 +13,7 @@
 , lib
 , mayastor
 , mayastor-dev
+, mayastor-cov
 , stdenv
 , utillinux
 , writeScriptBin
@@ -70,39 +71,49 @@ let
     #!${stdenv.shell}
     chroot /host /usr/bin/env -i PATH="/sbin:/bin:/usr/bin" iscsiadm "$@"
   '';
-
   mctl = writeScriptBin "mctl" ''
     /bin/mayastor-client "$@"
   '';
 in
 {
-  mayastor = dockerTools.buildImage (mayastorImageProps // {
-    name = "mayadata/mayastor";
-    contents = [ busybox mayastor mctl ];
-  });
+  mayastor = dockerTools.buildImage
+    (mayastorImageProps // {
+      name = "mayadata/mayastor";
+      contents = [ busybox mayastor mctl ];
+    });
 
-  mayastor-dev = dockerTools.buildImage (mayastorImageProps // {
-    name = "mayadata/mayastor-dev";
-    contents = [ busybox mayastor-dev ];
-  });
+  mayastor-dev = dockerTools.buildImage
+    (mayastorImageProps // {
+      name = "mayadata/mayastor-dev";
+      contents = [ busybox mayastor-dev ];
+    });
+
+  mayastor-cov = dockerTools.buildImage
+    (mayastorImageProps // {
+      name = "mayadata/mayastor-cov";
+      contents = [ busybox mayastor-cov ];
+    });
 
   # The algorithm for placing packages into the layers is not optimal.
   # There are a couple of layers with negligible size and then there is one
   # big layer with everything else. That defeats the purpose of layering.
-  mayastor-csi = dockerTools.buildLayeredImage (mayastorCsiImageProps // {
-    name = "mayadata/mayastor-csi";
-    contents = [ busybox mayastor mayastorIscsiadm ];
-    maxLayers = 42;
-  });
+  mayastor-csi = dockerTools.buildLayeredImage
+    (mayastorCsiImageProps // {
+      name = "mayadata/mayastor-csi";
+      contents = [ busybox mayastor mayastorIscsiadm ];
+      maxLayers = 42;
+    });
 
-  mayastor-csi-dev = dockerTools.buildImage (mayastorCsiImageProps // {
-    name = "mayadata/mayastor-csi-dev";
-    contents = [ busybox mayastor-dev mayastorIscsiadm ];
-  });
+  mayastor-csi-dev = dockerTools.buildImage
+    (mayastorCsiImageProps // {
+      name = "mayadata/mayastor-csi-dev";
+      contents = [ busybox mayastor-dev mayastorIscsiadm ];
+    });
 
-  mayastor-client = dockerTools.buildImage (clientImageProps // {
-    name = "mayadata/mayastor-client";
-    contents = [ busybox mayastor ];
-    config = { Entrypoint = [ "/bin/mayastor-client" ]; };
-  });
+  mayastor-client = dockerTools.buildImage
+    (clientImageProps // {
+      name = "mayadata/mayastor-client";
+      contents = [ busybox mayastor ];
+      config = { Entrypoint = [ "/bin/mayastor-client" ]; };
+    });
 }

--- a/nix/pkgs/mayastor/cargo-package.nix
+++ b/nix/pkgs/mayastor/cargo-package.nix
@@ -29,6 +29,10 @@ let
     rustc = channel.stable;
     cargo = channel.stable;
   };
+  rustNightly = makeRustPlatform {
+    rustc = channel.nightly;
+    cargo = channel.nightly;
+  };
   whitelistSource = src: allowedPrefixes:
     builtins.filterSource
       (path: type:
@@ -82,15 +86,25 @@ let
   };
 in
 {
-  release = rustPlatform.buildRustPackage (buildProps // {
-    cargoBuildFlags = "--bin mayastor --bin mayastor-client --bin mayastor-csi";
-    buildType = "release";
-    buildInputs = buildProps.buildInputs ++ [ libspdk ];
-    SPDK_PATH = "${libspdk}";
-  });
-  debug = rustPlatform.buildRustPackage (buildProps // {
-    buildType = "debug";
-    buildInputs = buildProps.buildInputs ++ [ libspdk-dev ];
-    SPDK_PATH = "${libspdk-dev}";
-  });
+  release = rustPlatform.buildRustPackage
+    (buildProps // {
+      cargoBuildFlags = "--bin mayastor --bin mayastor-client --bin mayastor-csi";
+      buildType = "release";
+      buildInputs = buildProps.buildInputs ++ [ libspdk ];
+      SPDK_PATH = "${libspdk}";
+    });
+  debug = rustPlatform.buildRustPackage
+    (buildProps // {
+      buildType = "debug";
+      buildInputs = buildProps.buildInputs ++ [ libspdk-dev ];
+      SPDK_PATH = "${libspdk-dev}";
+    });
+  cov = rustNightly.buildRustPackage
+    (buildProps // {
+      RUSTFLAGS = "-Z instrument-coverage";
+      buildType = "debug";
+      buildInputs = buildProps.buildInputs ++ [ libspdk-dev ];
+      SPDK_PATH = "${libspdk-dev}";
+    });
+
 }

--- a/nix/pkgs/mayastor/default.nix
+++ b/nix/pkgs/mayastor/default.nix
@@ -30,4 +30,5 @@ in
   release = project-builder.release;
   debug = project-builder.debug;
   adhoc = project-builder.adhoc;
+  cov = project-builder.cov;
 }

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -30,6 +30,7 @@ Options:
   -d, --dry-run              Output actions that would be taken, but don't run them.
   -h, --help                 Display this text.
   --registry <host[:port]>   Push the built images to the provided registry.
+  --coverage                 Build coverage-enabled version of images where possible.
   --debug                    Build debug version of images where possible.
   --skip-build               Don't perform nix-build.
   --skip-publish             Don't publish built images.
@@ -53,6 +54,7 @@ SKIP_PUBLISH=
 SKIP_BUILD=
 REGISTRY=
 ALIAS=
+COVERAGE=
 DEBUG=
 
 # Check if all needed tools are installed
@@ -108,6 +110,10 @@ while [ "$#" -gt 0 ]; do
       DEBUG="yes"
       shift
       ;;
+    --coverage)
+      COVERAGE="yes"
+      shift
+      ;;
     *)
       echo "Unknown option: $1"
       exit 1
@@ -115,13 +121,22 @@ while [ "$#" -gt 0 ]; do
   esac
 done
 
+if [ -n "$COVERAGE" ] && [ -n "$DEBUG" ]; then
+  echo "cannot specify --coverage and --debug"
+  exit 1
+fi
+
 cd $SCRIPTDIR/..
 
+# Note mayastor-csi now also part of mayastor image
+# TODO: remove mayastor-csi from these lists
 if [ -z "$IMAGES" ]; then
-  if [ -z "$DEBUG" ]; then
-    IMAGES="mayastor mayastor-csi mayastor-client"
-  else
+  if [ -n "$DEBUG" ]; then
     IMAGES="mayastor-dev mayastor-csi-dev mayastor-client"
+  elif [ -n "$COVERAGE" ]; then
+    IMAGES="mayastor-cov mayastor-csi mayastor-client"
+  else
+    IMAGES="mayastor mayastor-csi mayastor-client"
   fi
 fi
 


### PR DESCRIPTION
Allow optional building of a coverage-enabled
version of mayastor image. Option --coverage
added to release.sh.
Use mayastor image as host for mayastor-csi
for CI testing.