### PR TITLE
feat(grpc): add mayastor v1 service for pools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,9 +18,13 @@ artifacts/
 **/__pycache__
 /chart/charts/
 ansible-hosts
+test/python/common_pb2.py
+test/python/common_pb2_grpc.py
 /test/python/csi_pb2.py
 /test/python/csi_pb2_grpc.py
 /test/python/mayastor_pb2.py
 /test/python/mayastor_pb2_grpc.py
+/test/python/pool_pb2.py
+/test/python/pool_pb2_grpc.py
 /test/python/venv/*
 /package.json

--- a/mayastor/src/grpc/mayastor/v1.rs
+++ b/mayastor/src/grpc/mayastor/v1.rs
@@ -1,0 +1,196 @@
+use crate::{
+    core::Share,
+    grpc::{rpc_submit, GrpcClientContext, GrpcResult, Serializer},
+    lvs::{Error as LvsError, Lvs, PoolArgs},
+    subsys::PoolConfig,
+};
+use futures::FutureExt;
+use nix::errno::Errno;
+use std::{convert::TryFrom, fmt::Debug, time::Duration};
+use tonic::{Request, Response, Status};
+
+use rpc::mayastor::v1::*;
+
+#[derive(Debug)]
+struct UnixStream(tokio::net::UnixStream);
+
+use ::function_name::named;
+use std::panic::AssertUnwindSafe;
+
+#[derive(Debug)]
+pub struct MayastorSvc {
+    name: String,
+    interval: Duration,
+    client_context: tokio::sync::Mutex<Option<GrpcClientContext>>,
+}
+
+#[async_trait::async_trait]
+impl<F, T> Serializer<F, T> for MayastorSvc
+where
+    T: Send + 'static,
+    F: core::future::Future<Output = Result<T, Status>> + Send + 'static,
+{
+    async fn locked(&self, ctx: GrpcClientContext, f: F) -> Result<T, Status> {
+        let mut context_guard = self.client_context.lock().await;
+
+        // Store context as a marker of to detect abnormal termination of the
+        // request. Even though AssertUnwindSafe() allows us to
+        // intercept asserts in underlying method strategies, such a
+        // situation can still happen when the high-level future that
+        // represents gRPC call at the highest level (i.e. the one created
+        // by gRPC server) gets cancelled (due to timeout or somehow else).
+        // This can't be properly intercepted by 'locked' function itself in the
+        // first place, so the state needs to be cleaned up properly
+        // upon subsequent gRPC calls.
+        if let Some(c) = context_guard.replace(ctx) {
+            warn!("{}: gRPC method timed out, args: {}", c.id, c.args);
+        }
+
+        let fut = AssertUnwindSafe(f).catch_unwind();
+        let r = fut.await;
+
+        // Request completed, remove the marker.
+        let ctx = context_guard.take().expect("gRPC context disappeared");
+
+        match r {
+            Ok(r) => r,
+            Err(_e) => {
+                warn!("{}: gRPC method panicked, args: {}", ctx.id, ctx.args);
+                Err(Status::cancelled(format!(
+                    "{}: gRPC method panicked",
+                    ctx.id
+                )))
+            }
+        }
+    }
+}
+
+impl TryFrom<CreatePoolRequest> for PoolArgs {
+    type Error = LvsError;
+    fn try_from(pool: CreatePoolRequest) -> Result<Self, Self::Error> {
+        if pool.disks.is_empty() {
+            Err(LvsError::Invalid {
+                source: Errno::EINVAL,
+                msg: "Missing devices".to_string(),
+            })
+        } else {
+            Ok(Self {
+                name: pool.name,
+                disks: pool.disks,
+            })
+        }
+    }
+}
+
+impl MayastorSvc {
+    pub fn new(interval: Duration) -> Self {
+        Self {
+            name: String::from("CSISvc"),
+            interval,
+            client_context: tokio::sync::Mutex::new(None),
+        }
+    }
+}
+
+impl From<Lvs> for Pool {
+    fn from(l: Lvs) -> Self {
+        Self {
+            name: l.name().into(),
+            disks: vec![l.base_bdev().bdev_uri().unwrap_or_else(|| "".into())],
+            state: PoolState::PoolOnline.into(),
+            capacity: l.capacity(),
+            used: l.used(),
+        }
+    }
+}
+
+#[tonic::async_trait]
+impl mayastor_server::Mayastor for MayastorSvc {
+    #[named]
+    async fn create_pool(
+        &self,
+        request: Request<CreatePoolRequest>,
+    ) -> GrpcResult<Pool> {
+        self.locked(
+            GrpcClientContext::new(&request, function_name!()),
+            async move {
+                let args = request.into_inner();
+
+                if args.disks.is_empty() {
+                    return Err(Status::invalid_argument("Missing devices"));
+                }
+
+                let rx = rpc_submit::<_, _, LvsError>(async move {
+                    let pool = Lvs::create_or_import(PoolArgs::try_from(args)?)
+                        .await?;
+                    // Capture current pool config and export to file.
+                    PoolConfig::capture().export().await;
+                    Ok(Pool::from(pool))
+                })?;
+
+                rx.await
+                    .map_err(|_| Status::cancelled("cancelled"))?
+                    .map_err(Status::from)
+                    .map(Response::new)
+            },
+        )
+        .await
+    }
+
+    #[named]
+    async fn destroy_pool(
+        &self,
+        request: Request<DestroyPoolRequest>,
+    ) -> GrpcResult<Null> {
+        self.locked(
+            GrpcClientContext::new(&request, function_name!()),
+            async move {
+                let args = request.into_inner();
+                info!("{:?}", args);
+                let rx = rpc_submit::<_, _, LvsError>(async move {
+                    if let Some(pool) = Lvs::lookup(&args.name) {
+                        // Remove pool from current config and export to file.
+                        // Do this BEFORE we actually destroy the pool.
+                        let mut config = PoolConfig::capture();
+                        config.delete(&args.name);
+                        config.export().await;
+
+                        pool.destroy().await?;
+                    }
+                    Ok(Null {})
+                })?;
+
+                rx.await
+                    .map_err(|_| Status::cancelled("cancelled"))?
+                    .map_err(Status::from)
+                    .map(Response::new)
+            },
+        )
+        .await
+    }
+
+    #[named]
+    async fn list_pools(
+        &self,
+        request: Request<Null>,
+    ) -> GrpcResult<ListPoolsReply> {
+        self.locked(
+            GrpcClientContext::new(&request, function_name!()),
+            async move {
+                let rx = rpc_submit::<_, _, LvsError>(async move {
+                    Ok(ListPoolsReply {
+                        pools: Lvs::iter()
+                            .map(|l| l.into())
+                            .collect::<Vec<Pool>>(),
+                    })
+                })?;
+
+                rx.await
+                    .map_err(|_| Status::cancelled("cancelled"))?
+                    .map_err(Status::from)
+                    .map(Response::new)
+            },
+        )
+        .await
+    }
+}

--- a/mayastor/src/grpc/mayastor_grpc.rs
+++ b/mayastor/src/grpc/mayastor_grpc.rs
@@ -135,6 +135,7 @@ impl TryFrom<CreatePoolRequest> for PoolArgs {
             _ => Ok(Self {
                 name: args.name,
                 disks: args.disks,
+                uuid: None,
             }),
         }
     }

--- a/mayastor/src/grpc/mayastor_grpc.rs
+++ b/mayastor/src/grpc/mayastor_grpc.rs
@@ -32,8 +32,9 @@ use crate::{
         Serializer,
     },
     host::{blk_device, resource},
-    lvs::{Error as LvsError, Lvol, Lvs, PoolArgs},
+    lvs::{Error as LvsError, Lvol, Lvs},
     nexus_uri::NexusBdevError,
+    pool::PoolArgs,
     subsys::PoolConfig,
 };
 
@@ -125,17 +126,16 @@ impl MayastorSvc {
 
 impl TryFrom<CreatePoolRequest> for PoolArgs {
     type Error = LvsError;
-    fn try_from(pool: CreatePoolRequest) -> Result<Self, Self::Error> {
-        if pool.disks.is_empty() {
-            Err(LvsError::Invalid {
+    fn try_from(args: CreatePoolRequest) -> Result<Self, Self::Error> {
+        match args.disks.len() {
+            0 => Err(LvsError::Invalid {
                 source: Errno::EINVAL,
-                msg: "Missing devices".to_string(),
-            })
-        } else {
-            Ok(Self {
-                name: pool.name,
-                disks: pool.disks,
-            })
+                msg: "invalid argument, missing devices".to_string(),
+            }),
+            _ => Ok(Self {
+                name: args.name,
+                disks: args.disks,
+            }),
         }
     }
 }

--- a/mayastor/src/grpc/mod.rs
+++ b/mayastor/src/grpc/mod.rs
@@ -40,6 +40,9 @@ mod json_grpc;
 mod mayastor_grpc;
 mod nexus_grpc;
 mod server;
+pub mod mayastor {
+    pub mod v1;
+}
 
 mod v1 {
     pub mod bdev;

--- a/mayastor/src/grpc/mod.rs
+++ b/mayastor/src/grpc/mod.rs
@@ -40,8 +40,8 @@ mod json_grpc;
 mod mayastor_grpc;
 mod nexus_grpc;
 mod server;
-pub mod mayastor {
-    pub mod v1;
+pub mod v1 {
+    pub mod pool;
 }
 
 mod v1 {

--- a/mayastor/src/grpc/mod.rs
+++ b/mayastor/src/grpc/mod.rs
@@ -41,12 +41,9 @@ mod mayastor_grpc;
 mod nexus_grpc;
 mod server;
 pub mod v1 {
-    pub mod pool;
-}
-
-mod v1 {
     pub mod bdev;
     pub mod json;
+    pub mod pool;
 }
 
 #[derive(Debug)]

--- a/mayastor/src/grpc/server.rs
+++ b/mayastor/src/grpc/server.rs
@@ -14,7 +14,6 @@ use rpc::mayastor::{
     v1,
 };
 
-use rpc::mayastor::v1::mayastor_server::MayastorServer as MayastorRpcServer1;
 use std::{borrow::Cow, time::Duration};
 use tonic::transport::Server;
 use tracing::trace;
@@ -37,9 +36,8 @@ impl MayastorGrpcServer {
             .add_service(JsonRpcServer::new(JsonRpcSvc::new(address.clone())))
             .add_service(v1::json::JsonRpcServer::new(JsonService::new(
                 address.clone(),
-            .add_service(v1::pool::PoolRpcServer::new(PoolSvc::new(
-                Duration::from_millis(4),
             )))
+            .add_service(v1::pool::PoolRpcServer::new(PoolSvc::new()))
             .serve(endpoint);
 
         match svc.await {

--- a/mayastor/src/grpc/server.rs
+++ b/mayastor/src/grpc/server.rs
@@ -1,6 +1,7 @@
 use crate::grpc::{
     bdev_grpc::BdevSvc,
     json_grpc::JsonRpcSvc,
+    mayastor::v1::MayastorSvc as MayastorSvcV1,
     mayastor_grpc::MayastorSvc,
 };
 
@@ -13,6 +14,7 @@ use rpc::mayastor::{
     v1,
 };
 
+use rpc::mayastor::v1::mayastor_server::MayastorServer as MayastorRpcServer1;
 use std::{borrow::Cow, time::Duration};
 use tonic::transport::Server;
 use tracing::trace;
@@ -28,6 +30,9 @@ impl MayastorGrpcServer {
         let address = Cow::from(rpc_addr);
         let svc = Server::builder()
             .add_service(MayastorRpcServer::new(MayastorSvc::new(
+                Duration::from_millis(4),
+            )))
+            .add_service(MayastorRpcServer1::new(MayastorSvcV1::new(
                 Duration::from_millis(4),
             )))
             .add_service(BdevRpcServer::new(BdevSvc::new()))

--- a/mayastor/src/grpc/server.rs
+++ b/mayastor/src/grpc/server.rs
@@ -1,8 +1,8 @@
 use crate::grpc::{
     bdev_grpc::BdevSvc,
     json_grpc::JsonRpcSvc,
-    mayastor::v1::MayastorSvc as MayastorSvcV1,
     mayastor_grpc::MayastorSvc,
+    v1::pool::PoolSvc,
 };
 
 use crate::grpc::v1::{bdev::BdevService, json::JsonService};
@@ -32,14 +32,13 @@ impl MayastorGrpcServer {
             .add_service(MayastorRpcServer::new(MayastorSvc::new(
                 Duration::from_millis(4),
             )))
-            .add_service(MayastorRpcServer1::new(MayastorSvcV1::new(
-                Duration::from_millis(4),
-            )))
             .add_service(BdevRpcServer::new(BdevSvc::new()))
             .add_service(v1::bdev::BdevRpcServer::new(BdevService::new()))
             .add_service(JsonRpcServer::new(JsonRpcSvc::new(address.clone())))
             .add_service(v1::json::JsonRpcServer::new(JsonService::new(
                 address.clone(),
+            .add_service(v1::pool::PoolRpcServer::new(PoolSvc::new(
+                Duration::from_millis(4),
             )))
             .serve(endpoint);
 

--- a/mayastor/src/grpc/v1/pool.rs
+++ b/mayastor/src/grpc/v1/pool.rs
@@ -160,6 +160,7 @@ impl PoolRpc for PoolSvc {
             GrpcClientContext::new(&request, function_name!()),
             async move {
                 let args = request.into_inner();
+                info!("{:?}", args);
                 match PoolBackend::try_from(args.pooltype)? {
                     PoolBackend::Lvs => {
                         let rx = rpc_submit::<_, _, LvsError>(async move {
@@ -250,7 +251,7 @@ impl PoolRpc for PoolSvc {
                     } else {
                         return Err(LvsError::Invalid {
                             source: Errno::EINVAL,
-                            msg: format!("pool {} not found", args.name,),
+                            msg: format!("pool {} not found", args.name),
                         });
                     }
                     Ok(())
@@ -274,7 +275,7 @@ impl PoolRpc for PoolSvc {
             GrpcClientContext::new(&request, function_name!()),
             async move {
                 let args = request.into_inner();
-
+                info!("{:?}", args);
                 let rx = rpc_submit::<_, _, LvsError>(async move {
                     let pool = Lvs::import_from_args(PoolArgs::try_from(args)?)
                         .await?;

--- a/mayastor/src/lvs/lvs_pool.rs
+++ b/mayastor/src/lvs/lvs_pool.rs
@@ -3,7 +3,6 @@ use std::{convert::TryFrom, fmt::Debug, os::raw::c_void, ptr::NonNull};
 use futures::channel::oneshot;
 use nix::errno::Errno;
 use pin_utils::core_reexport::fmt::Formatter;
-use rpc::mayastor::CreatePoolRequest;
 use spdk_rs::libspdk::{
     lvol_store_bdev,
     spdk_bs_free_cluster_count,
@@ -43,6 +42,11 @@ impl From<*mut spdk_lvol_store> for Lvs {
 
 /// iterator over all lvol stores
 pub struct LvsIterator(*mut lvol_store_bdev);
+
+pub struct PoolArgs {
+    pub name: String,
+    pub disks: Vec<String>,
+}
 
 /// returns a new lvs iterator
 impl LvsIterator {
@@ -289,9 +293,7 @@ impl Lvs {
     }
 
     /// imports the pool if it exists, otherwise try to create it
-    pub async fn create_or_import(
-        args: CreatePoolRequest,
-    ) -> Result<Lvs, Error> {
+    pub async fn create_or_import(args: PoolArgs) -> Result<Lvs, Error> {
         if args.disks.len() != 1 {
             return Err(Error::Invalid {
                 source: Errno::EINVAL,

--- a/mayastor/src/lvs/mod.rs
+++ b/mayastor/src/lvs/mod.rs
@@ -1,6 +1,6 @@
 pub use error::Error;
 pub use lvol::{Lvol, PropName, PropValue};
-pub use lvs_pool::{Lvs, PoolArgs};
+pub use lvs_pool::Lvs;
 
 mod error;
 mod lvol;

--- a/mayastor/src/lvs/mod.rs
+++ b/mayastor/src/lvs/mod.rs
@@ -1,6 +1,6 @@
 pub use error::Error;
 pub use lvol::{Lvol, PropName, PropValue};
-pub use lvs_pool::Lvs;
+pub use lvs_pool::{Lvs, PoolArgs};
 
 mod error;
 mod lvol;

--- a/mayastor/src/pool.rs
+++ b/mayastor/src/pool.rs
@@ -137,11 +137,14 @@ impl From<Pool> for rpc::Pool {
     }
 }
 
-/// PoolArgs is the input for the grpc
-/// Create/Import requests which comtains name & disks
+/// PoolArgs is used to translate the input for the grpc
+/// Create/Import requests which comtains name, uuid & disks.
+/// This help us avoid importing grpc structs in the actual lvs mod
+#[derive(Clone)]
 pub struct PoolArgs {
     pub name: String,
     pub disks: Vec<String>,
+    pub uuid: Option<String>,
 }
 
 /// PoolBackend is the type of pool underneath Lvs, Lvm, etc

--- a/mayastor/src/pool.rs
+++ b/mayastor/src/pool.rs
@@ -140,7 +140,7 @@ impl From<Pool> for rpc::Pool {
 /// PoolArgs is used to translate the input for the grpc
 /// Create/Import requests which comtains name, uuid & disks.
 /// This help us avoid importing grpc structs in the actual lvs mod
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct PoolArgs {
     pub name: String,
     pub disks: Vec<String>,

--- a/mayastor/src/subsys/config/pool.rs
+++ b/mayastor/src/subsys/config/pool.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Display, fs, path::Path, sync::Mutex};
+use std::{convert::TryFrom, fmt::Display, fs, path::Path, sync::Mutex};
 
 use futures::channel::oneshot;
 use once_cell::sync::{Lazy, OnceCell};
@@ -9,7 +9,7 @@ use crate::{
     bdev::nexus::VerboseError,
     core::{runtime, Cores, Mthread, Reactor, Share},
     grpc::rpc_submit,
-    lvs::{Error as LvsError, Lvs},
+    lvs::{Error as LvsError, Lvs, PoolArgs},
     pool::{Pool as SpdkPool, PoolsIter},
     replica::ShareType,
 };
@@ -213,7 +213,7 @@ async fn create_pool(
     }
 
     let rx = rpc_submit::<_, _, LvsError>(async move {
-        let pool = Lvs::create_or_import(args).await?;
+        let pool = Lvs::create_or_import(PoolArgs::try_from(args)?).await?;
         Ok(pool.into())
     })?;
 

--- a/mayastor/src/subsys/config/pool.rs
+++ b/mayastor/src/subsys/config/pool.rs
@@ -175,6 +175,7 @@ impl From<&Pool> for PoolArgs {
         Self {
             name: pool.name.clone(),
             disks: pool.disks.clone(),
+            uuid: None,
         }
     }
 }

--- a/mayastor/tests/lvs_pool.rs
+++ b/mayastor/tests/lvs_pool.rs
@@ -1,8 +1,9 @@
 use common::MayastorTest;
 use mayastor::{
     core::{Bdev, MayastorCliArgs, Protocol, Share},
-    lvs::{Lvs, PoolArgs, PropName, PropValue},
+    lvs::{Lvs, PropName, PropValue},
     nexus_uri::bdev_create,
+    pool::PoolArgs,
     subsys::NvmfSubsystem,
 };
 

--- a/mayastor/tests/lvs_pool.rs
+++ b/mayastor/tests/lvs_pool.rs
@@ -1,11 +1,10 @@
 use common::MayastorTest;
 use mayastor::{
     core::{Bdev, MayastorCliArgs, Protocol, Share},
-    lvs::{Lvs, PropName, PropValue},
+    lvs::{Lvs, PoolArgs, PropName, PropValue},
     nexus_uri::bdev_create,
     subsys::NvmfSubsystem,
 };
-use rpc::mayastor::CreatePoolRequest;
 
 pub mod common;
 
@@ -31,7 +30,7 @@ async fn lvs_pool_test() {
 
     // should succeed to create a pool we can not import
     ms.spawn(async {
-        Lvs::create_or_import(CreatePoolRequest {
+        Lvs::create_or_import(PoolArgs {
             name: "tpool".into(),
             disks: vec!["aio:///tmp/disk1.img".into()],
         })
@@ -43,7 +42,7 @@ async fn lvs_pool_test() {
     // returns OK when the pool is already there and we create
     // it again
     ms.spawn(async {
-        assert!(Lvs::create_or_import(CreatePoolRequest {
+        assert!(Lvs::create_or_import(PoolArgs {
             name: "tpool".into(),
             disks: vec!["aio:///tmp/disk1.img".into()],
         })
@@ -139,7 +138,7 @@ async fn lvs_pool_test() {
 
     // create a second pool and ensure it filters correctly
     ms.spawn(async {
-        let pool2 = Lvs::create_or_import(CreatePoolRequest {
+        let pool2 = Lvs::create_or_import(PoolArgs {
             name: "tpool2".to_string(),
             disks: vec!["malloc:///malloc0?size_mb=64".to_string()],
         })
@@ -172,7 +171,7 @@ async fn lvs_pool_test() {
     ms.spawn(async {
         let pool = Lvs::lookup("tpool").unwrap();
         pool.export().await.unwrap();
-        let pool = Lvs::create_or_import(CreatePoolRequest {
+        let pool = Lvs::create_or_import(PoolArgs {
             name: "tpool".to_string(),
             disks: vec!["aio:///tmp/disk1.img".to_string()],
         })
@@ -303,7 +302,7 @@ async fn lvs_pool_test() {
         pool.destroy().await.unwrap();
         assert_eq!(NvmfSubsystem::first().unwrap().into_iter().count(), 1);
 
-        let pool = Lvs::create_or_import(CreatePoolRequest {
+        let pool = Lvs::create_or_import(PoolArgs {
             name: "tpool".into(),
             disks: vec!["aio:///tmp/disk1.img".into()],
         })
@@ -331,7 +330,7 @@ async fn lvs_pool_test() {
         assert_eq!(Bdev::bdev_first().into_iter().count(), 0);
 
         // importing a pool with the wrong name should fail
-        Lvs::create_or_import(CreatePoolRequest {
+        Lvs::create_or_import(PoolArgs {
             name: "jpool".into(),
             disks: vec!["aio:///tmp/disk1.img".into()],
         })
@@ -345,7 +344,7 @@ async fn lvs_pool_test() {
 
     // if not specified, default driver scheme should be AIO
     ms.spawn(async {
-        let pool = Lvs::create_or_import(CreatePoolRequest {
+        let pool = Lvs::create_or_import(PoolArgs {
             name: "tpool2".into(),
             disks: vec!["/tmp/disk2.img".into()],
         })

--- a/mayastor/tests/lvs_pool.rs
+++ b/mayastor/tests/lvs_pool.rs
@@ -41,19 +41,6 @@ async fn lvs_pool_test() {
     })
     .await;
 
-    // returns OK when the pool is already there and we create
-    // it again
-    ms.spawn(async {
-        assert!(Lvs::create_or_import(PoolArgs {
-            name: "tpool".into(),
-            disks: vec!["aio:///tmp/disk1.img".into()],
-            uuid: None,
-        })
-        .await
-        .is_ok())
-    })
-    .await;
-
     // should fail to create the pool again, notice that we use
     // create directly here to ensure that if we
     // have an idempotent snafu, we dont crash and

--- a/mayastor/tests/lvs_pool.rs
+++ b/mayastor/tests/lvs_pool.rs
@@ -34,6 +34,7 @@ async fn lvs_pool_test() {
         Lvs::create_or_import(PoolArgs {
             name: "tpool".into(),
             disks: vec!["aio:///tmp/disk1.img".into()],
+            uuid: None,
         })
         .await
         .unwrap();
@@ -46,6 +47,7 @@ async fn lvs_pool_test() {
         assert!(Lvs::create_or_import(PoolArgs {
             name: "tpool".into(),
             disks: vec!["aio:///tmp/disk1.img".into()],
+            uuid: None,
         })
         .await
         .is_ok())
@@ -57,7 +59,9 @@ async fn lvs_pool_test() {
     // have an idempotent snafu, we dont crash and
     // burn
     ms.spawn(async {
-        assert!(Lvs::create("tpool", "aio:///tmp/disk1.img").await.is_err())
+        assert!(Lvs::create("tpool", "aio:///tmp/disk1.img", None)
+            .await
+            .is_err())
     })
     .await;
 
@@ -111,7 +115,9 @@ async fn lvs_pool_test() {
         assert!(Lvs::import("tpool", "aio:///tmp/disk1.img").await.is_err());
 
         assert_eq!(Lvs::iter().count(), 0);
-        assert!(Lvs::create("tpool", "aio:///tmp/disk1.img").await.is_ok());
+        assert!(Lvs::create("tpool", "aio:///tmp/disk1.img", None)
+            .await
+            .is_ok());
 
         let pool = Lvs::lookup("tpool").unwrap();
         assert_ne!(uuid, pool.uuid());
@@ -142,6 +148,7 @@ async fn lvs_pool_test() {
         let pool2 = Lvs::create_or_import(PoolArgs {
             name: "tpool2".to_string(),
             disks: vec!["malloc:///malloc0?size_mb=64".to_string()],
+            uuid: None,
         })
         .await
         .unwrap();
@@ -175,6 +182,7 @@ async fn lvs_pool_test() {
         let pool = Lvs::create_or_import(PoolArgs {
             name: "tpool".to_string(),
             disks: vec!["aio:///tmp/disk1.img".to_string()],
+            uuid: None,
         })
         .await
         .unwrap();
@@ -306,6 +314,7 @@ async fn lvs_pool_test() {
         let pool = Lvs::create_or_import(PoolArgs {
             name: "tpool".into(),
             disks: vec!["aio:///tmp/disk1.img".into()],
+            uuid: None,
         })
         .await
         .unwrap();
@@ -334,6 +343,7 @@ async fn lvs_pool_test() {
         Lvs::create_or_import(PoolArgs {
             name: "jpool".into(),
             disks: vec!["aio:///tmp/disk1.img".into()],
+            uuid: None,
         })
         .await
         .err()
@@ -348,6 +358,7 @@ async fn lvs_pool_test() {
         let pool = Lvs::create_or_import(PoolArgs {
             name: "tpool2".into(),
             disks: vec!["/tmp/disk2.img".into()],
+            uuid: None,
         })
         .await
         .unwrap();

--- a/mayastor/tests/nexus_io.rs
+++ b/mayastor/tests/nexus_io.rs
@@ -9,6 +9,7 @@ use mayastor::{
     },
     core::MayastorCliArgs,
     lvs::Lvs,
+    pool::PoolArgs,
 };
 use once_cell::sync::OnceCell;
 use rpc::mayastor::{
@@ -568,7 +569,7 @@ async fn nexus_io_write_zeroes() {
     mayastor
         .spawn(async move {
             // Create local pool and replica
-            Lvs::create_or_import(CreatePoolRequest {
+            Lvs::create_or_import(PoolArgs {
                 name: POOL_NAME.to_string(),
                 disks: vec![BDEVNAME1.to_string()],
             })

--- a/mayastor/tests/nexus_io.rs
+++ b/mayastor/tests/nexus_io.rs
@@ -572,6 +572,7 @@ async fn nexus_io_write_zeroes() {
             Lvs::create_or_import(PoolArgs {
                 name: POOL_NAME.to_string(),
                 disks: vec![BDEVNAME1.to_string()],
+                uuid: None,
             })
             .await
             .unwrap();

--- a/mayastor/tests/replica_snapshot.rs
+++ b/mayastor/tests/replica_snapshot.rs
@@ -76,6 +76,7 @@ async fn replica_snapshot() {
             Lvs::create_or_import(PoolArgs {
                 name: POOL1_NAME.to_string(),
                 disks: vec![format!("aio://{}", DISKNAME1)],
+                uuid: None,
             })
             .await
             .unwrap();

--- a/mayastor/tests/replica_snapshot.rs
+++ b/mayastor/tests/replica_snapshot.rs
@@ -2,7 +2,8 @@ use common::bdev_io;
 use mayastor::{
     bdev::nexus::nexus_create,
     core::{BdevHandle, CoreError, MayastorCliArgs},
-    lvs::{Lvol, Lvs, PoolArgs},
+    lvs::{Lvol, Lvs},
+    pool::PoolArgs,
 };
 use rpc::mayastor::{
     CreatePoolRequest,

--- a/mayastor/tests/replica_snapshot.rs
+++ b/mayastor/tests/replica_snapshot.rs
@@ -2,7 +2,7 @@ use common::bdev_io;
 use mayastor::{
     bdev::nexus::nexus_create,
     core::{BdevHandle, CoreError, MayastorCliArgs},
-    lvs::{Lvol, Lvs},
+    lvs::{Lvol, Lvs, PoolArgs},
 };
 use rpc::mayastor::{
     CreatePoolRequest,
@@ -72,7 +72,7 @@ async fn replica_snapshot() {
 
     let t = mayastor
         .spawn(async move {
-            Lvs::create_or_import(CreatePoolRequest {
+            Lvs::create_or_import(PoolArgs {
                 name: POOL1_NAME.to_string(),
                 disks: vec![format!("aio://{}", DISKNAME1)],
             })

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -13,6 +13,7 @@ tonic = "0.5.2"
 bytes = "1.0.1"
 prost = "0.8.0"
 prost-derive = "0.8.0"
+prost-types = "0.8.0"
 serde = { version = "1.0.127", features = ["derive"] }
 serde_derive = "1.0.127"
 serde_json = "1.0.66"

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -17,4 +17,3 @@ prost-types = "0.8.0"
 serde = { version = "1.0.127", features = ["derive"] }
 serde_derive = "1.0.127"
 serde_json = "1.0.66"
-prost-types = "0.8.0"

--- a/rpc/build.rs
+++ b/rpc/build.rs
@@ -24,10 +24,7 @@ fn main() {
         .build_server(true)
         .type_attribute(".", "#[derive(serde::Serialize, serde::Deserialize)]")
         .compile(
-            &[
-                "mayastor-api/protobuf/mayastor.proto",
-                "mayastor-api/protobuf/v1/mayastor.proto",
-            ],
+            &["mayastor-api/protobuf/mayastor.proto"],
             &["mayastor-api/protobuf"],
         )
         .unwrap_or_else(|e| {
@@ -42,6 +39,7 @@ fn main() {
             &[
                 "mayastor-api/protobuf/v1/bdev.proto",
                 "mayastor-api/protobuf/v1/json.proto",
+                "mayastor-api/protobuf/v1/pool.proto",
             ],
             &["mayastor-api/protobuf/v1"],
         )

--- a/rpc/build.rs
+++ b/rpc/build.rs
@@ -24,7 +24,10 @@ fn main() {
         .build_server(true)
         .type_attribute(".", "#[derive(serde::Serialize, serde::Deserialize)]")
         .compile(
-            &["mayastor-api/protobuf/mayastor.proto"],
+            &[
+                "mayastor-api/protobuf/mayastor.proto",
+                "mayastor-api/protobuf/v1/mayastor.proto",
+            ],
             &["mayastor-api/protobuf"],
         )
         .unwrap_or_else(|e| {

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -55,6 +55,20 @@ pub mod mayastor {
                 json_rpc_server::{JsonRpc, JsonRpcServer},
                 JsonRpcRequest,
                 JsonRpcResponse,
+        }
+
+        pub mod pool {
+            pub use super::pb::{
+                list_pool_options::NameValue,
+                pool_rpc_server::{PoolRpc, PoolRpcServer},
+                CreatePoolRequest,
+                DestroyPoolRequest,
+                ImportPoolRequest,
+                ListPoolOptions,
+                ListPoolsResponse,
+                Pool,
+                PoolState,
+                PoolType,
             };
         }
     }

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -55,14 +55,15 @@ pub mod mayastor {
                 json_rpc_server::{JsonRpc, JsonRpcServer},
                 JsonRpcRequest,
                 JsonRpcResponse,
+            };
         }
 
         pub mod pool {
             pub use super::pb::{
-                list_pool_options::NameValue,
                 pool_rpc_server::{PoolRpc, PoolRpcServer},
                 CreatePoolRequest,
                 DestroyPoolRequest,
+                ExportPoolRequest,
                 ImportPoolRequest,
                 ListPoolOptions,
                 ListPoolsResponse,

--- a/scripts/pytest-tests.sh
+++ b/scripts/pytest-tests.sh
@@ -48,4 +48,6 @@ tests/replica_uuid
 tests/nexus_multipath
 tests/nexus
 
+v1/pool
+
 END

--- a/test/grpc/test_replica.js
+++ b/test/grpc/test_replica.js
@@ -195,10 +195,6 @@ describe('replica', function () {
     );
   });
 
-  it('should succeed if creating a pool that already exists', (done) => {
-    client.createPool({ name: POOL, disks: disks }, done);
-  });
-
   it('should list the pool', (done) => {
     client.listPools({}, (err, res) => {
       if (err) return done(err);

--- a/test/python/setup.sh
+++ b/test/python/setup.sh
@@ -11,6 +11,8 @@ fi
 cd "$SRCDIR"
 
 python -m grpc_tools.protoc --proto_path=rpc/mayastor-api/protobuf --grpc_python_out=test/python --python_out=test/python mayastor.proto
+python -m grpc_tools.protoc --proto_path=rpc/mayastor-api/protobuf/v1 --grpc_python_out=test/python --python_out=test/python \
+  common.proto pool.proto
 python -m grpc_tools.protoc --proto_path=csi/proto --grpc_python_out=test/python --python_out=test/python csi.proto
 
 virtualenv --no-setuptools test/python/venv

--- a/test/python/tests/replica/features/pool.feature
+++ b/test/python/tests/replica/features/pool.feature
@@ -18,7 +18,7 @@ Feature: Mayastor pool management
   Scenario: creating a pool with a name that already exists
     Given a pool "p0"
     When the user creates a pool with the name of an existing pool
-    Then the pool creation should succeed
+    Then the pool create command should fail
 
   Scenario: listing pools
     Given a pool "p0"

--- a/test/python/v1/hdl.py
+++ b/test/python/v1/hdl.py
@@ -1,0 +1,82 @@
+"""Common code that represents a mayastor handle."""
+from os import name
+import pool_pb2 as pool_pb
+import grpc
+import pool_pb2_grpc as pool_rpc
+from pytest_testconfig import config
+from functools import partial
+
+from google.protobuf import struct_pb2 as google_dot_protobuf_dot_struct__pb2
+
+pytest_plugins = ["docker_compose"]
+
+
+class MayastorHandle(object):
+    """Mayastor gRPC handle."""
+
+    def __init__(self, ip_v4):
+        """Init."""
+        self.ip_v4 = ip_v4
+        self.timeout = float(config["grpc"]["client_timeout"])
+        self.channel = grpc.insecure_channel(("%s:10124") % self.ip_v4)
+        self.pool_rpc = pool_rpc.PoolRpcStub(self.channel)
+        self._readiness_check()
+
+    def set_timeout(self, timeout):
+        self.timeout = timeout
+
+    def install_stub(self, name):
+        stub = getattr(pool_rpc, name)(self.channel)
+
+        # Install default timeout to all functions, ignore system attributes.
+        for f in dir(stub):
+            if not f.startswith("__"):
+                h = getattr(stub, f)
+                setattr(stub, f, partial(h, timeout=self.timeout))
+        return stub
+
+    def _readiness_check(self):
+        try:
+            self.pool_list(pool_pb.ListPoolOptions())
+        except grpc._channel._InactiveRpcError:
+            # This is to get around a gRPC bug.
+            # Retry once before failing
+            self.pool_list(pool_pb.ListPoolOptions())
+
+    def reconnect(self):
+        self.channel = grpc.insecure_channel(("%s:10124") % self.ip_v4)
+        self.pool_rpc = self.install_stub("PoolRpcStub")
+        self._readiness_check()
+
+    def __del__(self):
+        del self.channel
+
+    def close(self):
+        self.__del__()
+
+    def ip_address(self):
+        return self.ip_v4
+
+    def as_target(self) -> str:
+        """Returns this node as scheme which is used to designate this node to
+        be used as the node where the nexus shall be created on."""
+        node = "nvmt://{0}".format(self.ip_v4)
+        return node
+
+    def pool_create(self, name, bdev):
+        """Create a pool with given name on this node using the bdev as the
+        backend device. The bdev is implicitly created."""
+
+        disks = []
+        disks.append(bdev)
+        return self.pool_rpc.CreatePool(
+            pool_pb.CreatePoolRequest(name=name, disks=disks)
+        )
+
+    def pool_destroy(self, name):
+        """Destroy  the pool."""
+        return self.pool_rpc.DestroyPool(pool_pb.DestroyPoolRequest(name=name))
+
+    def pool_list(self, opts):
+        """Only list pools"""
+        return self.pool_rpc.ListPools(opts, wait_for_ready=True)

--- a/test/python/v1/mayastor.py
+++ b/test/python/v1/mayastor.py
@@ -1,0 +1,62 @@
+"Default fixtures that are considered to be reusable."
+import pytest
+from v1.hdl import MayastorHandle
+from common.command import run_cmd
+
+pytest_plugins = ["docker_compose"]
+
+
+def check_size(prev, current, delta):
+    "Validate that replica creation consumes space on the pool."
+    before = prev.pools[0].used
+    after = current.pools[0].used
+    assert delta == (before - after) >> 20
+
+
+@pytest.fixture(scope="function")
+def containers(docker_project, function_scoped_container_getter):
+    "Fixture to get handles to mayastor containers."
+    containers = {}
+    for name in docker_project.service_names:
+        containers[name] = function_scoped_container_getter.get(name)
+    yield containers
+
+
+@pytest.fixture(scope="function")
+def mayastors(docker_project, containers):
+    "Fixture to get a reference to mayastor gRPC handles"
+    handles = {}
+    for name, container in containers.items():
+        handles[name] = MayastorHandle(
+            container.get("NetworkSettings.Networks.mayastor_net.IPAddress")
+        )
+    yield handles
+
+
+@pytest.fixture(scope="function")
+def create_temp_files(containers):
+    "Create temp files for each run so we start out clean."
+    for name in containers.keys():
+        run_cmd(f"rm -f /tmp/{name}.img", True)
+    for name in containers.keys():
+        run_cmd(f"truncate -s 1G /tmp/{name}.img", True)
+
+
+@pytest.fixture(scope="module")
+def container_mod(docker_project, module_scoped_container_getter):
+    "Fixture to get handles to mayastor containers."
+    containers = {}
+    for name in docker_project.service_names:
+        containers[name] = module_scoped_container_getter.get(name)
+    yield containers
+
+
+@pytest.fixture(scope="module")
+def mayastor_mod(docker_project, container_mod):
+    "Fixture to get a reference to mayastor gRPC handles."
+    handles = {}
+    for name, container in container_mod.items():
+        handles[name] = MayastorHandle(
+            container.get("NetworkSettings.Networks.mayastor_net.IPAddress")
+        )
+    yield handles

--- a/test/python/v1/pool/docker-compose.yml
+++ b/test/python/v1/pool/docker-compose.yml
@@ -1,0 +1,39 @@
+#
+# {SRCDIR} should point to your working tree which should be your current pwd
+#
+
+version: '3'
+services:
+  ms0:
+    container_name: "ms0"
+    image: rust:latest
+    environment:
+        - MY_POD_IP=10.0.0.2
+        - NEXUS_NVMF_ANA_ENABLE=1
+        - NEXUS_NVMF_RESV_ENABLE=1
+    command: ${SRCDIR}/target/debug/mayastor -g 0.0.0.0 -l 1,2 -r /tmp/ms0.sock
+    networks:
+      mayastor_net:
+        ipv4_address: 10.0.0.2
+    cap_add:
+      # NUMA related
+      - SYS_ADMIN
+      - SYS_NICE
+      # uring needs mmap
+      - IPC_LOCK
+    security_opt:
+      # we can set this to a JSON file to allow per syscall access
+      - seccomp=unconfined
+    volumes:
+      - ${SRCDIR}:${SRCDIR}
+      - /nix:/nix
+      - /dev/hugepages:/dev/hugepages
+      - /tmp:/tmp
+      - /var/tmp:/var/tmp
+networks:
+  mayastor_net:
+    name: mayastor_net
+    ipam:
+      driver: default
+      config:
+        - subnet: "10.0.0.0/16"

--- a/test/python/v1/pool/features/pool.feature
+++ b/test/python/v1/pool/features/pool.feature
@@ -1,0 +1,44 @@
+Feature: Mayastor pool management
+
+  Background:
+    Given a mayastor instance "ms0"
+
+  Scenario: creating a pool using disk with invalid block size
+    When the user attempts to create a pool specifying a disk with an invalid block size
+    Then the pool creation should fail
+
+  Scenario: creating a pool with multiple disks
+    When the user attempts to create a pool specifying multiple disks
+    Then the pool creation should fail
+
+  Scenario: creating a pool with an AIO disk
+    When the user creates a pool specifying a URI representing an aio disk
+    Then the pool should be created
+
+  Scenario: creating a pool with a name that already exists
+    Given a pool "p0"
+    When the user creates a pool with the name of an existing pool
+    Then the pool creation should succeed
+
+  Scenario: listing pools
+    Given a pool "p0"
+    When the user lists the current pools
+    Then the pool should appear in the output list
+
+  Scenario: listing pool by name
+    Given a pool "p0"
+    When the user lists the current pool with name filter as p0
+    Then only the pool p0 should appear in the output list
+
+  Scenario: listing pool by name which does not exists
+    When the user lists the current pool with name filter as p1
+    Then no pool should not appear in the output list
+
+  Scenario: destroying a pool
+    Given a pool "p0"
+    When the user destroys the pool
+    Then the pool should be destroyed
+
+  Scenario: destroying a pool that does not exist
+    When the user destroys a pool that does not exist
+    Then the pool destroy command should succeed

--- a/test/python/v1/pool/features/pool.feature
+++ b/test/python/v1/pool/features/pool.feature
@@ -7,38 +7,72 @@ Feature: Mayastor pool management
     When the user attempts to create a pool specifying a disk with an invalid block size
     Then the pool creation should fail
 
+  Scenario: creating a pool using invalid uuid
+    When the user attempts to create a pool specifying an invalid uuid
+    Then the pool creation should fail
+
   Scenario: creating a pool with multiple disks
     When the user attempts to create a pool specifying multiple disks
     Then the pool creation should fail
+
+  Scenario: creating a pool using valid uuid
+    When the user attempts to create a pool specifying a valid uuid
+    Then the pool should be created with same uuid
 
   Scenario: creating a pool with an AIO disk
     When the user creates a pool specifying a URI representing an aio disk
     Then the pool should be created
 
   Scenario: creating a pool with a name that already exists
-    Given a pool "p0"
+    Given a pool "p0" on "disk0"
     When the user creates a pool with the name of an existing pool
-    Then the pool creation should succeed
+    Then the pool create command should fail
 
   Scenario: listing pools
-    Given a pool "p0"
+    Given a pool "p0" on "disk0"
+    Given a pool "p1" on "disk1"
     When the user lists the current pools
     Then the pool should appear in the output list
 
   Scenario: listing pool by name
-    Given a pool "p0"
-    When the user lists the current pool with name filter as p0
+    Given a pool "p0" on "disk0"
+    Given a pool "p1" on "disk1"
+    When the user lists the pool with name filter as p0
     Then only the pool p0 should appear in the output list
 
   Scenario: listing pool by name which does not exists
-    When the user lists the current pool with name filter as p1
+    Given a pool "p0" on "disk0"
+    When the user lists the pool with name filter as p1
     Then no pool should not appear in the output list
 
+  Scenario: exporting a pool removes the pool from the system
+    Given a pool "p0" on "disk0"
+    When the user exports the pool
+    Then the pool should be exported
+
   Scenario: destroying a pool
-    Given a pool "p0"
+    Given a pool "p0" on "disk0"
     When the user destroys the pool
     Then the pool should be destroyed
 
   Scenario: destroying a pool that does not exist
     When the user destroys a pool that does not exist
-    Then the pool destroy command should succeed
+    Then the pool destroy command should fail
+
+  Scenario: importing a pool
+    Given an aio pool
+    When the user exports the pool
+    And then imports the pool
+    Then the pool should be imported
+
+  Scenario: importing a pool with invalid uuid
+    Given an aio pool
+    When the user exports the pool
+    And then imports the pool with incorrect uuid
+    Then the pool should be not imported
+
+  Scenario: importing a pool with uuid
+    Given an aio pool with uuid
+    When the user exports the pool
+    And then imports the pool
+    Then the pool with same uuid should be imported

--- a/test/python/v1/pool/test_bdd_pool.py
+++ b/test/python/v1/pool/test_bdd_pool.py
@@ -1,5 +1,14 @@
+"""Mayastor pool management feature tests."""
+
 import pytest
-from pytest_bdd import given, scenario, then, when, parsers
+
+from pytest_bdd import (
+    given,
+    scenario,
+    then,
+    when,
+    parsers,
+)
 
 from common.command import run_cmd
 from v1.mayastor import container_mod, mayastor_mod
@@ -9,28 +18,63 @@ import pool_pb2 as pb
 
 
 @scenario("features/pool.feature", "creating a pool using disk with invalid block size")
-def test_fail_creating_a_pool_using_disk_with_invalid_block_size():
-    "Creating a pool using disk with invalid block size."
+def test_creating_a_pool_using_disk_with_invalid_block_size():
+    """creating a pool using disk with invalid block size."""
 
 
-@scenario("features/pool.feature", "creating a pool with multiple disks")
-def test_fail_creating_a_pool_with_multiple_disks():
-    "Creating a pool with multiple disks."
+@scenario("features/pool.feature", "creating a pool using invalid uuid")
+def test_creating_a_pool_using_disk_with_invalid_uuid():
+    """creating a pool using invalid uuid."""
 
 
-@scenario("features/pool.feature", "creating a pool with an AIO disk")
-def test_creating_a_pool_with_an_aio_disk():
-    "Creating a pool with an AIO disk."
+@scenario("features/pool.feature", "creating a pool using valid uuid")
+def test_creating_a_pool_using_disk_with_valid_uuid():
+    """creating a pool using valid uuid."""
 
 
 @scenario("features/pool.feature", "creating a pool with a name that already exists")
 def test_creating_a_pool_with_a_name_that_already_exists():
-    "Creating a pool with a name that already exists."
+    """creating a pool with a name that already exists."""
 
 
-@scenario("features/pool.feature", "listing pools")
-def test_listing_pools():
-    "Listing pools."
+@scenario("features/pool.feature", "creating a pool with an AIO disk")
+def test_creating_a_pool_with_an_aio_disk():
+    """creating a pool with an AIO disk."""
+
+
+@scenario("features/pool.feature", "creating a pool with multiple disks")
+def test_creating_a_pool_with_multiple_disks():
+    """creating a pool with multiple disks."""
+
+
+@scenario("features/pool.feature", "destroying a pool")
+def test_destroying_a_pool():
+    """destroying a pool."""
+
+
+@scenario("features/pool.feature", "destroying a pool that does not exist")
+def test_destroying_a_pool_that_does_not_exist():
+    """destroying a pool that does not exist."""
+
+
+@scenario("features/pool.feature", "exporting a pool removes the pool from the system")
+def test_exporting_a_pool_removes_the_pool_from_the_system():
+    """exporting a pool removes the pool from the system."""
+
+
+@scenario("features/pool.feature", "importing a pool")
+def test_importing_a_pool():
+    """importing a pool."""
+
+
+@scenario("features/pool.feature", "importing a pool with uuid")
+def test_importing_a_pool_with_uuid():
+    """importing a pool with uuid."""
+
+
+@scenario("features/pool.feature", "importing a pool with invalid uuid")
+def test_importing_a_pool_with_invalid_uuid():
+    """importing a pool with invalid uuid."""
 
 
 @scenario("features/pool.feature", "listing pool by name")
@@ -43,14 +87,9 @@ def test_listing_pool_by_name_which_does_not_exists():
     """listing pool by name which does not exists."""
 
 
-@scenario("features/pool.feature", "destroying a pool")
-def test_destroying_a_pool():
-    "Destroying a pool."
-
-
-@scenario("features/pool.feature", "destroying a pool that does not exist")
-def test_destroying_a_pool_that_does_not_exist():
-    "Destroying a pool that does not exist."
+@scenario("features/pool.feature", "listing pools")
+def test_listing_pools():
+    """listing pools."""
 
 
 @pytest.fixture
@@ -80,23 +119,36 @@ def replica_pools(get_mayastor_instance):
     pools = {}
     yield pools
     for name in pools.keys():
-        pool = get_mayastor_instance.pool_rpc.ListPools(
-            pb.ListPoolOptions(name=name)
-        ).pools[0]
-        get_mayastor_instance.pool_rpc.DestroyPool(
-            pb.DestroyPoolRequest(uuid=pool.uuid)
-        )
+        opts = pb.ListPoolOptions()
+        opts.name.value = name
+        pools = get_mayastor_instance.pool_rpc.ListPools(opts).pools
+        if len(pools) != 0:
+            opts = pb.DestroyPoolRequest()
+            opts.name = pools[0].name
+            opts.uuid.value = pools[0].uuid
+            get_mayastor_instance.pool_rpc.DestroyPool(opts)
 
 
 @pytest.fixture
 def create_pool(get_mayastor_instance, replica_pools):
-    def create(name, disks):
-        pool = get_mayastor_instance.pool_rpc.CreatePool(
-            pb.CreatePoolRequest(name=name, disks=disks)
-        )
+    def create(name, disks, uuid):
+        opts = pb.CreatePoolRequest(name=name, disks=disks)
+        if uuid is not None:
+            opts.uuid.value = uuid
+        pool = get_mayastor_instance.pool_rpc.CreatePool(opts)
         replica_pools[name] = pool
 
     yield create
+
+
+@pytest.fixture
+def list_by_name(get_mayastor_instance):
+    def list(name):
+        opts = pb.ListPoolOptions()
+        opts.name.value = name
+        return get_mayastor_instance.pool_rpc.ListPools(opts, wait_for_ready=True).pools
+
+    yield list
 
 
 @given(
@@ -107,51 +159,108 @@ def get_mayastor_instance(mayastor_mod, name):
     return mayastor_mod[name]
 
 
-@given(parsers.parse('a pool "{name}"'), target_fixture="get_pool_name")
-def get_pool_name(get_mayastor_instance, create_pool, name):
-    create_pool(name, ["malloc:///disk0?size_mb=100"])
+@given(parsers.parse('a pool "{name}" on "{disk}"'), target_fixture="get_pool_name")
+def get_pool_name(create_pool, name, disk):
+    create_pool(name, [f"malloc:///{disk}?size_mb=100"], None)
     return name
 
 
-@when("the user creates a pool specifying a URI representing an aio disk")
-def create_pool_from_aio_disk(get_mayastor_instance, create_pool, image_file):
-    create_pool("p0", [f"aio://{image_file}"])
+@given("an aio pool", target_fixture="an_aio_pool")
+def an_aio_pool(create_pool, image_file):
+    create_pool("p0", [f"aio://{image_file}"], None)
+    return "p0"
+
+
+@given("an aio pool with uuid", target_fixture="an_aio_pool")
+def an_aio_pool_with_uuid(create_pool, image_file):
+    create_pool("p0", [f"aio://{image_file}"], "45c09d69-3f6c-4029-b763-e055c37f06a5")
+    return "p0"
 
 
 @when("the user attempts to create a pool specifying a disk with an invalid block size")
-def attempt_to_create_pool_from_disk_with_invalid_block_size(
-    get_mayastor_instance, create_pool
-):
+def attempt_to_create_pool_from_disk_with_invalid_block_size(create_pool):
     with pytest.raises(grpc.RpcError) as error:
-        create_pool("p0", "malloc:///disk0?size_mb=100&blk_size=1024")
+        create_pool("p0", "malloc:///disk0?size_mb=100&blk_size=1024", None)
     assert error.value.code() == grpc.StatusCode.INVALID_ARGUMENT
 
 
+@when("the user attempts to create a pool specifying an invalid uuid")
+def attempt_to_create_pool__with_invalid_uuid(create_pool):
+    with pytest.raises(grpc.RpcError) as error:
+        create_pool("p0", "malloc:///disk0?size_mb=100", "invalid-uuid")
+    assert error.value.code() == grpc.StatusCode.INVALID_ARGUMENT
+
+
+@when("the user attempts to create a pool specifying a valid uuid")
+def attempt_to_create_pool_with_valid_uuid(create_pool):
+    create_pool(
+        "p0", ["malloc:///disk0?size_mb=100"], "45c09d69-3f6c-4029-b763-e055c37f06a5"
+    )
+
+
 @when("the user attempts to create a pool specifying multiple disks")
-def attempt_to_create_pool_from_multiple_disks(get_mayastor_instance, create_pool):
+def attempt_to_create_pool_from_multiple_disks(create_pool):
     with pytest.raises(grpc.RpcError) as error:
         create_pool(
-            "p0", ["malloc:///disk0?size_mb=100", "malloc:///disk1?size_mb=100"]
+            "p0", ["malloc:///disk0?size_mb=100", "malloc:///disk1?size_mb=100"], None
         )
     assert error.value.code() == grpc.StatusCode.INVALID_ARGUMENT
 
 
-@when("the user creates a pool with the name of an existing pool")
-def create_pool_that_already_exists(get_mayastor_instance, create_pool, get_pool_name):
-    create_pool(get_pool_name, ["malloc:///disk0?size_mb=100"])
+@when("the user creates a pool specifying a URI representing an aio disk")
+def create_pool_from_aio_disk(create_pool, image_file):
+    create_pool("p0", [f"aio://{image_file}"], None)
 
 
-@when("the user destroys a pool that does not exist")
-def destroy_pool_that_does_not_exist(get_mayastor_instance, find_pool):
-    assert find_pool("p0") == None
-    get_mayastor_instance.pool_rpc.DestroyPool(pb.DestroyPoolRequest(uuid="p0"))
+@when(
+    "the user creates a pool with the name of an existing pool",
+    target_fixture="create_pool_that_already_exists",
+)
+def create_pool_that_already_exists(create_pool, get_pool_name):
+    with pytest.raises(grpc.RpcError) as error:
+        create_pool(get_pool_name, ["malloc:///disk0?size_mb=100"], None)
+    return error
+
+
+@when(
+    "the user destroys a pool that does not exist",
+    target_fixture="destroy_non_existing_pool",
+)
+def destroy_non_existing_pool(get_mayastor_instance):
+    with pytest.raises(grpc.RpcError) as error:
+        get_mayastor_instance.pool_rpc.DestroyPool(
+            pb.DestroyPoolRequest(name="no-pool")
+        )
+    return error
 
 
 @when("the user destroys the pool")
 def destroy_pool(get_mayastor_instance, replica_pools, get_pool_name):
     pool = replica_pools[get_pool_name]
-    get_mayastor_instance.pool_rpc.DestroyPool(pb.DestroyPoolRequest(uuid=pool.uuid))
+    get_mayastor_instance.pool_rpc.DestroyPool(pb.DestroyPoolRequest(name=pool.name))
     del replica_pools[get_pool_name]
+
+
+@when("the user exports the pool")
+def the_user_exports_the_pool(get_mayastor_instance, find_pool):
+    pool = find_pool("p0")
+    get_mayastor_instance.pool_rpc.ExportPool(pb.ExportPoolRequest(name=pool.name))
+
+
+@when("then imports the pool")
+def then_imports_the_pool(get_mayastor_instance):
+    get_mayastor_instance.pool_rpc.ImportPool(
+        pb.ImportPoolRequest(name="p0", disks=["aio:///tmp/ms0-disk0.img"])
+    )
+
+
+@when("then imports the pool with incorrect uuid")
+def then_imports_the_pool_with_incorrect_uuid(get_mayastor_instance):
+    with pytest.raises(grpc.RpcError) as error:
+        opts = pb.ImportPoolRequest(name="p0", disks=["aio:///tmp/ms0-disk0.img"])
+        opts.uuid.value = "invalid"
+        get_mayastor_instance.pool_rpc.ImportPool(opts)
+    assert error.value.code() == grpc.StatusCode.INVALID_ARGUMENT
 
 
 @when("the user lists the current pools", target_fixture="list_pools")
@@ -162,40 +271,39 @@ def list_pools(get_mayastor_instance):
 
 
 @when(
-    "the user lists the current pool with name filter as p0",
+    "the user lists the pool with name filter as p0",
     target_fixture="list_existing_pool",
 )
 def list_existing_pool(get_mayastor_instance):
-    return get_mayastor_instance.pool_rpc.ListPools(
-        pb.ListPoolOptions(name="p0"), wait_for_ready=True
-    ).pools
+    opts = pb.ListPoolOptions()
+    opts.name.value = "p0"
+    return get_mayastor_instance.pool_rpc.ListPools(opts, wait_for_ready=True).pools
 
 
 @when(
-    "the user lists the current pool with name filter as p1",
+    "the user lists the pool with name filter as p1",
     target_fixture="list_non_existing_pool",
 )
 def list_non_existing_pool(get_mayastor_instance):
-    return get_mayastor_instance.pool_rpc.ListPools(
-        pb.ListPoolOptions(name="p1"), wait_for_ready=True
-    ).pools
+    opts = pb.ListPoolOptions()
+    opts.name.value = "p1"
+    return get_mayastor_instance.pool_rpc.ListPools(opts, wait_for_ready=True).pools
 
 
 @then("the pool creation should fail")
+@then("the pool should be not imported")
 def pool_creation_should_fail(find_pool):
     assert find_pool("p0") == None
 
 
-@then("the pool creation should succeed")
-@then("the pool should be created")
-def pool_creation_should_succeed(find_pool):
-    assert find_pool("p0") != None
+@then("the pool create command should fail")
+def the_pool_create_command_should_fail(create_pool_that_already_exists):
+    assert create_pool_that_already_exists.value.code() == grpc.StatusCode.INTERNAL
 
 
-@then("the pool destroy command should succeed")
-@then("the pool should be destroyed")
-def pool_destruction_should_succeed(find_pool):
-    assert find_pool("p0") == None
+@then("the pool destroy command should fail")
+def the_pool_destroy_command_should_fail(destroy_non_existing_pool):
+    assert destroy_non_existing_pool.value.code() == grpc.StatusCode.INVALID_ARGUMENT
 
 
 @then("the pool should appear in the output list")
@@ -204,12 +312,30 @@ def pool_should_appear_in_output(get_pool_name, list_pools):
 
 
 @then("only the pool p0 should appear in the output list")
-def only_the_pool_p0_should_appear_in_the_output_list(
-    get_pool_name, list_existing_pool
-):
-    assert get_pool_name in [pool.name for pool in list_existing_pool]
+def only_the_pool_p0_should_appear_in_the_output_list(list_existing_pool):
+    pools = list_existing_pool
+    assert len(pools) == 1
+    assert "p0" in [pool.name for pool in pools]
 
 
 @then("no pool should not appear in the output list")
 def no_pool_should_not_appear_in_the_output_list(list_non_existing_pool):
     assert len(list_non_existing_pool) == 0
+
+
+@then("the pool should be created")
+@then("the pool should be imported")
+def pool_creation_should_succeed(find_pool):
+    assert find_pool("p0") != None
+
+
+@then("the pool should be created with same uuid")
+@then("the pool with same uuid should be imported")
+def pool_created_with_same_uuid(find_pool):
+    assert find_pool("p0").uuid == "45c09d69-3f6c-4029-b763-e055c37f06a5"
+
+
+@then("the pool should be destroyed")
+@then("the pool should be exported")
+def pool_destruction_should_succeed(find_pool):
+    assert find_pool("p0") == None

--- a/test/python/v1/pool/test_bdd_pool.py
+++ b/test/python/v1/pool/test_bdd_pool.py
@@ -1,0 +1,215 @@
+import pytest
+from pytest_bdd import given, scenario, then, when, parsers
+
+from common.command import run_cmd
+from v1.mayastor import container_mod, mayastor_mod
+
+import grpc
+import pool_pb2 as pb
+
+
+@scenario("features/pool.feature", "creating a pool using disk with invalid block size")
+def test_fail_creating_a_pool_using_disk_with_invalid_block_size():
+    "Creating a pool using disk with invalid block size."
+
+
+@scenario("features/pool.feature", "creating a pool with multiple disks")
+def test_fail_creating_a_pool_with_multiple_disks():
+    "Creating a pool with multiple disks."
+
+
+@scenario("features/pool.feature", "creating a pool with an AIO disk")
+def test_creating_a_pool_with_an_aio_disk():
+    "Creating a pool with an AIO disk."
+
+
+@scenario("features/pool.feature", "creating a pool with a name that already exists")
+def test_creating_a_pool_with_a_name_that_already_exists():
+    "Creating a pool with a name that already exists."
+
+
+@scenario("features/pool.feature", "listing pools")
+def test_listing_pools():
+    "Listing pools."
+
+
+@scenario("features/pool.feature", "listing pool by name")
+def test_listing_pool_by_name():
+    """listing pool by name."""
+
+
+@scenario("features/pool.feature", "listing pool by name which does not exists")
+def test_listing_pool_by_name_which_does_not_exists():
+    """listing pool by name which does not exists."""
+
+
+@scenario("features/pool.feature", "destroying a pool")
+def test_destroying_a_pool():
+    "Destroying a pool."
+
+
+@scenario("features/pool.feature", "destroying a pool that does not exist")
+def test_destroying_a_pool_that_does_not_exist():
+    "Destroying a pool that does not exist."
+
+
+@pytest.fixture
+def image_file():
+    name = "/tmp/ms0-disk0.img"
+    run_cmd(f"rm -f '{name}'", True)
+    run_cmd(f"truncate -s 64M '{name}'", True)
+    yield name
+    run_cmd(f"rm -f '{name}'", True)
+
+
+@pytest.fixture
+def find_pool(get_mayastor_instance):
+    def find(name):
+        for pool in get_mayastor_instance.pool_rpc.ListPools(
+            pb.ListPoolOptions()
+        ).pools:
+            if pool.name == name:
+                return pool
+        return None
+
+    yield find
+
+
+@pytest.fixture
+def replica_pools(get_mayastor_instance):
+    pools = {}
+    yield pools
+    for name in pools.keys():
+        pool = get_mayastor_instance.pool_rpc.ListPools(
+            pb.ListPoolOptions(name=name)
+        ).pools[0]
+        get_mayastor_instance.pool_rpc.DestroyPool(
+            pb.DestroyPoolRequest(uuid=pool.uuid)
+        )
+
+
+@pytest.fixture
+def create_pool(get_mayastor_instance, replica_pools):
+    def create(name, disks):
+        pool = get_mayastor_instance.pool_rpc.CreatePool(
+            pb.CreatePoolRequest(name=name, disks=disks)
+        )
+        replica_pools[name] = pool
+
+    yield create
+
+
+@given(
+    parsers.parse('a mayastor instance "{name}"'),
+    target_fixture="get_mayastor_instance",
+)
+def get_mayastor_instance(mayastor_mod, name):
+    return mayastor_mod[name]
+
+
+@given(parsers.parse('a pool "{name}"'), target_fixture="get_pool_name")
+def get_pool_name(get_mayastor_instance, create_pool, name):
+    create_pool(name, ["malloc:///disk0?size_mb=100"])
+    return name
+
+
+@when("the user creates a pool specifying a URI representing an aio disk")
+def create_pool_from_aio_disk(get_mayastor_instance, create_pool, image_file):
+    create_pool("p0", [f"aio://{image_file}"])
+
+
+@when("the user attempts to create a pool specifying a disk with an invalid block size")
+def attempt_to_create_pool_from_disk_with_invalid_block_size(
+    get_mayastor_instance, create_pool
+):
+    with pytest.raises(grpc.RpcError) as error:
+        create_pool("p0", "malloc:///disk0?size_mb=100&blk_size=1024")
+    assert error.value.code() == grpc.StatusCode.INVALID_ARGUMENT
+
+
+@when("the user attempts to create a pool specifying multiple disks")
+def attempt_to_create_pool_from_multiple_disks(get_mayastor_instance, create_pool):
+    with pytest.raises(grpc.RpcError) as error:
+        create_pool(
+            "p0", ["malloc:///disk0?size_mb=100", "malloc:///disk1?size_mb=100"]
+        )
+    assert error.value.code() == grpc.StatusCode.INVALID_ARGUMENT
+
+
+@when("the user creates a pool with the name of an existing pool")
+def create_pool_that_already_exists(get_mayastor_instance, create_pool, get_pool_name):
+    create_pool(get_pool_name, ["malloc:///disk0?size_mb=100"])
+
+
+@when("the user destroys a pool that does not exist")
+def destroy_pool_that_does_not_exist(get_mayastor_instance, find_pool):
+    assert find_pool("p0") == None
+    get_mayastor_instance.pool_rpc.DestroyPool(pb.DestroyPoolRequest(uuid="p0"))
+
+
+@when("the user destroys the pool")
+def destroy_pool(get_mayastor_instance, replica_pools, get_pool_name):
+    pool = replica_pools[get_pool_name]
+    get_mayastor_instance.pool_rpc.DestroyPool(pb.DestroyPoolRequest(uuid=pool.uuid))
+    del replica_pools[get_pool_name]
+
+
+@when("the user lists the current pools", target_fixture="list_pools")
+def list_pools(get_mayastor_instance):
+    return get_mayastor_instance.pool_rpc.ListPools(
+        pb.ListPoolOptions(), wait_for_ready=True
+    ).pools
+
+
+@when(
+    "the user lists the current pool with name filter as p0",
+    target_fixture="list_existing_pool",
+)
+def list_existing_pool(get_mayastor_instance):
+    return get_mayastor_instance.pool_rpc.ListPools(
+        pb.ListPoolOptions(name="p0"), wait_for_ready=True
+    ).pools
+
+
+@when(
+    "the user lists the current pool with name filter as p1",
+    target_fixture="list_non_existing_pool",
+)
+def list_non_existing_pool(get_mayastor_instance):
+    return get_mayastor_instance.pool_rpc.ListPools(
+        pb.ListPoolOptions(name="p1"), wait_for_ready=True
+    ).pools
+
+
+@then("the pool creation should fail")
+def pool_creation_should_fail(find_pool):
+    assert find_pool("p0") == None
+
+
+@then("the pool creation should succeed")
+@then("the pool should be created")
+def pool_creation_should_succeed(find_pool):
+    assert find_pool("p0") != None
+
+
+@then("the pool destroy command should succeed")
+@then("the pool should be destroyed")
+def pool_destruction_should_succeed(find_pool):
+    assert find_pool("p0") == None
+
+
+@then("the pool should appear in the output list")
+def pool_should_appear_in_output(get_pool_name, list_pools):
+    assert get_pool_name in [pool.name for pool in list_pools]
+
+
+@then("only the pool p0 should appear in the output list")
+def only_the_pool_p0_should_appear_in_the_output_list(
+    get_pool_name, list_existing_pool
+):
+    assert get_pool_name in [pool.name for pool in list_existing_pool]
+
+
+@then("no pool should not appear in the output list")
+def no_pool_should_not_appear_in_the_output_list(list_non_existing_pool):
+    assert len(list_non_existing_pool) == 0


### PR DESCRIPTION
- adds the implementation of mayastor v1 service for Pool.
- adds separate rpcs to import and export pools
- operations on non-existing pool will return an error instead of null

Signed-off-by: shubham <shubham14bajpai@gmail.com>