### PR TITLE
Helm Chart configuration

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -10,3 +10,4 @@ dependencies:
     tags:
       - bitnami-etcd
     version: 6.2.3
+    condition: etcd.enabled

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -16,3 +16,12 @@
 {{- printf "%d" (add $i 1) }}
 {{- end }}
 {{- end }}
+
+{{/* Generate the etcd endpoint that should be used by mayastor */}}
+{{- define "etcdEndpoint" -}}
+    {{- if or .Values.etcd.enabled (not .Values.etcdEndpoint) }}
+        {{- printf "mayastor-etcd" }}
+    {{- else }}
+        {{- .Values.etcdEndpoint }}
+    {{- end }}
+{{- end }}

--- a/chart/templates/etcd/storage/localpv.yaml
+++ b/chart/templates/etcd/storage/localpv.yaml
@@ -1,5 +1,5 @@
 ---
-{{ if and .Values.etcd.persistence.enabled (eq .Values.etcd.persistence.storageClass "manual") }}
+{{ if and .Values.etcd.enabled .Values.etcd.persistence.enabled (eq .Values.etcd.persistence.storageClass "manual") }}
 {{- range $index, $end := until (.Values.etcd.replicaCount | int) }}
 apiVersion: v1
 kind: PersistentVolume

--- a/chart/templates/mayastor-daemonset.yaml
+++ b/chart/templates/mayastor-daemonset.yaml
@@ -28,6 +28,9 @@ spec:
       - name: registration-probe
         image: busybox:latest
         command: ['sh', '-c', 'until nc -vz core 50051; do echo "Waiting for registration service..."; sleep 1; done;']
+      - name: etcd-probe
+        image: busybox:latest
+        command: ['sh', '-c', 'until nc -vz {{ include "etcdEndpoint" . }} 2379; do echo "Waiting for etcd..."; sleep 1; done;']
       containers:
       - name: mayastor
         image: {{ include "mayastorImagesPrefix" . }}mayadata/mayastor:{{ .Values.mayastorImagesTag }}

--- a/chart/templates/mayastor-daemonset.yaml
+++ b/chart/templates/mayastor-daemonset.yaml
@@ -56,7 +56,7 @@ spec:
         - "-Rhttps://core:50051"
         - "-y/var/local/mayastor/config.yaml"
         - "-l{{ include "mayastorCpuSpec" . }}"
-        - "-pmayastor-etcd"
+        - "-p{{- include "etcdEndpoint" . -}}"
         command:
         - mayastor
         securityContext:

--- a/chart/templates/mayastor-daemonset.yaml
+++ b/chart/templates/mayastor-daemonset.yaml
@@ -25,7 +25,10 @@ spec:
       serviceAccountName: {{ .Values.serviceAccountName | quote }}
       {{- end }}
       dnsPolicy: ClusterFirstWithHostNet
-      nodeSelector: {{ .Values.nodeSelector | toYaml | nindent 8 }}
+      nodeSelector:
+        {{- range .Values.nodeSelector -}}
+        {{ . | toYaml | nindent 8 }}
+        {{- end }}
       affinity: {{ .Values.affinity | toYaml | nindent 8 }}
       initContainers:
       - name: registration-probe

--- a/chart/templates/mayastor-daemonset.yaml
+++ b/chart/templates/mayastor-daemonset.yaml
@@ -22,9 +22,8 @@ spec:
       hostNetwork: true
       # To resolve services in the namespace
       dnsPolicy: ClusterFirstWithHostNet
-      nodeSelector:
-        openebs.io/engine: mayastor
-        kubernetes.io/arch: amd64
+      nodeSelector: {{ .Values.nodeSelector | toYaml | nindent 8 }}
+      affinity: {{ .Values.affinity | toYaml | nindent 8 }}
       initContainers:
       - name: registration-probe
         image: busybox:latest

--- a/chart/templates/mayastor-daemonset.yaml
+++ b/chart/templates/mayastor-daemonset.yaml
@@ -20,10 +20,10 @@ spec:
         app: mayastor
     spec:
       hostNetwork: true
