### PR TITLE
fix(nexus): assertion failure in nexus_bdev resume()

### DIFF
--- a/mayastor/src/bdev/nexus/nexus_bdev.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev.rs
@@ -787,12 +787,13 @@ impl Nexus {
     pub async fn resume(&mut self) -> Result<(), Error> {
         assert_eq!(Cores::current(), Cores::first());
 
-        // if we are pausing we have concurrent requests for this
-        if matches!(self.pause_state.load(), NexusPauseState::Pausing) {
+        // In case nexus is already unpaused or is being paused, bail out.
+        if matches!(
+            self.pause_state.load(),
+            NexusPauseState::Pausing | NexusPauseState::Unpaused
+        ) {
             return Ok(());
         }
-
-        assert_eq!(self.pause_state.load(), NexusPauseState::Paused);
 
         info!(
             "{} resuming nexus, waiters: {}",


### PR DESCRIPTION
Resuming already unpaused nexus is now allowed (results in no-op)
and triggers no assertion, which simplifies high-level logic for
nexus suspend/resume clients.

Fixes CAS-1256