### PR TITLE
fix(nexus_v2): add uuid field to the nexus

### DIFF
--- a/chart/templates/csi-daemonset.yaml
+++ b/chart/templates/csi-daemonset.yaml
@@ -43,7 +43,9 @@ spec:
             fieldRef:
               fieldPath: status.podIP
         - name: RUST_BACKTRACE
-          value: "1"
+          value: "1"{{ if .Values.moac }}
+        - name: MOAC
+          value: "true"{{ end }}
         args:
         - "--csi-socket=/csi/csi.sock"
         - "--node-name=$(MY_NODE_NAME)"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -10,6 +10,7 @@ mayastorPools:
 # moac that does not update status of msp resource in some cases. Feel free to
 # remove when no longer needed.
 moacDebug: false
+moac: false
 
 csi:
   nvme:

--- a/csi/src/dev.rs
+++ b/csi/src/dev.rs
@@ -112,9 +112,14 @@ impl Device {
             if let Some(devname) =
                 match_dev::match_nvmf_device(&device, &nvmf_key)
             {
+                let nqn = if std::env::var("MOAC").is_ok() {
+                    format!("{}:nexus-{}", NVME_NQN_PREFIX, uuid.to_string())
+                } else {
+                    format!("{}:{}", NVME_NQN_PREFIX, uuid.to_string())
+                };
                 return Ok(Some(Box::new(nvmf::NvmfDetach::new(
                     devname.to_string(),
-                    format!("{}:nexus-{}", NVME_NQN_PREFIX, uuid.to_string()),
+                    nqn,
                 ))));
             }
         }

--- a/deploy/csi-daemonset.yaml
+++ b/deploy/csi-daemonset.yaml
@@ -30,7 +30,7 @@ spec:
       # the same.
       containers:
       - name: mayastor-csi
-        image: mayadata/mayastor-csi:develop
+        image: mayadata/mayastor:develop
         imagePullPolicy: Always
         # we need privileged because we mount filesystems and use mknod
         securityContext:
@@ -52,6 +52,8 @@ spec:
         - "--grpc-endpoint=$(MY_POD_IP):10199"
         - "--nvme-core-io-timeout=30"
         - "-v"
+        command:
+        - mayastor-csi
         volumeMounts:
         - name: device
           mountPath: /dev

--- a/deploy/mayastor-daemonset.yaml
+++ b/deploy/mayastor-daemonset.yaml
@@ -58,6 +58,8 @@ spec:
         - "-P/var/local/mayastor/pools.yaml"
         - "-l0"
         - "-pmayastor-etcd"
+        command:
+        - mayastor
         securityContext:
           privileged: true
         volumeMounts:

--- a/mayastor/src/bdev/nexus/nexus_persistence.rs
+++ b/mayastor/src/bdev/nexus/nexus_persistence.rs
@@ -108,7 +108,7 @@ impl Nexus {
     // TODO: Should we give up retrying eventually?
     async fn save(&self, info: &NexusInfo) {
         let mut output_err = true;
-        let nexus_uuid = self.bdev.uuid().to_string();
+        let nexus_uuid = self.uuid().to_string();
         loop {
             match PersistentStore::put(&nexus_uuid, info).await {
                 Ok(_) => {

--- a/mayastor/src/grpc/mayastor_grpc.rs
+++ b/mayastor/src/grpc/mayastor_grpc.rs
@@ -676,7 +676,7 @@ impl mayastor_server::Mayastor for MayastorSvc {
                     nexus_create_v2(
                         &args.name,
                         args.size,
-                        Some(&args.uuid),
+                        &args.uuid,
                         NexusNvmeParams {
                             min_cntlid: args.min_cntl_id as u16,
                             max_cntlid: args.max_cntl_id as u16,

--- a/mayastor/src/grpc/nexus_grpc.rs
+++ b/mayastor/src/grpc/nexus_grpc.rs
@@ -87,7 +87,7 @@ impl Nexus {
 
         rpc::NexusV2 {
             name: name_to_uuid(&self.name).to_string(),
-            uuid: self.bdev.uuid().to_string(),
+            uuid: self.uuid().to_string(),
             size: self.size,
             state: rpc::NexusState::from(self.status()) as i32,
             device_uri: self.get_share_uri().unwrap_or_default(),
@@ -131,6 +131,11 @@ pub fn uuid_to_name(uuid: &str) -> Result<String, Error> {
 /// Return error if nexus not found.
 pub fn nexus_lookup(uuid: &str) -> Result<&mut Nexus, Error> {
     if let Some(nexus) = instances().iter_mut().find(|n| n.name == uuid) {
+        Ok(nexus)
+    } else if let Some(nexus) = instances()
+        .iter_mut()
+        .find(|n| n.uuid().to_string() == uuid)
+    {
         Ok(nexus)
     } else {
         let name = uuid_to_name(uuid)?;

--- a/mayastor/tests/nexus_io.rs
+++ b/mayastor/tests/nexus_io.rs
@@ -393,7 +393,7 @@ async fn nexus_io_resv_acquire() {
             nexus_create_v2(
                 &NXNAME.to_string(),
                 32 * 1024 * 1024,
-                Some(UUID),
+                UUID,
                 nvme_params,
                 &[format!("nvmf://{}:8420/{}:{}", ip0, HOSTNQN, UUID)],
             )

--- a/scripts/grpc-test.sh
+++ b/scripts/grpc-test.sh
@@ -4,6 +4,7 @@ set -euxo pipefail
 
 export PATH="$PATH:${HOME}/.cargo/bin"
 export npm_config_jobs=$(nproc)
+export MOAC=true
 
 cargo build --all
 cd "$(dirname "$0")/../test/grpc"


### PR DESCRIPTION
fix(nexus_v2): add uuid field to the nexus

The CreateV2 was changed to use uuid's but all the lookups are made using
the name, even though the arg is called uuid...
This should be properly addressed as part of 1107 but for now use the
workaround of looking up by uuid if by name fails.

When a nexus is published the NQN is set to the name but the namespace uuid's are
set to the nexus UUID. This breaks the CSI plugin logic, as it expects them to be
the same...
As a WA for the moment, when using the V2 api set the bdev uuid to match
the name, if the name is a UUID. The uuid arg is then used as a means to identify
the nexus only.
This means the nqn and the namespace uuid is now using the nexus name, which in
case of the control plane on k8s, is the volume uuid.

Also tidiy up some corner cases with UUID's which may be reused with
different names - spdk does not seem to treat UUID as unique...

With V2 there is no "nexus-" prefix to add env variable to the CSI plugin
so that we may keep the same behaviour for MOAC testing.

--------------
chore: update the deploy yamls 