### PR TITLE
chore(ci): add BDD tests to check cross compatability between v0 & v1 gRPC versions

### DIFF
--- a/io-engine/src/grpc/v1/replica.rs
+++ b/io-engine/src/grpc/v1/replica.rs
@@ -108,15 +108,20 @@ impl ReplicaRpc for ReplicaService {
                 }).map_err(Status::from);
             }
 
-
             let rx = rpc_submit(async move {
                 let lvs = match Lvs::lookup_by_uuid(&args.pooluuid) {
                     Some(lvs) => lvs,
                     None => {
-                        return Err(LvsError::Invalid {
-                            source: Errno::ENOSYS,
-                            msg: format!("Pool {} not found", args.pooluuid),
-                        })
+                        // lookup takes care of backward compatibility
+                        match Lvs::lookup(&args.pooluuid) {
+                            Some(lvs) => lvs,
+                            None => {
+                                return Err(LvsError::Invalid {
+                                    source: Errno::ENOSYS,
+                                    msg: format!("Pool {} not found", args.pooluuid),
+                                })
+                            }
+                        }
                     }
                 };
                 // if pooltype is not Lvs, the provided replica uuid need to be added as

--- a/scripts/pytest-tests.sh
+++ b/scripts/pytest-tests.sh
@@ -52,4 +52,9 @@ v1/pool
 v1/replica
 v1/nexus
 
+cross-grpc-version/pool
+cross-grpc-version/nexus
+cross-grpc-version/rebuild
+cross-grpc-version/replica
+
 END

--- a/test/python/cross-grpc-version/nexus/docker-compose.yml
+++ b/test/python/cross-grpc-version/nexus/docker-compose.yml
@@ -1,0 +1,65 @@
+#
+# {SRCDIR} should point to your working tree which should be your current pwd
+#
+
+version: '3'
+services:
+  ms0:
+    container_name: "ms0"
+    image: rust:latest
+    environment:
+      - MY_POD_IP=10.0.0.2
+      - NEXUS_NVMF_ANA_ENABLE=1
+      - NEXUS_NVMF_RESV_ENABLE=1
+    command: ${SRCDIR}/target/debug/io-engine -g 0.0.0.0 -l 1,2 -r /tmp/ms0.sock
+    networks:
+      mayastor_net:
+        ipv4_address: 10.0.0.2
+    cap_add:
+      # NUMA related
+      - SYS_ADMIN
+      - SYS_NICE
+      # uring needs mmap
+      - IPC_LOCK
+    security_opt:
+      # we can set this to a JSON file to allow per syscall access
+      - seccomp=unconfined
+    volumes:
+      - ${SRCDIR}:${SRCDIR}
+      - /nix:/nix
+      - /dev/hugepages:/dev/hugepages
+      - /tmp:/tmp
+      - /var/tmp:/var/tmp
+  ms1:
+    container_name: "ms1"
+    image: rust:latest
+    environment:
+      - MY_POD_IP=10.0.0.3
+      - NEXUS_NVMF_ANA_ENABLE=1
+      - NEXUS_NVMF_RESV_ENABLE=1
+    command: ${SRCDIR}/target/debug/io-engine -g 0.0.0.0 -l 3,4 -r /tmp/ms1.sock
+    networks:
+      mayastor_net:
+        ipv4_address: 10.0.0.3
+    cap_add:
+      # NUMA related
+      - SYS_ADMIN
+      - SYS_NICE
+      # uring needs mmap
+      - IPC_LOCK
+    security_opt:
+      # we can set this to a JSON file to allow per syscall access
+      - seccomp=unconfined
+    volumes:
+      - ${SRCDIR}:${SRCDIR}
+      - /nix:/nix
+      - /dev/hugepages:/dev/hugepages
+      - /tmp:/tmp
+      - /var/tmp:/var/tmp
+networks:
+  mayastor_net:
+    name: mayastor_net
+    ipam:
+      driver: default
+      config:
+        - subnet: "10.0.0.0/16"

--- a/test/python/cross-grpc-version/nexus/features/nexus.feature
+++ b/test/python/cross-grpc-version/nexus/features/nexus.feature
@@ -1,0 +1,76 @@
+Feature: Mayastor nexus management
+
+  Background:
+    Given a local mayastor instance
+    And a remote mayastor instance
+
+  Scenario: creating the same nexus with v1 gRPC call
+    Given a v0 version nexus
+    When creating an identical v1 version nexus
+    Then the operation should fail
+
+  Scenario: destroying a v0 version nexus with v1 gRPC call
+    Given a v0 version nexus
+    When destroying the nexus
+    Then the nexus should be destroyed
+
+  Scenario: destroying a v0 version nexus without first unpublishing
+    Given a nexus published via "nvmf"
+    When destroying the nexus without unpublishing it
+    Then the nexus should be destroyed
+
+  Scenario: destroying a v0 version nexus that does not exist
+    When destroying a nexus that does not exist
+    Then the operation should fail
+
+  Scenario: listing nexuses created with v0 version using v1 gRPC call
+    Given a v0 version nexus
+    When listing all nexuses
+    Then the nexus should appear in the output list
+
+  Scenario: listing v0 nexus by name which does not exists
+    Given a v0 version nexus "86050f0e-6914-4e9c-92b9-1237fd6d17a6"
+    When the user lists the nexus with name filter as "22ca10d3-4f2b-4b95-9814-9181c025cc1a"
+    Then no nexus should appear in the output list
+
+  Scenario: removing a child from a v0 version nexus using v1 gRPC call
+    Given a v0 version nexus
+    When removing a child
+    Then the child should be successfully removed
+
+  Scenario: adding a child to a v0 version nexus using v1 gRPC call
+    Given a v0 version nexus
+    When removing a child
+    And adding the removed child
+    Then the child should be successfully added
+
+  Scenario: publishing a v0 version nexus using v1 gRPC call
+    Given a v0 version nexus
+    When publishing a nexus via "nvmf"
+    Then the nexus should be successfully published
+
+  Scenario: unpublishing a v0 version nexus using v1 gRPC call
+    Given a v0 version nexus published via "nvmf"
+    When unpublishing the nexus
+    Then the nexus should be successfully unpublished
+
+  Scenario: unpublishing a v0 version nexus using v1 gRPC call that is not published
+    Given an unpublished v0 version nexus
+    When unpublishing the nexus
+    Then the request should succeed
+
+  Scenario: republishing a v0 version nexus with the same protocol using v1 gRPC call
+    Given a v0 version nexus published via "nvmf"
+    When publishing the nexus with the same protocol
+    Then the nexus should be successfully published
+
+  Scenario: republishing a v0 version nexus with a different protocol using v1 gRPC call
+    Given a v0 version nexus published via "nvmf"
+    When attempting to publish the nexus with a different protocol
+    Then the request should fail
+
+  Scenario: publishing a v0 version nexus with a crypto-key using v1 gRPC call
+    Given an unpublished v0 version nexus
+    When publishing the nexus using a crypto-key
+    Then the request should succeed
+

--- a/test/python/cross-grpc-version/nexus/test_bdd_nexus.py
+++ b/test/python/cross-grpc-version/nexus/test_bdd_nexus.py
@@ -1,0 +1,554 @@
+import pytest
+from pytest_bdd import given, scenario, then, when, parsers
+
+from collections import namedtuple
+import subprocess
+
+from common.mayastor import container_mod, mayastor_mod
+from v1.mayastor import container_mod as v1_container_mod
+from v1.mayastor import mayastor_mod as v1_mayastor_mod
+from common.volume import Volume as v0_volume
+from v1.volume import Volume as v1_volume
+
+import grpc
+import mayastor_pb2 as pb
+import common_pb2 as common_pb
+import nexus_pb2 as nexus_pb
+
+BaseBdev = namedtuple("BaseBdev", "name uri")
+
+LocalFile = namedtuple("LocalFile", "path uri")
+
+
+@scenario("features/nexus.feature", "creating the same nexus with v1 gRPC call")
+def test_creating_the_same_nexus_with_v1_gRPC_call():
+    """creating the same nexus with v1 gRPC call."""
+
+
+@scenario("features/nexus.feature", "destroying a v0 version nexus with v1 gRPC call")
+def test_destroying_a_v0_version_nexus_with_v1_gRPC_call():
+    """destroying a v0 version nexus with v1 gRPC call."""
+
+
+@scenario(
+    "features/nexus.feature", "destroying a v0 version nexus without first unpublishing"
+)
+def test_destroying_a_v0_version_nexus_without_first_unpublishing():
+    """destroying a v0 version nexus without first unpublishing."""
+
+
+@scenario("features/nexus.feature", "destroying a v0 version nexus that does not exist")
+def test_destroying_a_v0_version_nexus_that_does_not_exist():
+    """destroying a v0 version nexus that does not exist."""
+
+
+@scenario(
+    "features/nexus.feature",
+    "listing nexuses created with v0 version using v1 gRPC call",
+)
+def test_listing_nexuses_created_with_v0_version_using_v1_gRPC_call():
+    """listing nexuses created with v0 version using v1 gRPC call."""
+
+
+@scenario("features/nexus.feature", "listing v0 nexus by name which does not exists")
+def test_listing_v0_nexus_by_name_which_does_not_exists():
+    """listing v0 nexus by name which does not exists."""
+
+
+@scenario(
+    "features/nexus.feature",
+    "removing a child from a v0 version nexus using v1 gRPC call",
+)
+def test_removing_a_child_from_a_v0_version_nexus_using_v1_gRPC_call():
+    """removing a child from a v0 version nexus using v1 gRPC call."""
+
+
+@scenario(
+    "features/nexus.feature", "adding a child to a v0 version nexus using v1 gRPC call"
+)
+def test_adding_a_child_to_a_v0_version_nexus_using_v1_gRPC_call():
+    """adding a child to a v0 version nexus using v1 gRPC call."""
+
+
+@scenario("features/nexus.feature", "publishing a v0 version nexus using v1 gRPC call")
+def test_publishing_a_v0_version_nexus_using_v1_gRPC_call():
+    """publishing a v0 version nexus using v1 RPC call."""
+
+
+@scenario(
+    "features/nexus.feature", "unpublishing a v0 version nexus using v1 gRPC call"
+)
+def test_unpublishing_a_v0_version_nexus_using_v1_gRPC_call():
+    """unpublishing a v0 version nexus using v1 gRPC call."""
+
+
+@scenario(
+    "features/nexus.feature",
+    "unpublishing a v0 version nexus using v1 gRPC call that is not published",
+)
+def test_unpublishing_a_v0_version_nexus_using_v1_gRPC_call_that_is_not_published():
+    """unpublishing a v0 version nexus using v1 gRPC call that is not published."""
+
+
+@scenario(
+    "features/nexus.feature",
+    "republishing a v0 version nexus with the same protocol using v1 gRPC call",
+)
+def test_republishing_a_v0_version_nexus_with_the_same_protocol_using_v1_gRPC_call():
+    """republishing a v0 version nexus with the same protocol using v1 gRPC call."""
+
+
+@scenario(
+    "features/nexus.feature",
+    "republishing a v0 version nexus with a different protocol using v1 gRPC call",
+)
+def test_fail_republishing_a_v0_version_nexus_with_a_different_protocol_using_v1_gRPC_call():
+    """republishing a v0 version nexus with a different protocol using v1 gRPC call."""
+
+
+@scenario(
+    "features/nexus.feature",
+    "publishing a v0 version nexus with a crypto-key using v1 gRPC call",
+)
+def test_publishing_a_v0_version_nexus_with_a_cryptokey_using_v1_gRPC_call():
+    """publishing a v0 version nexus with a crypto-key using v1 gRPC call."""
+
+
+@pytest.fixture(scope="module")
+def nexus_instance():
+    yield "ms1"
+
+
+@pytest.fixture(scope="module")
+def remote_instance():
+    yield "ms0"
+
+
+@pytest.fixture(scope="module")
+def base_instances(remote_instance, nexus_instance):
+    yield [remote_instance, nexus_instance]
+
+
+@pytest.fixture(scope="module")
+def nexus_uuid():
+    yield "86050f0e-6914-4e9c-92b9-1237fd6d17a6"
+
+
+def megabytes(n):
+    return n * 1024 * 1024
+
+
+def min_cntl_id():
+    return 1
+
+
+def max_cntl_id():
+    return 10
+
+
+def resv_key():
+    return 123
+
+
+def preempt_key():
+    return 0
+
+
+def nexus_info_key():
+    return "0"
+
+
+def share_type(protocol):
+    TYPES = {
+        "nbd": pb.ShareProtocolNexus.NEXUS_NBD,
+        "nvmf": pb.ShareProtocolNexus.NEXUS_NVMF,
+        "iscsi": pb.ShareProtocolNexus.NEXUS_ISCSI,
+    }
+    return TYPES[protocol]
+
+
+def share_protocol(name):
+    PROTOCOLS = {
+        "none": common_pb.NONE,
+        "nvmf": common_pb.NVMF,
+        "iscsi": common_pb.ISCSI,
+    }
+    return PROTOCOLS[name]
+
+
+def get_child_uris(nexus):
+    return [child.uri for child in nexus.children]
+
+
+@pytest.fixture(scope="module")
+def base_bdevs(mayastor_mod, base_instances):
+    devices = {}
+    for instance in base_instances:
+        uri = "malloc:///malloc0?size_mb=64&blk_size=4096"
+        name = mayastor_mod[instance].bdev.Create(pb.BdevUri(uri=uri)).name
+        devices[instance] = BaseBdev(name, uri)
+    yield devices
+    for instance, bdev in devices.items():
+        mayastor_mod[instance].bdev.Destroy(pb.BdevUri(uri=bdev.uri))
+
+
+@pytest.fixture(scope="module")
+def shared_remote_bdev_uri(mayastor_mod, base_bdevs, remote_instance):
+    name = base_bdevs[remote_instance].name
+    uri = (
+        mayastor_mod[remote_instance]
+        .bdev.Share(pb.BdevShareRequest(name=name, proto="nvmf"))
+        .uri
+    )
+    yield uri
+    mayastor_mod[remote_instance].bdev.Unshare(pb.BdevShareRequest(name=name))
+
+
+@pytest.fixture(scope="module")
+def file_types():
+    yield ["aio", "uring"]
+
+
+@pytest.fixture(scope="module")
+def local_files(file_types):
+    files = {}
+    for type in file_types:
+        path = f"/tmp/{type}-file.img"
+        uri = f"{type}://{path}?blk_size=4096"
+        subprocess.run(
+            ["sudo", "sh", "-c", f"rm -f '{path}' && truncate -s 64M '{path}'"],
+            check=True,
+        )
+        files[type] = LocalFile(path, uri)
+    yield files
+    for path in [file.path for file in files.values()]:
+        subprocess.run(["sudo", "sh", "-c", f"rm -f '{path}'"], check=True)
+
+
+@pytest.fixture(scope="module")
+def local_bdev_uri():
+    yield "bdev:///malloc0"
+
+
+@pytest.fixture
+def nexus_children(local_bdev_uri, shared_remote_bdev_uri, local_files):
+    return [local_bdev_uri, shared_remote_bdev_uri] + [
+        file.uri for file in local_files.values()
+    ]
+
+
+@pytest.fixture
+def created_nexuses(mayastor_mod, nexus_instance):
+    nexuses = {}
+    yield nexuses
+    for uuid in nexuses.keys():
+        mayastor_mod[nexus_instance].ms.DestroyNexus(pb.DestroyNexusRequest(uuid=uuid))
+
+
+@pytest.fixture
+def create_v0_nexus(mayastor_mod, nexus_instance, created_nexuses):
+    def create(uuid, size, children):
+        nexus = mayastor_mod[nexus_instance].ms.CreateNexus(
+            pb.CreateNexusRequest(uuid=uuid, size=size, children=children)
+        )
+        created_nexuses[uuid] = nexus
+        return nexus
+
+    yield create
+
+
+@pytest.fixture
+def create_v1_nexus(v1_mayastor_mod, nexus_instance, created_nexuses):
+    def create(
+        name,
+        uuid,
+        size,
+        min_cntl_id,
+        max_cntl_id,
+        resv_key,
+        preempt_key,
+        children,
+        nexus_info_key,
+    ):
+        nexus = v1_mayastor_mod[nexus_instance].nexus_rpc.CreateNexus(
+            nexus_pb.CreateNexusRequest(
+                name=name,
+                uuid=uuid,
+                size=size,
+                minCntlId=min_cntl_id,
+                maxCntlId=max_cntl_id,
+                resvKey=resv_key,
+                preemptKey=preempt_key,
+                nexusInfoKey=nexus_info_key,
+                children=children,
+            )
+        )
+        created_nexuses[uuid] = nexus
+        return nexus
+
+    yield create
+
+
+@pytest.fixture(scope="module")
+def find_nexus(mayastor_mod, nexus_instance):
+    def find(uuid):
+        for nexus in mayastor_mod[nexus_instance].ms.ListNexus(pb.Null()).nexus_list:
+            if nexus.uuid == uuid:
+                return nexus
+        return None
+
+    yield find
+
+
+@given("a local mayastor instance")
+def local_mayastor_instance(nexus_instance):
+    pass
+
+
+@given("a remote mayastor instance")
+def remote_mayastor_instance(remote_instance):
+    pass
+
+
+@given("a v0 version nexus")
+@given("an unpublished v0 version nexus")
+def get_nexus(create_v0_nexus, nexus_uuid, nexus_children):
+    create_v0_nexus(nexus_uuid, megabytes(64), nexus_children)
+
+
+@given(
+    parsers.parse('a v0 version nexus "{uuid}"'),
+    target_fixture="get_nexus_with_given_uuid",
+)
+def get_nexus_with_given_uuid(create_v0_nexus, uuid, nexus_children):
+    create_v0_nexus(uuid, megabytes(64), nexus_children)
+
+
+@given(
+    parsers.parse('a nexus published via "{protocol}"'),
+    target_fixture="get_published_nexus",
+)
+def get_published_nexus(
+    create_v0_nexus,
+    mayastor_mod,
+    nexus_instance,
+    nexus_uuid,
+    nexus_children,
+    find_nexus,
+    protocol,
+):
+    create_v0_nexus(nexus_uuid, megabytes(64), nexus_children)
+    mayastor_mod[nexus_instance].ms.PublishNexus(
+        pb.PublishNexusRequest(uuid=nexus_uuid, key="", share=share_type(protocol))
+    )
+    nexus = find_nexus(nexus_uuid)
+    assert nexus.device_uri
+
+
+@given(
+    parsers.parse('a v0 version nexus published via "{protocol}"'),
+    target_fixture="get_published_nexus",
+)
+def get_published_nexus(
+    create_v0_nexus,
+    mayastor_mod,
+    nexus_instance,
+    nexus_uuid,
+    nexus_children,
+    find_nexus,
+    protocol,
+):
+    create_v0_nexus(nexus_uuid, megabytes(64), nexus_children)
+    mayastor_mod[nexus_instance].ms.PublishNexus(
+        pb.PublishNexusRequest(uuid=nexus_uuid, key="", share=share_type(protocol))
+    )
+    nexus = find_nexus(nexus_uuid)
+    assert nexus.device_uri
+
+
+@when("creating an identical v1 version nexus")
+def creating_a_nexus(create_v1_nexus, nexus_uuid, nexus_children):
+    with pytest.raises(grpc.RpcError) as error:
+        create_v1_nexus(
+            nexus_uuid,
+            nexus_uuid,
+            megabytes(64),
+            min_cntl_id(),
+            max_cntl_id(),
+            resv_key(),
+            preempt_key(),
+            nexus_children,
+            nexus_info_key(),
+        )
+    assert error.value.code() == grpc.StatusCode.INTERNAL
+
+
+@when("destroying the nexus")
+@when("destroying the nexus without unpublishing it")
+def destroying_the_nexus(v1_mayastor_mod, nexus_instance, nexus_uuid, created_nexuses):
+    v1_mayastor_mod[nexus_instance].nexus_rpc.DestroyNexus(
+        nexus_pb.DestroyNexusRequest(uuid=nexus_uuid)
+    )
+    del created_nexuses[nexus_uuid]
+
+
+@when("destroying a nexus that does not exist")
+def destroying_a_nexus_that_does_not_exist(v1_mayastor_mod, nexus_instance):
+    with pytest.raises(grpc.RpcError) as error:
+        v1_mayastor_mod[nexus_instance].nexus_rpc.DestroyNexus(
+            nexus_pb.DestroyNexusRequest(uuid="e6629036-1376-494d-bbc2-0b6345ab10df")
+        )
+    assert error.value.code() == grpc.StatusCode.NOT_FOUND
+
+
+@when("listing all nexuses", target_fixture="list_nexuses")
+def list_nexuses(v1_mayastor_mod, nexus_instance):
+    return (
+        v1_mayastor_mod[nexus_instance]
+        .nexus_rpc.ListNexus(nexus_pb.ListNexusOptions())
+        .nexus_list
+    )
+
+
+@when(
+    parsers.parse('the user lists the nexus with name filter as "{name}"'),
+    target_fixture="list_non_existing_nexus",
+)
+def list_non_existing_nexus(v1_mayastor_mod, nexus_instance, name):
+    opts = nexus_pb.ListNexusOptions()
+    opts.name.value = name
+    return (
+        v1_mayastor_mod[nexus_instance]
+        .nexus_rpc.ListNexus(opts, wait_for_ready=True)
+        .nexus_list
+    )
+
+
+@when("removing a child")
+def remove_child(v1_mayastor_mod, nexus_instance, nexus_uuid, nexus_children):
+    v1_mayastor_mod[nexus_instance].nexus_rpc.RemoveChildNexus(
+        nexus_pb.RemoveChildNexusRequest(uuid=nexus_uuid, uri=nexus_children[0])
+    )
+
+
+@when("adding the removed child")
+def add_child(v1_mayastor_mod, nexus_instance, nexus_uuid, nexus_children):
+    nexus = (
+        v1_mayastor_mod[nexus_instance]
+        .nexus_rpc.AddChildNexus(
+            nexus_pb.AddChildNexusRequest(uuid=nexus_uuid, uri=nexus_children[0])
+        )
+        .nexus
+    )
+    assert (
+        nexus.children[len(nexus.children) - 1].state
+        == nexus_pb.ChildState.CHILD_STATE_DEGRADED
+    )
+
+
+@when(
+    parsers.parse('publishing a nexus via "{protocol}"'), target_fixture="publish_nexus"
+)
+def publish_nexus(v1_mayastor_mod, nexus_instance, nexus_uuid, protocol):
+    v1_mayastor_mod[nexus_instance].nexus_rpc.PublishNexus(
+        nexus_pb.PublishNexusRequest(
+            uuid=nexus_uuid, key="", share=share_type(protocol)
+        )
+    )
+
+
+@when("unpublishing the nexus")
+def unpublish_nexus(v1_mayastor_mod, nexus_instance, nexus_uuid):
+    v1_mayastor_mod[nexus_instance].nexus_rpc.UnpublishNexus(
+        nexus_pb.UnpublishNexusRequest(uuid=nexus_uuid)
+    )
+
+
+@when("publishing the nexus with the same protocol")
+def publishing_the_nexus_with_the_same_protocol(
+    find_nexus, v1_mayastor_mod, nexus_instance, nexus_uuid
+):
+    nexus = find_nexus(nexus_uuid)
+    v1_mayastor_mod[nexus_instance].nexus_rpc.PublishNexus(
+        nexus_pb.PublishNexusRequest(uuid=nexus_uuid, key="", share=common_pb.NVMF)
+    )
+
+
+@when("attempting to publish the nexus with a different protocol")
+def attempt_to_publish_nexus_with_different_protocol(
+    find_nexus, v1_mayastor_mod, nexus_instance, nexus_uuid
+):
+    nexus = find_nexus(nexus_uuid)
+    with pytest.raises(grpc.RpcError) as error:
+        v1_mayastor_mod[nexus_instance].nexus_rpc.PublishNexus(
+            nexus_pb.PublishNexusRequest(uuid=nexus_uuid, key="", share=common_pb.NONE)
+        )
+    assert error.value.code() == grpc.StatusCode.INVALID_ARGUMENT
+
+
+@when("publishing the nexus using a crypto-key")
+def publish_nexus_with_cryptokey(v1_mayastor_mod, nexus_instance, nexus_uuid):
+    v1_mayastor_mod[nexus_instance].nexus_rpc.PublishNexus(
+        nexus_pb.PublishNexusRequest(
+            uuid=nexus_uuid, key="0123456789123456", share=share_protocol("nvmf")
+        )
+    )
+
+
+@then("the operation should fail")
+@then("the request should fail")
+def operation_should_fail():
+    pass
+
+
+@then("the nexus should be destroyed")
+def nexus_should_be_destroyed(find_nexus, nexus_uuid):
+    assert find_nexus(nexus_uuid) == None
+
+
+@then("the operation should succeed")
+@then("the request should succeed")
+def operation_should_succeed():
+    pass
+
+
+@then("the nexus should appear in the output list")
+def nexus_should_appear_in_output(nexus_uuid, list_nexuses):
+    assert nexus_uuid in [nexus.uuid for nexus in list_nexuses]
+
+
+@then("no nexus should appear in the output list")
+def no_nexus_should_not_appear_in_the_output_list(list_non_existing_nexus):
+    assert len(list_non_existing_nexus) == 0
+
+
+@then("the child should be successfully removed")
+def the_child_should_be_successfully_removed(find_nexus, nexus_uuid, nexus_children):
+    nexus = find_nexus(nexus_uuid)
+    assert len(nexus.children) + 1 == len(nexus_children)
+    assert nexus_children[0] not in get_child_uris(nexus)
+
+
+@then("the child should be successfully added")
+def the_child_should_be_successfully_added(find_nexus, nexus_uuid, nexus_children):
+    nexus = find_nexus(nexus_uuid)
+    assert sorted(get_child_uris(nexus)) == sorted(nexus_children)
+    assert nexus.state == pb.NexusState.NEXUS_DEGRADED
+
+
+@then("the nexus should be successfully published")
+def nexus_successfully_published(find_nexus, nexus_uuid):
+    nexus = find_nexus(nexus_uuid)
+    assert nexus.device_uri
+
+
+@then("the nexus should be successfully unpublished")
+def nexus_successfully_unpublished(find_nexus, nexus_uuid):
+    nexus = find_nexus(nexus_uuid)
+    assert not nexus.device_uri
+
+
+@then("the nexus should be successfully published")
+def nexus_successfully_published(find_nexus, nexus_uuid):
+    nexus = find_nexus(nexus_uuid)
+    assert nexus.device_uri

--- a/test/python/cross-grpc-version/pool/docker-compose.yml
+++ b/test/python/cross-grpc-version/pool/docker-compose.yml
@@ -1,0 +1,39 @@
+#
+# {SRCDIR} should point to your working tree which should be your current pwd
+#
+
+version: '3'
+services:
+  ms0:
+    container_name: "ms0"
+    image: rust:latest
+    environment:
+      - MY_POD_IP=10.0.0.2
+      - NEXUS_NVMF_ANA_ENABLE=1
+      - NEXUS_NVMF_RESV_ENABLE=1
+    command: ${SRCDIR}/target/debug/io-engine -g 0.0.0.0 -l 1,2 -r /tmp/ms0.sock --env-context=--iova-mode=pa
+    networks:
+      mayastor_net:
+        ipv4_address: 10.0.0.2
+    cap_add:
+      # NUMA related
+      - SYS_ADMIN
+      - SYS_NICE
+      # uring needs mmap
+      - IPC_LOCK
+    security_opt:
+      # we can set this to a JSON file to allow per syscall access
+      - seccomp=unconfined
+    volumes:
+      - ${SRCDIR}:${SRCDIR}
+      - /nix:/nix
+      - /dev/hugepages:/dev/hugepages
+      - /tmp:/tmp
+      - /var/tmp:/var/tmp
+networks:
+  mayastor_net:
+    name: mayastor_net
+    ipam:
+      driver: default
+      config:
+        - subnet: "10.0.0.0/16"

--- a/test/python/cross-grpc-version/pool/features/pool.feature
+++ b/test/python/cross-grpc-version/pool/features/pool.feature
@@ -1,0 +1,31 @@
+Feature: Mayastor pool management
+
+  Background:
+    Given a mayastor instance "ms0"
+
+  Scenario: creating a v1 version pool with a v0 version pool name that already exists
+    Given a v0 version pool "p0" on "disk0"
+    When the user creates a v1 version pool with the name of an existing pool
+    Then the pool create command should fail
+
+  Scenario: listing pools created with v0 version using v1 grpc call
+    Given a v0 version pool "p0" on "disk0"
+    Given a v0 version pool "p1" on "disk1"
+    When the user lists the current pools
+    Then the pool should appear in the output list
+
+  Scenario: listing pool by name created with v0 version using v1 grpc call
+    Given a v0 version pool "p0" on "disk0"
+    Given a v0 version pool "p1" on "disk1"
+    When the user lists the pool with name filter as p0
+    Then only the pool p0 should appear in the output list
+
+  Scenario: listing v0 pool by name which does not exists using v1 grpc call
+    Given a v0 version pool "p0" on "disk0"
+    When the user lists the pool with name filter as p1
+    Then no pool should appear in the output list
+
+  Scenario: destroying a pool created with v0 version using v1 grpc call
+    Given a v0 version pool "p0" on "disk0"
+    When the user destroys the pool
+    Then the pool should be destroyed

--- a/test/python/cross-grpc-version/pool/test_bdd_pool.py
+++ b/test/python/cross-grpc-version/pool/test_bdd_pool.py
@@ -1,0 +1,210 @@
+"""Mayastor pool management feature tests."""
+
+import pytest
+
+from pytest_bdd import (
+    given,
+    scenario,
+    then,
+    when,
+    parsers,
+)
+
+from common.mayastor import container_mod, mayastor_mod
+from v1.mayastor import container_mod as container_mod_v1
+from v1.mayastor import mayastor_mod as mayastor_mod_v1
+
+import grpc
+import mayastor_pb2 as pb
+import pool_pb2 as pb2
+
+
+@given(
+    parsers.parse('a mayastor instance "{name}"'),
+    target_fixture="get_mayastor_instance",
+)
+def get_mayastor_instance(mayastor_mod, name):
+    return mayastor_mod[name]
+
+
+@pytest.fixture
+def v1_mayastor_instance(mayastor_mod_v1):
+    return mayastor_mod_v1["ms0"]
+
+
+@scenario(
+    "features/pool.feature",
+    "creating a v1 version pool with a v0 version pool name that already exists",
+)
+def test_creating_a_v1_version_pool_with_a_v0_version_pool_name_that_already_exists():
+    """creating a v1 version pool with a v0 version pool name that already exists."""
+
+
+@scenario(
+    "features/pool.feature", "listing pools created with v0 version using v1 grpc call"
+)
+def test_listing_pools_created_with_v0_version_using_v1_grpc_call():
+    """listing pools created with v0 version using v1 gRPC call."""
+
+
+@scenario(
+    "features/pool.feature",
+    "listing pool by name created with v0 version using v1 grpc call",
+)
+def test_listing_pool_by_name_created_with_v0_version_using_v1_grpc_call():
+    """listing pool by name created with v0 version using v1 gRPC call."""
+
+
+@scenario(
+    "features/pool.feature",
+    "listing v0 pool by name which does not exists using v1 grpc call",
+)
+def test_listing_v0_pool_by_name_which_does_not_exists_using_v1_grpc_call():
+    """listing v0 pool by name which does not exists using v1 grpc call."""
+
+
+@scenario(
+    "features/pool.feature",
+    "destroying a pool created with v0 version using v1 grpc call",
+)
+def test_destroying_a_pool_created_with_v0_version_using_v1_grpc_call():
+    """destroying a pool created with v0 version using v1 grpc call."""
+
+
+@pytest.fixture
+def v0_replica_pools(get_mayastor_instance):
+    pools = {}
+    yield pools
+    for name in pools.keys():
+        get_mayastor_instance.ms.DestroyPool(pb.DestroyPoolRequest(name=name))
+
+
+@pytest.fixture
+def create_v0_pool(get_mayastor_instance, v0_replica_pools):
+    def create(name, disks):
+        pool = get_mayastor_instance.ms.CreatePool(
+            pb.CreatePoolRequest(name=name, disks=disks)
+        )
+        v0_replica_pools[name] = pool
+
+    yield create
+
+
+@pytest.fixture
+def v1_replica_pools(v1_mayastor_instance):
+    pools = {}
+    yield pools
+    for name in pools.keys():
+        opts = pb2.ListPoolOptions()
+        opts.name.value = name
+        pools = v1_mayastor_instance.pool_rpc.ListPools(opts).pools
+        if len(pools) != 0:
+            opts = pb2.DestroyPoolRequest()
+            opts.name = pools[0].name
+            opts.uuid.value = pools[0].uuid
+            v1_mayastor_instance.pool_rpc.DestroyPool(opts)
+
+
+@pytest.fixture
+def create_v1_pool(v1_mayastor_instance, v1_replica_pools):
+    def create(name, disks, uuid):
+        opts = pb2.CreatePoolRequest(name=name, disks=disks)
+        if uuid is not None:
+            opts.uuid.value = uuid
+        pool = v1_mayastor_instance.pool_rpc.CreatePool(opts)
+        v1_replica_pools[name] = pool
+
+    yield create
+
+
+@pytest.fixture
+def find_pool(v1_mayastor_instance):
+    def find(name):
+        for pool in v1_mayastor_instance.pool_rpc.ListPools(
+            pb2.ListPoolOptions()
+        ).pools:
+            if pool.name == name:
+                return pool
+        return None
+
+    yield find
+
+
+@given(
+    parsers.parse('a v0 version pool "{name}" on "{disk}"'),
+    target_fixture="get_pool_name",
+)
+def get_pool_name(create_v0_pool, name, disk):
+    create_v0_pool(name, [f"malloc:///{disk}?size_mb=100"])
+    return name
+
+
+@when(
+    "the user creates a v1 version pool with the name of an existing pool",
+    target_fixture="create_pool_that_already_exists",
+)
+def create_pool_that_already_exists(create_v1_pool, get_pool_name):
+    with pytest.raises(grpc.RpcError) as error:
+        create_v1_pool(get_pool_name, ["malloc:///disk0?size_mb=100"], None)
+    return error
+
+
+@when("the user lists the current pools", target_fixture="list_pools")
+def list_pools(v1_mayastor_instance):
+    return v1_mayastor_instance.pool_rpc.ListPools(
+        pb2.ListPoolOptions(), wait_for_ready=True
+    ).pools
+
+
+@when(
+    "the user lists the pool with name filter as p0",
+    target_fixture="list_existing_pool",
+)
+def list_existing_pool(v1_mayastor_instance):
+    opts = pb2.ListPoolOptions()
+    opts.name.value = "p0"
+    return v1_mayastor_instance.pool_rpc.ListPools(opts, wait_for_ready=True).pools
+
+
+@when(
+    "the user lists the pool with name filter as p1",
+    target_fixture="list_non_existing_pool",
+)
+def list_non_existing_pool(v1_mayastor_instance):
+    opts = pb2.ListPoolOptions()
+    opts.name.value = "p1"
+    return v1_mayastor_instance.pool_rpc.ListPools(opts, wait_for_ready=True).pools
+
+
+@when("the user destroys the pool")
+def destroy_pool(v1_mayastor_instance, v0_replica_pools, get_pool_name):
+    pool = v0_replica_pools[get_pool_name]
+    v1_mayastor_instance.pool_rpc.DestroyPool(pb2.DestroyPoolRequest(name=pool.name))
+    del v0_replica_pools[get_pool_name]
+
+
+@then("the pool create command should fail")
+def the_pool_create_command_should_fail(create_pool_that_already_exists):
+    assert create_pool_that_already_exists.value.code() == grpc.StatusCode.INTERNAL
+
+
+@then("the pool should appear in the output list")
+def pool_should_appear_in_output(get_pool_name, list_pools):
+    assert get_pool_name in [pool.name for pool in list_pools]
+
+
+@then("only the pool p0 should appear in the output list")
+def only_the_pool_p0_should_appear_in_the_output_list(list_existing_pool):
+    pools = list_existing_pool
+    assert len(pools) == 1
+    assert "p0" in [pool.name for pool in pools]
+
+
+@then("no pool should appear in the output list")
+def no_pool_should_appear_in_the_output_list(list_non_existing_pool):
+    assert len(list_non_existing_pool) == 0
+
+
+@then("the pool should be destroyed")
+def pool_destruction_should_succeed(find_pool):
+    assert find_pool("p0") == None

--- a/test/python/cross-grpc-version/rebuild/docker-compose.yml
+++ b/test/python/cross-grpc-version/rebuild/docker-compose.yml
@@ -1,0 +1,39 @@
+#
+# {SRCDIR} should point to your working tree which should be your current pwd
+#
+
+version: '3'
+services:
+  ms0:
+    container_name: "ms0"
+    image: rust:latest
+    environment:
+      - MY_POD_IP=10.0.0.2
+      - NEXUS_NVMF_ANA_ENABLE=1
+      - NEXUS_NVMF_RESV_ENABLE=1
+    command: ${SRCDIR}/target/debug/io-engine -g 0.0.0.0 -l 1,2 -r /tmp/ms0.sock
+    networks:
+      mayastor_net:
+        ipv4_address: 10.0.0.2
+    cap_add:
+      # NUMA related
+      - SYS_ADMIN
+      - SYS_NICE
+      # uring needs mmap
+      - IPC_LOCK
+    security_opt:
+      # we can set this to a JSON file to allow per syscall access
+      - seccomp=unconfined
+    volumes:
+      - ${SRCDIR}:${SRCDIR}
+      - /nix:/nix
+      - /dev/hugepages:/dev/hugepages
+      - /tmp:/tmp
+      - /var/tmp:/var/tmp
+networks:
+  mayastor_net:
+    name: mayastor_net
+    ipam:
+      driver: default
+      config:
+        - subnet: "10.0.0.0/16"

--- a/test/python/cross-grpc-version/rebuild/features/rebuild.feature
+++ b/test/python/cross-grpc-version/rebuild/features/rebuild.feature
@@ -1,0 +1,70 @@
+Feature: Nexus rebuild functionality
+
+  Background:
+    Given a mayastor instance
+    And a v0 version nexus with a source child device
+
+  Scenario: running rebuild
+    When a target child is added to the nexus
+    And the rebuild operation is started
+    Then the nexus state is DEGRADED
+    And the source child state is ONLINE
+    And the target child state is DEGRADED
+    And the rebuild state is "running"
+    And the rebuild count is 1
+
+  Scenario: stopping rebuild
+    When a target child is added to the nexus
+    And the rebuild operation is started
+    And the rebuild operation is then stopped
+    Then the nexus state is DEGRADED
+    And the source child state is ONLINE
+    And the target child state is DEGRADED
+    And the rebuild state is undefined
+    And the rebuild count is 0
+
+  Scenario: pausing rebuild
+    When a target child is added to the nexus
+    And the rebuild operation is started
+    And the rebuild operation is then paused
+    And the rebuild statistics are requested
+    Then the nexus state is DEGRADED
+    And the source child state is ONLINE
+    And the target child state is DEGRADED
+    And the rebuild state is "paused"
+    And the rebuild statistics counter "blocks_total" is non-zero
+    And the rebuild statistics counter "blocks_recovered" is non-zero
+    And the rebuild statistics counter "progress" is non-zero
+    And the rebuild statistics counter "tasks_total" is non-zero
+    And the rebuild statistics counter "tasks_active" is zero
+
+  Scenario: resuming rebuild
+    When a target child is added to the nexus
+    And the rebuild operation is started
+    And the rebuild operation is then paused
+    And the rebuild operation is then resumed
+    Then the nexus state is DEGRADED
+    And the source child state is ONLINE
+    And the target child state is DEGRADED
+    And the rebuild state is "running"
+    And the rebuild count is 1
+
+  Scenario: setting a child ONLINE
+    When a target child is added to the nexus
+    And the target child is set OFFLINE
+    And the target child is then set ONLINE
+    Then the nexus state is DEGRADED
+    And the source child state is ONLINE
+    And the target child state is DEGRADED
+    And the rebuild state is "running"
+    And the rebuild count is 1
+
+  Scenario: setting a child OFFLINE
+    When a target child is added to the nexus
+    And the rebuild operation is started
+    And the target child is set OFFLINE
+    Then the nexus state is DEGRADED
+    And the source child state is ONLINE
+    And the target child state is DEGRADED
+    And the rebuild state is undefined
+    And the rebuild count is 0

--- a/test/python/cross-grpc-version/rebuild/test_bdd_rebuild.py
+++ b/test/python/cross-grpc-version/rebuild/test_bdd_rebuild.py
@@ -1,0 +1,271 @@
+import pytest
+from pytest_bdd import given, scenario, then, when, parsers
+
+import os
+import subprocess
+import time
+
+from common.mayastor import container_mod, mayastor_mod
+from common.volume import Volume
+from v1.mayastor import container_mod as v1_container_mod
+from v1.mayastor import mayastor_mod as v1_mayastor_mod
+
+from v1.volume import Volume
+
+import grpc
+import mayastor_pb2 as pb
+import nexus_pb2 as nexus_pb
+
+
+def megabytes(n):
+    return n * 1024 * 1024
+
+
+@pytest.fixture(scope="module")
+def local_files():
+    files = [f"/tmp/disk-rebuild-{base}.img" for base in ["source", "target"]]
+    for path in files:
+        subprocess.run(
+            ["sudo", "sh", "-c", f"rm -f '{path}' && truncate -s 64M '{path}'"],
+            check=True,
+        )
+    yield
+    for path in files:
+        subprocess.run(["sudo", "rm", "-f", path], check=True)
+
+
+@pytest.fixture(scope="module")
+def nexus_uuid():
+    yield "2c58c9f0-da89-4cb9-8097-dc67fa132493"
+
+
+@pytest.fixture(scope="module")
+def source_uri(local_files):
+    yield "aio:///tmp/disk-rebuild-source.img?blk_size=4096"
+
+
+@pytest.fixture(scope="module")
+def target_uri(local_files):
+    yield "aio:///tmp/disk-rebuild-target.img?blk_size=4096"
+
+
+def find_child(nexus, uri):
+    for child in nexus.children:
+        if child.uri == uri:
+            return child
+    return None
+
+
+def convert_nexus_state(state):
+    STATES = {
+        "UNKNOWN": nexus_pb.NexusState.NEXUS_UNKNOWN,
+        "ONLINE": nexus_pb.NexusState.NEXUS_ONLINE,
+        "DEGRADED": nexus_pb.NexusState.NEXUS_DEGRADED,
+        "FAULTED": nexus_pb.NexusState.NEXUS_FAULTED,
+    }
+    return STATES[state]
+
+
+def convert_child_state(state):
+    STATES = {
+        "UNKNOWN": pb.ChildState.CHILD_UNKNOWN,
+        "ONLINE": pb.ChildState.CHILD_ONLINE,
+        "DEGRADED": pb.ChildState.CHILD_DEGRADED,
+        "FAULTED": pb.ChildState.CHILD_FAULTED,
+    }
+    return STATES[state]
+
+
+@pytest.fixture(scope="module")
+def v0_mayastor_instance(mayastor_mod):
+    yield mayastor_mod["ms0"]
+
+
+@pytest.fixture(scope="module")
+def v1_mayastor_instance(v1_mayastor_mod):
+    yield v1_mayastor_mod["ms0"]
+
+
+def convert_child_action(state):
+    ACTIONS = {
+        "OFFLINE": nexus_pb.ChildAction.Offline,
+        "ONLINE": nexus_pb.ChildAction.Online,
+    }
+    return ACTIONS[state]
+
+
+@scenario("features/rebuild.feature", "running rebuild")
+def test_running_rebuild():
+    """Running rebuild."""
+
+
+@scenario("features/rebuild.feature", "stopping rebuild")
+def test_stopping_rebuild():
+    """Stopping rebuild."""
+
+
+@scenario("features/rebuild.feature", "pausing rebuild")
+def test_pausing_rebuild():
+    """Pausing rebuild."""
+
+
+@scenario("features/rebuild.feature", "resuming rebuild")
+def test_resuming_rebuild():
+    """Resuming rebuild."""
+
+
+@scenario("features/rebuild.feature", "setting a child ONLINE")
+def test_setting_a_child_online():
+    """Setting a child ONLINE."""
+
+
+@scenario("features/rebuild.feature", "setting a child OFFLINE")
+def test_setting_a_child_offline():
+    """Setting a child OFFLINE."""
+
+
+@given("a mayastor instance")
+@given(parsers.parse('a mayastor instance "{name}"'))
+def get_instance():
+    pass
+
+
+@given("a v0 version nexus")
+@given("a v0 version nexus with a source child device")
+def get_nexus(mayastor_nexus):
+    pass
+
+
+@pytest.fixture
+def mayastor_nexus(v0_mayastor_instance, nexus_uuid, source_uri):
+    nexus = v0_mayastor_instance.ms.CreateNexus(
+        pb.CreateNexusRequest(
+            uuid=nexus_uuid, size=megabytes(64), children=[source_uri]
+        )
+    )
+    yield nexus
+    v0_mayastor_instance.ms.DestroyNexus(pb.DestroyNexusRequest(uuid=nexus_uuid))
+
+
+@pytest.fixture(scope="module")
+def find_nexus(v0_mayastor_instance):
+    def find(uuid):
+        for nexus in v0_mayastor_instance.ms.ListNexus(pb.Null()).nexus_list:
+            if nexus.uuid == uuid:
+                return nexus
+        return None
+
+    yield find
+
+
+@pytest.fixture
+def nexus_state(mayastor_nexus, find_nexus, nexus_uuid):
+    yield find_nexus(nexus_uuid)
+
+
+@pytest.fixture
+def rebuild_state(v0_mayastor_instance, mayastor_nexus, nexus_uuid, target_uri):
+    try:
+        yield v0_mayastor_instance.ms.GetRebuildState(
+            pb.RebuildStateRequest(uuid=nexus_uuid, uri=target_uri)
+        ).state
+    except:
+        yield None
+
+
+@when("a target child is added to the nexus")
+def add_child(v1_mayastor_instance, mayastor_nexus, nexus_uuid, target_uri):
+    v1_mayastor_instance.nexus_rpc.AddChildNexus(
+        nexus_pb.AddChildNexusRequest(uuid=nexus_uuid, uri=target_uri, norebuild=True)
+    )
+
+
+@when("the rebuild operation is started")
+def start_rebuild(v1_mayastor_instance, mayastor_nexus, nexus_uuid, target_uri):
+    v1_mayastor_instance.nexus_rpc.StartRebuild(
+        nexus_pb.StartRebuildRequest(nexus_uuid=nexus_uuid, uri=target_uri)
+    )
+
+
+@when("the rebuild operation is then stopped")
+def stop_rebuild(v1_mayastor_instance, mayastor_nexus, nexus_uuid, target_uri):
+    v1_mayastor_instance.nexus_rpc.StopRebuild(
+        nexus_pb.StopRebuildRequest(nexus_uuid=nexus_uuid, uri=target_uri)
+    )
+    time.sleep(0.5)
+
+
+@when("the rebuild operation is then paused")
+def pause_rebuild(v1_mayastor_instance, mayastor_nexus, nexus_uuid, target_uri):
+    v1_mayastor_instance.nexus_rpc.PauseRebuild(
+        nexus_pb.PauseRebuildRequest(nexus_uuid=nexus_uuid, uri=target_uri)
+    )
+    time.sleep(0.5)
+
+
+@when(parsers.parse("the target child is set {state}"), target_fixture="set_child")
+@when(parsers.parse("the target child is then set {state}"), target_fixture="set_child")
+def set_child(v1_mayastor_instance, mayastor_nexus, nexus_uuid, target_uri, state):
+    v1_mayastor_instance.nexus_rpc.ChildOperation(
+        nexus_pb.ChildOperationRequest(
+            nexus_uuid=nexus_uuid, uri=target_uri, action=convert_child_action(state)
+        )
+    )
+
+
+@pytest.fixture
+def rebuild_v0_statistics(v0_mayastor_instance, mayastor_nexus, nexus_uuid, target_uri):
+    return v0_mayastor_instance.ms.GetRebuildStats(
+        pb.RebuildStatsRequest(uuid=nexus_uuid, uri=target_uri)
+    )
+
+
+@when("the rebuild statistics are requested", target_fixture="v1_rebuild_statistics")
+def v1_rebuild_statistics(v1_mayastor_instance, mayastor_nexus, nexus_uuid, target_uri):
+    return v1_mayastor_instance.nexus_rpc.GetRebuildStats(
+        nexus_pb.RebuildStatsRequest(nexus_uuid=nexus_uuid, uri=target_uri)
+    )
+
+
+@when("the rebuild operation is then resumed")
+def resume_rebuild(v1_mayastor_instance, mayastor_nexus, nexus_uuid, target_uri):
+    v1_mayastor_instance.nexus_rpc.ResumeRebuild(
+        nexus_pb.ResumeRebuildRequest(nexus_uuid=nexus_uuid, uri=target_uri)
+    )
+
+
+@then(parsers.parse("the nexus state is {expected}"))
+def check_nexus_state(nexus_state, expected):
+    assert nexus_state.state == convert_nexus_state(expected)
+
+
+@then(parsers.parse("the source child state is {expected}"))
+def check_source_child_state(nexus_state, source_uri, expected):
+    child = find_child(nexus_state, source_uri)
+    assert child.state == convert_child_state(expected)
+
+
+@then(parsers.parse("the target child state is {expected}"))
+def check_target_child_state(nexus_state, target_uri, expected):
+    child = find_child(nexus_state, target_uri)
+    assert child.state == convert_child_state(expected)
+
+
+@then(parsers.parse('the rebuild state is "{expected}"'))
+def check_rebuild_state(rebuild_state, expected):
+    assert rebuild_state == expected
+
+
+@then(parsers.parse("the rebuild count is {expected:d}"))
+def check_rebuild_count(nexus_state, expected):
+    assert nexus_state.rebuilds == expected
+
+
+@then("the rebuild state is undefined")
+def rebuild_state_is_undefined(rebuild_state):
+    assert rebuild_state is None
+
+
+@then(parsers.parse('the rebuild statistics counter "{name}" is {expected}'))
+def check_rebuild_statistics_counter(rebuild_v0_statistics, name, expected):
+    assert (getattr(rebuild_v0_statistics, name) == 0) == (expected == "zero")

--- a/test/python/cross-grpc-version/replica/docker-compose.yml
+++ b/test/python/cross-grpc-version/replica/docker-compose.yml
@@ -1,0 +1,39 @@
+#
+# {SRCDIR} should point to your working tree which should be your current pwd
+#
+
+version: '3'
+services:
+  ms0:
+    container_name: "ms0"
+    image: rust:latest
+    environment:
+      - MY_POD_IP=10.0.0.2
+      - NEXUS_NVMF_ANA_ENABLE=1
+      - NEXUS_NVMF_RESV_ENABLE=1
+    command: ${SRCDIR}/target/debug/io-engine -g 0.0.0.0 -l 0,1 -r /tmp/ms0.sock
+    networks:
+      mayastor_net:
+        ipv4_address: 10.0.0.2
+    cap_add:
+      # NUMA related
+      - SYS_ADMIN
+      - SYS_NICE
+      # uring needs mmap
+      - IPC_LOCK
+    security_opt:
+      # we can set this to a JSON file to allow per syscall access
+      - seccomp=unconfined
+    volumes:
+      - ${SRCDIR}:${SRCDIR}
+      - /nix:/nix
+      - /dev/hugepages:/dev/hugepages
+      - /tmp:/tmp
+      - /var/tmp:/var/tmp
+networks:
+  mayastor_net:
+    name: mayastor_net
+    ipam:
+      driver: default
+      config:
+        - subnet: "10.0.0.0/16"

--- a/test/python/cross-grpc-version/replica/features/replica.feature
+++ b/test/python/cross-grpc-version/replica/features/replica.feature
@@ -1,0 +1,74 @@
+Feature: Mayastor replica management
+
+  Background:
+    Given a mayastor instance "ms0"
+    And a pool "p0"
+
+  Scenario: creating a v1 version replica with a v0 version name that already exists
+    Given a v0 version replica "replica-1" with uuid "22ca10d3-4f2b-4b95-9814-9181c025cc1a"
+    When the user creates a v1 version replica with a name that already exists
+    Then the create replica command should fail
+    And replica should be present
+
+  Scenario: creating a v1 version replica with a v0 version uuid that already exists
+    Given a v0 version replica "replica-1" with uuid "22ca10d3-4f2b-4b95-9814-9181c025cc1a"
+    When the user creates a v1 version replica with a uuid that already exists
+    Then the create replica command should fail
+    And replica should be present
+
+  Scenario: listing replicas
+    Given a v0 version replica "replica-1" with uuid "22ca10d3-4f2b-4b95-9814-9181c025cc1a"
+    When the user lists the replicas with v1 gRPC call
+    Then "replica-1" should appear in the output list
+
+  Scenario: listing replicas by pool name on a pool with v0 version replicas
+    Given a v0 version replica "replica-1" with uuid "22ca10d3-4f2b-4b95-9814-9181c025cc1a"
+    When the user lists the replicas by pool name "p0"
+    Then "replica-1" should appear in the output list based on pool name
+
+  Scenario: listing v0 version replicas by replica name using v1 version gRPC call
+    Given a v0 version replica "replica-1" with uuid "22ca10d3-4f2b-4b95-9814-9181c025cc1a"
+    And a v0 version replica "replica-2" with uuid "11ca10d3-4f2b-4b95-9814-9181c025cc1a"
+    When the user lists the replica by replica name "replica-1"
+    Then "replica-1" should appear in the output list based on replica name
+    And only 1 replicas should be present in the output list based on replica name
+
+  Scenario: listing replicas by pool name with a non-existent pool name
+    Given a v0 version replica "replica-1" with uuid "22ca10d3-4f2b-4b95-9814-9181c025cc1a"
+    When the user lists the replicas by pool name "p1"
+    Then only 0 replicas should be present in the output list based on pool name
+
+  Scenario: sharing a v0 version replica over "nvmf" using v1 gRPC call
+    Given a replica that is unshared
+    When the user shares the replica over "nvmf"
+    Then the share state should change to "nvmf"
+
+  Scenario: sharing a v0 version replica over "iscsi" using v1 gRPC call
+    Given a replica that is unshared
+    When the user attempts to share the replica over "iscsi"
+    Then the share replica command should fail
+
+  Scenario: sharing a v0 version replica that is already shared with the same protocol using v1 gRPC call
+    Given a replica shared over "nvmf"
+    When the user shares the replica with the same protocol
+    Then the share replica command should succeed
+
+  Scenario: sharing a v0 version replica that is already shared with a different protocol using v1 gRPC call
+    Given a replica shared over "nvmf"
+    When the user attempts to share the replica with a different protocol
+    Then the share replica command should fail
+
+  Scenario: unsharing a v0 version replica using v1 gRPC call
+    Given a replica shared over "nvmf"
+    When the user unshares the replica
+    Then the share state should change to unshared
+
+  Scenario: unsharing a v0 version replica that is not shared using v1 gRPC call
+    Given a replica that is unshared
+    When the user unshares the replica
+    Then the share state should remain in unshared
+
+  Scenario: destroying a v0 version replica using v1 gRPC call
+    Given a v0 version replica "replica-1" with uuid "22ca10d3-4f2b-4b95-9814-9181c025cc1a"
+    When the user destroys the replica
+    Then the replica should be destroyed

--- a/test/python/cross-grpc-version/replica/test_bdd_replica.py
+++ b/test/python/cross-grpc-version/replica/test_bdd_replica.py
@@ -1,0 +1,433 @@
+import pytest
+from pytest_bdd import (
+    given,
+    scenario,
+    then,
+    when,
+    parsers,
+)
+
+from common.mayastor import container_mod
+from common.mayastor import mayastor_mod as v0_mayastor_mod
+
+# from v1.mayastor import container_mod as v1_container_mod
+from v1.mayastor import mayastor_mod as v1_mayastor_mod
+
+import grpc
+import replica_pb2 as replica_pb
+import common_pb2 as common_pb
+import mayastor_pb2 as pb
+
+
+@scenario(
+    "features/replica.feature",
+    "creating a v1 version replica with a v0 version name that already exists",
+)
+def test_creating_a_v1_version_replica_with_a_v0_version_name_that_already_exists():
+    """creating a v1 version replica with a v0 version name that already exists."""
+
+
+@scenario(
+    "features/replica.feature",
+    "creating a v1 version replica with a v0 version uuid that already exists",
+)
+def test_creating_a_v1_version_replica_with_a_v0_version_uuid_that_already_exists():
+    """creating a v1 version replica with a v0 version uuid that already exists."""
+
+
+@scenario("features/replica.feature", "listing replicas")
+def test_listing_replicas():
+    """Listing replicas."""
+
+
+@scenario(
+    "features/replica.feature",
+    "listing v0 version replicas by replica name using v1 version gRPC call",
+)
+def test_listing_v0_version_replicas_by_replica_name_using_v1_version_gRPC_call():
+    """listing v0 version replicas by replica name using v1 version gRPC call."""
+
+
+@scenario(
+    "features/replica.feature",
+    "listing replicas by pool name on a pool with v0 version replicas",
+)
+def test_listing_replicas_by_pool_name_on_a_pool_with_v0_version_replicas():
+    """listing replicas by pool name on a pool with v0 version replicas."""
+
+
+@scenario(
+    "features/replica.feature",
+    "listing replicas by pool name with a non-existent pool name",
+)
+def test_listing_replicas_by_pool_name_with_a_non_existent_pool():
+    """Listing replicas by pool name with a non-existent pool name."""
+
+
+@scenario(
+    "features/replica.feature",
+    'sharing a v0 version replica over "nvmf" using v1 gRPC call',
+)
+def test_sharing_a_v0_version_replica_over_nvmf_using_v1_gRPC_call():
+    """sharing a v0 version replica over "nvmf" using v1 gRPC call."""
+
+
+@scenario(
+    "features/replica.feature",
+    'sharing a v0 version replica over "iscsi" using v1 gRPC call',
+)
+def test_fail_sharing_a_v0_version_replica_over_iscsi_using_v1_gRPC_call():
+    """sharing a v0 version replica over "iscsi" using v1 gRPC call."""
+
+
+@scenario(
+    "features/replica.feature",
+    "sharing a v0 version replica that is already shared with the same protocol using v1 gRPC call",
+)
+def test_sharing_a_v0_version_replica_that_is_already_shared_with_the_same_protocol_using_v1_gRPC_call():
+    """sharing a v0 version replica that is already shared with the same protocol using v1 gRPC call."""
+
+
+@scenario(
+    "features/replica.feature",
+    "sharing a v0 version replica that is already shared with a different protocol using v1 gRPC call",
+)
+def test_fail_sharing_a_v0_version_replica_that_is_already_shared_with_a_different_protocol_using_v1_gRPC_call():
+    """sharing a v0 version replica that is already shared with a different protocol using v1 gRPC call."""
+
+
+@scenario(
+    "features/replica.feature", "unsharing a v0 version replica using v1 gRPC call"
+)
+def test_unsharing_a_v0_version_replica_using_v1_gRPC_call():
+    """unsharing a v0 version replica using v1 gRPC call."""
+
+
+@scenario(
+    "features/replica.feature",
+    "unsharing a v0 version replica that is not shared using v1 gRPC call",
+)
+def test_unsharing_a_v0_version_replica_that_is_not_shared_using_v1_gRPC_call():
+    """unsharing a v0 version replica that is not shared using v1 gRPC call."""
+
+
+@scenario(
+    "features/replica.feature", "destroying a v0 version replica using v1 gRPC call"
+)
+def test_destroying_a_v0_version_replica_using_v1_gRPC_call():
+    """destroying a v0 version replica using v1 gRPC call."""
+
+
+@pytest.fixture
+def replica_name():
+    yield "replica-1"
+
+
+@pytest.fixture
+def replica_uuid():
+    yield "22ca10d3-4f2b-4b95-9814-9181c025cc1a"
+
+
+@pytest.fixture(scope="module")
+def replica_size():
+    yield 32 * 1024 * 1024
+
+
+def share_protocol(name):
+    PROTOCOLS = {
+        "none": common_pb.NONE,
+        "nvmf": common_pb.NVMF,
+        "iscsi": common_pb.ISCSI,
+    }
+    return PROTOCOLS[name]
+
+
+@pytest.fixture(scope="module")
+def v0_mayastor_instance(v0_mayastor_mod):
+    yield v0_mayastor_mod["ms0"]
+
+
+@pytest.fixture(scope="module")
+def v1_mayastor_instance(v1_mayastor_mod):
+    yield v1_mayastor_mod["ms0"]
+
+
+@pytest.fixture(scope="module")
+def mayastor_pool(v0_mayastor_instance):
+    pool = v0_mayastor_instance.ms.CreatePool(
+        pb.CreatePoolRequest(name="p0", disks=["malloc:///disk0?size_mb=512"])
+    )
+    yield pool.name
+    v0_mayastor_instance.ms.DestroyPool(pb.DestroyPoolRequest(name=pool.name))
+
+
+@pytest.fixture
+def current_replicas(v0_mayastor_instance, mayastor_pool):
+    replicas = {}
+    yield replicas
+    for uuid in replicas.keys():
+        v0_mayastor_instance.ms.DestroyReplica(pb.DestroyReplicaRequest(uuid=uuid))
+
+
+@pytest.fixture
+def create_v0_replica(v0_mayastor_instance, mayastor_pool, current_replicas):
+    def create(name, uuid, size, share):
+        replica = v0_mayastor_instance.ms.CreateReplicaV2(
+            pb.CreateReplicaRequestV2(
+                pool=mayastor_pool, name=name, uuid=uuid, size=size, share=share
+            )
+        )
+        current_replicas[uuid] = replica
+
+    yield create
+
+
+@pytest.fixture
+def create_v1_replica(v1_mayastor_instance, mayastor_pool, current_replicas):
+    def create(name, uuid, size, share):
+        replica = v1_mayastor_instance.replica_rpc.CreateReplica(
+            replica_pb.CreateReplicaRequest(
+                pooluuid=mayastor_pool,
+                name=name,
+                uuid=uuid,
+                size=size,
+                share=share,
+            )
+        )
+        current_replicas[uuid] = replica
+
+    yield create
+
+
+@pytest.fixture
+def find_replica(v1_mayastor_instance, mayastor_pool):
+    def find(name, uuid):
+        for replica in v1_mayastor_instance.replica_rpc.ListReplicas(
+            replica_pb.ListReplicaOptions()
+        ).replicas:
+            if replica.name == name and replica.uuid == uuid:
+                return replica
+        return None
+
+    yield find
+
+
+@given(parsers.parse('a mayastor instance "{name}"'))
+def get_instance():
+    pass
+
+
+@given(parsers.parse('a pool "{name}"'))
+def get_pool(mayastor_pool):
+    pass
+
+
+@given(
+    parsers.parse('a v0 version replica "{name}" with uuid "{uuid}"'),
+    target_fixture="get_replica",
+)
+def get_replica(create_v0_replica, name, uuid, replica_size):
+    create_v0_replica(name, uuid, replica_size, pb.REPLICA_NONE)
+
+
+@given("a replica that is unshared")
+def get_unshared_replica(create_v0_replica, replica_name, replica_uuid, replica_size):
+    create_v0_replica(
+        replica_name, replica_uuid, replica_size, share=share_protocol("none")
+    )
+
+
+@given(parsers.parse('a replica shared over "{share}"'))
+def get_shared_replica(
+    create_v0_replica, replica_name, replica_uuid, replica_size, share
+):
+    create_v0_replica(
+        replica_name, replica_uuid, replica_size, share=share_protocol(share)
+    )
+
+
+@when("the user creates a v1 version replica with a name that already exists")
+def create_v1_replica_with_existing_name(
+    create_v1_replica, current_replicas, replica_uuid
+):
+    replica = current_replicas[replica_uuid]
+    with pytest.raises(grpc.RpcError) as error:
+        create_v1_replica(replica.name, replica.uuid, replica.size, share=replica.share)
+    assert error.value.code() == grpc.StatusCode.INTERNAL
+
+
+@when(
+    "the user creates a v1 version replica with a uuid that already exists",
+    target_fixture="create_v1_replica_with_existing_uuid",
+)
+def create_v1_replica_with_existing_uuid(create_v1_replica, replica_uuid, replica_size):
+    with pytest.raises(grpc.RpcError) as error:
+        create_v1_replica(
+            "replica-2", replica_uuid, replica_size, share=share_protocol("none")
+        )
+    assert error.value.code() == grpc.StatusCode.INTERNAL
+
+
+@when(
+    "the user lists the replicas with v1 gRPC call",
+    target_fixture="list_replicas",
+)
+def list_replicas(v1_mayastor_instance):
+    return v1_mayastor_instance.replica_rpc.ListReplicas(
+        replica_pb.ListReplicaOptions()
+    ).replicas
+
+
+@when(
+    parsers.parse('the user lists the replica by replica name "{name}"'),
+    target_fixture="list_replicas_by_name",
+)
+def list_replicas_by_name(v1_mayastor_instance, name):
+    opts = replica_pb.ListReplicaOptions()
+    opts.name.value = name
+    return v1_mayastor_instance.replica_rpc.ListReplicas(opts).replicas
+
+
+@when(
+    parsers.parse('the user lists the replicas by pool name "{pool_name}"'),
+    target_fixture="list_replicas_by_pool_name",
+)
+def list_replicas_by_pool_name(v1_mayastor_instance, pool_name):
+    opts = replica_pb.ListReplicaOptions()
+    opts.poolname.value = pool_name
+    return v1_mayastor_instance.replica_rpc.ListReplicas(opts).replicas
+
+
+@when(
+    parsers.parse('the user shares the replica over "{share}"'),
+    target_fixture="share_replica",
+)
+def share_replica(v1_mayastor_instance, replica_uuid, share):
+    v1_mayastor_instance.replica_rpc.ShareReplica(
+        replica_pb.ShareReplicaRequest(uuid=replica_uuid, share=share_protocol(share))
+    )
+
+
+@when('the user attempts to share the replica over "iscsi"')
+def attempt_to_share_replica_over_iscsi(v1_mayastor_instance, replica_uuid):
+    with pytest.raises(grpc.RpcError) as error:
+        v1_mayastor_instance.replica_rpc.ShareReplica(
+            replica_pb.ShareReplicaRequest(
+                uuid=replica_uuid, share=share_protocol("iscsi")
+            )
+        )
+    assert error.value.code() == grpc.StatusCode.INVALID_ARGUMENT
+
+
+@when("the user shares the replica with the same protocol")
+def share_replica_with_the_same_protocol(
+    v1_mayastor_instance, current_replicas, replica_uuid
+):
+    replica = current_replicas[replica_uuid]
+    v1_mayastor_instance.replica_rpc.ShareReplica(
+        replica_pb.ShareReplicaRequest(uuid=replica.uuid, share=replica.share)
+    )
+
+
+@when("the user attempts to share the replica with a different protocol")
+def attempt_to_share_replica_with_different_protocol(
+    v1_mayastor_instance, current_replicas, replica_uuid
+):
+    replica = current_replicas[replica_uuid]
+    share = common_pb.ISCSI if replica.share == common_pb.NVMF else common_pb.NVMF
+    with pytest.raises(grpc.RpcError) as error:
+        v1_mayastor_instance.replica_rpc.ShareReplica(
+            replica_pb.ShareReplicaRequest(uuid=replica.uuid, share=share)
+        )
+    assert error.value.code() == grpc.StatusCode.INVALID_ARGUMENT
+
+
+@when("the user unshares the replica")
+def unshare_replica(v1_mayastor_instance, replica_uuid):
+    v1_mayastor_instance.replica_rpc.UnshareReplica(
+        replica_pb.UnshareReplicaRequest(uuid=replica_uuid)
+    )
+
+
+@when("the user destroys the replica")
+def the_user_destroys_the_replica(v1_mayastor_instance, current_replicas, replica_uuid):
+    replica = current_replicas[replica_uuid]
+    v1_mayastor_instance.replica_rpc.DestroyReplica(
+        replica_pb.DestroyReplicaRequest(uuid=replica.uuid)
+    )
+    del current_replicas[replica_uuid]
+
+
+@then("the create replica command should fail")
+def create_replica_should_fail():
+    pass
+
+
+@then("replica should be present")
+@then("the replica is created")
+def create_replica_should_succeed(find_replica, replica_name, replica_uuid):
+    assert find_replica(replica_name, replica_uuid) != None
+
+
+@then(parsers.parse('"{name}" should appear in the output list'))
+def replica_should_appear_in_output(name, list_replicas):
+    assert name in [replica.name for replica in list_replicas]
+
+
+@then(parsers.parse('"{name}" should appear in the output list based on replica name'))
+def replica_should_appear_in_output_list(name, list_replicas_by_name):
+    assert name in [replica.name for replica in list_replicas_by_name]
+
+
+@then(
+    parsers.parse(
+        "only {n:d} replicas should be present in the output list based on replica name"
+    )
+)
+def no_of_replicas_in_output_list(list_replicas_by_name, n):
+    assert len(list_replicas_by_name) == n
+
+
+@then(parsers.parse('"{name}" should appear in the output list based on pool name'))
+def replica_should_appear_in_output_list(name, list_replicas_by_pool_name):
+    assert name in [replica.name for replica in list_replicas_by_pool_name]
+
+
+@then(
+    parsers.parse(
+        "only {n:d} replicas should be present in the output list based on pool name"
+    )
+)
+def no_of_replicas_in_output_list(list_replicas_by_pool_name, n):
+    assert len(list_replicas_by_pool_name) == n
+
+
+@then('the share state is "nvmf"')
+@then('the share state should change to "nvmf"')
+def share_state_is_nvmf(find_replica, replica_name, replica_uuid):
+    replica = find_replica(replica_name, replica_uuid)
+    assert replica != None
+    assert replica.share == common_pb.NVMF
+
+
+@then("the share replica command should fail")
+def share_replica_should_fail():
+    pass
+
+
+@then("the share replica command should succeed")
+def share_replica_should_succeed():
+    pass
+
+
+@then("the share state should remain in unshared")
+@then("the share state should change to unshared")
+def share_state_is_unshared(find_replica, replica_name, replica_uuid):
+    replica = find_replica(replica_name, replica_uuid)
+    assert replica != None
+    assert replica.share == common_pb.NONE
+
+
+@then("the replica should be destroyed")
+def replica_should_not_be_present(find_replica, replica_name, replica_uuid):
+    assert find_replica(replica_name, replica_uuid) == None


### PR DESCRIPTION
- Adds BDD tests for pool operations with v1 gRPC calls on top of v0 versioned pools to check for backward compatibility
- Adds BDD tests for nexus operations with v1 gRPC calls on top of v0 versioned nexus to check for backward compatibility
- Adds BDD tests for rebuild operations with v1 gRPC calls on top of v0 versioned replica to check for backward compatibility
- Adds BDD tests for replica operations with v1 gRPC calls on top of v0 versioned replca to check for backward compatibility

Signed-off-by: Abhishek Agarwal <abhishek.agarwal@mayadata.io>