### PR TITLE
Helm-template-update

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,16 @@
 [![Slack](https://img.shields.io/badge/JOIN-SLACK-blue)](https://kubernetes.slack.com/messages/openebs)
 [![built with nix](https://builtwithnix.org/badge.svg)](https://builtwithnix.org)
 
-Table of contents:
-==================
+## Table of contents
+
+---
+
 - [Quickly deploy it on K8s and get started](https://mayastor.gitbook.io)
-    - [Deploying on microk8s](/doc/microk8s.md)
+  - [Deploying on microk8s](/doc/microk8s.md)
 - [High-level overview](#overview)
-    - [The Nexus CAS module](#Nexus)
-    - [Local storage](#local-storage)
-    - [Exporting a Nexus](#exporting-the-nexus)
+  - [The Nexus CAS module](#Nexus)
+  - [Local storage](#local-storage)
+  - [Exporting a Nexus](#exporting-the-nexus)
 - [Building from source](/doc/build.md)
 - [Examples of the Nexus module](/doc/mcli.md)
 - [Frequently asked questions](/doc/FAQ.md)
@@ -20,23 +22,29 @@ Table of contents:
 <p align="justify">
 <strong>Mayastor</strong> is a cloud-native declarative data plane written in <strong>Rust.</strong>
 Our goal is to abstract storage resources and their differences through the data plane such that users only need to
-supply the <strong>what</strong> and do not have to worry about the <strong>how</strong> so that individual teams stay in control.
+supply the <strong>what</strong> and do not have to worry about the <strong>how</strong>
+so that individual teams stay in control.
 
 We also try to be as unopinionated as possible. What this means is that we try to work with the existing storage systems
- you might already have and unify them as abstract resources instead of swapping them out whenever the resources are local
- or remote.
+you might already have and unify them as abstract resources instead of swapping them out whenever the resources are local
+or remote.
 <br>
 <br>
+
 </p>
 
 Some targeted use cases are:
 
- - Low latency workloads for converged and segregated storage by leveraging NVMe/NVMe over Fabrics (NVMe-oF)
- - Micro-VM based containers like [Firecracker microVMs](https://github.com/firecracker-microvm/firecracker) and [Kata Containers](https://github.com/kata-containers/kata-containers) by providing storage over vhost-user
- - Programmatic based storage access, i.e write to block devices from within your application instead of making system calls
- - Storage unification to lift barriers so that you can start deploying cloud native apps on your existing storage without painful data gravity barriers that prevent progress and innovation
+- Low latency workloads for converged and segregated storage by leveraging NVMe/NVMe over Fabrics (NVMe-oF)
+- Micro-VM based containers like [Firecracker microVMs](https://github.com/firecracker-microvm/firecracker) and
+  [Kata Containers](https://github.com/kata-containers/kata-containers) by providing storage over vhost-user
+- Programmatic based storage access, i.e write to block devices from within your application instead of making system calls
+- Storage unification to lift barriers so that you can start deploying cloud native apps on your existing storage
+  without painful data gravity barriers that prevent progress and innovation
 
-# User Documentation
+## User Documentation
+
+---
 
 The official user documentation for the Mayastor Project is published here in GitBook format: [mayastor.gitbook.io](https://mayastor.gitbook.io/)
 
@@ -46,15 +54,18 @@ At a high-level, Mayastor consists of two major components.
 
 ### **Control plane:**
 
- * A microservices patterned control plane, centered around a core agent which publically exposes a RESTful API.  This is extended by a dedicated operator responsible 
- for managing the life cycle of "Mayastor Pools" (an abstraction for devices supplying the cluster with persistent backing storage) and a CSI compliant external provisioner (controller).
- Source code for the control plane components is located in its [own repository](https://github.com/openebs/mayastor-control-plane)
+- A microservices patterned control plane, centered around a core agent which publically exposes a RESTful API.
+  This is extended by a dedicated operator responsible for managing the life cycle of "Mayastor Pools"
+  (an abstraction for devices supplying the cluster with persistent backing storage) and a CSI compliant
+  external provisioner (controller).
+  Source code for the control plane components is located in its [own repository](https://github.com/openebs/mayastor-control-plane)
 
- * A _per_ node instance *mayastor-csi* plugin which implements the identity and node grpc services from CSI protocol.
+- A _per_ node instance _mayastor-csi_ plugin which implements the identity and node grpc services from CSI protocol.
 
 ### **Data plane:**
 
-* Each node you wish to use for storage or storage services will have to run a Mayastor daemon set. Mayastor itself has three major components: the Nexus, a local storage component, and the mayastor-csi plugin.
+- Each node you wish to use for storage or storage services will have to run a Mayastor daemon set. Mayastor itself has
+  three major components: the Nexus, a local storage component, and the mayastor-csi plugin.
 
 ## Nexus
 
@@ -65,10 +76,10 @@ selected to run your k8s workload. We call these from the Nexus' point of view i
 The goal we envision the Nexus to provide here, as it sits between the storage systems and PVCs, is loose coupling.
 
 A practical example: Once you are up and running with persistent workloads in a container, you need to move your data because
-the storage system that stores your PVC goes EOL.  You now can control how this impacts your team without getting into storage
-migration projects, which are always painful and complicated.  In reality, the individual storage volumes per team/app are
-relatively small, but today it is not possible for individual teams to handle their own storage needs. The Nexus provides the
-abstraction over the resources such that the developer teams stay in control.
+the storage system that stores your PVC goes EOL. You now can control how this impacts your team without getting into storage
+migration projects, which are always painful and complicated. In reality, the individual storage volumes per team/app are
+relatively small, but today it is not possible for individual teams to handle their own storage needs.
+The Nexus provides the abstraction over the resources such that the developer teams stay in control.
 
 The reason we think this can work is because applications have changed, and the way they are built allows us to rethink
 they way we do things. Moreover, due to hardware [changes](https://searchstorage.techtarget.com/tip/NVMe-performance-challenges-expose-the-CPU-chokepoint)
@@ -79,6 +90,7 @@ a single device to a protocol standard protocol. These storage URIs are generate
 track of what resources belong to what Nexus instance and subsequently to what PVC.
 
 You can also directly use the nexus from within your application code. For example:
+
 </p>
 
 ```rust
@@ -125,7 +137,8 @@ buf.as_slice().into_iter().map(|b| assert_eq!(b, 0xff)).for_each(drop);
 We think this can help a lot of database projects as well, where they typically have all the smarts in their database engine
 and they want the most simple (but fast) storage device. For a more elaborate example see some of the tests in mayastor/tests.
 
-To communicate with the children, the Nexus uses industry standard protocols. The Nexus supports direct access to local storage and remote storage using NVMe-oF TCP. Another advantage of the implementation is that if you were to remove
+To communicate with the children, the Nexus uses industry standard protocols. The Nexus supports direct access to local
+storage and remote storage using NVMe-oF TCP. Another advantage of the implementation is that if you were to remove
 the Nexus from the data path, you would still be able to access your data as if Mayastor was not there.
 
 The Nexus itself does not store any data and in its most simplistic form the Nexus is a proxy towards real storage
@@ -151,6 +164,7 @@ except for the fact that it is not local anymore.
 Similarly, if you do not want to use anything other than local storage, you can still use Mayastor to provide you with
 additional functionality that otherwise would require you setup kernel specific features like LVM for example.
 <br>
+
 </p>
 
 ## Exporting the Nexus
@@ -174,7 +188,7 @@ option if you are not sure how to use it. CSI services are not covered by the cl
 In following example of a client session is assumed that mayastor has been
 started and is running:
 
-```
+```bash
 $ dd if=/dev/zero of=/tmp/disk bs=1024 count=102400
 102400+0 records in
 102400+0 records out
@@ -207,7 +221,7 @@ $ mayastor-client pool destroy tpool
 Mayastor is developed under Apache 2.0 license at the project level. Some components of the project are derived from
 other open source projects and are distributed under their respective licenses.
 
-```http://www.apache.org/licenses/LICENSE-2.0```
+`http://www.apache.org/licenses/LICENSE-2.0`
 
 ### Contributions
 

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -3,10 +3,11 @@ name: mayastor
 description: Mayastor Helm chart for Kubernetes
 type: application
 version: 0.0.1
-# appVersion: "latest"
+appVersion: 1.0.1
 dependencies:
   - name: etcd
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-etcd
     version: 6.2.3
+    condition: etcd.enabled

--- a/chart/README.md
+++ b/chart/README.md
@@ -1,33 +1,29 @@
 # Helm chart for Mayastor
 
-Helm chart isn't published yet and is used mostly internally to generate yamls in `deploy/` directory and for end2end test. But chart should be deployable from this repo with helm anyway. Command below expects that:
+Helm chart isn't published yet and is used mostly internally to generate yamls in `deploy/` directory and for end2end test.
+But chart should be deployable from this repo with helm anyway. Command below expects that:
 
-  * you have k8s cluster up and running with [mayastor requirements](https://mayastor.gitbook.io/introduction/quickstart/preparing-the-cluster) fulfilled (take a look at [mayastor-terraform-playground](https://github.com/mayadata-io/mayastor-terraform-playground/) (WARNING - super-pre-alpha)
-  * kubectl is able to access your cluster without any arguments (i.e. you have cluster configured in config as default or your environment variable KUBECONFIG points to working kubeconfig)
+- you have k8s cluster up and running with [mayastor requirements](https://mayastor.gitbook.io/introduction/quickstart/preparing-the-cluster)
+  fulfilled (take a look at [mayastor-terraform-playground](https://github.com/mayadata-io/mayastor-terraform-playground/)
+  (WARNING - super-pre-alpha)
+- kubectl is able to access your cluster without any arguments (i.e. you have cluster configured in config as default or
+  your environment variable KUBECONFIG points to working kubeconfig)
 
-```
+```bash
 cd /path/to/openebs/Mayastor
 helm install mayastor ./chart --namespace=mayastor --create-namespace
 ```
 
 To uninstall:
 
-```
+```bash
 helm uninstall mayastor -n mayastor
 kubectl delete namespace mayastor
 ```
 
-Please note that the provided etcd deployment with its default values uses an EmptyDir Volume as its backing store and is not production ready.
+Please note that the provided etcd deployment with its default values uses an EmptyDir Volume as its backing store
+and is not production ready.
 
 # TODO
 
 [ ] publish :-)
-
-## templating
-
-[x] templatize namespace properly - mayastor namespace is hardcoded in yaml templates
-  - use Release.Namespace
-  - use Release.Name
-[ ] allow pulling image from authenticated repository
-[ ] allow changing image versions separately
-

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -16,3 +16,78 @@
 {{- printf "%d" (add $i 1) }}
 {{- end }}
 {{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "mayastor.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "mayastor.labels" -}}
+helm.sh/chart: {{ include "mayastor.chart" . }}
+openebs/engine: mayastor
+{{ include "mayastor.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "mayastor.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "mayastor.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "mayastor.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "mayastor.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create a normalized etcd name based on input parameters
+*/}}
+{{- define "mayastor.etcdURL" -}}
+{{- if .Values.etcd.enabled }}
+{{- printf "%s-etcd" .Release.Name }}
+{{- else }}
+{{- .Values.etcd.externalEtcdURL }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "mayastor.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "mayastor.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/chart/templates/etcd/storage/localpv.yaml
+++ b/chart/templates/etcd/storage/localpv.yaml
@@ -1,5 +1,5 @@
 ---
-{{ if and .Values.etcd.persistence.enabled (eq .Values.etcd.persistence.storageClass "manual") }}
+{{ if and .Values.etcd.persistence.enabled (eq .Values.etcd.persistence.storageClass "manual") .Values.etcd.enabled }}
 {{- range $index, $end := until (.Values.etcd.replicaCount | int) }}
 apiVersion: v1
 kind: PersistentVolume

--- a/chart/templates/mayastor-daemonset.yaml
+++ b/chart/templates/mayastor-daemonset.yaml
@@ -23,6 +23,9 @@ spec:
       labels:
         {{- include "mayastor.selectorLabels" . | nindent 8 }}
     spec:
+      {{- if .Values.runtimeClassName }}
+      runetimeClassName: {{ .Values.runtimeClassName | quote }}
+      {{- end }}
       serviceAccountName: {{ include "mayastor.serviceAccountName" . }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/chart/templates/mayastor-daemonset.yaml
+++ b/chart/templates/mayastor-daemonset.yaml
@@ -4,11 +4,11 @@ metadata:
   namespace: {{ .Release.Namespace }}
   name: mayastor
   labels:
-    openebs/engine: mayastor
+    {{- include "mayastor.labels" . | nindent 4 }}
 spec:
   selector:
     matchLabels:
-      app: mayastor
+      {{- include "mayastor.selectorLabels" . | nindent 6 }}
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:
@@ -16,92 +16,113 @@ spec:
   minReadySeconds: 10
   template:
     metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
-        app: mayastor
+        {{- include "mayastor.selectorLabels" . | nindent 8 }}
     spec:
-      hostNetwork: true
+      serviceAccountName: {{ include "mayastor.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      hostNetwork: {{ .Values.hostNetwork }}
       # To resolve services in the namespace
-      dnsPolicy: ClusterFirstWithHostNet
-      nodeSelector:
-        openebs.io/engine: mayastor
+      dnsPolicy: {{ .Values.dnsPolicy }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       initContainers:
-      - name: registration-probe
-        image: busybox:latest
-        command: ['sh', '-c', 'until nc -vz core 50051; do echo "Waiting for registration service..."; sleep 1; done;']
+        - name: registration-probe
+          image: "{{ .Values.registrationProbe.repository }}:{{ .Values.registrationProbe.tag | default "latest" }}"
+          command: ['sh', '-c', 'until nc -vz core 50051; do echo "Waiting for registration service..."; sleep 1; done;']
       containers:
-      - name: mayastor
-        image: {{ include "mayastorImagesPrefix" . }}mayadata/mayastor:{{ .Values.mayastorImagesTag }}
-        imagePullPolicy: {{ .Values.mayastorImagePullPolicy }}
-        env:
-        - name: RUST_LOG
-          value: info,mayastor={{ .Values.mayastorLogLevel }}
-        - name: NVMF_TCP_MAX_QUEUE_DEPTH
-          value: "32"
-        - name: MY_NODE_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
-        - name: MY_POD_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        args:
-        # The -l argument accepts cpu-list. Indexing starts at zero.
-        # For example -l 1,2,10-20 means use core 1, 2, 10 to 20.
-        # Note: Ensure that the CPU resources are updated accordingly.
-        #       If you use 2 CPUs, the CPU: field should also read 2.
-        - "-N$(MY_NODE_NAME)"
-        - "-g$(MY_POD_IP)"
-        - "-Rhttps://core:50051"
-        - "-y/var/local/mayastor/config.yaml"
-        - "-l{{ include "mayastorCpuSpec" . }}"
-        - "-pmayastor-etcd"
-        command:
-        - mayastor
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - name: device
-          mountPath: /dev
-        - name: udev
-          mountPath: /run/udev
-        - name: dshm
-          mountPath: /dev/shm
-        - name: configlocation
-          mountPath: /var/local/mayastor/
-        resources:
-          # NOTE: Each container must have mem/cpu limits defined in order to
-          # belong to Guaranteed QoS class, hence can never get evicted in case of
-          # pressure unless they exceed those limits. limits and requests must be the same.
-          limits:
-            cpu: "{{ .Values.mayastorCpuCount }}"
-            memory: "1Gi"
-            hugepages-2Mi: "{{ max .Values.mayastorHugePagesGiB 2 }}Gi"
-          requests:
-            cpu: "{{ .Values.mayastorCpuCount }}"
-            memory: "1Gi"
-            hugepages-2Mi: "{{ max .Values.mayastorHugePagesGiB 2 }}Gi"
-        ports:
-        - containerPort: 10124
-          protocol: TCP
-          name: mayastor
+        - name: mayastor
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.mayastorImagePullPolicy }}
+          env:
+          - name: RUST_LOG
+            value: info,mayastor={{ .Values.mayastorLogLevel }}
+          - name: NVMF_TCP_MAX_QUEUE_DEPTH
+            value: "32"
+          - name: MY_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: MY_POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          args:
+          # The -l argument accepts cpu-list. Indexing starts at zero.
+          # For example -l 1,2,10-20 means use core 1, 2, 10 to 20.
+          # Note: Ensure that the CPU resources are updated accordingly.
+          #       If you use 2 CPUs, the CPU: field should also read 2.
+          - "-N$(MY_NODE_NAME)"
+          - "-g$(MY_POD_IP)"
+          - "-Rhttps://core:50051"
+          - "-y/var/local/mayastor/config.yaml"
+          - "-l{{ include "mayastorCpuSpec" . }}"
+          - "-p{{ include "mayastor.etcdURL" . }}"
+          command:
+          - mayastor
+          securityContext:
+              {{- toYaml .Values.securityContext | nindent 12 }}
+          volumeMounts:
+          - name: device
+            mountPath: /dev
+          - name: udev
+            mountPath: /run/udev
+          - name: dshm
+            mountPath: /dev/shm
+          - name: configlocation
+            mountPath: /var/local/mayastor/
+          resources:
+            # NOTE: Each container must have mem/cpu limits defined in order to
+            # belong to Guaranteed QoS class, hence can never get evicted in case of
+            # pressure unless they exceed those limits. limits and requests must be the same.
+            limits:
+              cpu: "{{ .Values.mayastorCpuCount }}"
+              memory: "1Gi"
+              hugepages-2Mi: "{{ max .Values.mayastorHugePagesGiB 2 }}Gi"
+            requests:
+              cpu: "{{ .Values.mayastorCpuCount }}"
+              memory: "1Gi"
+              hugepages-2Mi: "{{ max .Values.mayastorHugePagesGiB 2 }}Gi"
+          ports:
+          - containerPort: 10124
+            protocol: TCP
+            name: mayastor
       volumes:
-      - name: device
-        hostPath:
-          path: /dev
-          type: Directory
-      - name: udev
-        hostPath:
-          path: /run/udev
-          type: Directory
-      - name: dshm
-        emptyDir:
-          medium: Memory
-          sizeLimit: "1Gi"
-      - name: hugepage
-        emptyDir:
-          medium: HugePages
-      - name: configlocation
-        hostPath:
-          path: /var/local/mayastor/
-          type: DirectoryOrCreate
+        - name: device
+          hostPath:
+            path: /dev
+            type: Directory
+        - name: udev
+          hostPath:
+            path: /run/udev
+            type: Directory
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: "1Gi"
+        - name: hugepage
+          emptyDir:
+            medium: HugePages
+        - name: configlocation
+          hostPath:
+            path: /var/local/mayastor/
+            type: DirectoryOrCreate
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/chart/templates/pool.yaml
+++ b/chart/templates/pool.yaml
@@ -4,9 +4,13 @@ apiVersion: "openebs.io/v1alpha1"
 kind: MayastorPool
 metadata:
   # Name can be anything as long as it is unique
-  name: pool-on-{{ .node }}
   # or let k8s to generate a unique pool name
-  #generateName: pool-
+  # if you use namePrefix, eg pool-
+  {{- if .namePrefix }}
+  generateName: {{ .namePrefix | quote }}
+  {{- else }}
+  name: pool-on-{{ .node }}
+  {{- end }}
   namespace: {{ $.Release.Namespace }}
 spec:
   node: {{ .node }}

--- a/chart/templates/serviceaccount.yaml
+++ b/chart/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "mayastor.serviceAccountName" . }}
+  labels:
+    {{- include "mayastor.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,14 +1,49 @@
-mayastorImagesTag: latest
-mayastorImagePullPolicy: Always
-mayastorCpuCount: "1"
-mayastorHugePagesGiB: "1"
-mayastorImagesRegistry: ""
-#mayastorPools:
-#  - node: "NODE_NAME"
-#    device: "DEVICE"
+fullnameOverride: ""
+image:
+  repository: mayadata/mayastor
+  pullPolicy: Always
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+registrationProbe:
+  repository: "busybox"
+  pullPolicy: Always
+  tag: latest
+
+imagePullSecrets: []
+# - name: "image-pull-secret"
+
+mayastorPools:
+  # - node: "NODE_NAME"
+  #   device: "DEVICE"
 # This option is intended for development yamls and motivated by the problem of
 # moac that does not update status of msp resource in some cases. Feel free to
 # remove when no longer needed.
+
+podAnnotations: {}
+
+podSecurityContext:
+  {}
+  # fsGroup: 2000
+
+securityContext:
+  privileged: true
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+hostNetwork: true
+dnsPolicy: ClusterFirstWithHostNet
+nodeSelector:
+  openebs.io/engine: mayastor
+tolerations: []
+affinity: {}
+
+mayastorCpuCount: "1"
+mayastorHugePagesGiB: "1"
+
 moacDebug: false
 moac: false
 
@@ -18,7 +53,20 @@ csi:
     io_timeout: "30"
     io_timeout_enabled: true
 
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
 etcd:
+  # Use if you want to have a install an etcd for openebs
+  enabled: false
+  # If bringing your own etcd cluster, provide it's url
+  externalEtcdURL: ""
   ## Number of replicas
   ##
   replicaCount: 1

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -5,6 +5,9 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
 
+# Runtime class to use. Defaults to cluster standard
+runtimeClassName: ""
+
 registrationProbe:
   repository: "busybox"
   pullPolicy: Always

--- a/scripts/generate-deploy-yamls.sh
+++ b/scripts/generate-deploy-yamls.sh
@@ -152,13 +152,13 @@ tmpd=$(mktemp -d /tmp/generate-deploy-yamls.sh.XXXXXXXX)
 trap "rm -fr '$tmpd'" HUP QUIT EXIT TERM INT
 
 # A rule of thumb: # of cpu cores equals to Gigs of hugepage memory
-template_params="mayastorImagesTag=$tag"
-template_params="$template_params,mayastorImagePullPolicy=$pull_policy"
+template_params="image.tag=$tag"
+template_params="$template_params,image.pullPolicy=$pull_policy"
 template_params="$template_params,mayastorCpuCount=$cores"
 template_params="$template_params,mayastorHugePagesGiB=$cores"
 template_params="$template_params,moacDebug=$moac_debug"
 if [ -n "$registry" ]; then
-  template_params="$template_params,mayastorImagesRegistry=$registry"
+  template_params="$template_params,image.registry=$registry"
 fi
 if [ -n "$pools" ]; then
   i=0


### PR DESCRIPTION
Several updates to the helm chart:

- Updated helm chart to use more standard parameters.
- Updated generate yaml script to use the standard parameters
- Added ability for user to provide their own ETCD if desired (toggle on the dependent chart, proper url in the container command)
- Added ability to reference a private image
  - Added ability to reference a different repository and a different image (instead of hardcoded mayastor/mayastor)
  - added ability to reference image pull secrets

Separately linted README slightly
