### PR TITLE
chore: add child state reasons to the v0 api

### DIFF
--- a/io-engine/src/bdev/nexus/nexus_child.rs
+++ b/io-engine/src/bdev/nexus/nexus_child.rs
@@ -95,7 +95,7 @@ pub enum Reason {
     OutOfSync,
     /// Thin-provisioned child failed a write operate because
     /// the underlying logical volume failed to allocate space.
-    /// This a recoverable state in case when addtional space
+    /// This a recoverable state in case when additional space
     /// can be freed from the logical volume store.
     NoSpace,
     /// The underlying device timed out.

--- a/io-engine/src/grpc/v0/nexus_grpc.rs
+++ b/io-engine/src/grpc/v0/nexus_grpc.rs
@@ -45,6 +45,28 @@ impl From<ChildState> for rpc::ChildState {
         }
     }
 }
+impl From<ChildState> for rpc::ChildStateReason {
+    fn from(child: ChildState) -> Self {
+        match child {
+            ChildState::Init => Self::Init,
+            ChildState::ConfigInvalid => Self::ConfigInvalid,
+            ChildState::Open => Self::None,
+            ChildState::Destroying => Self::Closed,
+            ChildState::Closed => Self::Closed,
+            ChildState::Faulted(reason) => match reason {
+                Reason::OutOfSync => Self::OutOfSync,
+                Reason::NoSpace => Self::NoSpace,
+                Reason::TimedOut => Self::TimedOut,
+                Reason::Unknown => Self::None,
+                Reason::CantOpen => Self::CannotOpen,
+                Reason::RebuildFailed => Self::RebuildFailed,
+                Reason::IoError => Self::IoFailure,
+                Reason::ByClient => Self::ByClient,
+                Reason::AdminCommandFailed => Self::AdminFailed,
+            },
+        }
+    }
+}
 
 impl From<NexusStatus> for rpc::NexusState {
     fn from(nexus: NexusStatus) -> Self {
@@ -89,6 +111,7 @@ impl<'c> NexusChild<'c> {
             uri: self.uri().to_string(),
             state: rpc::ChildState::from(self.state()) as i32,
             rebuild_progress: self.get_rebuild_progress(),
+            reason: rpc::ChildStateReason::from(self.state()) as i32,
         }
     }
 }


### PR DESCRIPTION
This is done because the control-plane does not support the v1 api yet.
This way we can proceed with supporting enospc.

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>