### PR TITLE
feat(libnvme-rs): new crate, implement connect, disconnect, list

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1460,7 +1460,9 @@ dependencies = [
  "cc",
  "glob",
  "libc",
+ "mio 0.8.0",
  "snafu",
+ "udev",
  "url",
 ]
 
@@ -1673,6 +1675,19 @@ name = "mio"
 version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8067b404fe97c70829f082dec8bcf4f71225d7eaea1d8645349cb76fa06205cc"
+dependencies = [
+ "libc",
+ "log",
+ "miow",
+ "ntapi",
+ "winapi",
+]
+
+[[package]]
+name = "mio"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba272f85fa0b41fc91872be579b3bbe0f56b792aa361a380eb669469f68dafb2"
 dependencies = [
  "libc",
  "log",
@@ -2822,7 +2837,7 @@ dependencies = [
  "bytes",
  "libc",
  "memchr",
- "mio",
+ "mio 0.7.14",
  "num_cpus",
  "once_cell",
  "parking_lot",
@@ -3063,12 +3078,13 @@ checksum = "b63708a265f51345575b27fe43f9500ad611579e764c79edbc2037b1121959ec"
 
 [[package]]
 name = "udev"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3193363f52bb34c6708ac2ffedcb5f7e5874f0329ef68e1315f27d8d768eb568"
+checksum = "1c960764f7e816eed851a96c364745d37f9fe71a2e7dba79fbd40104530b5dd0"
 dependencies = [
  "libc",
  "libudev-sys",
+ "mio 0.8.0",
  "pkg-config",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1453,6 +1453,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "libnvme-rs"
+version = "0.1.0"
+dependencies = [
+ "bindgen 0.59.1",
+ "cc",
+ "glob",
+ "libc",
+ "snafu",
+ "url",
+]
+
+[[package]]
 name = "libudev-sys"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1544,12 +1556,12 @@ dependencies = [
  "jsonrpc",
  "lazy_static",
  "libc",
+ "libnvme-rs",
  "log",
  "mbus_api",
  "md5",
  "merge",
  "nix",
- "nvmeadm",
  "once_cell",
  "parking_lot",
  "pin-utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
 	"csi",
 	"devinfo",
 	"jsonrpc",
+	"libnvme-rs",
 	"mayastor",
 	"mbus-api",
 	"nvmeadm",

--- a/ci.nix
+++ b/ci.nix
@@ -34,6 +34,7 @@ mkShell {
     kubernetes-helm
     libaio
     libbsd
+    libnvme
     libpcap
     libudev
     liburing

--- a/libnvme-rs/Cargo.toml
+++ b/libnvme-rs/Cargo.toml
@@ -19,3 +19,12 @@ glob = "0.3.0"
 libc = "0.2"
 snafu = "0.6.10"
 url = "2.2.2"
+
+[dependencies.mio08]
+package = "mio"
+features = ["os-ext"]
+version = "0.8"
+
+[dependencies.udev]
+features = ["hwdb", "mio"]
+version = "^0.6.3"

--- a/libnvme-rs/Cargo.toml
+++ b/libnvme-rs/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "libnvme-rs"
+description = "Rust bindings for libnvme"
+version = "0.1.0"
+edition = "2018"
+build = "build.rs"
+license = "Apache-2.0"
+authors = [
+  "Jonathan Teh <jonathan.teh@mayadata.io>",
+  "Jeffry Molanus <jeffry.molanus@gmail.com>",
+]
+
+[build-dependencies]
+bindgen = "0.59.1"
+cc = "1.0.69"
+
+[dependencies]
+glob = "0.3.0"
+libc = "0.2"
+snafu = "0.6.10"
+url = "2.2.2"

--- a/libnvme-rs/build.rs
+++ b/libnvme-rs/build.rs
@@ -1,0 +1,20 @@
+extern crate bindgen;
+
+use std::{env, path::PathBuf};
+
+fn main() {
+    println!("cargo:rustc-link-lib=nvme");
+    println!("cargo:rerun-if-changed=wrapper.h");
+
+    let bindings = bindgen::Builder::default()
+        .header("wrapper.h")
+        .parse_callbacks(Box::new(bindgen::CargoCallbacks))
+        .layout_tests(false)
+        .generate()
+        .expect("Unable to generate bindings");
+
+    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+    bindings
+        .write_to_file(out_path.join("bindings.rs"))
+        .expect("Couldn't write bindings!");
+}

--- a/libnvme-rs/src/error.rs
+++ b/libnvme-rs/src/error.rs
@@ -1,0 +1,27 @@
+use snafu::Snafu;
+
+#[derive(Debug, Snafu)]
+#[allow(missing_docs)]
+#[snafu(visibility = "pub(crate)")]
+pub enum NvmeError {
+    #[snafu(display("IO error:"))]
+    IoError { source: std::io::Error },
+    #[snafu(display("Lookup host failed: {}", rc))]
+    LookupHostError { rc: i32 },
+    #[snafu(display("Create controller failed: {}", rc))]
+    CreateCtrlrError { rc: i32 },
+    #[snafu(display("No controller found: {}", rc))]
+    AddCtrlrError { rc: i32 },
+    #[snafu(display("File IO error: {}", rc))]
+    FileIoError { rc: i32 },
+    #[snafu(display("NVMe URL invalid: {}", source))]
+    UrlError { source: url::ParseError },
+}
+
+impl From<std::io::Error> for NvmeError {
+    fn from(source: std::io::Error) -> NvmeError {
+        NvmeError::IoError {
+            source,
+        }
+    }
+}

--- a/libnvme-rs/src/lib.rs
+++ b/libnvme-rs/src/lib.rs
@@ -9,6 +9,7 @@ mod bindings {
 pub use bindings::*;
 
 pub mod error;
+mod nvme_device;
 mod nvme_tree;
 mod nvme_uri;
 

--- a/libnvme-rs/src/lib.rs
+++ b/libnvme-rs/src/lib.rs
@@ -1,0 +1,15 @@
+#![allow(non_upper_case_globals)]
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+
+#[allow(clippy::all)]
+mod bindings {
+    include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
+}
+pub use bindings::*;
+
+pub mod error;
+mod nvme_tree;
+mod nvme_uri;
+
+pub use nvme_uri::NvmeTarget;

--- a/libnvme-rs/src/nvme_device.rs
+++ b/libnvme-rs/src/nvme_device.rs
@@ -1,0 +1,20 @@
+pub struct NvmeDevice {
+    /// Namespace index
+    pub namespace: i32,
+    /// Device name
+    pub device: String,
+    /// Firmware
+    pub firmware: String,
+    /// Model
+    pub model: String,
+    /// Serial
+    pub serial: String,
+    /// Utilisation
+    pub utilisation: u64,
+    /// Maximum LBA
+    pub max_lba: u64,
+    /// Capacity
+    pub capacity: u64,
+    /// Sector size
+    pub sector_size: u32,
+}

--- a/libnvme-rs/src/nvme_tree.rs
+++ b/libnvme-rs/src/nvme_tree.rs
@@ -1,0 +1,149 @@
+/// RAII Wrapper for nvme_root_t
+pub(crate) struct NvmeRoot {
+    root: *mut crate::bindings::nvme_root,
+}
+
+impl NvmeRoot {
+    pub(crate) fn new(root: *mut crate::bindings::nvme_root) -> Self {
+        NvmeRoot {
+            root,
+        }
+    }
+    pub(crate) fn as_mut_ptr(&self) -> *mut crate::bindings::nvme_root {
+        self.root
+    }
+}
+
+impl Drop for NvmeRoot {
+    fn drop(&mut self) {
+        unsafe { crate::nvme_free_tree(self.root) }
+    }
+}
+
+/// Iterator for nvme_host_t
+pub(crate) struct NvmeHostIterator<'a> {
+    root: &'a NvmeRoot,
+    host: *mut crate::bindings::nvme_host,
+}
+
+impl<'a> NvmeHostIterator<'a> {
+    pub(crate) fn new(root: &'a NvmeRoot) -> Self {
+        Self {
+            root,
+            host: std::ptr::null_mut(),
+        }
+    }
+}
+
+impl<'a> Iterator for NvmeHostIterator<'a> {
+    type Item = *mut crate::bindings::nvme_host;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.host = if self.host.is_null() {
+            unsafe { crate::nvme_first_host(self.root.as_mut_ptr()) }
+        } else {
+            unsafe { crate::nvme_next_host(self.root.as_mut_ptr(), self.host) }
+        };
+        if self.host.is_null() {
+            None
+        } else {
+            Some(self.host)
+        }
+    }
+}
+
+/// Iterator for nvme_subsystem_t
+pub(crate) struct NvmeSubsystemIterator {
+    host: *mut crate::bindings::nvme_host,
+    subsys: *mut crate::bindings::nvme_subsystem,
+}
+
+impl NvmeSubsystemIterator {
+    pub(crate) fn new(host: *mut crate::bindings::nvme_host) -> Self {
+        Self {
+            host,
+            subsys: std::ptr::null_mut(),
+        }
+    }
+}
+
+impl Iterator for NvmeSubsystemIterator {
+    type Item = *mut crate::bindings::nvme_subsystem;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.subsys = if self.subsys.is_null() {
+            unsafe { crate::nvme_first_subsystem(self.host) }
+        } else {
+            unsafe { crate::nvme_next_subsystem(self.host, self.subsys) }
+        };
+        if self.subsys.is_null() {
+            None
+        } else {
+            Some(self.subsys)
+        }
+    }
+}
+
+/// Iterator for nvme_ctrl_t
+pub(crate) struct NvmeCtrlrIterator {
+    subsys: *mut crate::bindings::nvme_subsystem,
+    ctrlr: *mut crate::bindings::nvme_ctrl,
+}
+
+impl NvmeCtrlrIterator {
+    pub(crate) fn new(subsys: *mut crate::bindings::nvme_subsystem) -> Self {
+        Self {
+            subsys,
+            ctrlr: std::ptr::null_mut(),
+        }
+    }
+}
+
+impl Iterator for NvmeCtrlrIterator {
+    type Item = *mut crate::bindings::nvme_ctrl;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.ctrlr = if self.ctrlr.is_null() {
+            unsafe { crate::nvme_subsystem_first_ctrl(self.subsys) }
+        } else {
+            unsafe { crate::nvme_subsystem_next_ctrl(self.subsys, self.ctrlr) }
+        };
+        if self.ctrlr.is_null() {
+            None
+        } else {
+            Some(self.ctrlr)
+        }
+    }
+}
+
+/// Iterator for nvme_ns_t
+pub(crate) struct NvmeNamespaceIterator {
+    subsys: *mut crate::bindings::nvme_subsystem,
+    ns: *mut crate::bindings::nvme_ns,
+}
+
+impl NvmeNamespaceIterator {
+    pub(crate) fn new(subsys: *mut crate::bindings::nvme_subsystem) -> Self {
+        Self {
+            subsys,
+            ns: std::ptr::null_mut(),
+        }
+    }
+}
+
+impl Iterator for NvmeNamespaceIterator {
+    type Item = *mut crate::bindings::nvme_ns;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.ns = if self.ns.is_null() {
+            unsafe { crate::nvme_subsystem_first_ns(self.subsys) }
+        } else {
+            unsafe { crate::nvme_subsystem_next_ns(self.subsys, self.ns) }
+        };
+        if self.ns.is_null() {
+            None
+        } else {
+            Some(self.ns)
+        }
+    }
+}

--- a/libnvme-rs/src/nvme_tree.rs
+++ b/libnvme-rs/src/nvme_tree.rs
@@ -116,7 +116,7 @@ impl Iterator for NvmeCtrlrIterator {
     }
 }
 
