### PR TITLE
feat(nexus info key): use supplied key if present

### DIFF
--- a/mayastor/src/bdev/nexus/nexus_persistence.rs
+++ b/mayastor/src/bdev/nexus/nexus_persistence.rs
@@ -5,6 +5,30 @@ use std::time::Duration;
 
 type ChildUri = String;
 
+/// Information associated with the persisted NexusInfo structure.
+pub struct PersistentNexusInfo {
+    // Structure that is written to the persistent store.
+    inner: NexusInfo,
+    // Key to use to persist the NexusInfo structure.
+    // If `Some` the key has been supplied by the control plane.
+    key: Option<String>,
+}
+
+impl PersistentNexusInfo {
+    /// Create a new instance of PersistentNexusInfo.
+    pub(crate) fn new(key: Option<String>) -> Self {
+        Self {
+            inner: Default::default(),
+            key,
+        }
+    }
+
+    /// Get a mutable reference to the inner NexusInfo structure.
+    fn inner_mut(&mut self) -> &mut NexusInfo {
+        &mut self.inner
+    }
+}
+
 /// Definition of the nexus information that gets saved in the persistent
 /// store.
 #[derive(Serialize, Deserialize, Debug, Default)]
@@ -49,7 +73,9 @@ impl<'n> Nexus<'n> {
             return;
         }
 
-        let mut nexus_info = self.nexus_info.lock().await;
+        let mut persistent_nexus_info = self.nexus_info.lock().await;
+        let mut nexus_info = persistent_nexus_info.inner_mut();
+
         match op {
             PersistOp::Create => {
                 // Initialisation of the persistent info will overwrite any
@@ -92,7 +118,7 @@ impl<'n> Nexus<'n> {
             // Only update the state of the child if the precondition holds.
             PersistOp::UpdateCond((uri, state, f)) => {
                 // Do not persist the state if predicate fails.
-                if !f(&nexus_info) {
+                if !f(nexus_info) {
                     return;
                 }
 
@@ -112,7 +138,7 @@ impl<'n> Nexus<'n> {
                 nexus_info.clean_shutdown = true;
             }
         }
-        self.save(&nexus_info).await;
+        self.save(&persistent_nexus_info).await;
     }
 
     /// Determine child health.
@@ -124,11 +150,18 @@ impl<'n> Nexus<'n> {
     // consistency across restarts of Mayastor. Therefore, keep retrying
     // until successful.
     // TODO: Should we give up retrying eventually?
-    async fn save(&self, info: &NexusInfo) {
+    async fn save(&self, info: &PersistentNexusInfo) {
         let mut output_err = true;
         let nexus_uuid = self.uuid().to_string();
+        // If a key has been provided use this to store the NexusInfo.
+        // If a key is not provided, use the nexus uuid as the key.
+        let key = match &info.key {
+            Some(k) => k.clone(),
+            None => self.uuid().to_string(),
+        };
+
         loop {
-            match PersistentStore::put(&nexus_uuid, info).await {
+            match PersistentStore::put(&key, &info.inner).await {
                 Ok(_) => {
                     // The state was saved successfully.
                     break;

--- a/mayastor/src/bin/mayastor-client/nexus_cli.rs
+++ b/mayastor/src/bin/mayastor-client/nexus_cli.rs
@@ -74,6 +74,11 @@ pub fn subcommands<'a, 'b>() -> App<'a, 'b> {
                 .help("NVMe preempt key for children, 0 for no preemption"),
         )
         .arg(
+            Arg::with_name("nexus-info-key")
+                .required(true)
+                .help("Key used to persist the NexusInfo structure to the persistent store"),
+        )
+        .arg(
             Arg::with_name("children")
                 .required(true)
                 .multiple(true)
@@ -309,6 +314,10 @@ async fn nexus_create_v2(
         .unwrap_or_else(|e| e.exit());
     let preempt_key = value_t!(matches.value_of("preempt-key"), u64)
         .unwrap_or_else(|e| e.exit());
+    let nexus_info_key = matches
+        .value_of("nexus-info-key")
+        .unwrap_or_default()
+        .to_string();
 
     let response = ctx
         .client
@@ -321,6 +330,7 @@ async fn nexus_create_v2(
             resv_key,
             preempt_key,
             children,
+            nexus_info_key,
         })
         .await
         .context(GrpcStatus)?;

--- a/mayastor/src/grpc/mayastor_grpc.rs
+++ b/mayastor/src/grpc/mayastor_grpc.rs
@@ -808,6 +808,15 @@ impl mayastor_server::Mayastor for MayastorSvc {
             GrpcClientContext::new(&request, function_name!()),
             async move {
                 let args = request.into_inner();
+
+                // If the control plane has supplied a key, use it to store the
+                // NexusInfo.
+                let nexus_info_key = if args.nexus_info_key.is_empty() {
+                    None
+                } else {
+                    Some(args.nexus_info_key.to_string())
+                };
+
                 let rx = rpc_submit::<_, _, nexus::Error>(async move {
                     nexus::nexus_create_v2(
                         &args.name,
@@ -823,6 +832,7 @@ impl mayastor_server::Mayastor for MayastorSvc {
                             },
                         },
                         &args.children,
+                        nexus_info_key,
                     )
                     .await?;
                     let nexus = nexus_lookup(&args.name)?;

--- a/mayastor/src/grpc/v1/nexus.rs
+++ b/mayastor/src/grpc/v1/nexus.rs
@@ -237,6 +237,14 @@ impl NexusRpc for NexusService {
                         });
                     }
 
+                    // If the control plane has supplied a key, use it to store
+                    // the NexusInfo.
+                    let nexus_info_key = if args.nexus_info_key.is_empty() {
+                        None
+                    } else {
+                        Some(args.nexus_info_key.to_string())
+                    };
+
                     nexus::nexus_create_v2(
                         &args.name,
                         args.size,
@@ -251,6 +259,7 @@ impl NexusRpc for NexusService {
                             },
                         },
                         &args.children,
+                        nexus_info_key,
                     )
                     .await?;
                     let nexus = nexus_lookup(&args.uuid)?;

--- a/mayastor/tests/nexus_io.rs
+++ b/mayastor/tests/nexus_io.rs
@@ -401,6 +401,7 @@ async fn nexus_io_resv_acquire() {
                 UUID,
                 nvme_params,
                 &[format!("nvmf://{}:8420/{}:{}", ip0, HOSTNQN, UUID)],
+                None,
             )
             .await
             .unwrap();
@@ -461,6 +462,7 @@ async fn nexus_io_resv_acquire() {
             preempt_key: 0,
             children: [format!("nvmf://{}:8420/{}:{}", ip0, HOSTNQN, UUID)]
                 .to_vec(),
+            nexus_info_key: "".to_string(),
         })
         .await
         .unwrap();


### PR DESCRIPTION
Provide the ability to receive a key under which the NexusInfo structure
should be persisted. If provided by the control plane, this key will be
used otherwise it will default to the nexus UUID to ensure backwards
compatibility.