### PR TITLE
chore(spdk): updating to spdk 22.05

### DIFF
--- a/io-engine/src/bdev/aio.rs
+++ b/io-engine/src/bdev/aio.rs
@@ -142,7 +142,7 @@ impl CreateDestroy for Aio {
                 let (sender, receiver) = oneshot::channel::<ErrnoResult<()>>();
                 unsafe {
                     bdev_aio_delete(
-                        bdev.unsafe_inner_mut_ptr(),
+                        (*bdev.unsafe_inner_ptr()).name,
                         Some(done_errno_cb),
                         cb_arg(sender),
                     );

--- a/io-engine/src/bdev/malloc.rs
+++ b/io-engine/src/bdev/malloc.rs
@@ -213,7 +213,7 @@ impl CreateDestroy for Malloc {
 
             unsafe {
                 delete_malloc_disk(
-                    bdev.unsafe_inner_mut_ptr(),
+                    (*bdev.unsafe_inner_ptr()).name,
                     Some(done_errno_cb),
                     cb_arg(s),
                 );

--- a/io-engine/src/bdev/nexus/mod.rs
+++ b/io-engine/src/bdev/nexus/mod.rs
@@ -32,13 +32,7 @@ pub use nexus_bdev::{
 };
 pub(crate) use nexus_bdev_error::{nexus_err, Error};
 pub(crate) use nexus_channel::{DrEvent, NexusChannel};
-pub use nexus_child::{
-    lookup_nexus_child,
-    ChildError,
-    ChildState,
-    NexusChild,
-    Reason,
-};
+pub use nexus_child::{ChildError, ChildState, NexusChild, Reason};
 use nexus_io::{NexusBio, NioCtx};
 use nexus_io_subsystem::{NexusIoSubsystem, NexusPauseState};
 pub use nexus_iter::{

--- a/io-engine/src/bdev/nexus/nexus_bdev_children.rs
+++ b/io-engine/src/bdev/nexus/nexus_bdev_children.rs
@@ -717,7 +717,8 @@ impl<'n> DeviceEventListener for Nexus<'n> {
         dev_name: &str,
     ) {
         match evt {
-            DeviceEventType::DeviceRemoved => {
+            DeviceEventType::DeviceRemoved
+            | DeviceEventType::LoopbackRemoved => {
                 match self.as_mut().lookup_child_device_mut(dev_name) {
                     Some(child) => {
                         info!(

--- a/io-engine/src/bdev/nexus/nexus_child.rs
+++ b/io-engine/src/bdev/nexus/nexus_child.rs
@@ -10,7 +10,7 @@ use serde::Serialize;
 use snafu::{ResultExt, Snafu};
 use url::Url;
 
-use super::{nexus_iter_mut, nexus_lookup_mut, DrEvent};
+use super::{nexus_lookup_mut, DrEvent};
 
 use crate::{
     bdev::{device_create, device_destroy, device_lookup},
@@ -817,14 +817,4 @@ impl<'c> NexusChild<'c> {
             }
         }
     }
-}
-
-/// Looks up a child based on the underlying block device name.
-pub fn lookup_nexus_child(bdev_name: &str) -> Option<&mut NexusChild> {
-    for nexus in nexus_iter_mut() {
-        if let Some(c) = nexus.lookup_child_device_mut(bdev_name) {
-            return Some(c);
-        }
-    }
-    None
 }

--- a/io-engine/src/bdev/null_bdev.rs
+++ b/io-engine/src/bdev/null_bdev.rs
@@ -187,7 +187,7 @@ impl CreateDestroy for Null {
             let (s, r) = oneshot::channel::<ErrnoResult<()>>();
             unsafe {
                 spdk_rs::libspdk::bdev_null_delete(
-                    bdev.unsafe_inner_mut_ptr(),
+                    (*bdev.unsafe_inner_ptr()).name,
                     Some(done_errno_cb),
                     cb_arg(s),
                 )

--- a/io-engine/src/bdev/nvme.rs
+++ b/io-engine/src/bdev/nvme.rs
@@ -94,7 +94,7 @@ impl CreateDestroy for NVMe {
                 context.count,
                 Some(nvme_create_cb),
                 cb_arg(sender),
-                std::ptr::null_mut(), // context.prchk_flags,
+                std::ptr::null_mut(),
                 std::ptr::null_mut(),
                 false,
             )
@@ -156,7 +156,6 @@ const MAX_NAMESPACES: usize = 1;
 struct NvmeCreateContext {
     trid: spdk_nvme_transport_id,
     names: [*const c_char; MAX_NAMESPACES],
-    // prchk_flags: u32,
     count: u32,
 }
 
@@ -178,7 +177,6 @@ impl NvmeCreateContext {
         NvmeCreateContext {
             trid,
             names: [std::ptr::null_mut() as *mut c_char; MAX_NAMESPACES],
-            // prchk_flags: 0,
             count: MAX_NAMESPACES as u32,
         }
     }

--- a/io-engine/src/bdev/nvme.rs
+++ b/io-engine/src/bdev/nvme.rs
@@ -92,14 +92,11 @@ impl CreateDestroy for NVMe {
                 cname.as_ptr(),
                 &mut context.names[0],
                 context.count,
-                context.prchk_flags,
                 Some(nvme_create_cb),
                 cb_arg(sender),
+                std::ptr::null_mut(), // context.prchk_flags,
                 std::ptr::null_mut(),
                 false,
-                0,
-                0,
-                0,
             )
         };
 
@@ -159,7 +156,7 @@ const MAX_NAMESPACES: usize = 1;
 struct NvmeCreateContext {
     trid: spdk_nvme_transport_id,
     names: [*const c_char; MAX_NAMESPACES],
-    prchk_flags: u32,
+    // prchk_flags: u32,
     count: u32,
 }
 
@@ -181,7 +178,7 @@ impl NvmeCreateContext {
         NvmeCreateContext {
             trid,
             names: [std::ptr::null_mut() as *mut c_char; MAX_NAMESPACES],
-            prchk_flags: 0,
+            // prchk_flags: 0,
             count: MAX_NAMESPACES as u32,
         }
     }

--- a/io-engine/src/bdev/nvmf.rs
+++ b/io-engine/src/bdev/nvmf.rs
@@ -170,14 +170,11 @@ impl CreateDestroy for Nvmf {
                 cname.as_ptr(),
                 &mut context.names[0],
                 context.count,
-                context.prchk_flags,
                 Some(done_nvme_create_cb),
                 cb_arg(sender),
+                std::ptr::null_mut(), // context.prchk_flags,
                 std::ptr::null_mut(),
                 false,
-                0,
-                0,
-                0,
             )
         };
 
@@ -261,6 +258,7 @@ impl CreateDestroy for Nvmf {
 /// The Maximum number of namespaces that a single bdev will connect to
 const MAX_NAMESPACES: usize = 1;
 
+#[allow(dead_code)]
 struct NvmeCreateContext {
     trid: spdk_nvme_transport_id,
     names: [*const c_char; MAX_NAMESPACES],

--- a/io-engine/src/bdev/uring.rs
+++ b/io-engine/src/bdev/uring.rs
@@ -118,7 +118,7 @@ impl CreateDestroy for Uring {
                 let (sender, receiver) = oneshot::channel::<ErrnoResult<()>>();
                 unsafe {
                     delete_uring_bdev(
-                        bdev.unsafe_inner_mut_ptr(),
+                        (*bdev.unsafe_inner_ptr()).name,
                         Some(done_errno_cb),
                         cb_arg(sender),
                     );

--- a/io-engine/src/core/device_events.rs
+++ b/io-engine/src/core/device_events.rs
@@ -7,15 +7,16 @@ use std::{
 /// TODO
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum DeviceEventType {
-    /// TODO
+    /// Device has been removed.
     DeviceRemoved,
-
-    /// TODO
+    /// Special case for loopback device removal: loopback devices are not
+    /// real SPDK bdevs but bdev aliases. Deleting an alias won't make
+    /// SPDK send a proper bdev remove event.
+    LoopbackRemoved,
+    /// Device has been resized.
     DeviceResized,
-
     /// TODO
     MediaManagement,
-
     /// TODO
     AdminCommandCompletionFailed,
 }

--- a/io-engine/src/core/reactor.rs
+++ b/io-engine/src/core/reactor.rs
@@ -57,6 +57,7 @@ use spdk_rs::libspdk::{
     spdk_thread_lib_init_ext,
     spdk_thread_op,
     spdk_thread_send_msg,
+    SPDK_DEFAULT_MSG_MEMPOOL_SIZE,
     SPDK_THREAD_OP_NEW,
 };
 
@@ -133,6 +134,7 @@ impl Reactors {
                     Some(Self::do_op),
                     Some(Self::can_op),
                     0,
+                    SPDK_DEFAULT_MSG_MEMPOOL_SIZE as u64,
                 )
             };
             assert_eq!(rc, 0);

--- a/io-engine/src/subsys/config/opts.rs
+++ b/io-engine/src/subsys/config/opts.rs
@@ -243,6 +243,16 @@ pub struct NvmeBdevOpts {
     pub delay_cmd_submit: bool,
     /// attempts per I/O in bdev layer before I/O fails
     pub bdev_retry_count: i32,
+    /// TODO
+    pub transport_ack_timeout: u8,
+    /// TODO
+    pub ctrlr_loss_timeout_sec: i32,
+    /// TODO
+    pub reconnect_delay_sec: u32,
+    /// TODO
+    pub fast_io_fail_timeout_sec: u32,
+    /// TODO
+    pub disable_auto_failback: bool,
     /// enable creation of submission and completion queues asynchronously.
     pub async_mode: bool,
 }
@@ -286,6 +296,11 @@ impl Default for NvmeBdevOpts {
             io_queue_requests: 0,
             delay_cmd_submit: true,
             bdev_retry_count: try_from_env("NVME_BDEV_RETRY_COUNT", 0),
+            transport_ack_timeout: 0,
+            ctrlr_loss_timeout_sec: 0,
+            reconnect_delay_sec: 0,
+            fast_io_fail_timeout_sec: 0,
+            disable_auto_failback: false,
             async_mode: try_from_env("NVME_QPAIR_CONNECT_ASYNC", false),
         }
     }
@@ -308,6 +323,11 @@ impl From<spdk_bdev_nvme_opts> for NvmeBdevOpts {
             io_queue_requests: o.io_queue_requests,
             delay_cmd_submit: o.delay_cmd_submit,
             bdev_retry_count: o.bdev_retry_count,
+            transport_ack_timeout: o.transport_ack_timeout,
+            ctrlr_loss_timeout_sec: o.ctrlr_loss_timeout_sec,
+            reconnect_delay_sec: o.reconnect_delay_sec,
+            fast_io_fail_timeout_sec: o.fast_io_fail_timeout_sec,
+            disable_auto_failback: o.disable_auto_failback,
             async_mode: NvmeBdevOpts::default().async_mode,
         }
     }
@@ -330,6 +350,11 @@ impl From<&NvmeBdevOpts> for spdk_bdev_nvme_opts {
             io_queue_requests: o.io_queue_requests,
             delay_cmd_submit: o.delay_cmd_submit,
             bdev_retry_count: o.bdev_retry_count,
+            transport_ack_timeout: o.transport_ack_timeout,
+            ctrlr_loss_timeout_sec: o.ctrlr_loss_timeout_sec,
+            reconnect_delay_sec: o.reconnect_delay_sec,
+            fast_io_fail_timeout_sec: o.fast_io_fail_timeout_sec,
+            disable_auto_failback: o.disable_auto_failback,
         }
     }
 }
@@ -416,6 +441,7 @@ pub struct PosixSocketOpts {
     enable_placement_id: u32,
     enable_zerocopy_send_server: bool,
     enable_zerocopy_send_client: bool,
+    zerocopy_threshold: u32,
 }
 
 impl Default for PosixSocketOpts {
@@ -435,6 +461,7 @@ impl Default for PosixSocketOpts {
                 "SOCK_ZEROCOPY_SEND_CLIENT",
                 false,
             ),
+            zerocopy_threshold: 0,
         }
     }
 }
@@ -463,6 +490,7 @@ impl GetOpts for PosixSocketOpts {
             enable_placement_id: opts.enable_placement_id,
             enable_zerocopy_send_server: opts.enable_zerocopy_send_server,
             enable_zerocopy_send_client: opts.enable_zerocopy_send_client,
+            zerocopy_threshold: opts.zerocopy_threshold,
         }
     }
 
@@ -476,6 +504,7 @@ impl GetOpts for PosixSocketOpts {
             enable_placement_id: self.enable_placement_id,
             enable_zerocopy_send_server: self.enable_zerocopy_send_server,
             enable_zerocopy_send_client: self.enable_zerocopy_send_client,
+            zerocopy_threshold: self.zerocopy_threshold,
         };
 
         let size = std::mem::size_of::<spdk_sock_impl_opts>() as u64;

--- a/io-engine/tests/replica_uri.rs
+++ b/io-engine/tests/replica_uri.rs
@@ -24,6 +24,7 @@ const DISKSIZE_KB: u64 = 96 * 1024;
 const VOLUME_SIZE_MB: u64 = (DISKSIZE_KB / 1024) / 2;
 const VOLUME_SIZE_B: u64 = VOLUME_SIZE_MB * 1024 * 1024;
 const VOLUME_UUID: &str = "cb9e1a5c-7af8-44a7-b3ae-05390be75d83";
+const NEXUS_UUID: &str = "65acdaac-14c4-41d8-a55e-d03bfd7185a4";
 
 // pool name for mayastor from handle_index
 fn pool_name(handle_index: usize) -> String {
@@ -126,7 +127,7 @@ async fn replica_uri() {
     hdls[0]
         .mayastor
         .create_nexus(CreateNexusRequest {
-            uuid: VOLUME_UUID.to_string(),
+            uuid: NEXUS_UUID.to_string(),
             size: VOLUME_SIZE_B,
             children: [replica_loopback.uri, replica_nvmf.uri].to_vec(),
         })

--- a/nix/pkgs/libspdk/default.nix
+++ b/nix/pkgs/libspdk/default.nix
@@ -36,13 +36,13 @@
 let
   # Derivation attributes for production version of libspdk
   drvAttrs = rec {
-    version = "22.01-13a768291";
+    version = "22.05-46b8c8680";
 
     src = fetchFromGitHub {
       owner = "openebs";
       repo = "spdk";
-      rev = "13a768291942dc9c3ab63786aafd69e59e025c1d";
-      sha256 = "0vwqrz01wf3207mpm20y0a5cdz42x7s679qd6arpimc904l060mf";
+      rev = "46b8c86803fe3cb41ed3898ae6b9a95c8ef526d2";
+      sha256 = "sha256-eBrlnhaVeDoCMEiuOpj0hYNBsSC4XvHZ2uwXkI1xSfg=";
       fetchSubmodules = true;
     };
 


### PR DESCRIPTION
SPDK 22.05 stable has been released a couple of months ago.
It has a feature we need for thin provisioning: passing errno from blob store internals to bdev I/O layer.
However, this feature is half-baked: the errno is not propagated further, is not stored, and therefore cannot be accessed via Bdev API. To support this, I have added a patch for our SPDK branch, which I will submit via a separate PR. We need to integrate SPDK 22.05 first.

This PR contains commits from https://github.com/openebs/mayastor/pull/1167, which I'm going to merge first, and after that I'll update with PR to have only single commit SPDK 22.05.