### PR TITLE
fix(Jenkins): build correct images

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -577,10 +577,16 @@ pipeline {
             branch 'master'
             branch 'release/*'
             branch 'develop'
+            // TODO: For test purposes only. Remove after use.
+            branch 'trying'
           }
         }
       }
       steps {
+        // Clean the workspace and unstash the source to ensure we build the correct images.
+        cleanWs()
+        unstash 'source'
+
         withCredentials([usernamePassword(credentialsId: 'dockerhub', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
           sh 'echo $PASSWORD | docker login -u $USERNAME --password-stdin'
         }


### PR DESCRIPTION
Ensure the correct source code is used to build the images. This should
ensure that the latest images are pushed to the registry.