### PR TITLE
fix(csi): node_unpublish_volume() can fail (while reporting success)

### DIFF
--- a/test/python/k8s/bug/node_unpublish_bug.py
+++ b/test/python/k8s/bug/node_unpublish_bug.py
@@ -1,0 +1,315 @@
+#! /usr/bin/python3
+
+import libvirt
+import time
+import yaml
+
+from kubernetes import config, dynamic
+from kubernetes.client import api_client
+
+configuration = config.load_kube_config()
+client = dynamic.DynamicClient(api_client.ApiClient(configuration=configuration))
+
+
+def wait_for(kind, api, name, namespace, timeout, status, ready):
+    if status is not None:
+        if ready(status):
+            return 0, 0
+    timeout += 2
+    duration = 1
+    elapsed = 1
+    n = 0
+    while elapsed < timeout:
+        n += 1
+        time.sleep(duration)
+        duration, elapsed = elapsed, duration + elapsed
+        entity = api.get(name=name, namespace=namespace)
+        status = entity.get('status')
+        if status is not None:
+            if ready(status):
+                return n, elapsed - 1
+    raise Exception("timeout waiting for %s [%s] in namespace [%s] (checks=%d elapsed=%ds)" % (kind, name, namespace, n, elapsed - 1))
+
+
+def create_object(kind, api, body, name, namespace, timeout, ready):
+    entity = api.create(body=body, namespace=namespace)
+    n, elapsed = wait_for(kind, api, name, namespace, timeout, entity.get('status'), ready)
+    print("created %s [%s] in namespace [%s] (checks=%d elapsed=%ds)" % (kind, name, namespace, n, elapsed))
+
+
+def wait_until_deleted(kind, api, name, namespace, timeout):
+    timeout += 2
+    duration = 1
+    elapsed = 1
+    n = 0
+    while elapsed < timeout:
+        n += 1
+        time.sleep(duration)
+        duration, elapsed = elapsed, duration + elapsed
+        try:
+            api.get(name=name, namespace=namespace)
+        except dynamic.exceptions.NotFoundError:
+            return n, elapsed - 1
+    raise Exception("timeout waiting for %s [%s] in namespace [%s] (checks=%d elapsed=%ds)" % (kind, name, namespace, n, elapsed - 1))
+
+
+def delete_object(kind, api, name, namespace, timeout):
+    api.delete(name=name, namespace=namespace)
+    n, elapsed = wait_until_deleted(kind, api, name, namespace, timeout)
+    print("deleted %s [%s] from namespace [%s] (checks=%d elapsed=%ds)" % (kind, name, namespace, n, elapsed))
+
+
+def wait_for_mayastor_node(name, state):
+    version = "openebs.io/v1alpha1"
+    kind = "MayastorNode"
+    api = client.resources.get(api_version=version, kind=kind)
+    namespace = "mayastor"
+    n, elapsed = wait_for(kind, api, name, namespace, 300, None, lambda status: status == state)
+    print("%s [%s] in namespace [%s] is %s (checks=%d elapsed=%ds)" % (kind, name, namespace, state, n, elapsed))
+
+
+def wait_for_mayastor_pool(name, state):
+    version = "openebs.io/v1alpha1"
+    kind = "MayastorPool"
+    api = client.resources.get(api_version=version, kind=kind)
+    namespace = "mayastor"
+    n, elapsed = wait_for(kind, api, name, namespace, 300, None, lambda status: status.get('state') == state)
+    print("%s [%s] in namespace [%s] is %s (checks=%d elapsed=%ds)" % (kind, name, namespace, state, n, elapsed))
+
+
+def wait_until_persistent_volume_deleted(name):
+    version = "v1"
+    kind = "PersistentVolume"
+    api = client.resources.get(api_version=version, kind=kind)
+    namespace = "default"
+    n, elapsed = wait_until_deleted(kind, api, name, namespace, 600)
+    print("%s [%s] has been deleted from namespace [%s] (checks=%d elapsed=%ds)" % (kind, name, namespace, n, elapsed))
+
+
+def create_mayastor_pool(name, node, disk):
+    version = "openebs.io/v1alpha1"
+    kind = "MayastorPool"
+    api = client.resources.get(api_version=version, kind=kind)
+    namespace = "mayastor"
+    body = {
+        "apiVersion": "openebs.io/v1alpha1",
+        "kind": "MayastorPool",
+        "metadata": {
+            "name": name,
+            "namespace": namespace
+        },
+        "spec": {
+            "node": node,
+            "disks": [
+                disk
+            ]
+        }
+    }
+    create_object(kind, api, body, name, namespace, 300, lambda status: status.get('state') == 'online')
+
+
+def create_storage_class(name):
+    version = "storage.k8s.io/v1"
+    kind = "StorageClass"
+    api = client.resources.get(api_version=version, kind=kind)
+    namespace = "default"
+    body = {
+        "apiVersion": version,
+        "kind": kind,
+        "metadata": {
+            "name": name
+        },
+        "parameters": {
+            "repl": "1",
+            "protocol": "nvmf",
+            "ioTimeout": "30",
+            "fsType": "xfs",
+            "local": "false"
+        },
+        "provisioner": "io.openebs.csi-mayastor",
+        "volumeBindingMode": "WaitForFirstConsumer"
+    }
+    api.create(body=body, namespace=namespace)
+    print("created %s [%s] in namespace [%s]" % (kind, name, namespace))
+
+
+def create_persistent_volume_claim(name, sc_name):
+    version = "v1"
+    kind = "PersistentVolumeClaim"
+    api = client.resources.get(api_version=version, kind=kind)
+    namespace = "default"
+    body = {
+        "apiVersion": version,
+        "kind": kind,
+        "metadata": {
+            "name": name
+        },
+        "spec": {
+            "accessModes": [
+                "ReadWriteOnce"
+            ],
+            "resources": {
+                "requests": {
+                    "storage": "100Mi"
+                }
+            },
+            "storageClassName": sc_name
+        }
+    }
+    create_object(kind, api, body, name, namespace, 300, lambda status: status.get('phase') in ['Pending', 'Bound'])
+
+
+def get_persistent_volume_claim(name):
+    version = "v1"
+    kind = "PersistentVolumeClaim"
+    api = client.resources.get(api_version=version, kind=kind)
+    namespace = "default"
+    return api.get(name=name, namespace=namespace)
+
+
+def get_persistent_volume_name(pvc_name):
+    pvc = get_persistent_volume_claim(pvc_name)
+    return pvc.get('spec').get('volumeName')
+
+
+def create_fio_pod(name, pvc_name):
+    version = "v1"
+    kind = "Pod"
+    api = client.resources.get(api_version=version, kind=kind)
+    namespace = "default"
+    body = {
+        "apiVersion": version,
+        "kind": kind,
+        "metadata": {
+            "name": name
+        },
+        "spec": {
+            "nodeSelector": {
+                "openebs.io/workloads": "yes"
+            },
+            "volumes": [
+                {
+                    "name": "ms-volume",
+                    "persistentVolumeClaim": {
+                        "claimName": pvc_name
+                    }
+                }
+            ],
+            "containers": [
+                {
+                    "name": "fio",
+                    "image": "mayadata/fio",
+                    "args": [
+                        "fio",
+                        "--name=benchtest",
+                        "--size=64m",
+                        "--filename=/volume/test",
+                        "--direct=1",
+                        "--rw=randrw",
+                        "--ioengine=libaio",
+                        "--bs=4k",
+                        "--iodepth=16",
+                        "--numjobs=8",
+                        "--time_based",
+                        "--runtime=600"
+                    ],
+                    "volumeMounts": [
+                        {
+                            "mountPath": "/volume",
+                            "name": "ms-volume"
+                        }
+                    ]
+                }
+            ],
+            "restartPolicy": "Never"
+        }
+    }
+    create_object(kind, api, body, name, namespace, 300, lambda status: status.get('phase') == 'Running')
+
+
+def delete_failed_pod(name):
+    version = "v1"
+    kind = "Pod"
+    api = client.resources.get(api_version=version, kind=kind)
+    namespace = "default"
+
+    # wait until pod is in an error state
+    n, elapsed = wait_for(kind, api, name, namespace, 600, None, lambda status: status.get('phase') == 'Failed')
+    print("%s [%s] in namespace [%s] has failed (checks=%d elapsed=%ds)" % (kind, name, namespace, n, elapsed))
+
+    # delete the pod
+    delete_object(kind, api, name, namespace, 600)
+
+
+def delete_persistent_volume_claim(name):
+    version = "v1"
+    kind = "PersistentVolumeClaim"
+    api = client.resources.get(api_version=version, kind=kind)
+    namespace = "default"
+    delete_object(kind, api, name, namespace, 300)
+
+
+def delete_storage_class(name):
+    version = "storage.k8s.io/v1"
+    kind = "StorageClass"
+    api = client.resources.get(api_version=version, kind=kind)
+    namespace = "default"
+    delete_object(kind, api, name, namespace, 300)
+
+
+def delete_mayastor_pool(name):
+    version = "openebs.io/v1alpha1"
+    kind = "MayastorPool"
+    api = client.resources.get(api_version=version, kind=kind)
+    namespace = "mayastor"
+    delete_object(kind, api, name, namespace, 300)
+
+
+# perform initial setup
+create_mayastor_pool('ksnode-pool-2', 'ksnode-2', 'malloc:///m0?size_mb=512')
+create_storage_class('mayastor-1')
+create_persistent_volume_claim('ms-volume-claim', 'mayastor-1')
+
+# create the fio pod
+print("creating Pod [fio] ...")
+create_fio_pod('fio', 'ms-volume-claim')
+
+# get the name of the PV associated with the PVC
+persistent_volume_name = get_persistent_volume_name('ms-volume-claim')
+print("PersistentVolumeClaim [%s] has associated PersistentVolume [%s]" % ('ms-volume-claim', persistent_volume_name))
+
+# let fio run for a bit
+print("sleeping for 15s ...")
+time.sleep(15)
+
+# pull the plug on the node VM
+print("destroying Node [ksnode-2]")
+with libvirt.open('qemu:///system') as connection:
+    connection.lookupByName('ksnode-2').destroy()
+
+# wait for the fio pod to fail and then delete it
+print("polling Pod [fio] ...")
+delete_failed_pod('fio')
+
+# delete the PVC
+delete_persistent_volume_claim('ms-volume-claim')
+
+# wait for the associated PV to be deleted
+print("polling PersistentVolume [%s] ..." % persistent_volume_name)
+wait_until_persistent_volume_deleted(persistent_volume_name)
+
+# restart the node VM
+print("restarting Node [ksnode-2]")
+with libvirt.open('qemu:///system') as connection:
+    connection.lookupByName('ksnode-2').create()
+
+# wait until node is back online
+print("polling MayastorNode [ksnode-2] ...")
+wait_for_mayastor_node('ksnode-2', 'online')
+
+# wait until pool is back online
+wait_for_mayastor_pool('ksnode-pool-2', 'online')
+
+# perform remaining cleanup
+delete_storage_class('mayastor-1')
+delete_mayastor_pool('ksnode-pool-2')

