### PR TITLE
fix: build only the binaries for debug builds

### DIFF
--- a/nix/pkgs/io-engine/cargo-package.nix
+++ b/nix/pkgs/io-engine/cargo-package.nix
@@ -101,6 +101,7 @@ in
     SPDK_PATH = "${libspdk}";
   });
   debug = rustPlatform.buildRustPackage (buildProps // {
+    cargoBuildFlags = "--workspace --bins --exclude io-engine-bench";
     buildType = "debug";
     buildInputs = buildProps.buildInputs ++ [ libspdk-dev ];
     SPDK_PATH = "${libspdk-dev}";


### PR DESCRIPTION
This avoids building the benchmarks, which we don't need for container images anyway.
The benchmark is excluded explicitly anyway just to make it clear.

Resolves: #1155