### PR TITLE
feat(nexus): handle preempt key in NexusCreateV2

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -284,6 +284,7 @@ pipeline {
           stages {
             stage('checkout') {
               steps {
+                cleanWs()
                 checkout([
                   $class: 'GitSCM',
                   branches: scm.branches,

--- a/mayastor/src/bdev/nexus/nexus_bdev.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev.rs
@@ -358,6 +358,8 @@ pub struct NexusNvmeParams {
     pub(crate) max_cntlid: u16,
     /// NVMe reservation key for children
     pub(crate) resv_key: u64,
+    /// NVMe preempt key for children, 0 to not preempt
+    pub(crate) preempt_key: Option<std::num::NonZeroU64>,
 }
 
 impl Default for NexusNvmeParams {
@@ -366,6 +368,7 @@ impl Default for NexusNvmeParams {
             min_cntlid: NVME_MIN_CNTLID,
             max_cntlid: NVME_MAX_CNTLID,
             resv_key: 0x1234_5678,
+            preempt_key: None,
         }
     }
 }
@@ -379,6 +382,12 @@ impl NexusNvmeParams {
     }
     pub fn set_resv_key(&mut self, resv_key: u64) {
         self.resv_key = resv_key;
+    }
+    pub fn set_preempt_key(
+        &mut self,
+        preempt_key: Option<std::num::NonZeroU64>,
+    ) {
+        self.preempt_key = preempt_key;
     }
 }
 

--- a/mayastor/src/bdev/nexus/nexus_bdev_children.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev_children.rs
@@ -188,7 +188,10 @@ impl Nexus {
             info!("{}: child opened successfully {}", self.name, name);
 
             if let Err(e) = child
-                .acquire_write_exclusive(self.nvme_params.resv_key)
+                .acquire_write_exclusive(
+                    self.nvme_params.resv_key,
+                    self.nvme_params.preempt_key,
+                )
                 .await
             {
                 child_name = Err(e);
@@ -496,7 +499,10 @@ impl Nexus {
         let mut we_err: Result<(), Error> = Ok(());
         for child in self.children.iter() {
             if let Err(error) = child
-                .acquire_write_exclusive(self.nvme_params.resv_key)
+                .acquire_write_exclusive(
+                    self.nvme_params.resv_key,
+                    self.nvme_params.preempt_key,
+                )
                 .await
             {
                 we_err = Err(Error::ChildWriteExclusiveResvFailed {

--- a/mayastor/src/bin/mayastor-client/nexus_cli.rs
+++ b/mayastor/src/bin/mayastor-client/nexus_cli.rs
@@ -69,6 +69,11 @@ pub fn subcommands<'a, 'b>() -> App<'a, 'b> {
                 .help("NVMe reservation key for children"),
         )
         .arg(
+            Arg::with_name("preempt-key")
+                .required(true)
+                .help("NVMe preempt key for children, 0 for no preemption"),
+        )
+        .arg(
             Arg::with_name("children")
                 .required(true)
                 .multiple(true)
@@ -302,6 +307,8 @@ async fn nexus_create_v2(
         .unwrap_or_else(|e| e.exit());
     let resv_key = value_t!(matches.value_of("resv-key"), u64)
         .unwrap_or_else(|e| e.exit());
+    let preempt_key = value_t!(matches.value_of("preempt-key"), u64)
+        .unwrap_or_else(|e| e.exit());
 
     let response = ctx
         .client
@@ -312,6 +319,7 @@ async fn nexus_create_v2(
             min_cntl_id,
             max_cntl_id,
             resv_key,
+            preempt_key,
             children,
         })
         .await

--- a/mayastor/src/grpc/mayastor_grpc.rs
+++ b/mayastor/src/grpc/mayastor_grpc.rs
@@ -681,6 +681,10 @@ impl mayastor_server::Mayastor for MayastorSvc {
                             min_cntlid: args.min_cntl_id as u16,
                             max_cntlid: args.max_cntl_id as u16,
                             resv_key: args.resv_key,
+                            preempt_key: match args.preempt_key {
+                                0 => None,
+                                k => std::num::NonZeroU64::new(k),
+                            },
                         },
                         &args.children,
                     )

--- a/mayastor/tests/nexus_multipath.rs
+++ b/mayastor/tests/nexus_multipath.rs
@@ -440,6 +440,7 @@ async fn nexus_resv_acquire() {
             min_cntl_id: 1,
             max_cntl_id: 0xffef,
             resv_key: resv_key2,
+            preempt_key: 0,
             children: [format!("nvmf://{}:8420/{}:{}", ip0, HOSTNQN, UUID)]
                 .to_vec(),
         })

--- a/test/python/common/hdl.py
+++ b/test/python/common/hdl.py
@@ -137,10 +137,10 @@ class MayastorHandle(object):
         )
 
     def nexus_create_v2(
-        self, name, uuid, size, min_cntlid, max_cntlid, resv_key, children
+        self, name, uuid, size, min_cntlid, max_cntlid, resv_key, preempt_key, children
     ):
         """Create a nexus with the given name, uuid, size, NVMe controller ID range,
-        and NVMe reservation key for children. The children should be an array
+        NVMe reservation and preempt keys for children. The children should be an array
         of nvmf URIs."""
         return self.ms.CreateNexusV2(
             pb.CreateNexusV2Request(
@@ -150,6 +150,7 @@ class MayastorHandle(object):
                 minCntlId=min_cntlid,
                 maxCntlId=max_cntlid,
                 resvKey=resv_key,
+                preemptKey=preempt_key,
                 children=children,
             )
         )

--- a/test/python/tests/nexus_multipath/test_bdd_nexus_multipath.py
+++ b/test/python/tests/nexus_multipath/test_bdd_nexus_multipath.py
@@ -41,6 +41,7 @@ def create_nexus(
         min_cntlid,
         min_cntlid + 9,
         resv_key,
+        0,
         replicas,
     )
     uri = hdls["ms3"].nexus_publish(NEXUS_NAME)
@@ -79,6 +80,7 @@ def create_nexus_2(mayastor_mod, nexus_name, nexus_uuid, min_cntlid_2, resv_key_
         min_cntlid_2,
         min_cntlid_2 + 9,
         resv_key_2,
+        0,
         replicas,
     )
     uri = hdls["ms0"].nexus_publish(NEXUS_NAME)

--- a/test/python/tests/nexus_multipath/test_nexus_multipath.py
+++ b/test/python/tests/nexus_multipath/test_nexus_multipath.py
@@ -35,6 +35,7 @@ def create_nexus_no_destroy(
         min_cntlid,
         min_cntlid + 9,
         resv_key,
+        0,
         replicas,
     )
     uri = hdls["ms3"].nexus_publish(NEXUS_NAME)
@@ -80,6 +81,7 @@ def create_nexus_2_no_destroy(
         min_cntlid_2,
         min_cntlid_2 + 9,
         resv_key_2,
+        0,
         replicas,
     )
     uri = hdls["ms0"].nexus_publish(NEXUS_NAME)
@@ -176,6 +178,7 @@ def create_nexus_3_dev(
         min_cntlid_3,
         min_cntlid_3 + 9,
         resv_key_3,
+        0,
         replicas,
     )
     uri = hdls["ms1"].nexus_publish(NEXUS_NAME)


### PR DESCRIPTION
Pass through the preempt key from NexusCreateV2 to the reservation
acquire command that is sent to replicas when a nexus is created and
change the acquire action to preempt if the preempt key is non-zero,
otherwise it remains as acquire.

Add a test to check that a preempted nexus is no longer allowed to
write to replicas.

Fixes CAS-851