### PR TITLE
chore(test): validate remaining pytest tests

### DIFF
--- a/scripts/pytest-tests.sh
+++ b/scripts/pytest-tests.sh
@@ -1,6 +1,24 @@
 #! /usr/bin/env bash
 
-set -euxo pipefail
+set -eu -o pipefail
+
+function run_tests()
+{
+  while read name extra
+  do
+    case "$name" in
+      test_*)
+        if [ -f "$name.py" ]
+        then
+        (
+          set -x
+          pytest --tc-file=test_config.ini "$name.py"
+        )
+        fi
+      ;;
+    esac
+  done
+}
 
 if [ "${SRCDIR:-unset}" = unset ]
 then
@@ -8,19 +26,28 @@ then
   exit 1
 fi
 
-tests='test_bdd_pool'
-tests+=' test_bdd_replica'
-tests+=' test_bdd_nexus'
-tests+=' test_nexus_publish'
-tests+=' test_bdd_rebuild'
-tests+=' test_bdd_csi'
-tests+=' test_csi'
-tests+=' test_nexus_multipath'
-tests+=' test_bdd_nexus_multipath'
-
 cd "$SRCDIR/test/python" && source ./venv/bin/activate
 
-for ts in $tests
-do
-  pytest --tc-file=test_config.ini "$ts.py"
-done
+run_tests << 'END'
+
+test_bdd_pool
+test_bdd_replica
+test_bdd_nexus
+test_nexus_publish
+test_bdd_rebuild
+test_bdd_csi
+test_csi
+
+test_ana_client
+test_cli_controller
+test_replica_uuid
+# test_rpc
+
+test_bdd_nexus_multipath
+test_nexus_multipath
+
+test_multi_nexus
+test_nexus
+test_null_nexus
+
+END

--- a/test/python/common/fio.py
+++ b/test/python/common/fio.py
@@ -12,19 +12,16 @@ class Fio(object):
         self.runtime = runtime
         self.optstr = optstr
 
-    def build(self) -> str:
-        if isinstance(self.device, str):
-            devs = [self.device]
-        else:
-            devs = self.device
+    def build(self):
+        devs = [self.device] if isinstance(self.device, str) else self.device
 
         command = (
             "sudo fio --ioengine=linuxaio --direct=1 --bs=4k "
-            "--time_based=1  {} --rw={} "
+            "--time_based=1 {} --rw={} "
             "--group_reporting=1 --norandommap=1 --iodepth=64 "
-            "--runtime={} --name={} --filename="
-        ).format(self.optstr, self.rw, self.runtime, self.name)
-
-        command += "".join(map(str, devs))
+            "--runtime={} --name={} --filename={}"
+        ).format(
+            self.optstr, self.rw, self.runtime, self.name, ":".join(map(str, devs))
+        )
 
         return command

--- a/test/python/test_ana_client.py
+++ b/test/python/test_ana_client.py
@@ -1,5 +1,5 @@
 import pytest
