### PR TITLE
fix(python tests): cleanup containers

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -332,6 +332,9 @@ pipeline {
             stage('run tests') {
               steps {
                 sh 'printenv'
+                // Cleanup any existing containers.
+                // They could be lingering if there were previous test failures.
+                sh 'docker system prune -f'
                 sh 'nix-shell --run "./scripts/pytest-tests.sh" ci.nix'
               }
             }


### PR DESCRIPTION
Before running the python tests ensure that all existing containers are
destroyed. This will ensure that the python tests are run in a clean
environment.

It has been observed on CI that if containers are left around (due to
previous test failures) subsequent python tests will fail. The error
message will look like:
"compose.project.ProjectError: Encountered errors while bringing up the
project."