### PR TITLE
fix(nexus): fixing crash during nexus child retire

### DIFF
--- a/io-engine/src/bdev/nexus/nexus_bdev_children.rs
+++ b/io-engine/src/bdev/nexus/nexus_bdev_children.rs
@@ -967,15 +967,18 @@ impl<'n> Nexus<'n> {
         };
 
         if self.has_io_device {
+            info!("{:?}: disconnecting all channels...", self);
+
             self.traverse_io_channels(
                 update_failfast_cb,
                 update_failfast_done,
                 ctx,
             );
 
-            info!("{:?}: all channels disconnected", self);
             r.await
                 .expect("disconnect_all_children() sender already dropped");
+
+            info!("{:?}: all channels disconnected", self);
         }
 
         Ok(())

--- a/io-engine/src/bdev/nvmx/handle.rs
+++ b/io-engine/src/bdev/nvmx/handle.rs
@@ -248,15 +248,13 @@ fn complete_nvme_command(ctx: *mut NvmeIoCtx, cpl: *const spdk_nvme_cpl) {
     inner.discard_io();
 
     // Invoke caller's callback and free I/O context.
-    if op_succeeded {
-        (io_ctx.cb)(&*inner.device, IoCompletionStatus::Success, io_ctx.cb_arg);
+    let status = if op_succeeded {
+        IoCompletionStatus::Success
     } else {
-        (io_ctx.cb)(
-            &*inner.device,
-            IoCompletionStatus::NvmeError(nvme_command_status(cpl)),
-            io_ctx.cb_arg,
-        );
-    }
+        IoCompletionStatus::NvmeError(nvme_command_status(cpl))
+    };
+
+    (io_ctx.cb)(&*inner.device, status, io_ctx.cb_arg);
 
     free_nvme_io_ctx(ctx);
 }

--- a/io-engine/src/core/bdev.rs
+++ b/io-engine/src/core/bdev.rs
@@ -31,6 +31,7 @@ use crate::{
 /// It is not possible to remove a bdev through a core other than the management
 /// core. This means that the structure is always valid for the lifetime of the
 /// scope.
+#[derive(Copy, Clone)]
 pub struct Bdev<T: spdk_rs::BdevOps> {
     /// TODO
     inner: spdk_rs::Bdev<T>,
@@ -58,17 +59,6 @@ where
 {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
-    }
-}
-
-impl<T> Clone for Bdev<T>
-where
-    T: spdk_rs::BdevOps,
-{
-    fn clone(&self) -> Self {
-        Self {
-            inner: self.inner.clone(),
-        }
     }
 }
 


### PR DESCRIPTION
When a nexus child is an SPDK block device, retiring a child can cause
use-after-free of a wrapper object which refers to SPDK Bdev.
SPDK Bdev itself is not destroyed at that point, only the wrapper is
invalidated.

Signed-off-by: Dmitry Savitskiy <dmitry.savitsky@datacore.com>