-from common.mayastor import mayastor_mod
+from common.mayastor import container_mod, mayastor_mod
 from common.nvme import (
     nvme_connect,
     nvme_disconnect,

--- a/test/python/test_bdd_nexus.py
+++ b/test/python/test_bdd_nexus.py
@@ -4,7 +4,7 @@ from pytest_bdd import given, scenario, then, when, parsers
 from collections import namedtuple
 import subprocess
 
-from common.mayastor import mayastor_mod
+from common.mayastor import container_mod, mayastor_mod
 from common.volume import Volume
 
 import grpc

--- a/test/python/test_bdd_nexus_multipath.py
+++ b/test/python/test_bdd_nexus_multipath.py
@@ -4,7 +4,7 @@ from pytest_bdd import given, scenario, then, when, parsers
 
 from common.command import run_cmd
 from common.fio import Fio
-from common.mayastor import containers_mod, mayastor_mod
+from common.mayastor import container_mod, mayastor_mod
 
 import grpc
 import mayastor_pb2 as pb

--- a/test/python/test_bdd_pool.py
+++ b/test/python/test_bdd_pool.py
@@ -2,7 +2,7 @@ import pytest
 from pytest_bdd import given, scenario, then, when, parsers
 
 from common.command import run_cmd
-from common.mayastor import mayastor_mod
+from common.mayastor import container_mod, mayastor_mod
 
 import grpc
 import mayastor_pb2 as pb

--- a/test/python/test_bdd_rebuild.py
+++ b/test/python/test_bdd_rebuild.py
@@ -5,7 +5,7 @@ import os
 import subprocess
 import time
 
-from common.mayastor import mayastor_mod
+from common.mayastor import container_mod, mayastor_mod
 from common.volume import Volume
 
 import grpc

--- a/test/python/test_bdd_replica.py
+++ b/test/python/test_bdd_replica.py
@@ -1,7 +1,7 @@
 import pytest
 from pytest_bdd import given, scenario, then, when, parsers
 
-from common.mayastor import mayastor_mod
+from common.mayastor import container_mod, mayastor_mod
 
 import grpc
 import mayastor_pb2 as pb

--- a/test/python/test_cli_controller.py
+++ b/test/python/test_cli_controller.py
@@ -1,5 +1,5 @@
 import pytest
-from common.mayastor import containers_mod, mayastor_mod
+from common.mayastor import container_mod, mayastor_mod
 from common.msclient import get_msclient
 import mayastor_pb2 as pb
 import uuid
@@ -59,7 +59,7 @@ def ctrl_name_from_uri(uri):
 
 
 @pytest.mark.asyncio
-async def test_controller_list(create_replicas, create_nexus, mayastor_mod):
+async def test_controller_list(mayastor_mod, create_replicas, create_nexus):
     replica1 = mayastor_mod.get("ms1")
     replica2 = mayastor_mod.get("ms2")
     replicas = [replica1, replica2]
@@ -85,9 +85,7 @@ async def test_controller_list(create_replicas, create_nexus, mayastor_mod):
 
 
 @pytest.mark.asyncio
-async def test_controller_stats(
-    create_replicas, create_nexus, mayastor_mod, containers_mod
-):
+async def test_controller_stats(mayastor_mod, create_replicas, create_nexus):
     nexus = mayastor_mod.get("ms3")
     mscli = get_msclient().with_json_output().with_url(nexus.ip_address())
 

--- a/test/python/test_common.py
+++ b/test/python/test_common.py
@@ -1,5 +1,5 @@
 from common.hdl import MayastorHandle
-from common.mayastor import mayastor_mod
+from common.mayastor import container_mod, mayastor_mod
 import pytest
 
 

--- a/test/python/test_config.ini
+++ b/test/python/test_config.ini
@@ -1,5 +1,2 @@
-# VMs used to run, in effect, "nvme connect" on
-[load_generators]
-vm1 = 127.0.0.1
 [grpc]
 client_timeout = 120

--- a/test/python/test_nexus_multipath.py
+++ b/test/python/test_nexus_multipath.py
@@ -1,4 +1,5 @@
 from common.volume import Volume
+from common.mayastor import container_mod, mayastor_mod
 from common.hdl import MayastorHandle
 import logging
 import pytest
@@ -13,8 +14,6 @@ from common.nvme import (
     nvme_list_subsystems,
     nvme_resv_report,
 )
-
-from common.mayastor import containers_mod, mayastor_mod
 
 
 @pytest.fixture

--- a/test/python/test_nexus_publish.py
+++ b/test/python/test_nexus_publish.py
@@ -3,7 +3,7 @@ import pytest
 from collections import namedtuple
 import subprocess
 
-from common.mayastor import mayastor_mod
+from common.mayastor import container_mod, mayastor_mod
 
 import grpc
 import mayastor_pb2 as pb

--- a/test/python/test_null_nexus.py
+++ b/test/python/test_null_nexus.py
@@ -1,7 +1,7 @@
-from common.command import run_cmd_async_at
-from common.nvme import nvme_remote_connect, nvme_remote_disconnect
+from common.command import run_cmd_async
+from common.nvme import nvme_connect, nvme_disconnect
 from common.fio import Fio
-from common.mayastor import mayastors
+from common.mayastor import containers, mayastors
 import pytest
 import asyncio
 import mayastor_pb2 as pb
@@ -18,96 +18,6 @@ nexus_uuids = [
     "6956b466-7491-4b8f-9a97-731bf7c9fd9c",
     "c5fa226d-b1c7-4102-83b3-7f69ff1b311b",
     "0cc74b98-fcd9-4a95-93ea-7c921d56c8cc",
-    "460758a4-d87f-4738-8666-cd07c23077db",
-    "63c567c9-75a6-466f-940e-a4ec5163794d",
-    "e425b05c-0730-4c10-8d01-77a2a65b4016",
-    "38d73fea-6f69-4a80-8959-2e2705be0f52",
-    "7eae6f7c-a52a-4689-b591-9642a094b4cc",
-    "52978839-8813-4c38-8665-42a78eeab499",
-    "8dccd362-b0fa-473d-abd3-b9c4d2a95f48",
-    "41dd24c4-8d20-4ee7-b52d-45dfcd580c52",
-    "9d879d46-8f71-4520-8eac-2b749c76adb8",
-    "d53cf04b-032d-412d-822a-e6b8b308bc52",
-    "da6247ab-6c28-429b-8848-c290ee474a81",
-    "71e9aab8-a350-4768-ab56-a2c66fda4e80",
-    "2241726a-487f-4852-8735-ddf849c92145",
-    "dbbbd8d4-96a4-45ae-9403-9dd43e34db6d",
-    "51ceb351-f864-43fc-bf31-3e36f75d8e86",
-    "7f90415a-29b3-41cd-9918-2d35b3b66056",
-    "f594f29c-b227-46a7-b4a6-486243c9f500",
-    "563b91ab-7ffd-44fc-aead-c551e280587a",
-    "8616f575-bcc9-490e-9524-9e6e7d9c76cc",
-    "817d4ca0-1f52-40de-b3d2-e59ce28b05ee",
-    "0a1103de-c466-4f77-88ca-521044b18483",
-    "ef6ff58b-0307-43df-bb87-9db0d06c1818",
-    "615c6fbb-90c1-46d6-b47c-6436a023953d",
-    "201e80b9-9389-4013-ab3c-b85b40d0cb56",
-    "e392187b-657f-4b4b-a249-cae27b7a5ba5",
-    "19e34f44-ff93-437d-9c11-31adfc974d64",
-    "b9542cb0-12e9-4b32-9cab-3b476161e1c6",
-    "3db3bfb9-0453-48bf-bb57-bd51b35e7f77",
-    "10e1f9e8-4cb2-4a79-a3d4-2b6314b58ba7",
-    "5ab8188a-e622-4965-b558-3355a5ceb285",
-    "063e2338-c42a-4aee-b4ed-b97a6c3bdc2b",
-    "94b03db5-14d7-4668-a952-e71160a658fc",
-    "4d03a0bc-645c-45ce-8d5e-a9ca584dfcb0",
-    "1a038ddb-fb0d-45b3-a46c-bdd57030af9e",
-    "89eecdef-4dc7-4228-8794-7139f15bf966",
-    "67369dd2-9c6a-49f8-b7bb-32ecba8698f2",
-    "f57cc434-d00c-4fee-b85f-56126403bf31",
-    "f9458cf7-8a12-487c-88f2-19c89e1d60c5",
-    "a33aca3e-fa5f-4477-b945-78616316ffb0",
-    "965329ba-24c1-4de7-b988-5a0baa376e66",
-    "453adc9f-501e-4d03-8810-990b747296e3",
-    "3a95e49d-afaa-4f3f-871a-4ec96ab86380",
-    "710450f3-266a-462a-abc0-bd3cdf235568",
-    "619b8ec8-2098-47fc-a55c-0a4048687163",
-    "9e3ae3ee-ddfe-4d81-93c0-9c62737d96fb",
-    "bc320f97-3a1f-4c6f-a2ee-936bfb5f293c",
-    "e5e271a8-d099-4cf4-8035-1f1672b6b16e",
-    "0fae6293-57b6-4135-b7dc-317b210d89b6",
-    "b8debec5-ea8e-4063-bba9-630bd108752f",
-    "cab0e91e-4e27-4820-a734-06c0bcd3f6ae",
-    "4986c804-64e9-4fb9-93ce-8ad6ca0cd3b2",
-    "5604d2cd-8ba6-4322-900a-31396168b72c",
-    "1affafb6-2089-45b5-8938-e40de8f89381",
-    "1fc64e79-9875-4136-b312-9f5df02d7c93",
-    "7fe16343-40dd-4bb5-bc63-9021be0cafb7",
-    "d24ad88e-b4ed-4ca5-91a0-b7afbc99744a",
-    "65889c75-7b2b-40a6-bfec-7bd9db64d20a",
-    "f60c9d96-360c-4b50-a1a8-f3fce87e24d7",
-    "4b6dc95f-1fb2-47f5-9746-e0e3970cbbb3",
-    "b37eb168-6430-44f8-8242-d1e0110bc71e",
-    "e34264f2-c999-4a3e-b2af-53b0c4f45095",
-    "157e6489-a96c-4e8c-8843-928c89529fff",
-    "efcbca04-8b0b-4a48-b3f2-e644a732d16d",
-    "238e35f2-9baa-4540-8fbd-ee46d2eca2cc",
-    "2f7e6ffb-47d5-485e-9166-1d455f2ec824",
-    "f75099a7-8600-4e4e-8332-1d045b6b85e1",
-    "2323b974-420c-40f7-8296-a28c4bc6b64e",
-    "31e7dab5-dbcb-4c33-999f-0e6779dad480",
-    "5221023d-6a15-4eeb-bf82-b770fcf8576d",
-    "51eee369-d85f-4097-ab93-419d31c2205f",
-    "3beaf7e5-a70e-4687-a28f-f9c8ff9364d8",
-    "c80d88bb-b1ca-454f-b793-19b00b141479",
-    "fda3e343-1f29-4e4d-8e56-6dd77fe28838",
-    "298a065a-1571-434e-a8cd-7464890595be",
-    "64540a85-4260-4469-81be-fac0e831a0ad",
-    "1fc17318-cec1-40cd-86d4-f498ce3342a4",
-    "30096c80-6e35-4c3f-910b-99b4190b79e1",
-    "4451d707-39d9-4174-b7ea-8dcfc4c408d4",
-    "dbc05fa6-bd30-4e0d-997b-6f8cb8854141",
-    "4ce06ba7-9074-445d-b97b-d665f065d60e",
-    "80115d98-b7df-4ed2-8fd8-7c7464143ce4",
-    "aa7142fc-b6c3-4499-98a2-5f424912d107",
-    "8adf8819-c3eb-43ce-ad11-04e0d22dfb52",
-    "a21b7d6e-354e-4d2d-b75f-b5782dcef385",
-    "b7ac8c80-8dfa-4314-8d76-6a57f87ad32f",
-    "2b15ccf1-6ee2-4c7d-9286-5133b0b57844",
-    "f443ce61-8ba8-4490-8bf9-8c1c443a0aa2",
-    "73025002-8582-48f4-8e32-d9866e8d97d2",
-    "6eb21022-4a99-4dd8-b76f-f2715378253b",
-    "f0e074af-2f97-4c67-bac8-f29f409b9db2",
 ]
 
 
@@ -173,41 +83,30 @@ def share_null_devs(mayastors, create_null_devs):
         ms = mayastors.get(node)
         names = ms.bdev_list()
         for n in names:
-            ms.bdev_share((n.name))
+            ms.bdev_share(n.name)
 
 
-async def kill_after(container, sec):
-    """Kill the given container after sec seconds."""
-    await asyncio.sleep(sec)
-    container.kill()
+@pytest.fixture
+def connect_to_uris(create_nexus_devices):
+    devices = {}
 
+    for uri in create_nexus_devices:
+        devices[uri] = nvme_connect(uri)
 
-async def connect_to_uris(uris, target_vm):
-    devices = []
+    yield devices.values()
 
-    for uri in uris:
-        dev = await nvme_remote_connect(target_vm, uri)
-        devices.append(dev)
-
-    job = Fio("job1", "randwrite", devices).build()
-
-    return job
-
-
-async def disconnect_from_uris(uris, target_vm):
-    for uri in uris:
-        await nvme_remote_disconnect(target_vm, uri)
+    for uri in devices.keys():
+        try:
+            nvme_disconnect(uri)
+        except Exception:
+            pass
 
 
 @pytest.mark.asyncio
-async def test_null_nexus(create_nexus_devices, mayastors, target_vm):
-    vm = target_vm
-    uris = create_nexus_devices
+async def test_null_nexus(connect_to_uris, mayastors):
+    devices = connect_to_uris
     ms = mayastors.get("ms3")
     check_nexus_state(ms)
 
-    # removing the last three lines will allow you to do whatever against
-    # the containers at this point.
-    job = await connect_to_uris(uris, vm)
-    await run_cmd_async_at(vm, job)
-    await disconnect_from_uris(uris, vm)
+    job = Fio("job1", "randwrite", devices).build()
+    await run_cmd_async(job)

--- a/test/python/test_replica_uuid.py
+++ b/test/python/test_replica_uuid.py
@@ -1,6 +1,6 @@
 import pytest
 from pytest_bdd import given, scenario, then, when
-from common.mayastor import mayastor_mod
+from common.mayastor import container_mod, mayastor_mod
 import mayastor_pb2 as pb
 
 POOL_NAME = "pool0"

--- a/test/python/test_rpc.py
+++ b/test/python/test_rpc.py
@@ -1,36 +1,36 @@
-from common.hdl import MayastorHandle
-from common.command import run_cmd, run_cmd_async, run_cmd_async_at
-from common.mayastor import containers_mod, mayastor_mod
+from common.command import run_cmd
+from common.mayastor import container_mod, mayastor_mod
 import pytest
 import grpc
 import uuid as guid
 import asyncio
 
 
+@pytest.fixture
 def pool_file():
     return "/var/tmp/pool1.img"
 
 
 @pytest.fixture
-def create_temp_files():
-    run_cmd("rm -rf {}".format(pool_file()))
-    run_cmd("truncate -s 3G {}".format(pool_file()), True)
+def create_temp_file(pool_file):
+    run_cmd("rm -f {}".format(pool_file))
+    run_cmd("truncate -s 3G {}".format(pool_file), True)
     yield
-    run_cmd("rm -rf {}".format(pool_file()))
+    run_cmd("rm -f {}".format(pool_file))
 
 
 @pytest.mark.asyncio
-async def test_rpc_timeout(mayastor_mod, create_temp_files, containers_mod):
+async def test_rpc_timeout(container_mod, mayastor_mod, create_temp_file, pool_file):
+    ms1_c = container_mod.get("ms1")
     ms1 = mayastor_mod.get("ms1")
-    ms1_c = containers_mod.get("ms1")
     uuid = str(guid.uuid4())
 
-    timeout_pattern = """destroy_replica: gRPC method timed out, args: DestroyReplicaRequest {{ uuid: \"{}\" }}""".format(
+    timeout_pattern = 'destroy_replica: gRPC method timed out, args: DestroyReplicaRequest {{ uuid: "{}" }}'.format(
         uuid
     )
 
     # Create a pool and a big replica (> 1 GB)
-    ms1.pool_create("pool1", "uring://{}".format(pool_file()))
+    ms1.pool_create("pool1", "uring://{}".format(pool_file))
     ms1.replica_create("pool1", uuid, 2 * 1024 * 1024 * 1024)
 
     # Set timeout to the minimum possible value and reconnect handles.
@@ -38,8 +38,9 @@ async def test_rpc_timeout(mayastor_mod, create_temp_files, containers_mod):
     ms1.reconnect()
 
     # Destroy the replica and trigger the timeout.
-    with pytest.raises(grpc.RpcError) as e:
+    with pytest.raises(grpc.RpcError) as error:
         ms1.replica_destroy(uuid)
+    assert error.value.code() == grpc.StatusCode.INVALID_ARGUMENT
 
     # Should not see error message pattern, as we expect the call to be timed out.
     assert str(ms1_c.logs()).find(timeout_pattern) == -1


### PR DESCRIPTION
Include all current pytests in scripts/pytest-tests.sh.

Identify, and temporarily disable, those tests that
are currently failing and require additional work.