### PR TITLE
test(ana): validate on-demand replacement for a failed io path

### DIFF
--- a/test/python/common/nvme.py
+++ b/test/python/common/nvme.py
@@ -127,6 +127,12 @@ def nvme_disconnect(uri):
     subprocess.run(command, check=True, shell=True, capture_output=True)
 
 
+def nvme_disconnect_controller(name):
+    """Disconnect the given NVMe controller on this host."""
+    command = "sudo nvme disconnect -d {0}".format(name)
+    subprocess.run(command, check=True, shell=True, capture_output=True)
+
+
 def nvme_disconnect_all():
     """Disconnect from all connected nvme subsystems"""
     command = "sudo nvme disconnect-all"

--- a/test/python/tests/nexus_multipath/features/nexus-multipath.feature
+++ b/test/python/tests/nexus_multipath/features/nexus-multipath.feature
@@ -9,3 +9,11 @@ Feature: Mayastor nexus multipath management
     And both controllers are online
     When I start Fio
     Then I should be able to see IO flowing to one path only
+
+  Scenario: replace failed I/O path on demand for NVMe controller
+    Given a client connected to one nexus via single I/O path
+    And fio client is running against target nexus
+    When the only I/O path degrades
+    Then it should be possible to create a second nexus and connect it as the second path
+    And it should be possible to remove the first failed I/O path
+    And fio client should successfully complete with the replaced I/O path


### PR DESCRIPTION
Added a new testcase to validate on-demand replacement for a failed
I/O path and assure no interruption is observed by the fio client whilst
manipulating the paths.