-      # To resolve services in the namespace
       {{- if .Values.serviceAccountName }}
       serviceAccountName: {{ .Values.serviceAccountName | quote }}
       {{- end }}
+      # To resolve services in the namespace
       dnsPolicy: ClusterFirstWithHostNet
       nodeSelector:
         {{- range .Values.nodeSelector -}}

--- a/chart/templates/mayastor-daemonset.yaml
+++ b/chart/templates/mayastor-daemonset.yaml
@@ -21,6 +21,9 @@ spec:
     spec:
       hostNetwork: true
       # To resolve services in the namespace
+      {{- if .Values.serviceAccountName }}
+      serviceAccountName: {{ .Values.serviceAccountName | quote }}
+      {{- end }}
       dnsPolicy: ClusterFirstWithHostNet
       nodeSelector: {{ .Values.nodeSelector | toYaml | nindent 8 }}
       affinity: {{ .Values.affinity | toYaml | nindent 8 }}

--- a/chart/templates/mayastor-daemonset.yaml
+++ b/chart/templates/mayastor-daemonset.yaml
@@ -42,7 +42,7 @@ spec:
       {{- end }}
       containers:
       - name: mayastor
-        image: {{ include "mayastorImagesPrefix" . }}mayadata/mayastor:{{ .Values.mayastorImagesTag }}
+        image: {{ include "mayastorImagesPrefix" . }}{{ .Values.mayastorImage }}:{{ .Values.mayastorImagesTag }}
         imagePullPolicy: {{ .Values.mayastorImagePullPolicy }}
         env:
         - name: RUST_LOG

--- a/chart/templates/mayastor-daemonset.yaml
+++ b/chart/templates/mayastor-daemonset.yaml
@@ -75,6 +75,9 @@ spec:
           mountPath: /dev/shm
         - name: configlocation
           mountPath: /var/local/mayastor/
+        {{- if .Values.mayastorExtraVolumeMounts -}}
+        {{ .Values.mayastorExtraVolumeMounts | toYaml | nindent 8 }}
+        {{- end }}
         resources:
           # NOTE: Each container must have mem/cpu limits defined in order to
           # belong to Guaranteed QoS class, hence can never get evicted in case of
@@ -111,3 +114,6 @@ spec:
         hostPath:
           path: /var/local/mayastor/
           type: DirectoryOrCreate
+      {{- if .Values.mayastorExtraVolumes -}}
+      {{ .Values.mayastorExtraVolumes | toYaml | nindent 6 }}
+      {{- end }}

--- a/chart/templates/mayastor-daemonset.yaml
+++ b/chart/templates/mayastor-daemonset.yaml
@@ -112,7 +112,7 @@ spec:
           medium: HugePages
       - name: configlocation
         hostPath:
-          path: /var/local/mayastor/
+          path: {{ .Values.mayastorConfigLocation | quote }}
           type: DirectoryOrCreate
       {{- if .Values.mayastorExtraVolumes -}}
       {{ .Values.mayastorExtraVolumes | toYaml | nindent 6 }}

--- a/chart/templates/mayastor-daemonset.yaml
+++ b/chart/templates/mayastor-daemonset.yaml
@@ -38,7 +38,7 @@ spec:
         image: busybox:latest
         command: ['sh', '-c', 'until nc -vz {{ include "etcdEndpoint" . }} 2379; do echo "Waiting for etcd..."; sleep 1; done;']
       {{- if .Values.mayastorExtraInitContainers -}}
-      {{ .Values.mayastorExtraInitContainers | toYaml | nindent 6 }}
+      {{ tpl (.Values.mayastorExtraInitContainers | toYaml) . | nindent 6 }}
       {{- end }}
       containers:
       - name: mayastor

--- a/chart/templates/mayastor-daemonset.yaml
+++ b/chart/templates/mayastor-daemonset.yaml
@@ -31,6 +31,9 @@ spec:
       - name: etcd-probe
         image: busybox:latest
         command: ['sh', '-c', 'until nc -vz {{ include "etcdEndpoint" . }} 2379; do echo "Waiting for etcd..."; sleep 1; done;']
