### PR TITLE
fix(etcd): setup etcd tests with path from nix environment

### DIFF
--- a/ci.nix
+++ b/ci.nix
@@ -62,6 +62,7 @@ mkShell {
   PROTOC = io-engine.PROTOC;
   PROTOC_INCLUDE = io-engine.PROTOC_INCLUDE;
   SPDK_PATH = if nospdk then null else "${libspdk-dev}";
+  ETCD_BIN = "${etcd}/bin/etcd";
 
   shellHook = ''
     ${pkgs.lib.optionalString (nospdk) "cowsay ${nospdk_moth}"}

--- a/io-engine/tests/persistence.rs
+++ b/io-engine/tests/persistence.rs
@@ -342,7 +342,7 @@ async fn start_infrastructure(test_name: &str) -> ComposeTest {
         .add_container_spec(
             ContainerSpec::from_binary(
                 "etcd",
-                Binary::from_nix("etcd").with_args(vec![
+                Binary::from_nix(env!("ETCD_BIN")).with_args(vec![
                     "--data-dir",
                     "/tmp/etcd-data",
                     "--advertise-client-urls",

--- a/shell.nix
+++ b/shell.nix
@@ -52,6 +52,7 @@ mkShell {
   PROTOC = io-engine.PROTOC;
   PROTOC_INCLUDE = io-engine.PROTOC_INCLUDE;
   SPDK_PATH = if nospdk then null else "${libspdk-dev}";
+  ETCD_BIN = "${etcd}/bin/etcd";
 
   shellHook = ''
     ${pkgs.lib.optionalString (nospdk) "cowsay ${nospdk_moth}"}


### PR DESCRIPTION
By using the path directly we avoid being stopped at our tracks by the sudoers security.
Resolves: #1158

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>