--- a/test/python/k8s/bug/node_unpublish_bug.readme
+++ b/test/python/k8s/bug/node_unpublish_bug.readme
@@ -1,0 +1,153 @@
+
+Original Jira ticket CAS-817 is as follows:
+
+Description
+
+We test following scenario:
+
+0. nexus and app are running on different nodes
+1. bring down a node with nexus (nvmf target)
+2. wait for the nvmf initiator to time out
+3. wait for the xfs to give up on filesystem (any access will return IO error after this point without blocking)
+4. delete application pod
+
+What we would expect to happen is that the device is unmounted and unpublish succeeds.
+Instead we see repeated unpublish calls and nothing happens:
+
+```
+[2021-03-30T08:46:20Z TRACE mayastor_csi::node] node_unpublish_volume NodeUnpublishVolumeRequest { volume_id: "2ccacf4c-f5e5-4ce1-87c6-af7d5fae3de4", target_path: "/var/lib/kubelet/pods/97f41524-e00d-4929-9cd6-1247fb27ea81/volumes/kubernetes.io~csi/pvc-2ccacf4c-f5e5-4ce1-87c6-af7d5fae3de4/mount" }
+[2021-03-30T08:46:20Z TRACE mayastor_csi::node] node_unpublish_volume NodeUnpublishVolumeRequest { volume_id: "2ccacf4c-f5e5-4ce1-87c6-af7d5fae3de4", target_path: "/var/lib/kubelet/pods/97f41524-e00d-4929-9cd6-1247fb27ea81/volumes/kubernetes.io~csi/pvc-2ccacf4c-f5e5-4ce1-87c6-af7d5fae3de4/mount" }
+[2021-03-30T08:46:21Z TRACE mayastor_csi::node] node_unpublish_volume NodeUnpublishVolumeRequest { volume_id: "2ccacf4c-f5e5-4ce1-87c6-af7d5fae3de4", target_path: "/var/lib/kubelet/pods/97f41524-e00d-4929-9cd6-1247fb27ea81/volumes/kubernetes.io~csi/pvc-2ccacf4c-f5e5-4ce1-87c6-af7d5fae3de4/mount" }
+[2021-03-30T08:46:23Z TRACE mayastor_csi::node] node_unpublish_volume NodeUnpublishVolumeRequest { volume_id: "2ccacf4c-f5e5-4ce1-87c6-af7d5fae3de4", target_path: "/var/lib/kubelet/pods/97f41524-e00d-4929-9cd6-1247fb27ea81/volumes/kubernetes.io~csi/pvc-2ccacf4c-f5e5-4ce1-87c6-af7d5fae3de4/mount" }
+[2021-03-30T08:46:27Z TRACE mayastor_csi::node] node_unpublish_volume NodeUnpublishVolumeRequest { volume_id: "2ccacf4c-f5e5-4ce1-87c6-af7d5fae3de4", target_path: "/var/lib/kubelet/pods/97f41524-e00d-4929-9cd6-1247fb27ea81/volumes/kubernetes.io~csi/pvc-2ccacf4c-f5e5-4ce1-87c6-af7d5fae3de4/mount" }
+[2021-03-30T08:46:35Z TRACE mayastor_csi::node] node_unpublish_volume NodeUnpublishVolumeRequest { volume_id: "2ccacf4c-f5e5-4ce1-87c6-af7d5fae3de4", target_path: "/var/lib/kubelet/pods/97f41524-e00d-4929-9cd6-1247fb27ea81/volumes/kubernetes.io~csi/pvc-2ccacf4c-f5e5-4ce1-87c6-af7d5fae3de4/mount" }
+[2021-03-30T08:46:51Z TRACE mayastor_csi::node] node_unpublish_volume NodeUnpublishVolumeRequest { volume_id: "2ccacf4c-f5e5-4ce1-87c6-af7d5fae3de4", target_path: "/var/lib/kubelet/pods/97f41524-e00d-4929-9cd6-1247fb27ea81/volumes/kubernetes.io~csi/pvc-2ccacf4c-f5e5-4ce1-87c6-af7d5fae3de4/mount" }
+[2021-03-30T08:47:23Z TRACE mayastor_csi::node] node_unpublish_volume NodeUnpublishVolumeRequest { volume_id: "2ccacf4c-f5e5-4ce1-87c6-af7d5fae3de4", target_path: "/var/lib/kubelet/pods/97f41524-e00d-4929-9cd6-1247fb27ea81/volumes/kubernetes.io~csi/pvc-2ccacf4c-f5e5-4ce1-87c6-af7d5fae3de4/mount" }
+[2021-03-30T08:48:27Z TRACE mayastor_csi::node] node_unpublish_volume NodeUnpublishVolumeRequest { volume_id: "2ccacf4c-f5e5-4ce1-87c6-af7d5fae3de4", target_path: "/var/lib/kubelet/pods/97f41524-e00d-4929-9cd6-1247fb27ea81/volumes/kubernetes.io~csi/pvc-2ccacf4c-f5e5-4ce1-87c6-af7d5fae3de4/mount" }
+[2021-03-30T08:50:29Z TRACE mayastor_csi::node] node_unpublish_volume NodeUnpublishVolumeRequest { volume_id: "2ccacf4c-f5e5-4ce1-87c6-af7d5fae3de4", target_path: "/var/lib/kubelet/pods/97f41524-e00d-4929-9cd6-1247fb27ea81/volumes/kubernetes.io~csi/pvc-2ccacf4c-f5e5-4ce1-87c6-af7d5fae3de4/mount" }
+[2021-03-30T08:52:31Z TRACE mayastor_csi::node] node_unpublish_volume NodeUnpublishVolumeRequest { volume_id: "2ccacf4c-f5e5-4ce1-87c6-af7d5fae3de4", target_path: "/var/lib/kubelet/pods/97f41524-e00d-4929-9cd6-1247fb27ea81/volumes/kubernetes.io~csi/pvc-2ccacf4c-f5e5-4ce1-87c6-af7d5fae3de4/mount" }
+[2021-03-30T08:54:33Z TRACE mayastor_csi::node] node_unpublish_volume NodeUnpublishVolumeRequest { volume_id: "2ccacf4c-f5e5-4ce1-87c6-af7d5fae3de4", target_path: "/var/lib/kubelet/pods/97f41524-e00d-4929-9cd6-1247fb27ea81/volumes/kubernetes.io~csi/pvc-2ccacf4c-f5e5-4ce1-87c6-af7d5fae3de4/mount" }
+[2021-03-30T08:56:35Z TRACE mayastor_csi::node] node_unpublish_volume NodeUnpublishVolumeRequest { volume_id: "2ccacf4c-f5e5-4ce1-87c6-af7d5fae3de4", target_path: "/var/lib/kubelet/pods/97f41524-e00d-4929-9cd6-1247fb27ea81/volumes/kubernetes.io~csi/pvc-2ccacf4c-f5e5-4ce1-87c6-af7d5fae3de4/mount" }
+[2021-03-30T08:58:37Z TRACE mayastor_csi::node] node_unpublish_volume NodeUnpublishVolumeRequest { volume_id: "2ccacf4c-f5e5-4ce1-87c6-af7d5fae3de4", target_path: "/var/lib/kubelet/pods/97f41524-e00d-4929-9cd6-1247fb27ea81/volumes/kubernetes.io~csi/pvc-2ccacf4c-f5e5-4ce1-87c6-af7d5fae3de4/mount" }
+```
+
+Once the fs is manually unmounted (no force flag required) the unpublish proceeds to the end. We must find out why it's blocked in the middle and fix the root cause.
+
+
+Test to reproduce bug CAS-817
+-----------------------------
+
+The following describes the accompanying test to (automatically) reproduce the above bug.
+
+
+Prerequisites
+-------------
+
+The following python packages are required:
+  kubernetes
+  libvirt
+  yaml
+
+Setup
+-----
+
+1. Create "standard" kubernetes cluster.
+   It is assumed that you have a kubernetes cluster
+   set up as per the default terraform configuration:
+    - master node: ksnode-1
+    - worker nodes: ksnode-2 and ksnode-3
+
+2. Label the worker nodes.
+   The test assumes that Mayastor will run on ksnode-2, and the workload (fio) will run on ksnode-3.
+   To this end, labels need to be created on the respective nodes as follows:
+    > kubectl label node ksnode-2 openebs.io/engine=mayastor
+    > kubectl label node ksnode-3 openebs.io/workloads=yes
+
+3. Deploy MayaStor.
+
+4. Run the test:
+    > python node_unpublish_bug.py
+
+   The test will perform the following steps:
+    - create a MayastorPool
+    - create a StroageClass providing storage from the pool
+    - create a PVC requesting storage from the storage class
+    - create a Pod that consumes the PVC and starts running fio
+    - destroy node ksnode-2 (ie. the node running Mayastor)
+    - wait for the fio pod to fail
+    - delete the fio pod
+    - delete the PVC
+    - wait for the corresponding PV to be deleted
+    - restart node ksnode-2
+    - wait until the appropriate MayastorNode object shows the node is back online
+    - delete the storage class
+    - delete the MayastorPool
+
+
+Prior to the fix, a bug in CSI node_unpublish_volume() meant that the unpublish
+operation would never succeed. The observed behaviour in this case is as follows.
+After deleting the PVC, the time it takes for the corresponding PV to be deleted
+is much much longer than would otherwise be expected (10 minutes versus less than a second).
+Even when the PV is eventually deleted (presumably after some time limit somewhere has lapsed),
+the problem has not been resolved with the mayastor-csi log revealing an apparently endless loop,
+with the plugin receiving a call to node_unpublish_volume() about every 2 minutes.
+
+
+Results
+-------
+
+Prior to fix
+------------
+
+Note that it takes around 10 minutes from the point at which the PVC is deleted until the corresponding PV is removed
+
+  > ./node_unpublish_bug.py 
+  created MayastorPool [ksnode-pool-2] in namespace [mayastor] (checks=1 elapsed=1s)
+  created StorageClass [mayastor-1] in namespace [default]
+  created PersistentVolumeClaim [ms-volume-claim] in namespace [default] (checks=0 elapsed=0s)
+  creating Pod [fio] ...
+  created Pod [fio] in namespace [default] (checks=5 elapsed=12s)
+  PersistentVolumeClaim [ms-volume-claim] has associated PersistentVolume [pvc-4875be10-5ad4-4a4b-a38f-59c1e2acf7cf]
+  sleeping for 15s ...
+  destroying Node [ksnode-2]
+  polling Pod [fio] ...
+  Pod [fio] in namespace [default] has failed (checks=8 elapsed=54s)
+  deleted Pod [fio] from namespace [default] (checks=1 elapsed=1s)
+  deleted PersistentVolumeClaim [ms-volume-claim] from namespace [default] (checks=1 elapsed=1s)
+  polling PersistentVolume [pvc-4875be10-5ad4-4a4b-a38f-59c1e2acf7cf] ...
+  PersistentVolume [pvc-4875be10-5ad4-4a4b-a38f-59c1e2acf7cf] has been deleted from namespace [default] (checks=13 elapsed=609s)
+  restarting Node [ksnode-2]
+  polling MayastorNode [ksnode-2] ...
+  MayastorNode [ksnode-2] in namespace [mayastor] is online (checks=10 elapsed=143s)
+  MayastorPool [ksnode-pool-2] in namespace [mayastor] is online (checks=1 elapsed=1s)
+  deleted StorageClass [mayastor-1] from namespace [default] (checks=1 elapsed=1s)
+  deleted MayastorPool [ksnode-pool-2] from namespace [mayastor] (checks=1 elapsed=1s)
+
+After fix (using updated mayastor-csi image)
+--------------------------------------------
+
+Observe that, now, the corresponding PV is removed within 1 second of the PVC being deleted.
+Also, the mayastor-csi container log shows only a single call to node_unpublish_volume()
+
+  > ./node_unpublish_bug.py 
+  created MayastorPool [ksnode-pool-2] in namespace [mayastor] (checks=1 elapsed=1s)
+  created StorageClass [mayastor-1] in namespace [default]
+  created PersistentVolumeClaim [ms-volume-claim] in namespace [default] (checks=0 elapsed=0s)
+  creating Pod [fio] ...
+  created Pod [fio] in namespace [default] (checks=5 elapsed=12s)
+  PersistentVolumeClaim [ms-volume-claim] has associated PersistentVolume [pvc-ded6aacc-e160-4673-b6bd-4b67c268c939]
+  sleeping for 15s ...
+  destroying Node [ksnode-2]
+  polling Pod [fio] ...
+  Pod [fio] in namespace [default] has failed (checks=8 elapsed=54s)
+  deleted Pod [fio] from namespace [default] (checks=1 elapsed=1s)
+  deleted PersistentVolumeClaim [ms-volume-claim] from namespace [default] (checks=1 elapsed=1s)
+  polling PersistentVolume [pvc-ded6aacc-e160-4673-b6bd-4b67c268c939] ...
+  PersistentVolume [pvc-ded6aacc-e160-4673-b6bd-4b67c268c939] has been deleted from namespace [default] (checks=1 elapsed=1s)
+  restarting Node [ksnode-2]
+  polling MayastorNode [ksnode-2] ...
+  MayastorNode [ksnode-2] in namespace [mayastor] is online (checks=9 elapsed=88s)
+  MayastorPool [ksnode-pool-2] in namespace [mayastor] is online (checks=1 elapsed=1s)
+  deleted StorageClass [mayastor-1] from namespace [default] (checks=1 elapsed=1s)
+  deleted MayastorPool [ksnode-pool-2] from namespace [mayastor] (checks=1 elapsed=1s)
+


### PR DESCRIPTION
node_unpublish_volume() can fail (while reporting success)
if the nvmf target is unreachable, causing an endless loop
with node_unpublish_volume() being called repeatedly.

Cause:
A stat() call on the mountpoint can fail if the associated
nvmf target device is unreachable.
This failure is incorrectly interpreted to mean that the mountpoint
does not exist, and that the device has already been unmounted
when this is not the case. This causes node_unpublish_volume()
to report success without actually doing anything, and therefore
leaving the device mounted.

Fix:
The fix is to explicitly check for an error when calling stat(),
so as to to distinguish when there is an error other than 'NotFound',
and to still check for a mount in that case.