### PR TITLE
fix(mayastor): prevent auto-unpin of nexus

### DIFF
--- a/mayastor/src/bdev/nexus/mod.rs
+++ b/mayastor/src/bdev/nexus/mod.rs
@@ -53,7 +53,7 @@ pub use nexus_child::{
     NexusChild,
     Reason,
 };
-pub(crate) use nexus_io::{nexus_submit_io, NexusBio, NioCtx};
+pub(crate) use nexus_io::{nexus_submit_request, NioCtx};
 pub use nexus_iter::{
     nexus_iter,
     nexus_iter_mut,

--- a/mayastor/src/core/mod.rs
+++ b/mayastor/src/core/mod.rs
@@ -241,7 +241,7 @@ pub async fn device_monitor() {
             match w {
                 Command::RemoveDevice(nexus, child) => {
                     let rx = handle.spawn_local(async move {
-                        if let Some(mut n) =
+                        if let Some(n) =
                             crate::bdev::nexus::nexus_lookup_mut(&nexus)
                         {
                             if let Err(e) = n.destroy_child(&child).await {


### PR DESCRIPTION
This PR is a follow-up for #1052. It fixes a couple of things that I forgot to do in the original commit.

Mark BdevContainer (spdk-rs) and Nexus structures as "non-unpinnable". This leads to several fixes in Nexus use (replacing &mut self with Pin<&mut Self>). If a struct is not explicitly marked with marker::PhantomPinned, Rust assumes it is unpinnable and one can easily get a &mut to it. We don't want that for Bdev contexts, Nexus struct instances in particular.
Some trivial clean-ups of things like excessive "pub" use, etc.
Please also review the spdk-rs submodule part of this commit: mayadata-io/spdk-rs#2.