-/// Iterator for nvme_ns_t
+/// Iterator for nvme_ns_t given nvme_subsystem
 pub(crate) struct NvmeNamespaceIterator {
     subsys: *mut crate::bindings::nvme_subsystem,
     ns: *mut crate::bindings::nvme_ns,
@@ -139,6 +139,38 @@ impl Iterator for NvmeNamespaceIterator {
             unsafe { crate::nvme_subsystem_first_ns(self.subsys) }
         } else {
             unsafe { crate::nvme_subsystem_next_ns(self.subsys, self.ns) }
+        };
+        if self.ns.is_null() {
+            None
+        } else {
+            Some(self.ns)
+        }
+    }
+}
+
+/// Iterator for nvme_ns_t given nvme_ctrl
+pub(crate) struct NvmeNamespaceInCtrlrIterator {
+    ctrlr: *mut crate::bindings::nvme_ctrl,
+    ns: *mut crate::bindings::nvme_ns,
+}
+
+impl NvmeNamespaceInCtrlrIterator {
+    pub(crate) fn new(ctrlr: *mut crate::bindings::nvme_ctrl) -> Self {
+        Self {
+            ctrlr,
+            ns: std::ptr::null_mut(),
+        }
+    }
+}
+
+impl Iterator for NvmeNamespaceInCtrlrIterator {
+    type Item = *mut crate::bindings::nvme_ns;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.ns = if self.ns.is_null() {
+            unsafe { crate::nvme_ctrl_first_ns(self.ctrlr) }
+        } else {
+            unsafe { crate::nvme_ctrl_next_ns(self.ctrlr, self.ns) }
         };
         if self.ns.is_null() {
             None

--- a/libnvme-rs/src/nvme_uri.rs
+++ b/libnvme-rs/src/nvme_uri.rs
@@ -1,0 +1,292 @@
+use std::{convert::TryFrom, time::Duration};
+
+use url::{ParseError, Url};
+
+use crate::{
+    error::NvmeError,
+    nvme_tree::{
+        NvmeCtrlrIterator,
+        NvmeHostIterator,
+        NvmeNamespaceIterator,
+        NvmeRoot,
+        NvmeSubsystemIterator,
+    },
+};
+
+/// Wrapper for caller-owned C-strings from libnvme
+pub struct NvmeStringWrapper {
+    s: *mut i8,
+}
+
+impl NvmeStringWrapper {
+    pub fn new(s: *mut i8) -> Self {
+        NvmeStringWrapper {
+            s,
+        }
+    }
+    pub fn as_ptr(&self) -> *const i8 {
+        self.s
+    }
+}
+
+impl Drop for NvmeStringWrapper {
+    fn drop(&mut self) {
+        unsafe { libc::free(self.s as *mut _) }
+    }
+}
+
+#[derive(Debug, PartialEq)]
+enum NvmeTransportType {
+    Tcp,
+}
+
+impl NvmeTransportType {
+    fn to_str(&self) -> &str {
+        match self {
+            NvmeTransportType::Tcp => "tcp",
+        }
+    }
+}
+
+/// Structure representing an NVMe-oF target
+pub struct NvmeTarget {
+    /// Network address
+    traddr: String,
+    /// Transport service ID. For IP transports, a port number
+    trsvcid: u16,
+    /// Name of subsystem to connect to
+    subsysnqn: String,
+    /// Transport type
+    trtype: NvmeTransportType,
+}
+
+impl TryFrom<String> for NvmeTarget {
+    type Error = NvmeError;
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        NvmeTarget::try_from(value.as_str())
+    }
+}
+
+impl TryFrom<&str> for NvmeTarget {
+    type Error = NvmeError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        let url = Url::parse(value).map_err(|source| NvmeError::UrlError {
+            source,
+        })?;
+
+        let trtype = match url.scheme() {
+            "nvmf" | "nvmf+tcp" => Ok(NvmeTransportType::Tcp),
+            _ => Err(NvmeError::UrlError {
+                source: ParseError::IdnaError,
+            }),
+        }?;
+
+        let traddr = url
+            .host_str()
+            .ok_or(NvmeError::UrlError {
+                source: ParseError::EmptyHost,
+            })?
+            .into();
+
+        let subnqn = match url.path_segments() {
+            None => Err(NvmeError::UrlError {
+                source: ParseError::RelativeUrlWithCannotBeABaseBase,
+            }),
+            Some(s) => {
+                let segments = s.collect::<Vec<&str>>();
+                if segments[0].is_empty() {
+                    Err(NvmeError::UrlError {
+                        source: ParseError::RelativeUrlWithCannotBeABaseBase,
+                    })
+                } else {
+                    Ok(segments[0].to_string())
+                }
+            }
+        }?;
+
+        Ok(Self {
+            trtype,
+            traddr,
+            trsvcid: url.port().unwrap_or(4420),
+            subsysnqn: subnqn,
+        })
+    }
+}
+
+impl NvmeTarget {
+    /// Connect to NVMe target
+    /// Returns Ok on successful connect
+    pub fn connect(&self) -> Result<(), NvmeError> {
+        let r = NvmeRoot::new(unsafe { crate::nvme_scan(std::ptr::null()) });
+        let hostnqn =
+            NvmeStringWrapper::new(unsafe { crate::nvmf_hostnqn_from_file() });
+        let hostid =
+            NvmeStringWrapper::new(unsafe { crate::nvmf_hostid_from_file() });
+
+        let h = unsafe {
+            crate::nvme_lookup_host(
+                r.as_mut_ptr(),
+                hostnqn.as_ptr(),
+                hostid.as_ptr(),
+            )
+        };
+        if h.is_null() {
+            return Err(NvmeError::LookupHostError {
+                rc: -libc::ENOMEM,
+            });
+        }
+
+        let subsysnqn = std::ffi::CString::new(self.subsysnqn.clone()).unwrap();
+        let transport = std::ffi::CString::new(self.trtype.to_str()).unwrap();
+        let traddr = std::ffi::CString::new(self.traddr.clone()).unwrap();
+        let host_traddr = std::ptr::null_mut();
+        let host_iface = std::ptr::null_mut();
+        let trsvcid = std::ffi::CString::new(self.trsvcid.to_string()).unwrap();
+        let nvme_ctrl = unsafe {
+            crate::nvme_create_ctrl(
+                r.as_mut_ptr(),
+                subsysnqn.as_ptr(),
+                transport.as_ptr(),
+                traddr.as_ptr(),
+                host_traddr,
+                host_iface,
+                trsvcid.as_ptr(),
+            )
+        };
+        if nvme_ctrl.is_null() {
+            return Err(NvmeError::CreateCtrlrError {
+                rc: -libc::ENOMEM,
+            });
+        }
+        let cfg = crate::nvme_fabrics_config {
+            host_traddr,
+            host_iface,
+            queue_size: 0,
+            nr_io_queues: 0,
+            reconnect_delay: 0,
+            ctrl_loss_tmo: crate::NVMF_DEF_CTRL_LOSS_TMO as i32,
+            fast_io_fail_tmo: 0,
+            keep_alive_tmo: 0,
+            nr_write_queues: 0,
+            nr_poll_queues: 0,
+            tos: -1,
+            duplicate_connect: false,
+            disable_sqflow: false,
+            hdr_digest: false,
+            data_digest: false,
+            tls: false,
+        };
+        let ret = unsafe { crate::nvmf_add_ctrl(h, nvme_ctrl, &cfg) };
+        if ret != 0 {
+            return Err(NvmeError::AddCtrlrError {
+                rc: ret,
+            });
+        }
+        Ok(())
+    }
+
+    /// List block devices for this target
+    ///
+    /// `retries`: number of times to retry until at least one device is found
+    pub fn block_devices(
+        &self,
+        mut retries: usize,
+    ) -> Result<Vec<String>, NvmeError> {
+        let mut devices = Vec::<String>::new();
+        loop {
+            let r =
+                NvmeRoot::new(unsafe { crate::nvme_scan(std::ptr::null()) });
+            let hostiter = NvmeHostIterator::new(&r);
+            for host in hostiter {
+                let subsysiter = NvmeSubsystemIterator::new(host);
+                for subsys in subsysiter {
+                    let cstr = unsafe {
+                        std::ffi::CStr::from_ptr(crate::nvme_subsystem_get_nqn(
+                            subsys,
+                        ))
+                    };
+                    if cstr.to_str().unwrap() != self.subsysnqn {
+                        continue;
+                    }
+                    let nsiter = NvmeNamespaceIterator::new(subsys);
+                    for ns in nsiter {
+                        devices.push(format!(
+                            "/dev/{}",
+                            unsafe {
+                                std::ffi::CStr::from_ptr(
+                                    crate::nvme_ns_get_name(ns),
+                                )
+                            }
+                            .to_str()
+                            .unwrap()
+                        ));
+                    }
+                }
+            }
+
+            if retries == 0 || !devices.is_empty() {
+                break;
+            }
+            retries -= 1;
+            std::thread::sleep(Duration::from_millis(500));
+        }
+
+        Ok(devices)
+    }
+
+    /// Disconnect from NVMe target
+    ///
+    /// Returns number of controllers disconnected
+    pub fn disconnect(&self) -> Result<usize, NvmeError> {
+        let r = NvmeRoot::new(unsafe { crate::nvme_scan(std::ptr::null()) });
+        let mut i = 0;
+        let hostiter = NvmeHostIterator::new(&r);
+        for host in hostiter {
+            let subsysiter = NvmeSubsystemIterator::new(host);
+            for subsys in subsysiter {
+                let cstr = unsafe {
+                    std::ffi::CStr::from_ptr(crate::nvme_subsystem_get_nqn(
+                        subsys,
+                    ))
+                };
+                if cstr.to_str().unwrap() != self.subsysnqn {
+                    continue;
+                }
+                let ctrlriter = NvmeCtrlrIterator::new(subsys);
+                for c in ctrlriter {
+                    let ret = unsafe { crate::nvme_disconnect_ctrl(c) };
+                    if ret == 0 {
+                        i += 1;
+                    } else {
+                        return Err(NvmeError::FileIoError {
+                            rc: ret,
+                        });
+                    }
+                }
+            }
+        }
+        Ok(i)
+    }
+}
+
+#[test]
+fn nvme_parse_uri() {
+    let target =
+        NvmeTarget::try_from("nvmf://1.2.3.4:1234/testnqn.what-ever.foo")
+            .unwrap();
+
+    assert_eq!(target.trsvcid, 1234);
+    assert_eq!(target.traddr, "1.2.3.4");
+    assert_eq!(target.trtype, NvmeTransportType::Tcp);
+    assert_eq!(target.subsysnqn, "testnqn.what-ever.foo");
+
+    let target =
+        NvmeTarget::try_from("nvmf+tcp://1.2.3.4:1234/testnqn.what-ever.foo")
+            .unwrap();
+
+    assert_eq!(target.trsvcid, 1234);
+    assert_eq!(target.traddr, "1.2.3.4");
+    assert_eq!(target.trtype, NvmeTransportType::Tcp);
+    assert_eq!(target.subsysnqn, "testnqn.what-ever.foo");
+}

