### PR TITLE
Two random minor improvements

### DIFF
--- a/.github/workflows/pr-commitlint.yml
+++ b/.github/workflows/pr-commitlint.yml
@@ -17,8 +17,3 @@ jobs:
           first_commit=$(curl ${{ github.event.pull_request.commits_url }} 2>/dev/null | jq '.[0].sha' | sed 's/"//g')
           last_commit=HEAD^2 # don't lint the merge commit
           npx commitlint --from $first_commit~1 --to $last_commit -V
-      - name: Lint Pull Request
-        env:
-          TITLE: ${{ github.event.pull_request.title }}
-          BODY: ${{ github.event.pull_request.body }}
-        run: export NL=; printenv TITLE NL BODY | npx commitlint -V

--- a/mayastor/tests/common/mod.rs
+++ b/mayastor/tests/common/mod.rs
@@ -393,12 +393,12 @@ pub fn compare_devices(
     stdout
 }
 
-pub fn device_path_from_uri(device_uri: String) -> String {
+pub fn device_path_from_uri(device_uri: &str) -> String {
     assert_ne!(
-        Url::parse(device_uri.as_str()),
+        Url::parse(device_uri),
         Err(ParseError::RelativeUrlWithoutBase)
     );
-    let url = Url::parse(device_uri.as_str()).unwrap();
+    let url = Url::parse(device_uri).unwrap();
     String::from(url.path())
 }
 

--- a/mayastor/tests/core.rs
+++ b/mayastor/tests/core.rs
@@ -230,7 +230,7 @@ async fn core_5() {
                 .unwrap();
                 let nexus = nexus_lookup(nexus_name).unwrap();
                 let device = common::device_path_from_uri(
-                    nexus
+                    &nexus
                         .share(ShareProtocolNexus::NexusNbd, None)
                         .await
                         .unwrap(),

--- a/mayastor/tests/nexus_rebuild.rs
+++ b/mayastor/tests/nexus_rebuild.rs
@@ -103,7 +103,7 @@ async fn nexus_create(size: u64, children: u64, fill_random: bool) {
 async fn nexus_share() -> String {
     let nexus = nexus_lookup(nexus_name()).unwrap();
     let device = common::device_path_from_uri(
-        nexus
+        &nexus
             .share(ShareProtocolNexus::NexusNbd, None)
             .await
             .unwrap(),


### PR DESCRIPTION
Originally I aimed to also remove `etcd` from the default `nix-shell` as part of this based [on Jeffrey's advice in my previous PR](https://github.com/openebs/mayastor/pull/1004#discussion_r695568965) but for some reason the `persistence` tests fail to find the `etcd` binary when it's from the host and not nix. After spending some hours trying to debug that, I gave-up.