### PR TITLE
fix(nvmx): support for Unmap and WriteZeroes IoTypes

### DIFF
--- a/mayastor/src/bdev/nvmx/device.rs
+++ b/mayastor/src/bdev/nvmx/device.rs
@@ -178,8 +178,8 @@ impl BlockDevice for NvmeBlockDevice {
             | IoType::Abort => true,
             IoType::Compare => self.ns.supports_compare(),
             IoType::NvmeIoMd => self.ns.md_size() > 0,
-            IoType::Unmap => false,
-            IoType::WriteZeros => true,
+            IoType::Unmap => self.ns.supports_deallocate(),
+            IoType::WriteZeros => self.ns.supports_write_zeroes(),
             IoType::CompareAndWrite => false,
             _ => false,
         }

--- a/mayastor/src/bdev/nvmx/namespace.rs
+++ b/mayastor/src/bdev/nvmx/namespace.rs
@@ -3,12 +3,15 @@ use std::ptr::NonNull;
 use spdk_sys::{
     spdk_nvme_ns,
     spdk_nvme_ns_get_extended_sector_size,
+    spdk_nvme_ns_get_flags,
     spdk_nvme_ns_get_md_size,
     spdk_nvme_ns_get_num_sectors,
     spdk_nvme_ns_get_optimal_io_boundary,
     spdk_nvme_ns_get_size,
     spdk_nvme_ns_get_uuid,
     spdk_nvme_ns_supports_compare,
+    SPDK_NVME_NS_DEALLOCATE_SUPPORTED,
+    SPDK_NVME_NS_WRITE_ZEROES_SUPPORTED,
 };
 
 #[derive(Debug)]
@@ -36,6 +39,22 @@ impl NvmeNamespace {
 
     pub fn supports_compare(&self) -> bool {
         unsafe { spdk_nvme_ns_supports_compare(self.0.as_ptr()) }
+    }
+
+    pub fn supports_deallocate(&self) -> bool {
+        unsafe {
+            spdk_nvme_ns_get_flags(self.0.as_ptr())
+                & SPDK_NVME_NS_DEALLOCATE_SUPPORTED
+                > 0
+        }
+    }
+
+    pub fn supports_write_zeroes(&self) -> bool {
+        unsafe {
+            spdk_nvme_ns_get_flags(self.0.as_ptr())
+                & SPDK_NVME_NS_WRITE_ZEROES_SUPPORTED
+                > 0
+        }
     }
 
     pub fn alignment(&self) -> u64 {

--- a/spdk-sys/build.rs
+++ b/spdk-sys/build.rs
@@ -91,6 +91,7 @@ fn main() {
         .allowlist_function("^nvme_qpair_.*")
         .allowlist_function("^nvme_ctrlr_.*")
         .blocklist_type("^longfunc")
+        .allowlist_type("^spdk_nvme_ns_flags")
         .allowlist_type("^spdk_nvme_registered_ctrlr.*")
         .allowlist_type("^spdk_nvme_reservation.*")
         .allowlist_var("^NVMF.*")

--- a/test/python/tests/nexus/test_nexus.py
+++ b/test/python/tests/nexus/test_nexus.py
@@ -342,6 +342,11 @@ async def test_nexus_cntlid(create_nexus_v2, min_cntlid):
         id_ctrl = nvme_id_ctrl(dev)
         assert id_ctrl["cntlid"] == min_cntlid
 
+        # Test optional command support
+        oncs = id_ctrl["oncs"]
+        assert oncs & 0x04, "should support Dataset Management"
+        assert oncs & 0x08, "should support Write Zeroes"
+
     finally:
         # disconnect target before we shut down
         nvme_disconnect(uri)


### PR DESCRIPTION
Make support for these IoTypes dependent on the controller's ONCS (Optional NVM Command Support) field instead of hardcoding.

Fixes CAS-1164