### PR TITLE
fix(nexus): fixing assert failure when removing non-existing child

### DIFF
--- a/io-engine/src/bdev/nexus/nexus_bdev_children.rs
+++ b/io-engine/src/bdev/nexus/nexus_bdev_children.rs
@@ -277,7 +277,10 @@ impl<'n> Nexus<'n> {
         let paused = self.as_mut().pause_rebuild_jobs(uri).await;
 
         let idx = match self.children_iter().position(|c| c.uri() == uri) {
-            None => return Ok(()),
+            None => {
+                paused.resume().await;
+                return Ok(());
+            }
             Some(val) => val,
         };
 


### PR DESCRIPTION
Signed-off-by: Dmitry Savitskiy <dmitry.savitskiy@datacore.com>