### PR TITLE
fix(helm chart): remove local pool config store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,7 +419,7 @@ dependencies = [
 
 [[package]]
 name = "composer"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "bollard",
  "futures",
@@ -551,7 +551,7 @@ dependencies = [
 
 [[package]]
 name = "csi"
-version = "0.2.0"
+version = "1.0.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -709,7 +709,7 @@ dependencies = [
 
 [[package]]
 name = "devinfo"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "bindgen 0.59.1",
  "snafu",
@@ -1413,7 +1413,7 @@ checksum = "078e285eafdfb6c4b434e0d31e8cfcb5115b651496faca5749b88fafd4f23bfd"
 
 [[package]]
 name = "jsonrpc"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "nix",
  "serde",
@@ -1514,7 +1514,7 @@ checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "mayastor"
-version = "0.9.0"
+version = "1.0.0"
 dependencies = [
  "ansi_term 0.12.1",
  "assert_matches",
@@ -1583,7 +1583,7 @@ dependencies = [
 
 [[package]]
 name = "mbus_api"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "async-trait",
  "composer",
@@ -1812,7 +1812,7 @@ dependencies = [
 
 [[package]]
 name = "nvmeadm"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "derive_builder",
  "enum-primitive-derive",
@@ -2260,7 +2260,7 @@ dependencies = [
 
 [[package]]
 name = "rpc"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "bytes",
  "prost",
@@ -2568,7 +2568,7 @@ dependencies = [
 
 [[package]]
 name = "spdk-sys"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "bindgen 0.59.1",
  "cc",
@@ -2696,7 +2696,7 @@ dependencies = [
 
 [[package]]
 name = "sysfs"
-version = "0.1.0"
+version = "1.0.0"
 
 [[package]]
 name = "tap"

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -13,6 +13,6 @@
 {{- if gt $i 0 }}
 {{- printf "," }}
 {{- end }}
-{{- printf "%d" $i }}
+{{- printf "%d" (add $i 1) }}
 {{- end }}
 {{- end }}

--- a/chart/templates/mayastor-daemonset.yaml
+++ b/chart/templates/mayastor-daemonset.yaml
@@ -53,7 +53,6 @@ spec:
         - "-g$(MY_POD_IP)"
         - "-nnats"
         - "-y/var/local/mayastor/config.yaml"
-        - "-P/var/local/mayastor/pools.yaml"
         - "-l{{ include "mayastorCpuSpec" . }}"
         - "-pmayastor-etcd"
         command:

--- a/chart/templates/mayastor-daemonset.yaml
+++ b/chart/templates/mayastor-daemonset.yaml
@@ -80,11 +80,11 @@ spec:
           limits:
             cpu: "{{ .Values.mayastorCpuCount }}"
             memory: "1Gi"
-            hugepages-2Mi: "{{ add .Values.mayastorHugePagesGiB 1 }}Gi"
+            hugepages-2Mi: "{{ max .Values.mayastorHugePagesGiB 2 }}Gi"
           requests:
             cpu: "{{ .Values.mayastorCpuCount }}"
             memory: "1Gi"
-            hugepages-2Mi: "{{ add .Values.mayastorHugePagesGiB 1 }}Gi"
+            hugepages-2Mi: "{{ max .Values.mayastorHugePagesGiB 2 }}Gi"
         ports:
         - containerPort: 10124
           protocol: TCP

--- a/chart/templates/mayastor-daemonset.yaml
+++ b/chart/templates/mayastor-daemonset.yaml
@@ -36,9 +36,6 @@ spec:
         env:
         - name: RUST_LOG
           value: info,mayastor={{ .Values.mayastorLogLevel }}
-        - name: NVMF_TCP_MAX_QPAIRS_PER_CTRL
-          # Current recommendation is to set this value to be the number of cores provided to mayastor (see -l argument) plus 1.
-          value: "{{ add .Values.mayastorCpuCount 1 }}"
         - name: NVMF_TCP_MAX_QUEUE_DEPTH
           value: "32"
         - name: MY_NODE_NAME

--- a/chart/templates/mayastor-daemonset.yaml
+++ b/chart/templates/mayastor-daemonset.yaml
@@ -36,6 +36,11 @@ spec:
         env:
         - name: RUST_LOG
           value: info,mayastor={{ .Values.mayastorLogLevel }}
+        - name: NVMF_TCP_MAX_QPAIRS_PER_CTRL
+          # Current recommendation is to set this value to be the number of cores provided to mayastor (see -l argument) plus 1.
+          value: "{{ add .Values.mayastorCpuCount 1 }}"
+        - name: NVMF_TCP_MAX_QUEUE_DEPTH
+          value: "32"
         - name: MY_NODE_NAME
           valueFrom:
             fieldRef:
@@ -74,12 +79,12 @@ spec:
           # pressure unless they exceed those limits. limits and requests must be the same.
           limits:
             cpu: "{{ .Values.mayastorCpuCount }}"
-            memory: "512Mi"
-            hugepages-2Mi: "{{ .Values.mayastorHugePagesGiB }}Gi"
+            memory: "1Gi"
+            hugepages-2Mi: "{{ add .Values.mayastorHugePagesGiB 1 }}Gi"
           requests:
             cpu: "{{ .Values.mayastorCpuCount }}"
-            memory: "512Mi"
-            hugepages-2Mi: "{{ .Values.mayastorHugePagesGiB }}Gi"
+            memory: "1Gi"
+            hugepages-2Mi: "{{ add .Values.mayastorHugePagesGiB 1 }}Gi"
         ports:
         - containerPort: 10124
           protocol: TCP

--- a/composer/Cargo.toml
+++ b/composer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "composer"
-version = "0.1.0"
+version = "1.0.0"
 authors = ["Tiago Castro <tiago.castro@mayadata.io>"]
 edition = "2018"
 

--- a/csi/Cargo.toml
+++ b/csi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Jan Kryl <jan.kryl@mayadata.io>", "Jeffry Molanus <jeffry.molanus@mayadata.io"]
 name = "csi"
-version = "0.2.0"
+version = "1.0.0"
 edition = "2018"
 
 [[bin]]
@@ -21,7 +21,7 @@ failure = "0.1.8"
 futures = { version = "0.3.16", default-features = false }
 glob = "0.3.0"
 lazy_static = "1.4.0"
-nvmeadm = { path = "../nvmeadm", version = "0.1.0" }
+nvmeadm = { path = "../nvmeadm" }
 proc-mounts = "0.2.4"
 prost = "0.8.0"
 prost-derive = "0.8.0"
@@ -30,7 +30,7 @@ regex = "1.5.4"
 serde_json = "1.0.66"
 snafu = "0.6.10"
 sys-mount = "1.3.0"
-sysfs = { path = "../sysfs", version = "0.1.0" }
+sysfs = { path = "../sysfs" }
 tokio = { version = "1.10.0", features = ["full"] }
 tokio-stream = { version = "0.1.7", features = ["net"] }
 tonic = "0.5.2"

--- a/deploy/csi-daemonset.yaml
+++ b/deploy/csi-daemonset.yaml
@@ -30,7 +30,7 @@ spec:
       # the same.
       containers:
       - name: mayastor-csi
-        image: mayadata/mayastor:v1.0.0
+        image: mayadata/mayastor:v1.0.1
         imagePullPolicy: IfNotPresent
         # we need privileged because we mount filesystems and use mknod
         securityContext:

--- a/deploy/mayastor-daemonset.yaml
+++ b/deploy/mayastor-daemonset.yaml
@@ -54,7 +54,6 @@ spec:
         - "-N$(MY_NODE_NAME)"
         - "-g$(MY_POD_IP)"
         - "-nnats"
-        - "-P/var/local/mayastor/pools.yaml"
         - "-l1"
         - "-pmayastor-etcd"
         command:

--- a/deploy/mayastor-daemonset.yaml
+++ b/deploy/mayastor-daemonset.yaml
@@ -38,9 +38,6 @@ spec:
         env:
         - name: RUST_LOG
           value: info,mayastor=info
-        - name: NVMF_TCP_MAX_QPAIRS_PER_CTRL
-          # Current recommendation is to set this value to be the number of cores provided to mayastor (see -l argument) plus 1.
-          value: "2"
         - name: NVMF_TCP_MAX_QUEUE_DEPTH
           value: "32"
         - name: MY_NODE_NAME

--- a/deploy/mayastor-daemonset.yaml
+++ b/deploy/mayastor-daemonset.yaml
@@ -33,11 +33,16 @@ spec:
         command: ['sh', '-c', 'until nc -vz nats 4222; do echo "Waiting for message bus..."; sleep 1; done;']
       containers:
       - name: mayastor
-        image: mayadata/mayastor:v1.0.0
+        image: mayadata/mayastor:v1.0.1
         imagePullPolicy: IfNotPresent
         env:
         - name: RUST_LOG
           value: info,mayastor=info
+        - name: NVMF_TCP_MAX_QPAIRS_PER_CTRL
+          # Current recommendation is to set this value to be the number of cores provided to mayastor (see -l argument) plus 1.
+          value: "2"
+        - name: NVMF_TCP_MAX_QUEUE_DEPTH
+          value: "32"
         - name: MY_NODE_NAME
           valueFrom:
             fieldRef:
@@ -50,10 +55,11 @@ spec:
         # The -l argument accepts cpu-list. Indexing starts at zero.
         # For example -l 1,2,10-20 means use core 1, 2, 10 to 20.
         # Note: Ensure that the CPU resources are updated accordingly.
-        # If you use 2 CPUs, the CPU: field should also read 2.
+        #       If you use 2 CPUs, the CPU: field should also read 2.
         - "-N$(MY_NODE_NAME)"
         - "-g$(MY_POD_IP)"
         - "-nnats"
+        - "-y/var/local/mayastor/config.yaml"
         - "-l1"
         - "-pmayastor-etcd"
         command:
@@ -73,7 +79,6 @@ spec:
           # NOTE: Each container must have mem/cpu limits defined in order to
           # belong to Guaranteed QoS class, hence can never get evicted in case of
           # pressure unless they exceed those limits. limits and requests must be the same.
-          #
           limits:
             cpu: "1"
             memory: "1Gi"

--- a/devinfo/Cargo.toml
+++ b/devinfo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "devinfo"
-version = "0.1.0"
+version = "1.0.0"
 authors = ["Jeffry Molanus <jeffry.molanus@gmail.com>"]
 edition = "2018"
 

--- a/jsonrpc/Cargo.toml
+++ b/jsonrpc/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Jeffry Molanus <jeffry.molanus@gmail.com>"]
 edition = "2018"
 name = "jsonrpc"
-version = "0.1.0"
+version = "1.0.0"
 
 [dependencies]
 nix = "0.22.1"

--- a/mayastor/Cargo.toml
+++ b/mayastor/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Jeffry Molanus <jeffry.molanus@gmail.com>"]
 edition = "2018"
 name = "mayastor"
-version = "0.9.0"
+version = "1.0.0"
 default-run = "mayastor-client"
 
 [[bin]]
@@ -113,5 +113,5 @@ version = "0.8.2"
 [dev-dependencies]
 assert_matches = "1.5.0"
 composer = { path = "../composer" }
-nvmeadm = {path = "../nvmeadm", version = "0.1.0"}
+nvmeadm = { path = "../nvmeadm" }
 run_script = "0.8.0"

--- a/mayastor/src/bdev/nexus/mod.rs
+++ b/mayastor/src/bdev/nexus/mod.rs
@@ -28,6 +28,7 @@ mod nexus_channel;
 pub(crate) mod nexus_child;
 pub mod nexus_fn_table;
 pub mod nexus_io;
+pub mod nexus_io_subsystem;
 pub mod nexus_label;
 pub mod nexus_metadata;
 pub mod nexus_module;

--- a/mayastor/src/bdev/nexus/nexus_bdev.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev.rs
@@ -967,8 +967,43 @@ impl Nexus {
             // schedule the deletion of the child eventhough etcd has not been
             // updated yet we do not need to wait for that to
             // complete anyway.
-            MWQ.enqueue(Command::RemoveDevice(self.name.clone(), name));
-            self.persist(PersistOp::Update((uri.clone(), child.state())))
+            MWQ.enqueue(Command::RemoveDevice(self.name.clone(), name.clone()));
+
+            // Do not persist child state in case it's the last healthy child of
+            // the nexus: let Control Plane reconstruct the nexus
+            // using this device as the replica with the most recent
+            // user data.
+            self.persist(PersistOp::UpdateCond(
+                (uri.clone(), child.state(), &|nexus_info| {
+                    // Determine the amount of healthy replicas in the persistent state and
+                    // check against the last healthy replica remaining.
+                    let num_healthy = nexus_info.children.iter().fold(0, |n, c| {
+                        if c.healthy {
+                            n + 1
+                        } else {
+                            n
+                        }
+                    });
+
+                    match num_healthy {
+                        0 => {
+                            warn!(
+                                "nexus {}: no healthy replicas persent in persistent store when retiring replica {}:
+                                not persisting the replica state",
+                                &name, &uri,
+                            );
+                            false
+                        }
+                        1 => {
+                            warn!(
+                                "nexus {}: retiring the last healthy replica {}, not persisting the replica state",
+                                &name, &uri,
+                            );
+                            false
+                        },
+                        _ => true,
+                    }
+                })))
                 .await;
         }
         self.resume().await

--- a/mayastor/src/bdev/nexus/nexus_io_subsystem.rs
+++ b/mayastor/src/bdev/nexus/nexus_io_subsystem.rs
@@ -1,0 +1,182 @@
+use std::{
+    collections::VecDeque,
+    sync::atomic::{AtomicU32, Ordering},
+};
+
+use crossbeam::atomic::AtomicCell;
+use futures::channel::oneshot;
+
+use crate::{
+    bdev::nexus::nexus_bdev::Error as NexusError,
+    core::{Bdev, Cores, Protocol, Share},
+    subsys::NvmfSubsystem,
+};
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum NexusPauseState {
+    Unpaused,
+    Pausing,
+    Paused,
+    Unpausing,
+}
+
+/// Abstraction for managing pausing/unpausing I/O on NVMe subsystem, allowing
+/// concurrent pause/resume calls by serializing low-level SPDK calls.
+#[derive(Debug)]
+pub struct NexusIoSubsystem {
+    name: String,
+    bdev: Bdev,
+    pause_state: AtomicCell<NexusPauseState>,
+    pause_waiters: VecDeque<oneshot::Sender<i32>>,
+    pause_cnt: AtomicU32,
+}
+
+impl NexusIoSubsystem {
+    /// Create a new instance of Nexus I/O subsystem for a given nexus name and
+    /// block device.
+    pub fn new(name: String, bdev: Bdev) -> Self {
+        Self {
+            pause_state: AtomicCell::new(NexusPauseState::Unpaused),
+            pause_waiters: VecDeque::with_capacity(8), /* Default number of
+                                                        * replicas */
+            pause_cnt: AtomicU32::new(0),
+            name,
+            bdev,
+        }
+    }
+
+    /// Suspend any incoming IO to the bdev pausing the controller allows us to
+    /// handle internal events and which is a protocol feature.
+    /// In case concurrent pause requests take place, the other callers
+    /// will wait till the nexus is resumed and will continue execution
+    /// with the nexus paused once they are awakened via resume().
+    /// Note: in order to handle concurrent pauses properly, this function must
+    /// be called only from the master core.
+    pub async fn suspend(&mut self) -> Result<(), NexusError> {
+        assert_eq!(Cores::current(), Cores::first());
+
+        trace!(?self.name, "pausing nexus I/O");
+
+        loop {
+            let state = self.pause_state.compare_exchange(
+                NexusPauseState::Unpaused,
+                NexusPauseState::Pausing,
+            );
+
+            match state {
+                Ok(NexusPauseState::Unpaused) => {
+                    // Pause subsystem. The only acceptable counter transition
+                    // is: 0 -> 1.
+                    assert_eq!(
+                        self.pause_cnt.fetch_add(1, Ordering::SeqCst),
+                        0,
+                        "Corrupted subsystem pause counter"
+                    );
+
+                    if let Some(Protocol::Nvmf) = self.bdev.shared() {
+                        if let Some(subsystem) =
+                            NvmfSubsystem::nqn_lookup(&self.name)
+                        {
+                            trace!(nexus=%self.name, nqn=%subsystem.get_nqn(), "pausing subsystem");
+                            subsystem.pause().await.unwrap();
+                            trace!(nexus=%self.name, nqn=%subsystem.get_nqn(), "subsystem paused");
+                        }
+                    }
+
+                    // Mark subsystem as paused after it has been paused.
+                    self.pause_state
+                        .compare_exchange(
+                            NexusPauseState::Pausing,
+                            NexusPauseState::Paused,
+                        )
+                        .expect("Failed to mark subsystem as Paused");
+                    break;
+                }
+                // Subsystem is already paused, increment number of paused.
+                Err(NexusPauseState::Paused) => {
+                    trace!(nexus=%self.name, "nexus is already paused, incrementing refcount");
+                    self.pause_cnt.fetch_add(1, Ordering::SeqCst);
+                    break;
+                }
+                // Wait till the subsystem has completed transition and retry
+                // operation.
+                Err(NexusPauseState::Unpausing)
+                | Err(NexusPauseState::Pausing) => {
+                    trace!(nexus=%self.name, "nexus is in intermediate state, deferring Pause operation");
+                    let (s, r) = oneshot::channel::<i32>();
+                    self.pause_waiters.push_back(s);
+                    r.await.unwrap();
+                    trace!(nexus=%self.name, "nexus completed state transition, retrying Pause operation");
+                }
+                _ => {
+                    panic!("Corrupted I/O subsystem state");
+                }
+            };
+        }
+
+        // Resume one waiter in case there are any.
+        if !self.pause_waiters.is_empty() {
+            let w = self.pause_waiters.pop_front().unwrap();
+            trace!(nexus=%self.name, "resuming the first Pause waiter");
+            w.send(0).expect("I/O subsystem pause waiter disappeared");
+        }
+
+        trace!(?self.name, "nexus I/O paused");
+        Ok(())
+    }
+
+    /// Resume IO to the bdev.
+    /// Note: in order to handle concurrent resumes properly, this function must
+    /// be called only from the master core.
+    pub async fn resume(&mut self) -> Result<(), NexusError> {
+        assert_eq!(Cores::current(), Cores::first());
+
+        trace!(?self.name, "resuming nexus I/O");
+
+        loop {
+            match self.pause_state.load() {
+                // Already unpaused, bail out.
+                NexusPauseState::Unpaused => {
+                    break;
+                }
+                // Simultaneous pausing/unpausing: wait till the subsystem has
+                // completed transition and retry operation.
+                NexusPauseState::Pausing | NexusPauseState::Unpausing => {
+                    trace!(?self.name, "nexus is in intermediate state, deferring Resume operation");
+                    let (s, r) = oneshot::channel::<i32>();
+                    self.pause_waiters.push_back(s);
+                    r.await.unwrap();
+                    trace!(?self.name, "completed state transition, retrying Resume operation");
+                }
+                // Unpause the subsystem, taking into account the overall number
+                // of pauses.
+                NexusPauseState::Paused => {
+                    let v = self.pause_cnt.fetch_sub(1, Ordering::SeqCst);
+                    // In case the last pause discarded, resume the subsystem.
+                    if v == 1 {
+                        if let Some(subsystem) =
+                            NvmfSubsystem::nqn_lookup(&self.name)
+                        {
+                            self.pause_state.store(NexusPauseState::Unpausing);
+                            trace!(nexus=%self.name, nqn=%subsystem.get_nqn(), "resuming subsystem");
+                            subsystem.resume().await.unwrap();
+                            trace!(nexus=%self.name, nqn=%subsystem.get_nqn(), "subsystem resumed");
+                        }
+                        self.pause_state.store(NexusPauseState::Unpaused);
+                    }
+                    break;
+                }
+            }
+        }
+
+        // Resume one waiter in case there are any.
+        if !self.pause_waiters.is_empty() {
+            trace!(nexus=%self.name, "resuming the first Resume waiter");
+            let w = self.pause_waiters.pop_front().unwrap();
+            w.send(0).expect("I/O subsystem resume waiter disappeared");
+        }
+
+        trace!(?self.name, "nexus I/O resumed");
+        Ok(())
+    }
+}

--- a/mayastor/src/bdev/nexus/nexus_persistence.rs
+++ b/mayastor/src/bdev/nexus/nexus_persistence.rs
@@ -29,20 +29,25 @@ pub struct ChildInfo {
 }
 
 /// Defines the type of persist operations.
-pub(crate) enum PersistOp {
+pub(crate) enum PersistOp<'a> {
     /// Create a persistent entry.
     Create,
     /// Add a child to an existing persistent entry.
     AddChild((ChildUri, ChildState)),
     /// Update a persistent entry.
     Update((ChildUri, ChildState)),
+    /// Update a persistent entry only when a precondition on this NexusInfo
+    /// holds. Predicate is called under protection of the NexusInfo lock,
+    /// so the check is assumed to be atomic and not interfering with other
+    /// modifications of the same NexusInfo.
+    UpdateCond((ChildUri, ChildState, &'a dyn Fn(&NexusInfo) -> bool)),
     /// Save the clean shutdown variable.
     Shutdown,
 }
 
 impl Nexus {
     /// Persist information to the store.
-    pub(crate) async fn persist(&self, op: PersistOp) {
+    pub(crate) async fn persist(&self, op: PersistOp<'_>) {
         if !PersistentStore::enabled() {
             return;
         }
@@ -81,6 +86,22 @@ impl Nexus {
                 // Only update the state of the child that has changed. Do not
                 // update the other children or "clean shutdown" information.
                 // This should only be called on a child state change.
+                nexus_info.children.iter_mut().for_each(|c| {
+                    if c.uuid == uuid {
+                        c.healthy = Self::child_healthy(&state);
+                    }
+                });
+            }
+            // Only update the state of the child if the precondition holds.
+            PersistOp::UpdateCond((uri, state, f)) => {
+                // Do not persist the state if predicate fails.
+                if !f(&nexus_info) {
+                    return;
+                }
+
+                let uuid =
+                    NexusChild::uuid(&uri).expect("Failed to get child UUID.");
+
                 nexus_info.children.iter_mut().for_each(|c| {
                     if c.uuid == uuid {
                         c.healthy = Self::child_healthy(&state);

--- a/mayastor/src/bdev/nvmx/channel.rs
+++ b/mayastor/src/bdev/nvmx/channel.rs
@@ -650,7 +650,7 @@ impl NvmeControllerIoChannel {
 
 impl Drop for NvmeControllerIoChannel {
     fn drop(&mut self) {
-        debug!("I/O channel {:p} dropped", self.0.as_ptr());
+        trace!("I/O channel {:p} dropped", self.0.as_ptr());
         unsafe { spdk_put_io_channel(self.0.as_ptr()) }
     }
 }

--- a/mayastor/src/subsys/config/opts.rs
+++ b/mayastor/src/subsys/config/opts.rs
@@ -181,7 +181,10 @@ impl Default for NvmfTcpTransportOpts {
             in_capsule_data_size: 4096,
             max_io_size: 131_072,
             io_unit_size: 131_072,
-            max_qpairs_per_ctrl: 32,
+            max_qpairs_per_ctrl: try_from_env(
+                "NVMF_TCP_MAX_QPAIRS_PER_CTRL",
+                32,
+            ),
             num_shared_buf: try_from_env("NVMF_TCP_NUM_SHARED_BUF", 2048),
             buf_cache_size: try_from_env("NVMF_TCP_BUF_CACHE_SIZE", 64),
             dif_insert_or_strip: false,

--- a/mbus-api/Cargo.toml
+++ b/mbus-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbus_api"
-version = "0.1.0"
+version = "1.0.0"
 authors = ["Tiago Castro <tiago.castro@mayadata.io>"]
 edition = "2018"
 

--- a/nvmeadm/Cargo.toml
+++ b/nvmeadm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nvmeadm"
-version = "0.1.0"
+version = "1.0.0"
 authors = ["Jeffry Molanus <jeffry.molanus@gmail.com>"]
 edition = "2018"
 

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rpc"
-version = "0.1.0"
+version = "1.0.0"
 authors = ["Jeffry Molanus <jeffry.molanus@gmail.com>"]
 edition = "2018"
 

--- a/spdk-sys/Cargo.toml
+++ b/spdk-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "spdk-sys"
 description = "Rust bindings for SPDK library"
-version = "0.1.0"
+version = "1.0.0"
 edition = "2018"
 links = "spdk"
 build = "build.rs"

--- a/sysfs/Cargo.toml
+++ b/sysfs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysfs"
-version = "0.1.0"
+version = "1.0.0"
 authors = ["Jeffry Molanus <jeffry.molanus@gmail.com>"]
 edition = "2018"
 


### PR DESCRIPTION
- Removes -P argument from the mayastor container
  spec, as the use of a local pool config store
  has been deprecated and conflicts with the
  control plane's state store

- Removes the same from the pre-generated
  mayastor-daemonset definition in the /deploy
  folder, which is referenced in the user docs