### PR TITLE
feat(libnvme-rs): new crate, implement connect and disconnect 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1469,6 +1469,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "libnvme-rs"
+version = "0.1.0"
+dependencies = [
+ "bindgen 0.59.1",
+ "cc",
+ "glob",
+ "libc",
+ "snafu",
+ "url",
+]
+
+[[package]]
 name = "libudev-sys"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1560,6 +1572,7 @@ dependencies = [
  "jsonrpc",
  "lazy_static",
  "libc",
+ "libnvme-rs",
  "log",
  "mbus_api",
  "md5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
 	"csi",
 	"devinfo",
 	"jsonrpc",
+	"libnvme-rs",
 	"mayastor",
 	"mbus-api",
 	"nvmeadm",

--- a/ci.nix
+++ b/ci.nix
@@ -34,6 +34,7 @@ mkShell {
     kubernetes-helm
     libaio
     libiscsi
+    libnvme
     libudev
     liburing
     llvmPackages_11.libclang

--- a/libnvme-rs/Cargo.toml
+++ b/libnvme-rs/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "libnvme-rs"
+description = "Rust bindings for libnvme"
+version = "0.1.0"
+edition = "2018"
+build = "build.rs"
+license = "Apache-2.0"
+authors = [
+  "Jonathan Teh <jonathan.teh@mayadata.io>",
+  "Jeffry Molanus <jeffry.molanus@gmail.com>",
+]
+
+[build-dependencies]
+bindgen = "0.59.1"
+cc = "1.0.69"
+
+[dependencies]
+glob = "0.3.0"
+libc = "0.2"
+snafu = "0.6.10"
+url = "2.2.2"

--- a/libnvme-rs/build.rs
+++ b/libnvme-rs/build.rs
@@ -1,0 +1,20 @@
+extern crate bindgen;
+
+use std::{env, path::PathBuf};
+
+fn main() {
+    println!("cargo:rustc-link-lib=nvme");
+    println!("cargo:rerun-if-changed=wrapper.h");
+
+    let bindings = bindgen::Builder::default()
+        .header("wrapper.h")
+        .parse_callbacks(Box::new(bindgen::CargoCallbacks))
+        .layout_tests(false)
+        .generate()
+        .expect("Unable to generate bindings");
+
+    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+    bindings
+        .write_to_file(out_path.join("bindings.rs"))
+        .expect("Couldn't write bindings!");
+}

--- a/libnvme-rs/src/error.rs
+++ b/libnvme-rs/src/error.rs
@@ -1,0 +1,65 @@
+use snafu::Snafu;
+
+#[derive(Debug, Snafu)]
+#[allow(missing_docs)]
+#[snafu(visibility = "pub(crate)")]
+pub enum NvmeError {
+    #[snafu(display("IO error:"))]
+    IoError { source: std::io::Error },
+    #[snafu(display("Failed to parse {}: {}, {}", path, contents, error))]
+    ValueParseError {
+        path: String,
+        contents: String,
+        error: String,
+    },
+    #[snafu(display("Failed to parse value"))]
+    ParseError {},
+    #[snafu(display("File IO error: {}, {}", filename, source))]
+    FileIoError {
+        filename: String,
+        source: std::io::Error,
+    },
+    #[snafu(display("nqn: {} not found", text))]
+    NqnNotFound { text: String },
+    #[snafu(display("No nvmf subsystems found"))]
+    NoSubsystems,
+    #[snafu(display("Connect in progress"))]
+    ConnectInProgress,
+    #[snafu(display("NVMe connect failed: {}, {}", filename, source))]
+    ConnectError {
+        source: std::io::Error,
+        filename: String,
+    },
+    #[snafu(display("Lookup host failed: {}", rc))]
+    LookupHostError { rc: i32 },
+    #[snafu(display("Add controller failed: {}", rc))]
+    AddCtrlrError { rc: i32 },
+    //#[snafu(display("IO error during NVMe discovery"))]
+    //DiscoveryError { source: nix::Error },
+    #[snafu(display("Controller with nqn: {} not found", text))]
+    CtlNotFound { text: String },
+    #[snafu(display("Invalid path {}: {}", path, source))]
+    InvalidPath {
+        source: std::path::StripPrefixError,
+        path: String,
+    },
+    #[snafu(display("NVMe subsystems error: {}, {}", path_prefix, source))]
+    SubSysError {
+        source: glob::PatternError,
+        path_prefix: String,
+    },
+    #[snafu(display("NVMe URI invalid: {}", source))]
+    UrlError { source: url::ParseError },
+    #[snafu(display("Transport type {} not supported", trtype))]
+    TransportError { trtype: String },
+    #[snafu(display("Invalid parameter: {}", text))]
+    InvalidParam { text: String },
+}
+
+impl From<std::io::Error> for NvmeError {
+    fn from(source: std::io::Error) -> NvmeError {
+        NvmeError::IoError {
+            source,
+        }
+    }
+}

--- a/libnvme-rs/src/lib.rs
+++ b/libnvme-rs/src/lib.rs
@@ -1,0 +1,40 @@
+#![allow(non_upper_case_globals)]
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+
+#[allow(clippy::all)]
+mod bindings {
+    include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
+}
+pub use bindings::*;
+
+pub mod error;
+pub mod nvme_namespaces;
+mod nvme_tree;
+mod nvme_uri;
+
+use error::{IoError, NvmeError};
+use snafu::ResultExt;
+use std::{fs, path::Path, str::FromStr};
+
+pub use nvme_uri::NvmeTarget;
+
+/// Read and parse value from a sysfs file
+pub fn parse_value<T>(dir: &Path, file: &str) -> Result<T, NvmeError>
+where
+    T: FromStr,
+    T::Err: ToString,
+{
+    let path = dir.join(file);
+    let s = fs::read_to_string(&path).context(IoError {})?;
+    let s = s.trim();
+
+    match s.parse() {
+        Ok(v) => Ok(v),
+        Err(e) => Err(NvmeError::ValueParseError {
+            path: path.as_path().to_str().unwrap().to_string(),
+            contents: s.to_string(),
+            error: e.to_string(),
+        }),
+    }
+}

--- a/libnvme-rs/src/nvme_namespaces.rs
+++ b/libnvme-rs/src/nvme_namespaces.rs
@@ -1,0 +1,92 @@
+use crate::{error, parse_value};
+use error::NvmeError;
+use glob::glob;
+use std::{os::unix::fs::FileTypeExt, path::Path};
+
+/// NvmeDevices are devices that are already connected to the kernel
+/// they have not interaction with the fabric itself. Notice that a
+/// nvme device, for the post part is a subsystem + nsid.
+
+#[derive(Debug, Default)]
+pub struct NvmeDevice {
+    /// device path of the device
+    pub path: String,
+    /// the device model defined by the manufacturer
+    model: String,
+    /// serial number of the device
+    serial: String,
+    /// the size in bytes
+    size: u64,
+    /// the UUID for the device
+    uuid: String,
+    /// the world wide name of the device typically wwn.uuid
+    wwid: String,
+    /// the namespace id
+    nsid: u64,
+    /// firmware revision
+    fw_rev: String,
+    /// the nqn of the subsystem this device instance is connected to
+    pub subsysnqn: String,
+}
+
+impl NvmeDevice {
+    /// Construct a new NVMe device from a given path. The [struct.NvmeDevice]
+    /// will fill in all the details defined within the structure or return an
+    /// error if the value for the structure could not be found.
+    fn new(p: &Path) -> Result<Self, NvmeError> {
+        let name = p.file_name().unwrap().to_str().unwrap();
+        let devpath = format!("/sys/block/{}", name);
+        let subsyspath = format!("/sys/block/{}/device", name);
+        let source = Path::new(devpath.as_str());
+        let subsys = Path::new(subsyspath.as_str());
+
+        Ok(NvmeDevice {
+            path: p.display().to_string(),
+            fw_rev: parse_value(subsys, "firmware_rev")?,
+            subsysnqn: parse_value(subsys, "subsysnqn")?,
+            model: parse_value(subsys, "model")?,
+            serial: parse_value(subsys, "serial")?,
+            size: parse_value(source, "size")?,
+            // /* NOTE: during my testing, it seems that NON fabric devices
+            //  * do not have a UUID, this means that local PCIe devices will
+            //  * be filtered out automatically. We should not depend on this
+            //  * feature or, bug until we gather more data
+            uuid: parse_value(source, "uuid")
+                .unwrap_or_else(|_| String::from("N/A")),
+            wwid: parse_value(source, "wwid")?,
+            nsid: parse_value(source, "nsid")?,
+        })
+    }
+}
+/// The DeviceList of all NVMe devices found that provide all properties as
+/// defined in the [struct.NvmeDevice]
+#[derive(Debug, Default)]
+pub struct NvmeDeviceList {
+    devices: Vec<String>,
+}
+
+impl Iterator for NvmeDeviceList {
+    type Item = Result<NvmeDevice, NvmeError>;
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some(e) = self.devices.pop() {
+            return Some(NvmeDevice::new(Path::new(&e)));
+        }
+        None
+    }
+}
+
+impl NvmeDeviceList {
+    /// glob sysfs and filter out all devices that start with /dev/nvme
+    pub fn new() -> Self {
+        let mut list = NvmeDeviceList::default();
+        let path_entries = glob("/dev/nvme*").unwrap();
+        for path in path_entries.flatten() {
+            if let Ok(meta) = std::fs::metadata(&path) {
+                if meta.file_type().is_block_device() {
+                    list.devices.push(path.display().to_string());
+                }
+            }
+        }
+        list
+    }
+}

--- a/libnvme-rs/src/nvme_tree.rs
+++ b/libnvme-rs/src/nvme_tree.rs
@@ -1,0 +1,117 @@
+/// RAII Wrapper for nvme_root_t
+pub struct NvmeRoot {
+    root: *mut crate::bindings::nvme_root,
+}
+
+impl NvmeRoot {
+    pub fn new(root: *mut crate::bindings::nvme_root) -> Self {
+        NvmeRoot {
+            root,
+        }
+    }
+    pub fn as_mut_ptr(&self) -> *mut crate::bindings::nvme_root {
+        self.root
+    }
+}
+
+impl Drop for NvmeRoot {
+    fn drop(&mut self) {
+        unsafe { crate::nvme_free_tree(self.root) }
+    }
+}
+
+/// Iterator for nvme_host_t
+pub(crate) struct NvmeHostIterator<'a> {
+    root: &'a NvmeRoot,
+    host: *mut crate::bindings::nvme_host,
+}
+
+impl<'a> NvmeHostIterator<'a> {
+    pub(crate) fn new(root: &'a NvmeRoot) -> Self {
+        Self {
+            root,
+            host: std::ptr::null_mut(),
+        }
+    }
+}
+
+impl<'a> Iterator for NvmeHostIterator<'a> {
+    type Item = *mut crate::bindings::nvme_host;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.host = if self.host.is_null() {
+            unsafe { crate::nvme_first_host(self.root.as_mut_ptr()) }
+        } else {
+            unsafe { crate::nvme_next_host(self.root.as_mut_ptr(), self.host) }
+        };
+        if self.host.is_null() {
+            None
+        } else {
+            Some(self.host)
+        }
+    }
+}
+
+/// Iterator for nvme_subsystem_t
+pub(crate) struct NvmeSubsystemIterator {
+    host: *mut crate::bindings::nvme_host,
+    subsys: *mut crate::bindings::nvme_subsystem,
+}
+
+impl NvmeSubsystemIterator {
+    pub(crate) fn new(host: *mut crate::bindings::nvme_host) -> Self {
+        Self {
+            host,
+            subsys: std::ptr::null_mut(),
+        }
+    }
+}
+
+impl Iterator for NvmeSubsystemIterator {
+    type Item = *mut crate::bindings::nvme_subsystem;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.subsys = if self.subsys.is_null() {
+            unsafe { crate::nvme_first_subsystem(self.host) }
+        } else {
+            unsafe { crate::nvme_next_subsystem(self.host, self.subsys) }
+        };
+        if self.subsys.is_null() {
+            None
+        } else {
+            Some(self.subsys)
+        }
+    }
+}
+
+/// Iterator for nvme_ctrl_t
+pub(crate) struct NvmeCtrlrIterator {
+    subsys: *mut crate::bindings::nvme_subsystem,
+    ctrlr: *mut crate::bindings::nvme_ctrl,
+}
+
+impl NvmeCtrlrIterator {
+    pub(crate) fn new(subsys: *mut crate::bindings::nvme_subsystem) -> Self {
+        Self {
+            subsys,
+            ctrlr: std::ptr::null_mut(),
+        }
+    }
+}
+
+impl Iterator for NvmeCtrlrIterator {
+    type Item = *mut crate::bindings::nvme_ctrl;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.ctrlr = if self.ctrlr.is_null() {
+            unsafe { crate::nvme_subsystem_first_ctrl(self.subsys) }
+        } else {
+            unsafe { crate::nvme_subsystem_next_ctrl(self.subsys, self.ctrlr) }
+        };
+        if self.ctrlr.is_null() {
+            None
+        } else {
+            Some(self.ctrlr)
+        }
+    }
+}

