### PR TITLE
chore: update charts to add 2Gi as a minimum hugepages

### DIFF
--- a/chart/templates/mayastor-daemonset.yaml
+++ b/chart/templates/mayastor-daemonset.yaml
@@ -80,11 +80,11 @@ spec:
           limits:
             cpu: "{{ .Values.mayastorCpuCount }}"
             memory: "1Gi"
-            hugepages-2Mi: "{{ add .Values.mayastorHugePagesGiB 1 }}Gi"
+            hugepages-2Mi: "{{ max .Values.mayastorHugePagesGiB 2 }}Gi"
           requests:
             cpu: "{{ .Values.mayastorCpuCount }}"
             memory: "1Gi"
-            hugepages-2Mi: "{{ add .Values.mayastorHugePagesGiB 1 }}Gi"
+            hugepages-2Mi: "{{ max .Values.mayastorHugePagesGiB 2 }}Gi"
         ports:
         - containerPort: 10124
           protocol: TCP


### PR DESCRIPTION
Rather than adding 1Gi extra just set 2Gi as the minimum.