### PR TITLE
fix(build): fix arm64 build

### DIFF
--- a/chart/templates/mayastor-daemonset.yaml
+++ b/chart/templates/mayastor-daemonset.yaml
@@ -24,7 +24,6 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       nodeSelector:
         openebs.io/engine: mayastor
-        kubernetes.io/arch: amd64
       initContainers:
       - name: registration-probe
         image: busybox:latest

--- a/deploy/mayastor-daemonset.yaml
+++ b/deploy/mayastor-daemonset.yaml
@@ -26,7 +26,6 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       nodeSelector:
         openebs.io/engine: mayastor
-        kubernetes.io/arch: amd64
       initContainers:
       - name: registration-probe
         image: busybox:latest

--- a/nix/pkgs/libspdk/default.nix
+++ b/nix/pkgs/libspdk/default.nix
@@ -133,6 +133,7 @@ let
       install -v build/lib/pkgconfig/*.pc        $out/lib/pkgconfig/
       install -v dpdk/build/lib/*.a              $out/lib/
       install -v dpdk/build/lib/pkgconfig/*.pc   $out/lib/pkgconfig/
+    '' + lib.optionalString targetPlatform.isx86_64 ''
       install -v intel-ipsec-mb/lib/*.a          $out/lib/
 
       # fix paths in pkg config files


### PR DESCRIPTION
Fix build on arm64 platform. Intel-ipsec-mb lib is only specific to
x64_64 platform.
And Mayastor can run on arm64 now, not just x86_64.

Signed-off-by: Xinliang Liu <xinliang.liu@linaro.org>

This PR is related to Mayastor arm64 support: https://github.com/openebs/mayastor/issues/1063