--- a/libnvme-rs/wrapper.h
+++ b/libnvme-rs/wrapper.h
@@ -1,0 +1,2 @@
+#include <stddef.h>
+#include <libnvme.h>

--- a/mayastor/Cargo.toml
+++ b/mayastor/Cargo.toml
@@ -114,5 +114,5 @@ version = "0.8.2"
 [dev-dependencies]
 assert_matches = "1.5.0"
 composer = { path = "../composer" }
-nvmeadm = { path = "../nvmeadm" }
+libnvme-rs = {path = "../libnvme-rs", version = "0.1.0"}
 run_script = "0.8.0"

--- a/mayastor/tests/persistence.rs
+++ b/mayastor/tests/persistence.rs
@@ -171,10 +171,11 @@ async fn persist_io_failure() {
         .expect("Failed to unshare");
 
     // Create and connect NVMF target.
-    let target = nvmeadm::NvmeTarget::try_from(nexus_uri.clone()).unwrap();
-    let devices = target.connect().unwrap();
+    let target = libnvme_rs::NvmeTarget::try_from(nexus_uri.clone()).unwrap();
+    target.connect().unwrap();
+    let devices = target.block_devices(2).unwrap();
     let fio_hdl = tokio::spawn(async move {
-        fio_run_verify(&devices[0].path.to_string()).unwrap()
+        fio_run_verify(&devices[0].to_string()).unwrap()
     });
 
     fio_hdl.await.unwrap();

--- a/nix/mayastor-overlay.nix
+++ b/nix/mayastor-overlay.nix
@@ -2,6 +2,7 @@ self: super: {
 
   fio = super.callPackage ./pkgs/fio { };
   images = super.callPackage ./pkgs/images { };
+  libnvme = super.callPackage ./pkgs/libnvme { };
   libspdk = (super.callPackage ./pkgs/libspdk { }).release;
   libspdk-dev = (super.callPackage ./pkgs/libspdk { }).debug;
   mayastor = (super.callPackage ./pkgs/mayastor { }).release;

--- a/nix/pkgs/libnvme/default.nix
+++ b/nix/pkgs/libnvme/default.nix
@@ -1,0 +1,19 @@
+{ stdenv, lib, fetchgit, json_c, libuuid, meson, ninja, openssl, pkg-config, python3, sources }:
+
+stdenv.mkDerivation rec {
+  version = sources.libnvme.rev;
+  name = "libnvme-${version}";
+
+  src = sources.libnvme;
+
+  nativeBuildInputs = [ json_c libuuid meson ninja openssl pkg-config python3 ];
+  meta = {
+    description = "Userspace NVMe library";
+    longDescription = ''
+      This is the libnvme development C library. libnvme provides type defintions for NVMe specification structures, enumerations, and bit fields, helper functions to construct, dispatch, and decode commands and payloads, and utilities to connect, scan, and manage nvme devices on a Linux system.
+    '';
+    homepage = "https://github.com/linux-nvme/libnvme";
+    licenses = lib.licenses.lgpl21Plus;
+    maintainers = "jonathan.teh@mayadata.io";
+  };
+}

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -1,4 +1,16 @@
 {
+    "libnvme": {
+        "branch": "master",
+        "description": "nvme client library",
+        "homepage": "https://github.com/linux-nvme/libnvme",
+        "owner": "linux-nvme",
+        "repo": "libnvme",
+        "rev": "c434d43faee6e6e93ac5ad603ef94a77299fa178",
+        "sha256": "0wkr0axmm4wqjncb6x7fjyg0wxjdi9f2qd3df6ph671qh5ralrjy",
+        "type": "tarball",
+        "url": "https://github.com/linux-nvme/libnvme/archive/c434d43faee6e6e93ac5ad603ef94a77299fa178.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
     "niv": {
         "branch": "master",
         "description": "Easy dependency management for Nix projects",

--- a/shell.nix
+++ b/shell.nix
@@ -28,6 +28,7 @@ mkShell {
     fio
     libaio
     libbsd
+    libnvme
     libpcap
     libudev
     liburing


### PR DESCRIPTION
New crate that uses the libnvme development C library. Reuse NvmeTarget, and some NvmeErrors, from nvmeadm and implement connect and disconnect to an NVMe-oF target, and list connections using libnvme.

Fixes CAS-1218, CAS-1217
Starts on CAS-1220