--- a/libnvme-rs/src/nvme_uri.rs
+++ b/libnvme-rs/src/nvme_uri.rs
@@ -1,0 +1,237 @@
+use std::{convert::TryFrom, time::Duration};
+
+use url::{ParseError, Url};
+
+use crate::{
+    error::NvmeError,
+    nvme_namespaces::{NvmeDevice, NvmeDeviceList},
+    nvme_tree::{
+        NvmeCtrlrIterator,
+        NvmeHostIterator,
+        NvmeRoot,
+        NvmeSubsystemIterator,
+    },
+};
+
+/// Wrapper for caller-owned C-strings from libnvme
+pub struct NvmeStringWrapper {
+    s: *mut i8,
+}
+
+impl NvmeStringWrapper {
+    pub fn new(s: *mut i8) -> Self {
+        NvmeStringWrapper {
+            s,
+        }
+    }
+    pub fn as_ptr(&self) -> *const i8 {
+        self.s
+    }
+}
+
+impl Drop for NvmeStringWrapper {
+    fn drop(&mut self) {
+        unsafe { libc::free(self.s as *mut _) }
+    }
+}
+
+/// Structure representing an NVMe-oF target
+pub struct NvmeTarget {
+    host: String,
+    port: u16,
+    subsysnqn: String,
+    trtype: String,
+}
+
+impl TryFrom<String> for NvmeTarget {
+    type Error = NvmeError;
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        NvmeTarget::try_from(value.as_str())
+    }
+}
+
+impl TryFrom<&str> for NvmeTarget {
+    type Error = NvmeError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        let url = Url::parse(value).map_err(|source| NvmeError::UrlError {
+            source,
+        })?;
+
+        let trtype = match url.scheme() {
+            "nvmf" | "nvmf+tcp" => Ok("tcp"),
+            _ => Err(NvmeError::UrlError {
+                source: ParseError::IdnaError,
+            }),
+        }?
+        .into();
+
+        let host = url
+            .host_str()
+            .ok_or(NvmeError::UrlError {
+                source: ParseError::EmptyHost,
+            })?
+            .into();
+
+        let subnqn = match url.path_segments() {
+            None => Err(NvmeError::UrlError {
+                source: ParseError::RelativeUrlWithCannotBeABaseBase,
+            }),
+            Some(s) => {
+                let segments = s.collect::<Vec<&str>>();
+                if segments[0].is_empty() {
+                    Err(NvmeError::UrlError {
+                        source: ParseError::RelativeUrlWithCannotBeABaseBase,
+                    })
+                } else {
+                    Ok(segments[0].to_string())
+                }
+            }
+        }?;
+
+        Ok(Self {
+            trtype,
+            host,
+            port: url.port().unwrap_or(4420),
+            subsysnqn: subnqn,
+        })
+    }
+}
+
+impl NvmeTarget {
+    /// Connect to NVMe target
+    /// Returns vector of NVMe devices that were connected
+    pub fn connect(&self) -> Result<Vec<NvmeDevice>, NvmeError> {
+        if self.trtype != "tcp" {
+            return Err(NvmeError::TransportError {
+                trtype: self.trtype.clone(),
+            });
+        }
+
+        let r = NvmeRoot::new(unsafe { crate::nvme_scan(std::ptr::null()) });
+        let hostnqn =
+            NvmeStringWrapper::new(unsafe { crate::nvmf_hostnqn_from_file() });
+        let hostid =
+            NvmeStringWrapper::new(unsafe { crate::nvmf_hostid_from_file() });
+
+        let h = unsafe {
+            crate::nvme_lookup_host(
+                r.as_mut_ptr(),
+                hostnqn.as_ptr(),
+                hostid.as_ptr(),
+            )
+        };
+        if h.is_null() {
+            return Err(NvmeError::LookupHostError {
+                rc: -libc::ENOMEM,
+            });
+        }
+
+        let subsysnqn = std::ffi::CString::new(self.subsysnqn.clone()).unwrap();
+        let transport = std::ffi::CString::new("tcp").unwrap();
+        let traddr = std::ffi::CString::new(self.host.clone()).unwrap();
+        let host_traddr = std::ptr::null();
+        let host_iface = std::ptr::null();
+        let trsvcid = std::ffi::CString::new(self.port.to_string()).unwrap();
+        let nvme_ctrl = unsafe {
+            crate::nvme_create_ctrl(
+                subsysnqn.as_ptr(),
+                transport.as_ptr(),
+                traddr.as_ptr(),
+                host_traddr,
+                host_iface,
+                trsvcid.as_ptr(),
+            )
+        };
+        let cfg = crate::nvme_fabrics_config {
+            queue_size: 0,
+            nr_io_queues: 0,
+            reconnect_delay: 0,
+            ctrl_loss_tmo: crate::NVMF_DEF_CTRL_LOSS_TMO as i32,
+            fast_io_fail_tmo: 0,
+            keep_alive_tmo: 0,
+            nr_write_queues: 0,
+            nr_poll_queues: 0,
+            tos: -1,
+            duplicate_connect: false,
+            disable_sqflow: false,
+            hdr_digest: false,
+            data_digest: false,
+        };
+        let ret = unsafe {
+            crate::nvmf_add_ctrl(h, nvme_ctrl, &cfg, cfg.disable_sqflow)
+        };
+        if ret != 0 {
+            return Err(NvmeError::AddCtrlrError {
+                rc: ret,
+            });
+        }
+
+        let mut retries = 10;
+        let mut all_nvme_devices;
+        loop {
+            std::thread::sleep(Duration::from_millis(1000));
+
+            all_nvme_devices = NvmeDeviceList::new()
+                .filter_map(Result::ok)
+                .filter(|b| b.subsysnqn == self.subsysnqn)
+                .collect::<Vec<_>>();
+
+            retries -= 1;
+            if retries == 0 || !all_nvme_devices.is_empty() {
+                break;
+            }
+        }
+
+        Ok(all_nvme_devices)
+    }
+
+    /// Disconnect from NVMe target
+    /// Returns number of controllers disconnected
+    pub fn disconnect(&self) -> Result<usize, NvmeError> {
+        let r = NvmeRoot::new(unsafe { crate::nvme_scan(std::ptr::null()) });
+        let mut i = 0;
+        let hostiter = NvmeHostIterator::new(&r);
+        for host in hostiter {
+            let subsysiter = NvmeSubsystemIterator::new(host);
+            for subsys in subsysiter {
+                let cstr = unsafe {
+                    std::ffi::CStr::from_ptr(crate::nvme_subsystem_get_nqn(
+                        subsys,
+                    ))
+                };
+                if cstr.to_str().unwrap() != self.subsysnqn {
+                    continue;
+                }
+                let ctrlriter = NvmeCtrlrIterator::new(subsys);
+                for c in ctrlriter {
+                    if unsafe { crate::nvme_disconnect_ctrl(c) == 0 } {
+                        i += 1;
+                    }
+                }
+            }
+        }
+        Ok(i)
+    }
+}
+
+#[test]
+fn nvme_parse_uri() {
+    let target =
+        NvmeTarget::try_from("nvmf://1.2.3.4:1234/testnqn.what-ever.foo")
+            .unwrap();
+
+    assert_eq!(target.port, 1234);
+    assert_eq!(target.host, "1.2.3.4");
+    assert_eq!(target.trtype, "tcp");
+    assert_eq!(target.subsysnqn, "testnqn.what-ever.foo");
+
+    let target =
+        NvmeTarget::try_from("nvmf+tcp://1.2.3.4:1234/testnqn.what-ever.foo")
+            .unwrap();
+
+    assert_eq!(target.port, 1234);
+    assert_eq!(target.host, "1.2.3.4");
+    assert_eq!(target.trtype, "tcp");
+    assert_eq!(target.subsysnqn, "testnqn.what-ever.foo");
+}

