### PR TITLE
fix(ci): fixed rpath in matastor docker image

### DIFF
--- a/nix/pkgs/mayastor/cargo-package.nix
+++ b/nix/pkgs/mayastor/cargo-package.nix
@@ -85,11 +85,15 @@ let
     doCheck = false;
     meta = { platforms = lib.platforms.linux; };
     fixupPhase = ''
+      local ms_lib_path
+      local new_rpath
       echo "fixing rpaths in mayastor binaries to point to $out/lib"
+      ms_lib_path=$(echo "$out/lib" | sed 's/\//\\\//g')
+      new_rpath=$(patchelf --print-rpath "$out/bin/mayastor" | sed -r 's/\/build\/mayastor(\/[^:]*)+/'"$ms_lib_path"'/')
       patchelf \
           --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-          --set-rpath $out/lib \
-          $out/bin/mayastor
+          --set-rpath "$new_rpath" \
+          "$out/bin/mayastor"
     '';
   };
 in


### PR DESCRIPTION
Mayastor binary had an incorrect RPATH set at fixup phase of
image build. The fixup was needed after SPDK linkage was
refactored, but RPATH subsitution was done incorrectly at
that time.