### PR TITLE
test(e2e): use mayastor image for mayastor-csi daemonset

### DIFF
--- a/chart/templates/csi-daemonset.yaml
+++ b/chart/templates/csi-daemonset.yaml
@@ -28,7 +28,7 @@ spec:
       # the same.
       containers:
       - name: mayastor-csi
-        image: {{ include "mayastorImagesPrefix" . }}mayadata/mayastor-csi:{{ .Values.mayastorImagesTag }}
+        image: {{ include "mayastorImagesPrefix" . }}mayadata/mayastor:{{ .Values.mayastorImagesTag }}
         imagePullPolicy: {{ .Values.mayastorImagePullPolicy }}
         # we need privileged because we mount filesystems and use mknod
         securityContext:
@@ -50,6 +50,8 @@ spec:
         - "--grpc-endpoint=$(MY_POD_IP):10199"{{ if .Values.csi.nvme.io_timeout_enabled }}
         - "--nvme-core-io-timeout={{ .Values.csi.nvme.io_timeout }}"{{ end }}
         - "-v"
+        command:
+        - mayastor-csi
         volumeMounts:
         - name: device
           mountPath: /dev

--- a/chart/templates/mayastor-daemonset.yaml
+++ b/chart/templates/mayastor-daemonset.yaml
@@ -56,6 +56,8 @@ spec:
         - "-P/var/local/mayastor/pools.yaml"
         - "-l{{ include "mayastorCpuSpec" . }}"
         - "-pmayastor-etcd"
+        command:
+        - mayastor
         securityContext:
           privileged: true
         volumeMounts:


### PR DESCRIPTION
Use mayastor image as host for mayastor-csi for CI testing.
Use the "command" field in the yamls for mayastor and mayastor-csi to specify unambiguously which binary to run.
Part of PR #1007 moved to separate PR as requested in review.
This relates to mq-1989.