### PR TITLE
fix(nvmx): handle failures from processing completions for admin comands

### DIFF
--- a/mayastor/src/bdev/nvmx/controller_inner.rs
+++ b/mayastor/src/bdev/nvmx/controller_inner.rs
@@ -74,6 +74,7 @@ pub(crate) struct TimeoutConfig {
     ctrlr: SpdkNvmeController,
     reset_attempts: u32,
     next_reset_time: Instant,
+    destroy_in_progress: AtomicCell<bool>,
 }
 
 impl Drop for TimeoutConfig {
@@ -93,6 +94,7 @@ impl TimeoutConfig {
             ctrlr: SpdkNvmeController(NonNull::dangling()),
             reset_attempts: MAX_RESET_ATTEMPTS,
             next_reset_time: Instant::now(),
+            destroy_in_progress: AtomicCell::new(false),
         }
     }
 
@@ -100,6 +102,11 @@ impl TimeoutConfig {
         self as *const _ as *mut _
     }
 
+    pub fn start_device_destroy(&mut self) -> bool {
+        self.destroy_in_progress
+            .compare_exchange(false, true)
+            .is_ok()
+    }
     pub fn set_controller(&mut self, ctrlr: SpdkNvmeController) {
         self.ctrlr = ctrlr;
     }

--- a/mayastor/tests/nexus_multipath.rs
+++ b/mayastor/tests/nexus_multipath.rs
@@ -51,6 +51,8 @@ fn nvme_connect(
         } else {
             eprintln!("{}", msg);
         }
+    } else {
+        std::thread::sleep(std::time::Duration::from_secs(1));
     }
 
     status

--- a/mayastor/tests/nvme_device_timeout.rs
+++ b/mayastor/tests/nvme_device_timeout.rs
@@ -216,7 +216,9 @@ async fn test_io_timeout(action_on_timeout: DeviceTimeoutAction) {
         .spawn(async move {
             let ctx = unsafe { Box::from_raw(io_ctx.into_inner()) };
 
-            device_destroy(&ctx.device_url).await.unwrap();
+            device_destroy(&ctx.device_url)
+                .await
+                .expect_err("device should have already been destroyed");
         })
         .await;
 

--- a/mayastor/tests/persistence.rs
+++ b/mayastor/tests/persistence.rs
@@ -132,11 +132,12 @@ async fn persist_clean_shutdown() {
 
     assert!(nexus_info.clean_shutdown);
 
+    // Children are no longer open, therefore not healthy
     let child = child_info(&nexus_info, &uuid(&child1));
-    assert!(child.healthy);
+    assert!(!child.healthy);
 
     let child = child_info(&nexus_info, &uuid(&child2));
-    assert!(child.healthy);
+    assert!(!child.healthy);
 }
 
 /// This test checks that the state of a child is successfully updated in the
@@ -196,7 +197,7 @@ async fn persist_io_failure() {
     );
     assert_eq!(
         get_child(ms1, nexus_uuid, &child2).await.state,
-        ChildState::ChildFaulted as i32
+        ChildState::ChildDegraded as i32
     );
 
     // Use etcd-client to check the persisted entry.


### PR DESCRIPTION
Handle it by scheduling a future once, and only once, to destroy the
device if spdk_nvme_ctrlr_process_admin_completions() returns an
error, usually -ENXIO if the remote child is unreachable when
handling admin commands such as keep-alive.

This means an unreachable remote child on an idle nexus is now noticed
and the child is marked as degraded. In the case where the nexus is
under IO load and 2 remote replicas are unreachable at almost the same
time, both replicas are now consistently degraded.

Fixes CAS-941