### PR TITLE
fix(lvol): referring lvol name after destroy

### DIFF
--- a/mayastor/src/lvs/lvol.rs
+++ b/mayastor/src/lvs/lvol.rs
@@ -305,12 +305,15 @@ impl Lvol {
 
         r.await
             .expect("lvol destroy callback is gone")
-            .to_result(|e| Error::RepDestroy {
-                source: Errno::from_i32(e),
-                name: self.name(),
+            .to_result(|e| {
+                warn!("error while destroying lvol {}", name);
+                Error::RepDestroy {
+                    source: Errno::from_i32(e),
+                    name: name.clone(),
+                }
             })?;
 
-        info!("Destroyed {}", name);
+        info!("destroyed lvol {}", name);
         Ok(name)
     }
 


### PR DESCRIPTION
Fixed use of Lvol name after it has been freed.
This partially fixes CAS-1258.

Fixes CAS-1258.

This commit fixes crash of mayastor pod when a device on that node is detached. It does not fix crash of mayastor  pod hosting a nexus.