### PR TITLE
fix(nexus): persist state of newly added child to etcd

### DIFF
--- a/mayastor/src/bdev/nexus/nexus_bdev_rebuild.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev_rebuild.rs
@@ -21,6 +21,7 @@ use crate::{
             },
             nexus_channel::DrEvent,
             nexus_child::{ChildState, Reason},
+            nexus_persistence::PersistOp,
         },
         VerboseError,
     },
@@ -265,6 +266,10 @@ impl Nexus {
                     "Child {} has been rebuilt successfully",
                     recovering_child.get_name()
                 );
+                let child_name = recovering_child.get_name().to_string();
+                let child_state = recovering_child.state();
+                self.persist(PersistOp::Update((child_name, child_state)))
+                    .await;
             }
             RebuildState::Stopped => {
                 info!(

--- a/mayastor/src/bdev/nexus/nexus_persistence.rs
+++ b/mayastor/src/bdev/nexus/nexus_persistence.rs
@@ -32,6 +32,8 @@ pub struct ChildInfo {
 pub(crate) enum PersistOp {
     /// Create a persistent entry.
     Create,
+    /// Add a child to an existing persistent entry.
+    AddChild((ChildUri, ChildState)),
     /// Update a persistent entry.
     Update((ChildUri, ChildState)),
     /// Save the clean shutdown variable.
@@ -62,6 +64,16 @@ impl Nexus {
                     };
                     nexus_info.children.push(child_info);
                 });
+            }
+            PersistOp::AddChild((uri, state)) => {
+                // Add the state of a new child.
+                // This should only be called on adding a new child.
+                let child_info = ChildInfo {
+                    uuid: NexusChild::uuid(&uri)
+                        .expect("Failed to get child UUID."),
+                    healthy: Self::child_healthy(&state),
+                };
+                nexus_info.children.push(child_info);
             }
             PersistOp::Update((uri, state)) => {
                 let uuid =


### PR DESCRIPTION
Introduce PersistOp::AddChild to add the state of a newly added child
to NexusInfo and persist it to etcd. Update the state of the new
child when it has rebuilt successfully.

Fixes CAS-1157