--- a/libnvme-rs/wrapper.h
+++ b/libnvme-rs/wrapper.h
@@ -1,0 +1,2 @@
+#include <stddef.h>
+#include <libnvme.h>

--- a/mayastor/Cargo.toml
+++ b/mayastor/Cargo.toml
@@ -114,5 +114,6 @@ version = "0.8.2"
 [dev-dependencies]
 assert_matches = "1.5.0"
 composer = { path = "../composer" }
+libnvme-rs = {path = "../libnvme-rs", version = "0.1.0"}
 nvmeadm = {path = "../nvmeadm", version = "0.1.0"}
 run_script = "0.8.0"

--- a/mayastor/tests/mount_fs.rs
+++ b/mayastor/tests/mount_fs.rs
@@ -1,7 +1,7 @@
 use once_cell::sync::OnceCell;
 use std::convert::TryFrom;
 
-extern crate nvmeadm;
+extern crate libnvme_rs;
 
 use mayastor::{
     bdev::{nexus_create, nexus_lookup},
@@ -35,7 +35,7 @@ fn get_ms() -> &'static MayastorTest<'static> {
 
 async fn create_connected_nvmf_nexus(
     ms: &'static MayastorTest<'static>,
-) -> (nvmeadm::NvmeTarget, String) {
+) -> (libnvme_rs::NvmeTarget, String) {
     let uri = ms
         .spawn(async {
             create_nexus().await;
@@ -48,7 +48,7 @@ async fn create_connected_nvmf_nexus(
         .await;
 
     // Create and connect NVMF target.
-    let target = nvmeadm::NvmeTarget::try_from(uri).unwrap();
+    let target = libnvme_rs::NvmeTarget::try_from(uri).unwrap();
     let devices = target.connect().unwrap();
 
     assert_eq!(devices.len(), 1);
@@ -96,7 +96,7 @@ async fn mount_test(ms: &'static MayastorTest<'static>, fstype: &str) {
             .await;
 
         // Create and connect NVMF target.
-        let target = nvmeadm::NvmeTarget::try_from(uri).unwrap();
+        let target = libnvme_rs::NvmeTarget::try_from(uri).unwrap();
         let devices = target.connect().unwrap();
 
         assert_eq!(devices.len(), 1);

--- a/mayastor/tests/persistence.rs
+++ b/mayastor/tests/persistence.rs
@@ -171,7 +171,7 @@ async fn persist_io_failure() {
         .expect("Failed to unshare");
 
     // Create and connect NVMF target.
-    let target = nvmeadm::NvmeTarget::try_from(nexus_uri.clone()).unwrap();
+    let target = libnvme_rs::NvmeTarget::try_from(nexus_uri.clone()).unwrap();
     let devices = target.connect().unwrap();
     let fio_hdl = tokio::spawn(async move {
         fio_run_verify(&devices[0].path.to_string()).unwrap()

--- a/nix/mayastor-overlay.nix
+++ b/nix/mayastor-overlay.nix
@@ -3,6 +3,7 @@ self: super: {
   fio = super.callPackage ./pkgs/fio { };
   images = super.callPackage ./pkgs/images { };
   libiscsi = super.callPackage ./pkgs/libiscsi { };
+  libnvme = super.callPackage ./pkgs/libnvme { };
   libspdk = (super.callPackage ./pkgs/libspdk { }).release;
   libspdk-dev = (super.callPackage ./pkgs/libspdk { }).debug;
   mayastor = (super.callPackage ./pkgs/mayastor { }).release;

--- a/nix/pkgs/libnvme/default.nix
+++ b/nix/pkgs/libnvme/default.nix
@@ -1,0 +1,19 @@
+{ stdenv, lib, fetchgit, json_c, libuuid, meson, ninja, pkg-config, python3, sources }:
+
+stdenv.mkDerivation rec {
+  version = sources.libnvme.rev;
+  name = "libnvme-${version}";
+
+  src = sources.libnvme;
+
+  nativeBuildInputs = [ json_c libuuid meson ninja pkg-config python3 ];
+  meta = {
+    description = "Userspace NVMe library";
+    longDescription = ''
+      This is the libnvme development C library. libnvme provides type defintions for NVMe specification structures, enumerations, and bit fields, helper functions to construct, dispatch, and decode commands and payloads, and utilities to connect, scan, and manage nvme devices on a Linux system.
+    '';
+    homepage = "https://github.com/linux-nvme/libnvme";
+    licenses = lib.licenses.lgpl21Plus;
+    maintainers = "jonathan.teh@mayadata.io";
+  };
+}

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -11,6 +11,18 @@
         "url": "https://github.com/sahlberg/libiscsi/archive/eea5d3ba8e8fca98cde4b16b77f23a4fd683f3ba.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
+    "libnvme": {
+        "branch": "master",
+        "description": "nvme client library",
+        "homepage": "https://github.com/linux-nvme/libnvme",
+        "owner": "linux-nvme",
+        "repo": "libnvme",
+        "rev": "aa9369009f128ed6a6049d7729743151758d342c",
+        "sha256": "0n9j7xpvscw46699q6rx8lrjh1qgwp239jrsz5vikvha55nk19sn",
+        "type": "tarball",
+        "url": "https://github.com/linux-nvme/libnvme/archive/aa9369009f128ed6a6049d7729743151758d342c.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
     "niv": {
         "branch": "master",
         "description": "Easy dependency management for Nix projects",

--- a/shell.nix
+++ b/shell.nix
@@ -28,6 +28,7 @@ mkShell {
     fio
     libaio
     libiscsi
+    libnvme
     libudev
     liburing
     llvmPackages_11.libclang


### PR DESCRIPTION
New crate that uses the libnvme development C library. Reuse NvmeTarget, and associated code like NvmeDevice and NvmeError, from nvmeadm and implement connect and disconnect to an NVMe target using libnvme.

Fixes CAS-1218