### PR TITLE
chore(bdev): cleanup core bdev code

### DIFF
--- a/mayastor/src/bdev/aio.rs
+++ b/mayastor/src/bdev/aio.rs
@@ -101,10 +101,10 @@ impl CreateDestroy for Aio {
 
         if let Some(mut bdev) = UntypedBdev::lookup_by_name(&self.name) {
             if let Some(uuid) = self.uuid {
-                unsafe { bdev.as_mut().set_uuid(uuid.into()) };
+                unsafe { bdev.set_raw_uuid(uuid.into()) };
             }
 
-            if !bdev.as_mut().add_alias(&self.alias) {
+            if !bdev.add_alias(&self.alias) {
                 error!(
                     "failed to add alias {} to device {}",
                     self.alias,
@@ -124,11 +124,11 @@ impl CreateDestroy for Aio {
     async fn destroy(self: Box<Self>) -> Result<(), Self::Error> {
         match UntypedBdev::lookup_by_name(&self.name) {
             Some(mut bdev) => {
-                bdev.as_mut().remove_alias(&self.alias);
+                bdev.remove_alias(&self.alias);
                 let (sender, receiver) = oneshot::channel::<ErrnoResult<()>>();
                 unsafe {
                     bdev_aio_delete(
-                        bdev.as_ptr(),
+                        bdev.unsafe_inner_mut_ptr(),
                         Some(done_errno_cb),
                         cb_arg(sender),
                     );

--- a/mayastor/src/bdev/aio.rs
+++ b/mayastor/src/bdev/aio.rs
@@ -10,7 +10,7 @@ use spdk_rs::libspdk::{bdev_aio_delete, create_aio_bdev};
 
 use crate::{
     bdev::{dev::reject_unknown_parameters, util::uri, CreateDestroy, GetName},
-    core::Bdev,
+    core::UntypedBdev,
     ffihelper::{cb_arg, done_errno_cb, ErrnoResult},
     nexus_uri::{self, NexusBdevError},
 };
@@ -80,7 +80,7 @@ impl CreateDestroy for Aio {
 
     /// Create an AIO bdev
     async fn create(&self) -> Result<String, Self::Error> {
-        if Bdev::lookup_by_name(&self.name).is_some() {
+        if UntypedBdev::lookup_by_name(&self.name).is_some() {
             return Err(NexusBdevError::BdevExists {
                 name: self.get_name(),
             });
@@ -99,7 +99,7 @@ impl CreateDestroy for Aio {
             });
         }
 
-        if let Some(mut bdev) = Bdev::lookup_by_name(&self.name) {
+        if let Some(mut bdev) = UntypedBdev::lookup_by_name(&self.name) {
             if let Some(uuid) = self.uuid {
                 unsafe { bdev.as_mut().set_uuid(uuid.into()) };
             }
@@ -122,7 +122,7 @@ impl CreateDestroy for Aio {
 
     /// Destroy the given AIO bdev
     async fn destroy(self: Box<Self>) -> Result<(), Self::Error> {
-        match Bdev::lookup_by_name(&self.name) {
+        match UntypedBdev::lookup_by_name(&self.name) {
             Some(mut bdev) => {
                 bdev.as_mut().remove_alias(&self.alias);
                 let (sender, receiver) = oneshot::channel::<ErrnoResult<()>>();

--- a/mayastor/src/bdev/loopback.rs
+++ b/mayastor/src/bdev/loopback.rs
@@ -12,7 +12,7 @@ use crate::{
         CreateDestroy,
         GetName,
     },
-    core::Bdev,
+    core::UntypedBdev,
     nexus_uri::{self, NexusBdevError},
 };
 
@@ -66,7 +66,7 @@ impl CreateDestroy for Loopback {
     type Error = NexusBdevError;
 
     async fn create(&self) -> Result<String, Self::Error> {
-        if let Some(mut bdev) = Bdev::lookup_by_name(&self.name) {
+        if let Some(mut bdev) = UntypedBdev::lookup_by_name(&self.name) {
             if self.uuid.is_some() && Some(bdev.uuid()) != self.uuid {
                 return Err(NexusBdevError::BdevWrongUuid {
                     name: self.get_name(),
@@ -94,7 +94,7 @@ impl CreateDestroy for Loopback {
         if let Some(child) = lookup_nexus_child(&self.name) {
             child.remove();
         }
-        if let Some(mut bdev) = Bdev::lookup_by_name(&self.name) {
+        if let Some(mut bdev) = UntypedBdev::lookup_by_name(&self.name) {
             bdev.as_mut().remove_alias(&self.alias);
         }
         Ok(())

--- a/mayastor/src/bdev/loopback.rs
+++ b/mayastor/src/bdev/loopback.rs
@@ -74,7 +74,7 @@ impl CreateDestroy for Loopback {
                 });
             }
 
-            if !bdev.as_mut().add_alias(&self.alias) {
+            if !bdev.add_alias(&self.alias) {
                 error!(
                     "failed to add alias {} to device {}",
                     self.alias,
@@ -95,7 +95,7 @@ impl CreateDestroy for Loopback {
             child.remove();
         }
         if let Some(mut bdev) = UntypedBdev::lookup_by_name(&self.name) {
-            bdev.as_mut().remove_alias(&self.alias);
+            bdev.remove_alias(&self.alias);
         }
         Ok(())
     }

--- a/mayastor/src/bdev/malloc.rs
+++ b/mayastor/src/bdev/malloc.rs
@@ -169,7 +169,7 @@ impl CreateDestroy for Malloc {
 
         if let Some(mut bdev) = UntypedBdev::lookup_by_name(&self.name) {
             if let Some(uuid) = self.uuid {
-                unsafe { bdev.set_uuid(uuid.into()) };
+                unsafe { bdev.set_raw_uuid(uuid.into()) };
             }
 
             if !bdev.add_alias(&self.alias) {
@@ -195,7 +195,7 @@ impl CreateDestroy for Malloc {
 
             unsafe {
                 delete_malloc_disk(
-                    bdev.legacy_as_ptr().as_ptr(),
+                    bdev.unsafe_inner_mut_ptr(),
                     Some(done_errno_cb),
                     cb_arg(s),
                 );

--- a/mayastor/src/bdev/malloc.rs
+++ b/mayastor/src/bdev/malloc.rs
@@ -13,7 +13,7 @@ use url::Url;
 
 use spdk_rs::{
     libspdk::{create_malloc_disk, delete_malloc_disk, spdk_bdev},
-    DummyBdev,
+    UntypedBdev,
 };
 
 use crate::{
@@ -140,7 +140,7 @@ impl CreateDestroy for Malloc {
     type Error = NexusBdevError;
 
     async fn create(&self) -> Result<String, Self::Error> {
-        if DummyBdev::lookup_by_name(&self.name).is_some() {
+        if UntypedBdev::lookup_by_name(&self.name).is_some() {
             return Err(NexusBdevError::BdevExists {
                 name: self.name.clone(),
             });
@@ -167,7 +167,7 @@ impl CreateDestroy for Malloc {
             });
         }
 
-        if let Some(mut bdev) = DummyBdev::lookup_by_name(&self.name) {
+        if let Some(mut bdev) = UntypedBdev::lookup_by_name(&self.name) {
             if let Some(uuid) = self.uuid {
                 unsafe { bdev.set_uuid(uuid.into()) };
             }
@@ -189,7 +189,7 @@ impl CreateDestroy for Malloc {
     }
 
     async fn destroy(self: Box<Self>) -> Result<(), Self::Error> {
-        if let Some(mut bdev) = DummyBdev::lookup_by_name(&self.name) {
+        if let Some(mut bdev) = UntypedBdev::lookup_by_name(&self.name) {
             bdev.remove_alias(&self.alias);
             let (s, r) = oneshot::channel::<ErrnoResult<()>>();
 

--- a/mayastor/src/bdev/nexus/mod.rs
+++ b/mayastor/src/bdev/nexus/mod.rs
@@ -109,10 +109,11 @@ pub fn register_module() {
                         message: "invalid protocol".to_string(),
                     });
                 }
-                if let Some(bdev) = UntypedBdev::lookup_by_name(&args.name) {
+                if let Some(mut bdev) = UntypedBdev::lookup_by_name(&args.name) {
+                    let mut bdev = Pin::new(&mut bdev);
                     match proto.as_str() {
                         "nvmf" => {
-                            bdev.share_nvmf(Some((args.cntlid_min, args.cntlid_max)))
+                            bdev.as_mut().share_nvmf(Some((args.cntlid_min, args.cntlid_max)))
                                 .await
                                 .map_err(|e| {
                                     JsonRpcError {
@@ -127,7 +128,7 @@ pub fn register_module() {
                             })
                         },
                         "iscsi" => {
-                            bdev.share_iscsi()
+                            bdev.as_mut().share_iscsi()
                                 .await
                                 .map_err(|e| {
                                     JsonRpcError {

--- a/mayastor/src/bdev/nexus/mod.rs
+++ b/mayastor/src/bdev/nexus/mod.rs
@@ -93,7 +93,7 @@ pub fn register_module() {
     nexus_module::register_module();
 
     use crate::{
-        core::{Bdev, Share},
+        core::{Share, UntypedBdev},
         jsonrpc::{jsonrpc_register, Code, JsonRpcError, Result},
     };
 
@@ -109,7 +109,7 @@ pub fn register_module() {
                         message: "invalid protocol".to_string(),
                     });
                 }
-                if let Some(bdev) = Bdev::lookup_by_name(&args.name) {
+                if let Some(bdev) = UntypedBdev::lookup_by_name(&args.name) {
                     match proto.as_str() {
                         "nvmf" => {
                             bdev.share_nvmf(Some((args.cntlid_min, args.cntlid_max)))

--- a/mayastor/src/bdev/nexus/nexus_bdev.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev.rs
@@ -1156,8 +1156,8 @@ impl<'n> Nexus<'n> {
 // Unsafe part of Nexus.
 impl<'n> Nexus<'n> {
     /// TODO
-    pub(crate) unsafe fn bdev(&self) -> Bdev {
-        Bdev::from(self.bdev_raw.as_ptr())
+    pub(crate) unsafe fn bdev(&self) -> Bdev<Nexus<'n>> {
+        Bdev::from_ptr(self.bdev_raw.as_ptr()).unwrap()
     }
 
     /// Sets the required alignment of the Nexus.

--- a/mayastor/src/bdev/null.rs
+++ b/mayastor/src/bdev/null.rs
@@ -12,7 +12,7 @@ use uuid::Uuid;
 
 use crate::{
     bdev::{dev::reject_unknown_parameters, util::uri, CreateDestroy, GetName},
-    core::Bdev,
+    core::UntypedBdev,
     ffihelper::{cb_arg, done_errno_cb, ErrnoResult, IntoCString},
     nexus_uri::{
         NexusBdevError,
@@ -131,7 +131,7 @@ impl CreateDestroy for Null {
     type Error = NexusBdevError;
 
     async fn create(&self) -> Result<String, Self::Error> {
-        if Bdev::lookup_by_name(&self.name).is_some() {
+        if UntypedBdev::lookup_by_name(&self.name).is_some() {
             return Err(NexusBdevError::BdevExists {
                 name: self.name.clone(),
             });
@@ -163,7 +163,7 @@ impl CreateDestroy for Null {
             });
         }
 
-        if let Some(mut bdev) = Bdev::lookup_by_name(&self.name) {
+        if let Some(mut bdev) = UntypedBdev::lookup_by_name(&self.name) {
             if let Some(uuid) = self.uuid {
                 unsafe { bdev.as_mut().set_uuid(uuid.into()) };
             }
@@ -185,7 +185,7 @@ impl CreateDestroy for Null {
     }
 
     async fn destroy(self: Box<Self>) -> Result<(), Self::Error> {
-        if let Some(mut bdev) = Bdev::lookup_by_name(&self.name) {
+        if let Some(mut bdev) = UntypedBdev::lookup_by_name(&self.name) {
             bdev.as_mut().remove_alias(&self.alias);
             let (s, r) = oneshot::channel::<ErrnoResult<()>>();
             unsafe {

--- a/mayastor/src/bdev/null.rs
+++ b/mayastor/src/bdev/null.rs
@@ -165,10 +165,10 @@ impl CreateDestroy for Null {
 
         if let Some(mut bdev) = UntypedBdev::lookup_by_name(&self.name) {
             if let Some(uuid) = self.uuid {
-                unsafe { bdev.as_mut().set_uuid(uuid.into()) };
+                unsafe { bdev.set_raw_uuid(uuid.into()) };
             }
 
-            if !bdev.as_mut().add_alias(&self.alias) {
+            if !bdev.add_alias(&self.alias) {
                 error!(
                     "failed to add alias {} to device {}",
                     self.alias,
@@ -186,11 +186,11 @@ impl CreateDestroy for Null {
 
     async fn destroy(self: Box<Self>) -> Result<(), Self::Error> {
         if let Some(mut bdev) = UntypedBdev::lookup_by_name(&self.name) {
-            bdev.as_mut().remove_alias(&self.alias);
+            bdev.remove_alias(&self.alias);
             let (s, r) = oneshot::channel::<ErrnoResult<()>>();
             unsafe {
                 spdk_rs::libspdk::bdev_null_delete(
-                    bdev.as_ptr(),
+                    bdev.unsafe_inner_mut_ptr(),
                     Some(done_errno_cb),
                     cb_arg(s),
                 )

--- a/mayastor/src/bdev/nvme.rs
+++ b/mayastor/src/bdev/nvme.rs
@@ -18,7 +18,7 @@ use spdk_rs::libspdk::{
 
 use crate::{
     bdev::{CreateDestroy, GetName},
-    core::Bdev,
+    core::UntypedBdev,
     ffihelper::{cb_arg, errno_result_from_i32, ErrnoResult, IntoCString},
     nexus_uri::{self, NexusBdevError},
 };
@@ -68,7 +68,7 @@ impl CreateDestroy for NVMe {
                 .expect("done callback receiver side disappeared");
         }
 
-        if Bdev::lookup_by_name(&self.name).is_some() {
+        if UntypedBdev::lookup_by_name(&self.name).is_some() {
             return Err(NexusBdevError::BdevExists {
                 name: self.name.clone(),
             });
@@ -111,7 +111,7 @@ impl CreateDestroy for NVMe {
                 name: self.name.clone(),
             })?;
 
-        let success = Bdev::lookup_by_name(&self.get_name())
+        let success = UntypedBdev::lookup_by_name(&self.get_name())
             .map(|mut b| b.as_mut().add_alias(&self.url.to_string()))
             .expect("bdev created but not found!");
 
@@ -126,7 +126,7 @@ impl CreateDestroy for NVMe {
     }
 
     async fn destroy(self: Box<Self>) -> Result<(), Self::Error> {
-        if let Some(mut bdev) = Bdev::lookup_by_name(&self.get_name()) {
+        if let Some(mut bdev) = UntypedBdev::lookup_by_name(&self.get_name()) {
             bdev.as_mut().remove_alias(&self.url.to_string());
             let errno = unsafe {
                 bdev_nvme_delete(

--- a/mayastor/src/bdev/nvme.rs
+++ b/mayastor/src/bdev/nvme.rs
@@ -112,7 +112,7 @@ impl CreateDestroy for NVMe {
             })?;
 
         let success = UntypedBdev::lookup_by_name(&self.get_name())
-            .map(|mut b| b.as_mut().add_alias(&self.url.to_string()))
+            .map(|mut b| b.add_alias(&self.url.to_string()))
             .expect("bdev created but not found!");
 
         if !success {
@@ -127,7 +127,7 @@ impl CreateDestroy for NVMe {
 
     async fn destroy(self: Box<Self>) -> Result<(), Self::Error> {
         if let Some(mut bdev) = UntypedBdev::lookup_by_name(&self.get_name()) {
-            bdev.as_mut().remove_alias(&self.url.to_string());
+            bdev.remove_alias(&self.url.to_string());
             let errno = unsafe {
                 bdev_nvme_delete(
                     self.name.clone().into_cstring().as_ptr(),

--- a/mayastor/src/bdev/nvmf.rs
+++ b/mayastor/src/bdev/nvmf.rs
@@ -217,7 +217,7 @@ impl CreateDestroy for Nvmf {
                     error!("Connected to device {} but expect to connect to {} instead", bdev.uuid_as_string(), u.to_hyphenated().to_string());
                 }
             };
-            if !bdev.as_mut().add_alias(&self.alias) {
+            if !bdev.add_alias(&self.alias) {
                 error!(
                     "Failed to add alias {} to device {}",
                     self.alias,
@@ -236,7 +236,7 @@ impl CreateDestroy for Nvmf {
     async fn destroy(self: Box<Self>) -> Result<(), Self::Error> {
         match UntypedBdev::lookup_by_name(&self.get_name()) {
             Some(mut bdev) => {
-                bdev.as_mut().remove_alias(&self.alias);
+                bdev.remove_alias(&self.alias);
                 let cname = CString::new(self.name.clone()).unwrap();
 
                 let errno = unsafe {

--- a/mayastor/src/bdev/nvmf.rs
+++ b/mayastor/src/bdev/nvmf.rs
@@ -23,7 +23,7 @@ use spdk_rs::libspdk::{
 
 use crate::{
     bdev::{dev::reject_unknown_parameters, util::uri, CreateDestroy, GetName},
-    core::Bdev,
+    core::UntypedBdev,
     ffihelper::{cb_arg, errno_result_from_i32, ErrnoResult},
     nexus_uri::{self, NexusBdevError},
 };
@@ -140,7 +140,7 @@ impl CreateDestroy for Nvmf {
 
     /// Create an NVMF bdev
     async fn create(&self) -> Result<String, Self::Error> {
-        if Bdev::lookup_by_name(&self.get_name()).is_some() {
+        if UntypedBdev::lookup_by_name(&self.get_name()).is_some() {
             return Err(NexusBdevError::BdevExists {
                 name: self.get_name(),
             });
@@ -211,7 +211,7 @@ impl CreateDestroy for Nvmf {
                 name: self.name.clone(),
             });
         }
-        if let Some(mut bdev) = Bdev::lookup_by_name(&self.get_name()) {
+        if let Some(mut bdev) = UntypedBdev::lookup_by_name(&self.get_name()) {
             if let Some(u) = self.uuid {
                 if bdev.uuid_as_string() != u.to_hyphenated().to_string() {
                     error!("Connected to device {} but expect to connect to {} instead", bdev.uuid_as_string(), u.to_hyphenated().to_string());
@@ -234,7 +234,7 @@ impl CreateDestroy for Nvmf {
 
     /// Destroy the given NVMF bdev
     async fn destroy(self: Box<Self>) -> Result<(), Self::Error> {
-        match Bdev::lookup_by_name(&self.get_name()) {
+        match UntypedBdev::lookup_by_name(&self.get_name()) {
             Some(mut bdev) => {
                 bdev.as_mut().remove_alias(&self.alias);
                 let cname = CString::new(self.name.clone()).unwrap();

--- a/mayastor/src/bin/casperf.rs
+++ b/mayastor/src/bin/casperf.rs
@@ -6,7 +6,6 @@ use rand::Rng;
 use mayastor::{
     core::{
         mayastor_env_stop,
-        Bdev,
         Cores,
         Descriptor,
         IoChannel,
@@ -14,6 +13,7 @@ use mayastor::{
         MayastorEnvironment,
         Mthread,
         Reactors,
+        UntypedBdev,
     },
     logger,
     nexus_uri::bdev_create,
@@ -51,7 +51,7 @@ const IO_SIZE: u64 = 512;
 #[derive(Debug)]
 #[allow(dead_code)]
 struct Job {
-    bdev: Bdev,
+    bdev: UntypedBdev,
     /// descriptor to the bdev
     desc: Descriptor,
     /// io channel being used to submit IO
@@ -137,7 +137,7 @@ impl Job {
                 eprintln!("Failed to open URI {}: {}", bdev, e);
                 std::process::exit(1);
             })
-            .map(|name| Bdev::lookup_by_name(&name).unwrap())
+            .map(|name| UntypedBdev::lookup_by_name(&name).unwrap())
             .unwrap();
 
         let desc = bdev.open(true).unwrap();

--- a/mayastor/src/bin/initiator.rs
+++ b/mayastor/src/bin/initiator.rs
@@ -17,11 +17,11 @@ use mayastor::{
     bdev::{device_create, device_open},
     core::{
         mayastor_env_stop,
-        Bdev,
         CoreError,
         MayastorCliArgs,
         MayastorEnvironment,
         Reactor,
+        UntypedBdev,
     },
     jsonrpc::print_error_chain,
     logger,
@@ -81,9 +81,9 @@ impl From<io::Error> for Error {
 type Result<T, E = Error> = std::result::Result<T, E>;
 
 /// Create initiator bdev.
-async fn create_bdev(uri: &str) -> Result<Bdev> {
+async fn create_bdev(uri: &str) -> Result<UntypedBdev> {
     let bdev_name = bdev_create(uri).await?;
-    let bdev = Bdev::lookup_by_name(&bdev_name)
+    let bdev = UntypedBdev::lookup_by_name(&bdev_name)
         .expect("Failed to lookup the created bdev");
     Ok(bdev)
 }

--- a/mayastor/src/core/bdev.rs
+++ b/mayastor/src/core/bdev.rs
@@ -1,6 +1,7 @@
 use std::{
-    convert::TryFrom,
     fmt::{Debug, Display, Formatter},
+    ops::{Deref, DerefMut},
+    pin::Pin,
 };
 
 use async_trait::async_trait;
@@ -16,7 +17,6 @@ use crate::{
         BlockDeviceIoStats,
         CoreError,
         Descriptor,
-        IoType,
         ShareIscsi,
         ShareNvmf,
         UnshareIscsi,
@@ -41,24 +41,164 @@ pub struct Bdev<T: spdk_rs::BdevOps> {
 /// TODO
 pub type UntypedBdev = Bdev<()>;
 
+/// Allow transparent use of `spdk_rs` methods.
+impl<T> Deref for Bdev<T>
+where
+    T: spdk_rs::BdevOps,
+{
+    type Target = spdk_rs::Bdev<T>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+/// Allow transparent use of `spdk_rs` mutable methods.
+impl<T> DerefMut for Bdev<T>
+where
+    T: spdk_rs::BdevOps,
+{
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+
+// impl<T> Clone for Bdev<T>
+// where
+//     T: spdk_rs::BdevOps,
+// {
+//     fn clone(&self) -> Self {
+//         Self {
+//             inner: self.inner.clone(),
+//         }
+//     }
+// }
+
+impl<T: spdk_rs::BdevOps> Bdev<T> {
+    /// TODO
+    pub(crate) fn new(b: spdk_rs::Bdev<T>) -> Self {
+        Self {
+            inner: b,
+        }
+    }
+
+    /// Constructs a Bdev from a raw SPDK pointer.
+    pub(crate) unsafe fn checked_from_ptr(
+        bdev: *mut spdk_bdev,
+    ) -> Option<Self> {
+        if bdev.is_null() {
+            None
+        } else {
+            Some(Self::new(spdk_rs::Bdev::unsafe_from_inner_ptr(bdev)))
+        }
+    }
+
+    /// Opens a Bdev by its name in read_write mode.
+    pub fn open_by_name(
+        name: &str,
+        read_write: bool,
+    ) -> Result<Descriptor, CoreError> {
+        if let Some(bdev) = Self::lookup_by_name(name) {
+            bdev.open(read_write)
+        } else {
+            Err(CoreError::OpenBdev {
+                source: Errno::ENODEV,
+            })
+        }
+    }
+
+    /// Opens the current Bdev.
+    /// A Bdev can be opened multiple times resulting in a new descriptor for
+    /// each call.
+    pub fn open(&self, read_write: bool) -> Result<Descriptor, CoreError> {
+        match spdk_rs::BdevDesc::<()>::open(
+            self.name(),
+            read_write,
+            SpdkBlockDevice::bdev_event_callback,
+        ) {
+            Ok(d) => Ok(Descriptor::new(d)),
+            Err(err) => Err(CoreError::OpenBdev {
+                source: err,
+            }),
+        }
+    }
+
+    /// Looks up a Bdev by its name.
+    pub fn lookup_by_name(name: &str) -> Option<Self> {
+        spdk_rs::Bdev::<T>::lookup_by_name(name).map(Self::new)
+    }
+
+    /// Looks up a Bdev by its uuid.
+    pub fn lookup_by_uuid_str(uuid: &str) -> Option<Self> {
+        match Self::bdev_first() {
+            None => None,
+            Some(bdev) => {
+                let b: Vec<Self> = bdev
+                    .into_iter()
+                    .filter(|b| b.uuid_as_string() == uuid)
+                    .collect();
+
+                b.first().map(|b| Self {
+                    inner: b.inner.clone(),
+                })
+            }
+        }
+    }
+
+    /// Returns the name of driver module for the given Bdev.
+    pub fn driver(&self) -> &str {
+        self.inner.module_name()
+    }
+
+    /// Returns the first bdev in the list.
+    pub fn bdev_first() -> Option<Self> {
+        BdevIter::<T>::new().next()
+    }
+
+    /// TODO
+    pub async fn stats_async(&self) -> Result<BlockDeviceIoStats, CoreError> {
+        match self.inner.stats_async().await {
+            Ok(stat) => Ok(BlockDeviceIoStats {
+                num_read_ops: stat.num_read_ops,
+                num_write_ops: stat.num_write_ops,
+                bytes_read: stat.bytes_read,
+                bytes_written: stat.bytes_written,
+                num_unmap_ops: stat.num_unmap_ops,
+                bytes_unmapped: stat.bytes_unmapped,
+            }),
+            Err(err) => Err(CoreError::DeviceStatisticsError {
+                source: err,
+            }),
+        }
+    }
+}
+
 #[async_trait(? Send)]
-impl<T: spdk_rs::BdevOps> Share for Bdev<T> {
+impl<T> Share for Bdev<T>
+where
+    T: spdk_rs::BdevOps,
+{
     type Error = CoreError;
     type Output = String;
 
     /// share the bdev over iscsi
-    async fn share_iscsi(&self) -> Result<Self::Output, Self::Error> {
-        iscsi::share(self.name(), &self.as_untyped(), Side::Nexus)
-            .context(ShareIscsi {})
+    async fn share_iscsi(
+        self: Pin<&mut Self>,
+    ) -> Result<Self::Output, Self::Error> {
+        let name = self.name().to_string();
+        let me = unsafe { self.get_unchecked_mut() };
+
+        iscsi::share(&name, me, Side::Nexus).context(ShareIscsi {})
     }
 
     /// share the bdev over NVMe-OF TCP
     async fn share_nvmf(
-        &self,
+        self: Pin<&mut Self>,
         cntlid_range: Option<(u16, u16)>,
     ) -> Result<Self::Output, Self::Error> {
-        let subsystem =
-            NvmfSubsystem::try_from(self.as_untyped()).context(ShareNvmf {})?;
+        let me = unsafe { self.get_unchecked_mut() };
+
+        let subsystem = NvmfSubsystem::try_from(me).context(ShareNvmf {})?;
         if let Some((cntlid_min, cntlid_max)) = cntlid_range {
             subsystem
                 .set_cntlid_range(cntlid_min, cntlid_max)
@@ -68,7 +208,9 @@ impl<T: spdk_rs::BdevOps> Share for Bdev<T> {
     }
 
     /// unshare the bdev regardless of current active share
-    async fn unshare(&self) -> Result<Self::Output, Self::Error> {
+    async fn unshare(
+        self: Pin<&mut Self>,
+    ) -> Result<Self::Output, Self::Error> {
         match self.shared() {
             Some(Protocol::Nvmf) => {
                 if let Some(subsystem) = NvmfSubsystem::nqn_lookup(self.name())
@@ -108,7 +250,7 @@ impl<T: spdk_rs::BdevOps> Share for Bdev<T> {
 
     /// return the URI that was used to construct the bdev
     fn bdev_uri(&self) -> Option<String> {
-        for alias in self.as_ref().aliases().iter() {
+        for alias in self.aliases().iter() {
             if let Ok(mut uri) = url::Url::parse(alias) {
                 if bdev_uri_eq(self, &uri) {
                     if !uri.query_pairs().any(|e| e.0 == "uuid") {
@@ -124,7 +266,7 @@ impl<T: spdk_rs::BdevOps> Share for Bdev<T> {
 
     /// return the URI that was used to construct the bdev, without uuid
     fn bdev_uri_original(&self) -> Option<String> {
-        for alias in self.as_ref().aliases().iter() {
+        for alias in self.aliases().iter() {
             if let Ok(uri) = url::Url::parse(alias) {
                 if bdev_uri_eq(self, &uri) {
                     return Some(uri.to_string());
@@ -135,235 +277,19 @@ impl<T: spdk_rs::BdevOps> Share for Bdev<T> {
     }
 }
 
-impl<T: spdk_rs::BdevOps> Bdev<T> {
-    /// TODO
-    pub(crate) fn new(b: spdk_rs::Bdev<T>) -> Self {
-        Self {
-            inner: b,
-        }
-    }
-
-    /// construct bdev from raw pointer
-    pub(crate) fn from_ptr(bdev: *mut spdk_bdev) -> Option<Bdev<T>> {
-        if bdev.is_null() {
-            None
-        } else {
-            Some(Self::new(spdk_rs::Bdev::legacy_from_ptr(bdev)))
-        }
-    }
-
-    /// returns the bdev as a ptr
-    /// dont use please
-    pub fn as_ptr(&self) -> *mut spdk_bdev {
-        self.inner.legacy_as_ptr().as_ptr()
-    }
-
-    /// TODO
-    fn as_untyped(&self) -> UntypedBdev {
-        UntypedBdev::from_ptr(self.as_ptr()).unwrap()
-    }
-
-    /// TODO
-    #[allow(dead_code)]
-    pub(crate) fn as_ref(&self) -> &spdk_rs::Bdev<T> {
-        &self.inner
-    }
-
-    /// TODO
-    #[allow(dead_code)]
-    pub(crate) fn as_mut(&mut self) -> &mut spdk_rs::Bdev<T> {
-        &mut self.inner
-    }
-
-    /// open a bdev by its name in read_write mode.
-    pub fn open_by_name(
-        name: &str,
-        read_write: bool,
-    ) -> Result<Descriptor, CoreError> {
-        if let Some(bdev) = Self::lookup_by_name(name) {
-            bdev.open(read_write)
-        } else {
-            Err(CoreError::OpenBdev {
-                source: Errno::ENODEV,
-            })
-        }
-    }
-
-    /// Opens the current Bdev.
-    /// A Bdev can be opened multiple times resulting in a new descriptor for
-    /// each call.
-    pub fn open(&self, read_write: bool) -> Result<Descriptor, CoreError> {
-        match spdk_rs::BdevDesc::<()>::open(
-            self.name(),
-            read_write,
-            SpdkBlockDevice::bdev_event_callback,
-        ) {
-            Ok(d) => Ok(Descriptor::new(d)),
-            Err(err) => Err(CoreError::OpenBdev {
-                source: err,
-            }),
-        }
-    }
-
-    /// returns true if this bdev is claimed by some other component
-    pub fn is_claimed(&self) -> bool {
-        self.inner.is_claimed()
-    }
-
-    /// returns by who the bdev is claimed
-    pub fn claimed_by(&self) -> Option<String> {
-        self.inner.claimed_by().map(|m| m.name().to_string())
-    }
-
-    /// lookup a bdev by its name
-    pub fn lookup_by_name(name: &str) -> Option<Bdev<T>> {
-        spdk_rs::Bdev::<T>::lookup_by_name(name).map(Self::new)
-    }
-
-    /// lookup a bdev by its uuid
-    pub fn lookup_by_uuid(uuid: &str) -> Option<Bdev<T>> {
-        match Self::bdev_first() {
-            None => None,
-            Some(bdev) => {
-                let b: Vec<Bdev<T>> = bdev
-                    .into_iter()
-                    .filter(|b| b.uuid_as_string() == uuid)
-                    .collect();
-                b.first().cloned()
-            }
-        }
-    }
-
-    /// returns the block_size of the underlying device
-    pub fn block_len(&self) -> u32 {
-        self.inner.block_len()
-    }
-
-    /// number of blocks for this device
-    pub fn num_blocks(&self) -> u64 {
-        self.inner.num_blocks()
-    }
-
-    /// return the bdev size in bytes
-    pub fn size_in_bytes(&self) -> u64 {
-        self.inner.size_in_bytes()
-    }
-
-    /// returns the alignment of the bdev
-    pub fn alignment(&self) -> u64 {
-        self.inner.alignment()
-    }
-
-    /// returns the required alignment of the bdev
-    pub fn required_alignment(&self) -> u8 {
-        self.inner.required_alignment()
-    }
-
-    /// returns the configured product name
-    pub fn product_name(&self) -> &str {
-        self.inner.product_name()
-    }
-
-    /// returns the name of driver module for the given bdev
-    pub fn driver(&self) -> &str {
-        self.inner.module_name()
-    }
-
-    /// returns the bdev name
-    pub fn name(&self) -> &str {
-        self.inner.name()
-    }
-
-    /// return the UUID of this bdev
-    pub fn uuid(&self) -> uuid::Uuid {
-        self.inner.uuid().into()
-    }
-
-    /// return the UUID of this bdev as a hyphenated string
-    pub fn uuid_as_string(&self) -> String {
-        self.uuid().to_hyphenated().to_string()
-    }
-
-    /// returns whenever the bdev supports the requested IO type
-    pub fn io_type_supported(&self, io_type: IoType) -> bool {
-        self.inner.io_type_supported(io_type)
-    }
-
-    /// returns the first bdev in the list
-    pub fn bdev_first() -> Option<Bdev<T>> {
-        BdevIter::<T>::new().next()
-    }
-
-    /// TODO
-    pub async fn stats_async(&self) -> Result<BlockDeviceIoStats, CoreError> {
-        match self.inner.stats_async().await {
-            Ok(stat) => Ok(BlockDeviceIoStats {
-                num_read_ops: stat.num_read_ops,
-                num_write_ops: stat.num_write_ops,
-                bytes_read: stat.bytes_read,
-                bytes_written: stat.bytes_written,
-                num_unmap_ops: stat.num_unmap_ops,
-                bytes_unmapped: stat.bytes_unmapped,
-            }),
-            Err(err) => Err(CoreError::DeviceStatisticsError {
-                source: err,
-            }),
-        }
-    }
-}
-
-impl<T: spdk_rs::BdevOps> Clone for Bdev<T> {
-    fn clone(&self) -> Self {
-        Self {
-            inner: self.inner.clone(),
-        }
-    }
-}
-
-pub struct BdevIter<T: spdk_rs::BdevOps>(spdk_rs::BdevGlobalIter<T>);
-
-impl<T: spdk_rs::BdevOps> IntoIterator for Bdev<T> {
-    type Item = Bdev<T>;
-    type IntoIter = BdevIter<T>;
-    fn into_iter(self) -> Self::IntoIter {
-        BdevIter::new()
-    }
-}
-
-/// iterator over the bdevs in the global bdev list
-impl<T: spdk_rs::BdevOps> Iterator for BdevIter<T> {
-    type Item = Bdev<T>;
-    fn next(&mut self) -> Option<Bdev<T>> {
-        self.0.next().map(Self::Item::new)
-    }
-}
-
-impl<T: spdk_rs::BdevOps> Default for BdevIter<T> {
-    fn default() -> Self {
-        BdevIter(spdk_rs::Bdev::iter_all())
-    }
-}
-
-impl<T: spdk_rs::BdevOps> BdevIter<T> {
-    pub fn new() -> Self {
-        Default::default()
-    }
-}
-
-impl From<*mut spdk_bdev> for UntypedBdev {
-    fn from(bdev: *mut spdk_bdev) -> Self {
-        Self::from_ptr(bdev)
-            .expect("nullptr dereference while accessing a bdev")
-    }
-}
-
-impl<T: spdk_rs::BdevOps> Display for Bdev<T> {
+impl<T> Display for Bdev<T>
+where
+    T: spdk_rs::BdevOps,
+{
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
         write!(f, "name: {}, driver: {}", self.name(), self.driver(),)
     }
 }
 
-impl<T: spdk_rs::BdevOps> Debug for Bdev<T> {
+impl<T> Debug for Bdev<T>
+where
+    T: spdk_rs::BdevOps,
+{
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
         write!(
             f,
@@ -375,5 +301,48 @@ impl<T: spdk_rs::BdevOps> Debug for Bdev<T> {
             self.block_len(),
             self.alignment(),
         )
+    }
+}
+
+/// TODO
+pub struct BdevIter<T: spdk_rs::BdevOps>(spdk_rs::BdevGlobalIter<T>);
+
+impl<T> IntoIterator for Bdev<T>
+where
+    T: spdk_rs::BdevOps,
+{
+    type Item = Bdev<T>;
+    type IntoIter = BdevIter<T>;
+    fn into_iter(self) -> Self::IntoIter {
+        BdevIter::new()
+    }
+}
+
+/// iterator over the bdevs in the global bdev list
+impl<T> Iterator for BdevIter<T>
+where
+    T: spdk_rs::BdevOps,
+{
+    type Item = Bdev<T>;
+    fn next(&mut self) -> Option<Bdev<T>> {
+        self.0.next().map(Self::Item::new)
+    }
+}
+
+impl<T> Default for BdevIter<T>
+where
+    T: spdk_rs::BdevOps,
+{
+    fn default() -> Self {
+        BdevIter(spdk_rs::Bdev::iter_all())
+    }
+}
+
+impl<T> BdevIter<T>
+where
+    T: spdk_rs::BdevOps,
+{
+    pub fn new() -> Self {
+        Default::default()
     }
 }

--- a/mayastor/src/core/descriptor.rs
+++ b/mayastor/src/core/descriptor.rs
@@ -18,7 +18,14 @@ use spdk_rs::{
 
 use crate::{
     bdev::nexus::NEXUS_MODULE_NAME,
-    core::{channel::IoChannel, Bdev, BdevHandle, CoreError, Mthread},
+    core::{
+        channel::IoChannel,
+        Bdev,
+        BdevHandle,
+        CoreError,
+        Mthread,
+        UntypedBdev,
+    },
 };
 
 /// NewType around a descriptor, multiple descriptor to the same bdev is
@@ -89,7 +96,7 @@ impl Descriptor {
 
     /// Return the bdev associated with this descriptor, a descriptor cannot
     /// exist without a bdev
-    pub fn get_bdev(&self) -> Bdev {
+    pub fn get_bdev(&self) -> UntypedBdev {
         Bdev::new(self.0.bdev())
     }
 

--- a/mayastor/src/core/handle.rs
+++ b/mayastor/src/core/handle.rs
@@ -27,7 +27,7 @@ use spdk_rs::{
 };
 
 use crate::{
-    core::{Bdev, CoreError, Descriptor, IoChannel},
+    core::{Bdev, CoreError, Descriptor, IoChannel, UntypedBdev},
     ffihelper::cb_arg,
     subsys,
 };
@@ -50,7 +50,7 @@ impl BdevHandle {
         read_write: bool,
         claim: bool,
     ) -> Result<BdevHandle, CoreError> {
-        if let Ok(desc) = Bdev::open_by_name(name, read_write) {
+        if let Ok(desc) = UntypedBdev::open_by_name(name, read_write) {
             if claim && !desc.claim() {
                 return Err(CoreError::BdevNotFound {
                     name: name.into(),
@@ -65,8 +65,8 @@ impl BdevHandle {
     }
 
     /// open a new bdev handle given a bdev
-    pub fn open_with_bdev(
-        bdev: &Bdev,
+    pub fn open_with_bdev<T: spdk_rs::BdevOps>(
+        bdev: &Bdev<T>,
         read_write: bool,
     ) -> Result<BdevHandle, CoreError> {
         let desc = bdev.open(read_write)?;
@@ -79,7 +79,7 @@ impl BdevHandle {
     }
 
     /// get the bdev associated with this handle
-    pub fn get_bdev(&self) -> Bdev {
+    pub fn get_bdev(&self) -> UntypedBdev {
         self.desc.get_bdev()
     }
 

--- a/mayastor/src/core/io_driver.rs
+++ b/mayastor/src/core/io_driver.rs
@@ -12,7 +12,7 @@ use spdk_rs::libspdk::{
 };
 
 use crate::{
-    core::{Bdev, Cores, Descriptor, IoChannel, Mthread},
+    core::{Cores, Descriptor, IoChannel, Mthread, UntypedBdev},
     ffihelper::pair,
     nexus_uri::bdev_create,
 };
@@ -146,7 +146,7 @@ impl Io {
 #[allow(dead_code)]
 pub struct Job {
     /// that drives IO to a bdev using its own channel.
-    bdev: Bdev,
+    bdev: UntypedBdev,
     /// descriptor to the bdev
     desc: Descriptor,
     /// io channel used to submit IO
@@ -262,7 +262,7 @@ pub struct Builder {
     /// type of workload to generate
     iot: IoType,
     /// existing bdev to use instead of creating one
-    bdev: Option<Bdev>,
+    bdev: Option<UntypedBdev>,
     /// core to start the job on, the command will crash if the core is invalid
     core: u32,
 }
@@ -297,7 +297,7 @@ impl Builder {
     }
 
     /// use the given bdev instead of the URI to create the job
-    pub fn bdev(mut self, bdev: Bdev) -> Self {
+    pub fn bdev(mut self, bdev: UntypedBdev) -> Self {
         self.bdev = Some(bdev);
         self
     }
@@ -312,7 +312,7 @@ impl Builder {
             self.bdev.take().unwrap()
         } else {
             let name = bdev_create(&self.uri).await.unwrap();
-            Bdev::lookup_by_name(&name).unwrap()
+            UntypedBdev::lookup_by_name(&name).unwrap()
         };
 
         let desc = bdev.open(true).unwrap();

--- a/mayastor/src/core/mod.rs
+++ b/mayastor/src/core/mod.rs
@@ -5,7 +5,7 @@ use std::{fmt::Debug, sync::atomic::AtomicUsize, time::Duration};
 use nix::errno::Errno;
 use snafu::Snafu;
 
-pub use bdev::{Bdev, BdevIter};
+pub use bdev::{Bdev, BdevIter, UntypedBdev};
 pub use block_device::{
     BlockDevice,
     BlockDeviceDescriptor,

--- a/mayastor/src/core/share.rs
+++ b/mayastor/src/core/share.rs
@@ -1,7 +1,7 @@
 use crate::lvs::Error;
 use async_trait::async_trait;
 use pin_utils::core_reexport::fmt::Formatter;
-use std::{convert::TryFrom, fmt::Display};
+use std::{convert::TryFrom, fmt::Display, pin::Pin};
 
 #[derive(Debug, PartialOrd, PartialEq)]
 /// Indicates what protocol the bdev is shared as
@@ -46,14 +46,31 @@ impl Display for Protocol {
 pub trait Share: std::fmt::Debug {
     type Error;
     type Output: std::fmt::Display + std::fmt::Debug;
-    async fn share_iscsi(&self) -> Result<Self::Output, Self::Error>;
+
+    /// TODO
+    async fn share_iscsi(
+        self: Pin<&mut Self>,
+    ) -> Result<Self::Output, Self::Error>;
+
+    /// TODO
     async fn share_nvmf(
-        &self,
+        self: Pin<&mut Self>,
         cntlid_range: Option<(u16, u16)>,
     ) -> Result<Self::Output, Self::Error>;
-    async fn unshare(&self) -> Result<Self::Output, Self::Error>;
+
+    /// TODO
+    async fn unshare(self: Pin<&mut Self>)
+        -> Result<Self::Output, Self::Error>;
+
+    /// TODO
     fn shared(&self) -> Option<Protocol>;
+
+    /// TODO
     fn share_uri(&self) -> Option<String>;
+
+    /// TODO
     fn bdev_uri(&self) -> Option<String>;
+
+    /// TODO
     fn bdev_uri_original(&self) -> Option<String>;
 }

--- a/mayastor/src/grpc/v1/bdev.rs
+++ b/mayastor/src/grpc/v1/bdev.rs
@@ -20,8 +20,11 @@ use std::convert::TryFrom;
 use tonic::{Request, Response, Status};
 use url::Url;
 
-impl From<core::Bdev> for Bdev {
-    fn from(b: crate::core::Bdev) -> Self {
+impl<T> From<core::Bdev<T>> for Bdev
+where
+    T: spdk_rs::BdevOps,
+{
+    fn from(b: core::Bdev<T>) -> Self {
         Self {
             name: b.name().to_string(),
             uuid: b.uuid_as_string(),

--- a/mayastor/src/grpc/v1/replica.rs
+++ b/mayastor/src/grpc/v1/replica.rs
@@ -1,5 +1,5 @@
 use crate::{
-    core::{Bdev, CoreError, Protocol, Share},
+    core::{Bdev, CoreError, Protocol, Share, UntypedBdev},
     grpc::{rpc_submit, GrpcClientContext, GrpcResult, Serializer},
     lvs::{Error as LvsError, Lvol, Lvs},
     nexus_uri::NexusBdevError,
@@ -199,7 +199,7 @@ impl ReplicaRpc for ReplicaService {
             info!("{:?}", args);
             let rx = rpc_submit::<_, _, LvsError>(async move {
                 let mut lvols = Vec::new();
-                if let Some(bdev) = Bdev::bdev_first() {
+                if let Some(bdev) = UntypedBdev::bdev_first() {
                     lvols = bdev
                         .into_iter()
                         .filter(|b| b.driver() == "lvol")

--- a/mayastor/src/lvs/lvol.rs
+++ b/mayastor/src/lvs/lvol.rs
@@ -30,7 +30,7 @@ use spdk_rs::libspdk::{
 
 use crate::{
     bdev::nexus::Nexus,
-    core::{Bdev, CoreError, Mthread, Protocol, Share},
+    core::{Bdev, CoreError, Mthread, Protocol, Share, UntypedBdev},
     ffihelper::{
         cb_arg,
         errno_result_from_i32,
@@ -78,10 +78,10 @@ impl Display for PropName {
 /// struct representing an lvol
 pub struct Lvol(pub(crate) NonNull<spdk_lvol>);
 
-impl TryFrom<Bdev> for Lvol {
+impl TryFrom<UntypedBdev> for Lvol {
     type Error = Error;
 
-    fn try_from(b: Bdev) -> Result<Self, Self::Error> {
+    fn try_from(b: UntypedBdev) -> Result<Self, Self::Error> {
         if b.driver() == "lvol" {
             unsafe {
                 Ok(Lvol(NonNull::new_unchecked(vbdev_lvol_get_from_bdev(
@@ -97,7 +97,7 @@ impl TryFrom<Bdev> for Lvol {
     }
 }
 
-impl From<Lvol> for Bdev {
+impl From<Lvol> for UntypedBdev {
     fn from(l: Lvol) -> Self {
         Bdev::from(unsafe { l.0.as_ref().bdev })
     }
@@ -202,7 +202,7 @@ impl Lvol {
     }
 
     /// returns the underlying bdev of the lvol
-    pub(crate) fn as_bdev(&self) -> Bdev {
+    pub(crate) fn as_bdev(&self) -> UntypedBdev {
         Bdev::from(unsafe { self.0.as_ref().bdev })
     }
     /// return the size of the lvol in bytes

--- a/mayastor/src/nexus_uri.rs
+++ b/mayastor/src/nexus_uri.rs
@@ -120,47 +120,55 @@ pub async fn bdev_destroy(uri: &str) -> Result<(), NexusBdevError> {
     uri::parse(uri)?.destroy().await
 }
 
+/// TODO
 pub fn bdev_get_name(uri: &str) -> Result<String, NexusBdevError> {
     Ok(uri::parse(uri)?.get_name())
 }
 
-impl std::cmp::PartialEq<url::Url> for &Bdev {
-    fn eq(&self, uri: &url::Url) -> bool {
-        match uri::parse(&uri.to_string()) {
-            Ok(device) if device.get_name() == self.name() => {
-                self.driver()
-                    == match uri.scheme() {
-                        "nvmf" | "pcie" => "nvme",
-                        scheme => scheme,
-                    }
-            }
-            _ => false,
+/// TODO
+pub fn bdev_uri_eq<T>(bdev: &Bdev<T>, uri: &url::Url) -> bool
+where
+    T: spdk_rs::BdevOps,
+{
+    match uri::parse(&uri.to_string()) {
+        Ok(device) if device.get_name() == bdev.name() => {
+            bdev.driver()
+                == match uri.scheme() {
+                    "nvmf" | "pcie" => "nvme",
+                    scheme => scheme,
+                }
         }
+        _ => false,
     }
 }
 
-impl std::cmp::PartialEq<url::Url> for Bdev {
-    fn eq(&self, uri: &url::Url) -> bool {
-        match uri::parse(&uri.to_string()) {
-            Ok(device) if device.get_name() == self.name() => {
-                self.driver()
-                    == match uri.scheme() {
-                        "nvmf" | "pcie" => "nvme",
-                        scheme => scheme,
-                    }
-            }
-            _ => false,
+/// TODO
+pub fn bdev_url_eq<T>(bdev: &Bdev<T>, uri: &url::Url) -> bool
+where
+    T: spdk_rs::BdevOps,
+{
+    match uri::parse(&uri.to_string()) {
+        Ok(device) if device.get_name() == bdev.name() => {
+            bdev.driver()
+                == match uri.scheme() {
+                    "nvmf" | "pcie" => "nvme",
+                    scheme => scheme,
+                }
         }
+        _ => false,
     }
 }
 
-impl TryFrom<Bdev> for url::Url {
+impl<T> TryFrom<Bdev<T>> for url::Url
+where
+    T: spdk_rs::BdevOps,
+{
     type Error = NexusBdevError;
 
-    fn try_from(bdev: Bdev) -> Result<Self, Self::Error> {
+    fn try_from(bdev: Bdev<T>) -> Result<Self, Self::Error> {
         for alias in bdev.as_ref().aliases().iter() {
             if let Ok(mut uri) = url::Url::parse(alias) {
-                if bdev == uri {
+                if bdev_uri_eq(&bdev, &uri) {
                     if !uri.query_pairs().any(|e| e.0 == "uuid") {
                         uri.query_pairs_mut()
                             .append_pair("uuid", &bdev.uuid_as_string());

--- a/mayastor/src/nexus_uri.rs
+++ b/mayastor/src/nexus_uri.rs
@@ -166,7 +166,7 @@ where
     type Error = NexusBdevError;
 
     fn try_from(bdev: Bdev<T>) -> Result<Self, Self::Error> {
-        for alias in bdev.as_ref().aliases().iter() {
+        for alias in bdev.aliases().iter() {
             if let Ok(mut uri) = url::Url::parse(alias) {
                 if bdev_uri_eq(&bdev, &uri) {
                     if !uri.query_pairs().any(|e| e.0 == "uuid") {
@@ -180,7 +180,7 @@ where
 
         Err(NexusBdevError::BdevNoUri {
             name: bdev.name().to_string(),
-            aliases: bdev.as_ref().aliases(),
+            aliases: bdev.aliases(),
         })
     }
 }

--- a/mayastor/src/pool.rs
+++ b/mayastor/src/pool.rs
@@ -21,7 +21,7 @@ use spdk_rs::libspdk::{
     vbdev_lvol_store_next,
 };
 
-use crate::core::Bdev;
+use crate::core::UntypedBdev;
 
 /// Structure representing a pool which comprises lvol store and
 /// underlying bdev.
@@ -53,7 +53,7 @@ impl Pool {
     }
 
     /// Get base bdev for the pool (in our case AIO or uring bdev).
-    pub fn get_base_bdev(&self) -> Bdev {
+    pub fn get_base_bdev(&self) -> UntypedBdev {
         let base_bdev_ptr = unsafe { (*self.lvs_bdev_ptr).bdev };
         base_bdev_ptr.into()
     }

--- a/mayastor/src/pool.rs
+++ b/mayastor/src/pool.rs
@@ -21,7 +21,7 @@ use spdk_rs::libspdk::{
     vbdev_lvol_store_next,
 };
 
-use crate::core::UntypedBdev;
+use crate::core::{Bdev, UntypedBdev};
 
 /// Structure representing a pool which comprises lvol store and
 /// underlying bdev.
@@ -54,8 +54,7 @@ impl Pool {
 
     /// Get base bdev for the pool (in our case AIO or uring bdev).
     pub fn get_base_bdev(&self) -> UntypedBdev {
-        let base_bdev_ptr = unsafe { (*self.lvs_bdev_ptr).bdev };
-        base_bdev_ptr.into()
+        unsafe { Bdev::checked_from_ptr((*self.lvs_bdev_ptr).bdev).unwrap() }
     }
 
     /// Get capacity of the pool in bytes.

--- a/mayastor/src/rebuild/rebuild_impl.rs
+++ b/mayastor/src/rebuild/rebuild_impl.rs
@@ -18,12 +18,12 @@ use spdk_rs::{
 use crate::{
     bdev::{device_open, nexus::VerboseError},
     core::{
-        Bdev,
         BlockDevice,
         BlockDeviceDescriptor,
         BlockDeviceHandle,
         RangeContext,
         Reactors,
+        UntypedBdev,
     },
     nexus_uri::bdev_get_name,
 };
@@ -184,8 +184,8 @@ impl RebuildJob {
             nexus.to_string(),
         );
 
-        let nexus_descriptor =
-            Bdev::open_by_name(&nexus, false).context(BdevNotFound {
+        let nexus_descriptor = UntypedBdev::open_by_name(&nexus, false)
+            .context(BdevNotFound {
                 bdev: nexus.to_string(),
             })?;
 

--- a/mayastor/src/subsys/nvmf/admin_cmd.rs
+++ b/mayastor/src/subsys/nvmf/admin_cmd.rs
@@ -116,7 +116,7 @@ extern "C" fn nvmf_create_snapshot_hdlr(req: *mut spdk_nvmf_request) -> i32 {
         return -1;
     }
 
-    let bd = Bdev::from(bdev);
+    let bd = unsafe { Bdev::checked_from_ptr(bdev).unwrap() };
     if bd.driver() == nexus::NEXUS_MODULE_NAME {
         // Received command on a published Nexus
         set_snapshot_time(unsafe { &mut *spdk_nvmf_request_get_cmd(req) });

--- a/mayastor/src/target/iscsi.rs
+++ b/mayastor/src/target/iscsi.rs
@@ -9,6 +9,7 @@ use std::{
     cell::RefCell,
     ffi::CString,
     os::raw::{c_char, c_int},
+    pin::Pin,
     ptr,
 };
 
@@ -39,7 +40,7 @@ use spdk_rs::libspdk::{
 };
 
 use crate::{
-    core::{Protocol, Reactor, Share, UntypedBdev},
+    core::{Bdev, Protocol, Reactor, Share, UntypedBdev},
     ffihelper::{cb_arg, done_errno_cb, ErrnoResult},
     subsys::Config,
     target::Side,
@@ -172,9 +173,9 @@ pub fn fini() {
 
     Reactor::block_on(async {
         if let Some(bdevs) = UntypedBdev::bdev_first() {
-            for b in bdevs {
+            for mut b in bdevs {
                 if let Some(Protocol::Iscsi) = b.shared() {
-                    if let Err(e) = b.unshare().await {
+                    if let Err(e) = Pin::new(&mut b).unshare().await {
                         error!(
                             "{} shared but failed to unshare {}",
                             b.name(),
@@ -187,12 +188,15 @@ pub fn fini() {
     });
 }
 
-fn share_as_iscsi_target(
+fn share_as_iscsi_target<T>(
     bdev_name: &str,
-    bdev: &UntypedBdev,
+    bdev: &mut Bdev<T>,
     mut pg_idx: c_int,
     mut ig_idx: c_int,
-) -> Result<String, Error> {
+) -> Result<String, Error>
+where
+    T: spdk_rs::BdevOps,
+{
     let iqn = target_name(bdev_name).into_cstring();
 
     let tgt = unsafe {
@@ -223,7 +227,7 @@ fn share_as_iscsi_target(
     } else {
         let _ = unsafe {
             spdk_bdev_module_claim_bdev(
-                bdev.as_ptr(),
+                bdev.unsafe_inner_mut_ptr(),
                 std::ptr::null_mut(),
                 ISCSI_BDEV_MOD.as_mut_ptr(),
             )
@@ -234,11 +238,14 @@ fn share_as_iscsi_target(
 
 /// Export given bdev over iscsi. That involves creating iscsi target and
 /// adding the bdev as LUN to it.
-pub fn share(
+pub fn share<T>(
     bdev_name: &str,
-    bdev: &UntypedBdev,
+    bdev: &mut Bdev<T>,
     side: Side,
-) -> Result<String> {
+) -> Result<String>
+where
+    T: spdk_rs::BdevOps,
+{
     if bdev.is_claimed() {
         return Err(Error::CreateTarget {
             msg: "already shared".to_string(),
@@ -280,10 +287,10 @@ pub async fn unshare(bdev_name: &str) -> Result<()> {
         .await
         .expect("Cancellation is not supported")
         .context(DestroyTarget {})?;
-    let bdev = UntypedBdev::lookup_by_name(bdev_name)
+    let mut bdev = UntypedBdev::lookup_by_name(bdev_name)
         .expect("unshared a non-existing bdev?!");
     unsafe {
-        spdk_bdev_module_release_bdev(bdev.as_ptr());
+        spdk_bdev_module_release_bdev(bdev.unsafe_inner_mut_ptr());
     };
     info!("Destroyed iscsi target {}", bdev_name);
     Ok(())

--- a/mayastor/src/target/nvmf.rs
+++ b/mayastor/src/target/nvmf.rs
@@ -1,20 +1,21 @@
 //! Methods for creating nvmf targets
 
-use std::convert::TryFrom;
-
 use crate::{
-    core::UntypedBdev,
+    core::Bdev,
     subsys::{NvmfError, NvmfSubsystem},
 };
 
 /// Export given bdev over nvmf target.
-pub async fn share(uuid: &str, bdev: &UntypedBdev) -> Result<(), NvmfError> {
+pub async fn share<T>(uuid: &str, bdev: &Bdev<T>) -> Result<(), NvmfError>
+where
+    T: spdk_rs::BdevOps,
+{
     if let Some(ss) = NvmfSubsystem::nqn_lookup(uuid) {
         assert_eq!(bdev.name(), ss.bdev().unwrap().name());
         return Ok(());
     };
 
-    let ss = NvmfSubsystem::try_from(bdev.clone())?;
+    let ss = NvmfSubsystem::try_from(bdev)?;
     ss.start().await?;
 
     Ok(())

--- a/mayastor/src/target/nvmf.rs
+++ b/mayastor/src/target/nvmf.rs
@@ -3,12 +3,12 @@
 use std::convert::TryFrom;
 
 use crate::{
-    core::Bdev,
+    core::UntypedBdev,
     subsys::{NvmfError, NvmfSubsystem},
 };
 
 /// Export given bdev over nvmf target.
-pub async fn share(uuid: &str, bdev: &Bdev) -> Result<(), NvmfError> {
+pub async fn share(uuid: &str, bdev: &UntypedBdev) -> Result<(), NvmfError> {
     if let Some(ss) = NvmfSubsystem::nqn_lookup(uuid) {
         assert_eq!(bdev.name(), ss.bdev().unwrap().name());
         return Ok(());

--- a/mayastor/tests/child_size.rs
+++ b/mayastor/tests/child_size.rs
@@ -5,7 +5,7 @@ use once_cell::sync::OnceCell;
 use common::MayastorTest;
 use mayastor::{
     bdev::nexus::{nexus_create, nexus_lookup_mut},
-    core::{Bdev, MayastorCliArgs},
+    core::{MayastorCliArgs, UntypedBdev},
 };
 
 pub mod common;
@@ -35,22 +35,22 @@ fn mayastor() -> &'static MayastorTest<'static> {
 async fn child_size_ok() {
     mayastor()
         .spawn(async {
-            assert_eq!(Bdev::bdev_first().into_iter().count(), 0);
+            assert_eq!(UntypedBdev::bdev_first().into_iter().count(), 0);
             assert!(create_nexus(16, vec![32, 24, 16]).await);
 
-            let bdev = Bdev::lookup_by_name("core_nexus").unwrap();
+            let bdev = UntypedBdev::lookup_by_name("core_nexus").unwrap();
             assert_eq!(bdev.name(), "core_nexus");
 
-            let bdev =
-                Bdev::lookup_by_name("m0").expect("child bdev m0 not found");
+            let bdev = UntypedBdev::lookup_by_name("m0")
+                .expect("child bdev m0 not found");
             assert_eq!(bdev.name(), "m0");
 
-            let bdev =
-                Bdev::lookup_by_name("m1").expect("child bdev m1 not found");
+            let bdev = UntypedBdev::lookup_by_name("m1")
+                .expect("child bdev m1 not found");
             assert_eq!(bdev.name(), "m1");
 
-            let bdev =
-                Bdev::lookup_by_name("m2").expect("child bdev m2 not found");
+            let bdev = UntypedBdev::lookup_by_name("m2")
+                .expect("child bdev m2 not found");
             assert_eq!(bdev.name(), "m2");
 
             let nexus =
@@ -58,10 +58,10 @@ async fn child_size_ok() {
             nexus.destroy().await.unwrap();
 
             assert!(nexus_lookup_mut("core_nexus").is_none());
-            assert!(Bdev::lookup_by_name("core_nexus").is_none());
-            assert!(Bdev::lookup_by_name("m0").is_none());
-            assert!(Bdev::lookup_by_name("m1").is_none());
-            assert_eq!(Bdev::bdev_first().into_iter().count(), 0);
+            assert!(UntypedBdev::lookup_by_name("core_nexus").is_none());
+            assert!(UntypedBdev::lookup_by_name("m0").is_none());
+            assert!(UntypedBdev::lookup_by_name("m1").is_none());
+            assert_eq!(UntypedBdev::bdev_first().into_iter().count(), 0);
         })
         .await;
 }
@@ -70,15 +70,15 @@ async fn child_size_ok() {
 async fn child_too_small() {
     mayastor()
         .spawn(async {
-            assert_eq!(Bdev::bdev_first().into_iter().count(), 0);
+            assert_eq!(UntypedBdev::bdev_first().into_iter().count(), 0);
             assert!(!create_nexus(16, vec![16, 16, 8]).await);
 
             assert!(nexus_lookup_mut("core_nexus").is_none());
-            assert!(Bdev::lookup_by_name("core_nexus").is_none());
-            assert!(Bdev::lookup_by_name("m0").is_none());
-            assert!(Bdev::lookup_by_name("m1").is_none());
-            assert!(Bdev::lookup_by_name("m2").is_none());
-            assert_eq!(Bdev::bdev_first().into_iter().count(), 0);
+            assert!(UntypedBdev::lookup_by_name("core_nexus").is_none());
+            assert!(UntypedBdev::lookup_by_name("m0").is_none());
+            assert!(UntypedBdev::lookup_by_name("m1").is_none());
+            assert!(UntypedBdev::lookup_by_name("m2").is_none());
+            assert_eq!(UntypedBdev::bdev_first().into_iter().count(), 0);
         })
         .await;
 }
@@ -87,15 +87,15 @@ async fn child_too_small() {
 async fn too_small_for_metadata() {
     mayastor()
         .spawn(async {
-            assert_eq!(Bdev::bdev_first().into_iter().count(), 0);
+            assert_eq!(UntypedBdev::bdev_first().into_iter().count(), 0);
             assert!(!create_nexus(4, vec![16, 8, 4]).await);
 
             assert!(nexus_lookup_mut("core_nexus").is_none());
-            assert!(Bdev::lookup_by_name("core_nexus").is_none());
-            assert!(Bdev::lookup_by_name("m0").is_none());
-            assert!(Bdev::lookup_by_name("m1").is_none());
-            assert!(Bdev::lookup_by_name("m2").is_none());
-            assert_eq!(Bdev::bdev_first().into_iter().count(), 0);
+            assert!(UntypedBdev::lookup_by_name("core_nexus").is_none());
+            assert!(UntypedBdev::lookup_by_name("m0").is_none());
+            assert!(UntypedBdev::lookup_by_name("m1").is_none());
+            assert!(UntypedBdev::lookup_by_name("m2").is_none());
+            assert_eq!(UntypedBdev::bdev_first().into_iter().count(), 0);
         })
         .await;
 }

--- a/mayastor/tests/core.rs
+++ b/mayastor/tests/core.rs
@@ -9,7 +9,7 @@ use mayastor::{
         nexus::{nexus_create, nexus_lookup_mut},
         util::uring,
     },
-    core::{Bdev, BdevHandle, MayastorCliArgs, Protocol},
+    core::{Bdev, BdevHandle, MayastorCliArgs, Protocol, UntypedBdev},
     nexus_uri::{bdev_create, bdev_destroy},
 };
 
@@ -71,12 +71,12 @@ async fn core() {
 }
 
 async fn works() {
-    assert!(Bdev::lookup_by_name("core_nexus").is_none());
+    assert!(UntypedBdev::lookup_by_name("core_nexus").is_none());
     create_nexus().await;
-    let b = Bdev::lookup_by_name("core_nexus").unwrap();
+    let b = UntypedBdev::lookup_by_name("core_nexus").unwrap();
     assert_eq!(b.name(), "core_nexus");
 
-    let desc = Bdev::open_by_name("core_nexus", false).unwrap();
+    let desc = UntypedBdev::open_by_name("core_nexus", false).unwrap();
     let channel = desc.get_channel().expect("failed to get IO channel");
     drop(channel);
     drop(desc);
@@ -93,9 +93,9 @@ async fn core_2() {
             let n =
                 nexus_lookup_mut("core_nexus").expect("failed to lookup nexus");
 
-            let d1 = Bdev::open_by_name("core_nexus", true)
+            let d1 = UntypedBdev::open_by_name("core_nexus", true)
                 .expect("failed to open first desc to nexus");
-            let d2 = Bdev::open_by_name("core_nexus", true)
+            let d2 = UntypedBdev::open_by_name("core_nexus", true)
                 .expect("failed to open second desc to nexus");
 
             let ch1 = d1.get_channel().expect("failed to get channel!");

--- a/mayastor/tests/core.rs
+++ b/mayastor/tests/core.rs
@@ -9,7 +9,7 @@ use mayastor::{
         nexus::{nexus_create, nexus_lookup_mut},
         util::uring,
     },
-    core::{Bdev, BdevHandle, MayastorCliArgs, Protocol, UntypedBdev},
+    core::{BdevHandle, MayastorCliArgs, Protocol, UntypedBdev},
     nexus_uri::{bdev_create, bdev_destroy},
 };
 

--- a/mayastor/tests/iscsi_tgt.rs
+++ b/mayastor/tests/iscsi_tgt.rs
@@ -18,12 +18,12 @@ async fn iscsi_target() {
     ms.spawn(async {
         // test we can create a nvmf subsystem
         let b = bdev_create(BDEV).await.unwrap();
-        let bdev = UntypedBdev::lookup_by_name(&b).unwrap();
-        iscsi::share(&b, &bdev, Side::Nexus).unwrap();
+        let mut bdev = UntypedBdev::lookup_by_name(&b).unwrap();
+        iscsi::share(&b, &mut bdev, Side::Nexus).unwrap();
 
         // test we can not create the same one again
-        let bdev = UntypedBdev::lookup_by_name("malloc0").unwrap();
-        let should_err = iscsi::share("malloc0", &bdev, Side::Nexus);
+        let mut bdev = UntypedBdev::lookup_by_name("malloc0").unwrap();
+        let should_err = iscsi::share("malloc0", &mut bdev, Side::Nexus);
         assert!(should_err.is_err());
 
         // verify the bdev is claimed by our target

--- a/mayastor/tests/iscsi_tgt.rs
+++ b/mayastor/tests/iscsi_tgt.rs
@@ -1,5 +1,5 @@
 use mayastor::{
-    core::{Bdev, MayastorCliArgs},
+    core::{MayastorCliArgs, UntypedBdev},
     nexus_uri::bdev_create,
     target::{iscsi, Side},
 };
@@ -18,26 +18,26 @@ async fn iscsi_target() {
     ms.spawn(async {
         // test we can create a nvmf subsystem
         let b = bdev_create(BDEV).await.unwrap();
-        let bdev = Bdev::lookup_by_name(&b).unwrap();
+        let bdev = UntypedBdev::lookup_by_name(&b).unwrap();
         iscsi::share(&b, &bdev, Side::Nexus).unwrap();
 
         // test we can not create the same one again
-        let bdev = Bdev::lookup_by_name("malloc0").unwrap();
+        let bdev = UntypedBdev::lookup_by_name("malloc0").unwrap();
         let should_err = iscsi::share("malloc0", &bdev, Side::Nexus);
         assert!(should_err.is_err());
 
         // verify the bdev is claimed by our target
-        let bdev = Bdev::bdev_first().unwrap();
+        let bdev = UntypedBdev::bdev_first().unwrap();
         assert!(bdev.is_claimed());
         assert_eq!(bdev.claimed_by().unwrap(), "iSCSI Target");
 
         // unshare the iSCSI target
-        let bdev = Bdev::lookup_by_name("malloc0").unwrap();
+        let bdev = UntypedBdev::lookup_by_name("malloc0").unwrap();
         let should_err = iscsi::unshare(bdev.name()).await;
         assert!(!should_err.is_err());
 
         // verify the bdev is not claimed by our target anymore
-        let bdev = Bdev::bdev_first().unwrap();
+        let bdev = UntypedBdev::bdev_first().unwrap();
         assert!(!bdev.is_claimed());
     })
     .await

--- a/mayastor/tests/lock_lba_range.rs
+++ b/mayastor/tests/lock_lba_range.rs
@@ -12,13 +12,13 @@ use crossbeam::channel::unbounded;
 use mayastor::{
     bdev::nexus::{nexus_create, nexus_lookup_mut},
     core::{
-        Bdev,
         IoChannel,
         MayastorCliArgs,
         MayastorEnvironment,
         RangeContext,
         Reactor,
         Reactors,
+        UntypedBdev,
     },
 };
 use spdk_rs::DmaBuf;
@@ -44,7 +44,7 @@ struct ShareableContext {
 impl ShareableContext {
     /// Create a new Shareable Context
     pub fn new(offset: u64, len: u64) -> ShareableContext {
-        let nexus = Bdev::open_by_name(NEXUS_NAME, true).unwrap();
+        let nexus = UntypedBdev::open_by_name(NEXUS_NAME, true).unwrap();
         Self {
             ctx: Rc::new(RefCell::new(RangeContext::new(offset, len))),
             ch: Rc::new(RefCell::new(nexus.get_channel().unwrap())),
@@ -108,7 +108,7 @@ async fn lock_range(
     ctx: &mut RangeContext,
     ch: &IoChannel,
 ) -> Result<(), nix::errno::Errno> {
-    let nexus = Bdev::open_by_name(NEXUS_NAME, true).unwrap();
+    let nexus = UntypedBdev::open_by_name(NEXUS_NAME, true).unwrap();
     nexus.lock_lba_range(ctx, ch).await
 }
 
@@ -116,7 +116,7 @@ async fn unlock_range(
     ctx: &mut RangeContext,
     ch: &IoChannel,
 ) -> Result<(), nix::errno::Errno> {
-    let nexus = Bdev::open_by_name(NEXUS_NAME, true).unwrap();
+    let nexus = UntypedBdev::open_by_name(NEXUS_NAME, true).unwrap();
     nexus.unlock_lba_range(ctx, ch).await
 }
 
@@ -125,7 +125,7 @@ async fn unlock_range(
 fn lock_unlock() {
     test_ini();
     Reactor::block_on(async {
-        let nexus = Bdev::open_by_name(NEXUS_NAME, true).unwrap();
+        let nexus = UntypedBdev::open_by_name(NEXUS_NAME, true).unwrap();
         let mut ctx = RangeContext::new(1, 5);
         let ch = nexus.get_channel().unwrap();
         nexus
@@ -145,7 +145,7 @@ fn lock_unlock() {
 fn lock_unlock_different_context() {
     test_ini();
     Reactor::block_on(async {
-        let nexus = Bdev::open_by_name(NEXUS_NAME, true).unwrap();
+        let nexus = UntypedBdev::open_by_name(NEXUS_NAME, true).unwrap();
 
         let mut ctx = RangeContext::new(1, 5);
         let ch = nexus.get_channel().unwrap();
@@ -267,7 +267,7 @@ fn lock_then_fe_io() {
     // Issue front-end I/O
     let (io_sender, io_receiver) = unbounded::<()>();
     reactor.send_future(async move {
-        let nexus_desc = Bdev::open_by_name(NEXUS_NAME, true).unwrap();
+        let nexus_desc = UntypedBdev::open_by_name(NEXUS_NAME, true).unwrap();
         let h = nexus_desc.into_handle().unwrap();
 
         let blk = 2;

--- a/mayastor/tests/lvs_pool.rs
+++ b/mayastor/tests/lvs_pool.rs
@@ -1,6 +1,6 @@
 use common::MayastorTest;
 use mayastor::{
-    core::{Bdev, MayastorCliArgs, Protocol, Share},
+    core::{MayastorCliArgs, Protocol, Share, UntypedBdev},
     lvs::{Lvs, PropName, PropValue},
     nexus_uri::bdev_create,
     pool::PoolArgs,
@@ -324,7 +324,7 @@ async fn lvs_pool_test() {
 
         // no bdevs left
 
-        assert_eq!(Bdev::bdev_first().into_iter().count(), 0);
+        assert_eq!(UntypedBdev::bdev_first().into_iter().count(), 0);
 
         // importing a pool with the wrong name should fail
         Lvs::create_or_import(PoolArgs {

--- a/mayastor/tests/malloc_bdev.rs
+++ b/mayastor/tests/malloc_bdev.rs
@@ -1,6 +1,6 @@
 use common::MayastorTest;
 use mayastor::{
-    core::{Bdev, MayastorCliArgs},
+    core::{MayastorCliArgs, UntypedBdev},
     nexus_uri::{bdev_create, bdev_destroy},
 };
 use spdk_rs::DmaBuf;
@@ -24,8 +24,8 @@ async fn malloc_bdev() {
     .await;
 
     ms.spawn(async {
-        let m0 = Bdev::open_by_name("malloc0", true).unwrap();
-        let m1 = Bdev::open_by_name("malloc1", true).unwrap();
+        let m0 = UntypedBdev::open_by_name("malloc0", true).unwrap();
+        let m1 = UntypedBdev::open_by_name("malloc1", true).unwrap();
 
         assert_eq!(
             m0.get_bdev().size_in_bytes(),

--- a/mayastor/tests/mayastor_compose_basic.rs
+++ b/mayastor/tests/mayastor_compose_basic.rs
@@ -3,7 +3,7 @@ use mayastor::{
         device_lookup,
         nexus::{nexus_create, nexus_lookup_mut},
     },
-    core::{Bdev, MayastorCliArgs},
+    core::{MayastorCliArgs, UntypedBdev},
     nexus_uri::bdev_create,
 };
 use rpc::mayastor::{BdevShareRequest, BdevUri, Null};
@@ -96,7 +96,7 @@ async fn compose_up_down() {
 
     let bdevs = mayastor
         .spawn(async {
-            Bdev::bdev_first()
+            UntypedBdev::bdev_first()
                 .unwrap()
                 .into_iter()
                 .map(|b| b.name().to_string())

--- a/mayastor/tests/nexus_share.rs
+++ b/mayastor/tests/nexus_share.rs
@@ -9,6 +9,7 @@ use mayastor::{
         UntypedBdev,
     },
 };
+use std::pin::Pin;
 
 pub mod common;
 use common::MayastorTest;
@@ -36,33 +37,33 @@ async fn nexus_share_test() {
                 .await
                 .unwrap();
 
-                let nexus = nexus_lookup_mut("nexus0").unwrap();
+                let mut nexus = nexus_lookup_mut("nexus0").unwrap();
 
                 // this should be idempotent so validate that sharing the
                 // same thing over the same protocol
                 // works
-                let share = nexus.share_iscsi().await.unwrap();
-                let share2 = nexus.share_iscsi().await.unwrap();
+                let share = nexus.as_mut().share_iscsi().await.unwrap();
+                let share2 = nexus.as_mut().share_iscsi().await.unwrap();
                 assert_eq!(share, share2);
                 assert_eq!(nexus.shared(), Some(Protocol::Iscsi));
             });
 
             // sharing the nexus over nvmf should fail
             Reactor::block_on(async {
-                let nexus = nexus_lookup_mut("nexus0").unwrap();
-                assert!(nexus.share_nvmf(None).await.is_err());
-                assert_eq!(nexus.shared(), Some(Protocol::Iscsi));
+                let mut nexus = nexus_lookup_mut("nexus0").unwrap();
+                assert!(nexus.as_mut().share_nvmf(None).await.is_err());
+                assert_eq!(nexus.as_mut().shared(), Some(Protocol::Iscsi));
             });
 
             // unshare the nexus and then share over nvmf
             Reactor::block_on(async {
-                let nexus = nexus_lookup_mut("nexus0").unwrap();
-                nexus.unshare().await.unwrap();
+                let mut nexus = nexus_lookup_mut("nexus0").unwrap();
+                nexus.as_mut().unshare().await.unwrap();
                 let shared = nexus.shared();
                 assert_eq!(shared, Some(Protocol::Off));
 
-                let shared = nexus.share_nvmf(None).await.unwrap();
-                let shared2 = nexus.share_nvmf(None).await.unwrap();
+                let shared = nexus.as_mut().share_nvmf(None).await.unwrap();
+                let shared2 = nexus.as_mut().share_nvmf(None).await.unwrap();
 
                 assert_eq!(shared, shared2);
                 assert_eq!(nexus.shared(), Some(Protocol::Nvmf));
@@ -71,9 +72,10 @@ async fn nexus_share_test() {
             // sharing the bdev directly, over iSCSI or nvmf should result
             // in an error
             Reactor::block_on(async {
-                let bdev = UntypedBdev::lookup_by_name("nexus0").unwrap();
-                assert!(bdev.share_iscsi().await.is_err());
-                assert!(bdev.share_nvmf(None).await.is_err());
+                let mut bdev = UntypedBdev::lookup_by_name("nexus0").unwrap();
+                let mut bdev = Pin::new(&mut bdev);
+                assert!(bdev.as_mut().share_iscsi().await.is_err());
+                assert!(bdev.as_mut().share_nvmf(None).await.is_err());
             });
 
             // unshare the nexus

--- a/mayastor/tests/nexus_share.rs
+++ b/mayastor/tests/nexus_share.rs
@@ -2,11 +2,11 @@ use mayastor::{
     bdev::nexus::{nexus_create, nexus_lookup_mut},
     core::{
         mayastor_env_stop,
-        Bdev,
         MayastorCliArgs,
         Protocol,
         Reactor,
         Share,
+        UntypedBdev,
     },
 };
 
@@ -71,7 +71,7 @@ async fn nexus_share_test() {
             // sharing the bdev directly, over iSCSI or nvmf should result
             // in an error
             Reactor::block_on(async {
-                let bdev = Bdev::lookup_by_name("nexus0").unwrap();
+                let bdev = UntypedBdev::lookup_by_name("nexus0").unwrap();
                 assert!(bdev.share_iscsi().await.is_err());
                 assert!(bdev.share_nvmf(None).await.is_err());
             });
@@ -85,7 +85,7 @@ async fn nexus_share_test() {
             Reactor::block_on(async {
                 let nexus = nexus_lookup_mut("nexus0").unwrap();
                 assert_eq!(nexus.shared(), Some(Protocol::Off));
-                let bdev = Bdev::lookup_by_name("nexus0").unwrap();
+                let bdev = UntypedBdev::lookup_by_name("nexus0").unwrap();
                 assert_eq!(bdev.shared(), Some(Protocol::Off));
                 nexus.destroy().await.unwrap();
             });

--- a/mayastor/tests/nvmf.rs
+++ b/mayastor/tests/nvmf.rs
@@ -3,10 +3,10 @@ use std::convert::TryFrom;
 use mayastor::{
     core::{
         mayastor_env_stop,
-        Bdev,
         MayastorCliArgs,
         MayastorEnvironment,
         Reactor,
+        UntypedBdev,
     },
     nexus_uri::bdev_create,
     subsys::{NvmfSubsystem, SubType},
@@ -30,7 +30,7 @@ fn nvmf_target() {
             // test we can create a nvmf subsystem
             Reactor::block_on(async {
                 let b = bdev_create(BDEVNAME1).await.unwrap();
-                let bdev = Bdev::lookup_by_name(&b).unwrap();
+                let bdev = UntypedBdev::lookup_by_name(&b).unwrap();
 
                 let ss = NvmfSubsystem::try_from(bdev).unwrap();
                 ss.start().await.unwrap();
@@ -38,7 +38,7 @@ fn nvmf_target() {
 
             // test we can not create the same one again
             Reactor::block_on(async {
-                let bdev = Bdev::lookup_by_name(BDEVNAME1).unwrap();
+                let bdev = UntypedBdev::lookup_by_name(BDEVNAME1).unwrap();
 
                 let should_err = NvmfSubsystem::try_from(bdev);
                 assert!(should_err.is_err());
@@ -55,7 +55,7 @@ fn nvmf_target() {
             // verify the bdev is claimed by our target -- make sure we skip
             // over the discovery controller
             Reactor::block_on(async {
-                let bdev = Bdev::bdev_first().unwrap();
+                let bdev = UntypedBdev::bdev_first().unwrap();
                 assert!(bdev.is_claimed());
                 assert_eq!(bdev.claimed_by().unwrap(), "NVMe-oF Target");
 

--- a/mayastor/tests/nvmf.rs
+++ b/mayastor/tests/nvmf.rs
@@ -1,5 +1,3 @@
-use std::convert::TryFrom;
-
 use mayastor::{
     core::{
         mayastor_env_stop,
@@ -32,7 +30,7 @@ fn nvmf_target() {
                 let b = bdev_create(BDEVNAME1).await.unwrap();
                 let bdev = UntypedBdev::lookup_by_name(&b).unwrap();
 
-                let ss = NvmfSubsystem::try_from(bdev).unwrap();
+                let ss = NvmfSubsystem::try_from(&bdev).unwrap();
                 ss.start().await.unwrap();
             });
 
@@ -40,7 +38,7 @@ fn nvmf_target() {
             Reactor::block_on(async {
                 let bdev = UntypedBdev::lookup_by_name(BDEVNAME1).unwrap();
 
-                let should_err = NvmfSubsystem::try_from(bdev);
+                let should_err = NvmfSubsystem::try_from(&bdev);
                 assert!(should_err.is_err());
             });
 

--- a/mayastor/tests/replica_timeout.rs
+++ b/mayastor/tests/replica_timeout.rs
@@ -1,7 +1,7 @@
 use common::{compose::Builder, MayastorTest};
 use mayastor::{
     bdev::nexus::{nexus_create, nexus_lookup_mut, NexusStatus},
-    core::{Bdev, MayastorCliArgs, Protocol, UntypedBdev},
+    core::{MayastorCliArgs, Protocol, UntypedBdev},
     nexus_uri::bdev_get_name,
     subsys::{Config, NvmeBdevOpts},
 };

--- a/mayastor/tests/replica_timeout.rs
+++ b/mayastor/tests/replica_timeout.rs
@@ -1,7 +1,7 @@
 use common::{compose::Builder, MayastorTest};
 use mayastor::{
     bdev::nexus::{nexus_create, nexus_lookup_mut, NexusStatus},
-    core::{Bdev, MayastorCliArgs, Protocol},
+    core::{Bdev, MayastorCliArgs, Protocol, UntypedBdev},
     nexus_uri::bdev_get_name,
     subsys::{Config, NvmeBdevOpts},
 };
@@ -75,7 +75,8 @@ async fn replica_stop_cont() {
                 .await
                 .expect("should publish nexus over nvmf");
             assert!(
-                Bdev::lookup_by_name(&bdev_get_name(&c).unwrap()).is_some(),
+                UntypedBdev::lookup_by_name(&bdev_get_name(&c).unwrap())
+                    .is_some(),
                 "child bdev must exist"
             );
         })
@@ -124,7 +125,8 @@ async fn replica_stop_cont() {
     mayastor
         .spawn(async move {
             assert!(
-                Bdev::lookup_by_name(&bdev_get_name(&c).unwrap()).is_none(),
+                UntypedBdev::lookup_by_name(&bdev_get_name(&c).unwrap())
+                    .is_none(),
                 "child bdev must be destroyed"
             );
             let nx = nexus_lookup_mut(NXNAME).unwrap();

--- a/mayastor/tests/thread.rs
+++ b/mayastor/tests/thread.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use mayastor::core::{Bdev, Cores, MayastorCliArgs, Mthread, Share};
+use mayastor::core::{Cores, MayastorCliArgs, Mthread, Share, UntypedBdev};
 
 pub mod common;
 use common::MayastorTest;
@@ -31,7 +31,7 @@ async fn runtime_to_mayastor() {
     let st = Mthread::get_init();
     let rx = st
         .spawn_local(async move {
-            let bdev = Bdev::lookup_by_name("malloc0").unwrap();
+            let bdev = UntypedBdev::lookup_by_name("malloc0").unwrap();
             bdev.share_nvmf(None).await.unwrap();
         })
         .unwrap();

--- a/mayastor/tests/thread.rs
+++ b/mayastor/tests/thread.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use std::{pin::Pin, time::Duration};
 
 use mayastor::core::{Cores, MayastorCliArgs, Mthread, Share, UntypedBdev};
 
@@ -31,7 +31,8 @@ async fn runtime_to_mayastor() {
     let st = Mthread::get_init();
     let rx = st
         .spawn_local(async move {
-            let bdev = UntypedBdev::lookup_by_name("malloc0").unwrap();
+            let mut bdev = UntypedBdev::lookup_by_name("malloc0").unwrap();
+            let bdev = Pin::new(&mut bdev);
             bdev.share_nvmf(None).await.unwrap();
         })
         .unwrap();


### PR DESCRIPTION
core::Bdev made a generic similar to underlying spdk_rs::Bdev.
Nexus now works with core::Bdev<Nexus>.
core::UntypedBdev type introduced for code that does not need to know about
actual Bdev type.
This is an intermediate cleanup for ongoing work of refactoring Bdev layer in
Mayastor.