+      {{- if .Values.mayastorExtraInitContainers -}}
+      {{ .Values.mayastorExtraInitContainers | toYaml | nindent 6 }}
+      {{- end }}
       containers:
       - name: mayastor
         image: {{ include "mayastorImagesPrefix" . }}mayadata/mayastor:{{ .Values.mayastorImagesTag }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -23,6 +23,8 @@ nodeSelector:
 
 affinity: {}
 
+serviceAccountName: ""
+
 csi:
   nvme:
     # nvme_core module io timeout in seconds

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -20,8 +20,8 @@ moacDebug: false
 moac: false
 
 nodeSelector:
-  openebs.io/engine: mayastor
-  kubernetes.io/arch: amd64
+  - openebs.io/engine: mayastor
+  - kubernetes.io/arch: amd64
 
 affinity: {}
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -4,6 +4,8 @@ mayastorCpuCount: "1"
 mayastorHugePagesGiB: "1"
 mayastorImagesRegistry: ""
 mayastorConfigLocation: /var/local/mayastor
+mayastorLogLevel: info
+
 mayastorExtraVolumeMounts: []
 mayastorExtraVolumes: []
 mayastorExtraInitContainers: []

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,4 +1,5 @@
 mayastorImagesTag: latest
+mayastorImage: mayadata/mayastor
 mayastorImagePullPolicy: Always
 mayastorCpuCount: "1"
 mayastorHugePagesGiB: "1"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -3,7 +3,10 @@ mayastorImagePullPolicy: Always
 mayastorCpuCount: "1"
 mayastorHugePagesGiB: "1"
 mayastorImagesRegistry: ""
+mayastorExtraVolumeMounts: []
+mayastorExtraVolumes: []
 mayastorExtraInitContainers: []
+
 #mayastorPools:
 #  - node: "NODE_NAME"
 #    device: "DEVICE"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -3,6 +3,7 @@ mayastorImagePullPolicy: Always
 mayastorCpuCount: "1"
 mayastorHugePagesGiB: "1"
 mayastorImagesRegistry: ""
+mayastorExtraInitContainers: []
 #mayastorPools:
 #  - node: "NODE_NAME"
 #    device: "DEVICE"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -3,6 +3,7 @@ mayastorImagePullPolicy: Always
 mayastorCpuCount: "1"
 mayastorHugePagesGiB: "1"
 mayastorImagesRegistry: ""
+mayastorConfigLocation: /var/local/mayastor
 mayastorExtraVolumeMounts: []
 mayastorExtraVolumes: []
 mayastorExtraInitContainers: []

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -19,6 +19,10 @@ csi:
     io_timeout_enabled: true
 
 etcd:
+  ## Deploy bitnami helm chart
+  ##
+  enabled: true
+
   ## Number of replicas
   ##
   replicaCount: 1

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -12,6 +12,12 @@ mayastorImagesRegistry: ""
 moacDebug: false
 moac: false
 
+nodeSelector:
+  openebs.io/engine: mayastor
+  kubernetes.io/arch: amd64
+
+affinity: {}
+
 csi:
   nvme:
     # nvme_core module io timeout in seconds

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -18,6 +18,9 @@ csi:
     io_timeout: "30"
     io_timeout_enabled: true
 
+# Use an external etcd endpoint, if etcd.enabled=false
+etcdEndpoint: ""
+
 etcd:
   ## Deploy bitnami helm chart
   ##


### PR DESCRIPTION
### Summary

Add a few configuration options to the Mayastor Helm Chart. The default values maintain backwards compatibility.

### Changes

- `mayastorImage`, use a custom mayastor image
- `etcd.enabled`, controls whether the etcd dependency chart is deployed
- `etcdEndpoint`, supports using an external etcd
- `serviceAccountName`, supports setting a custom service account name for the mayastor pod
- `mayastorExtraVolumeMounts` and `mayastorExtraVolumes`, add extra volumes to the mayastor pod
- `mayastorExtraInitContainers`, add extra initContainers to the mayastor pod
- `mayastorConfigLocation`, configure the location of the mayastor config file
- `nodeSelector`, configurable nodeSelector labels.
- `affinity`, configure affinity rules for the mayastor pods