### PR TITLE
chore: don't add default max qpairs per controller

### DIFF
--- a/chart/templates/mayastor-daemonset.yaml
+++ b/chart/templates/mayastor-daemonset.yaml
@@ -36,9 +36,6 @@ spec:
         env:
         - name: RUST_LOG
           value: info,mayastor={{ .Values.mayastorLogLevel }}
-        - name: NVMF_TCP_MAX_QPAIRS_PER_CTRL
-          # Current recommendation is to set this value to be the number of cores provided to mayastor (see -l argument) plus 1.
-          value: "{{ add .Values.mayastorCpuCount 1 }}"
         - name: NVMF_TCP_MAX_QUEUE_DEPTH
           value: "32"
         - name: MY_NODE_NAME

--- a/deploy/mayastor-daemonset.yaml
+++ b/deploy/mayastor-daemonset.yaml
@@ -38,9 +38,6 @@ spec:
         env:
         - name: RUST_LOG
           value: info,mayastor=info
-        - name: NVMF_TCP_MAX_QPAIRS_PER_CTRL
-          # Current recommendation is to set this value to be the number of cores provided to mayastor (see -l argument) plus 1.
-          value: "2"
         - name: NVMF_TCP_MAX_QUEUE_DEPTH
           value: "32"
         - name: MY_NODE_NAME


### PR DESCRIPTION
Limiting the qpairs to a low value means we cannot then allocate more for the rebuilds.