### PR TITLE
fix: add libnvme-rs to cargo-package

### DIFF
--- a/nix/pkgs/mayastor/cargo-package.nix
+++ b/nix/pkgs/mayastor/cargo-package.nix
@@ -47,6 +47,7 @@ let
     "csi"
     "devinfo"
     "jsonrpc"
+    "libnvme-rs"
     "mayastor"
     "mbus-api"
     "nvmeadm"


### PR DESCRIPTION
Its cargo.toml turns out to be a dependency when building the image
though it's only used for Mayastor cargo tests.