### PR TITLE
chore(kato timeout): increase from 1 to 15 seconds

### DIFF
--- a/mayastor/src/subsys/config/opts.rs
+++ b/mayastor/src/subsys/config/opts.rs
@@ -271,7 +271,7 @@ impl Default for NvmeBdevOpts {
             action_on_timeout: 4,
             timeout_us: try_from_env("NVME_TIMEOUT_US", 5_000_000),
             timeout_admin_us: try_from_env("NVME_TIMEOUT_ADMIN_US", 5_000_000),
-            keep_alive_timeout_ms: try_from_env("NVME_KATO_MS", 1_000),
+            keep_alive_timeout_ms: try_from_env("NVME_KATO_MS", 15_000),
             retry_count: try_from_env("NVME_RETRY_COUNT", 0),
             arbitration_burst: 0,
             low_priority_weight: 0,


### PR DESCRIPTION
Increase the keepalive timeout to make it more resilient to temporary
failures such as network failures and will prevent the nexus child from
being prematurely faulted.