### PR TITLE
fix(thin-provisioning): several fixes regarding this feature

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
         name: Commit Lint
         description: Runs commitlint against the commit message.
         language: system
-        entry: bash -c "npm install @commitlint/config-conventional @commitlint/cli; cat $1 | npx commitlint"
+        entry: bash -c "npm install @commitlint/config-conventional @commitlint/cli; cat $1 | grep -v '^#' | npx commitlint"
         args: [$1]
         stages: [commit-msg]
     -   id: python-check

--- a/io-engine/src/lvs/lvs_lvol.rs
+++ b/io-engine/src/lvs/lvs_lvol.rs
@@ -47,6 +47,9 @@ use crate::{
     subsys::NvmfReq,
 };
 
+// Wipe `WIPE_SUPER_LEN` bytes if unmap is not supported.
+pub(crate) const WIPE_SUPER_LEN: u64 = (1 << 20) * 8;
+
 /// properties we allow for being set on the lvol, this information is stored on
 /// disk
 #[derive(Debug, Copy, Clone, PartialEq)]
@@ -292,7 +295,7 @@ impl Lvol {
             // write zero to the first 8MB which wipes the metadata and the
             // first 4MB of the data partition
             let range =
-                std::cmp::min(self.as_bdev().size_in_bytes(), (1 << 20) * 8);
+                std::cmp::min(self.as_bdev().size_in_bytes(), WIPE_SUPER_LEN);
             for offset in 0 .. (range / buf_size) {
                 hdl.write_at(offset * buf.len(), &buf).await.map_err(|e| {
                     error!(?self, ?e);

--- a/io-engine/src/lvs/lvs_store.rs
+++ b/io-engine/src/lvs/lvs_store.rs
@@ -670,6 +670,15 @@ impl Lvs {
             });
         }
 
+        // As it stands lvs pools can't grow, so limit the max replica size to
+        // the pool capacity.
+        if size > self.capacity() {
+            return Err(Error::RepCreate {
+                source: Errno::EOVERFLOW,
+                name: name.to_string(),
+            });
+        }
+
         let (s, r) = pair::<ErrnoResult<*mut spdk_lvol>>();
 
         let cname = name.into_cstring();

--- a/io-engine/tests/nexus_thin.rs
+++ b/io-engine/tests/nexus_thin.rs
@@ -44,7 +44,7 @@ async fn nexus_thin_nospc_local_single() {
     let pool_0 = PoolBuilder::new()
         .with_name("pool0")
         .with_uuid("6e3c062c-293b-46e6-8ab3-ff13c1643437")
-        .with_bdev("malloc:///mem0?size_mb=30");
+        .with_bdev("malloc:///mem0?size_mb=60");
 
     let mut repl_0 = ReplicaBuilder::new()
         .with_pool(&pool_0)
@@ -114,7 +114,7 @@ async fn nexus_thin_nospc_remote_single() {
     let pool_0 = PoolBuilder::new()
         .with_name("pool0")
         .with_uuid("6e3c062c-293b-46e6-8ab3-ff13c1643437")
-        .with_bdev("malloc:///mem0?size_mb=30");
+        .with_bdev("malloc:///mem0?size_mb=60");
 
     let mut repl_0 = ReplicaBuilder::new()
         .with_pool(&pool_0)

--- a/test/python/tests/nexus/test_nexus.py
+++ b/test/python/tests/nexus/test_nexus.py
@@ -223,7 +223,7 @@ def test_enospace_on_volume(mayastors, create_replica):
     pools.append(nodes["ms1"].pools_as_uris()[0])
     nexus_node = nodes["ms3"].as_target()
 
-    v = Volume(uuid, nexus_node, pools, 100 * 1024 * 1024)
+    v = Volume(uuid, nexus_node, pools, 80 * 1024 * 1024)
 
     with pytest.raises(grpc.RpcError) as error:
         v.create()

--- a/test/python/v1/nexus/test_nexus.py
+++ b/test/python/v1/nexus/test_nexus.py
@@ -211,7 +211,7 @@ def test_enospace_on_volume(mayastors, create_replica):
     pools.append(nodes["ms1"].pools_as_uris()[0])
     nexus_node = nodes["ms3"].as_target()
 
-    v = Volume(uuid, nexus_node, pools, 100 * 1024 * 1024)
+    v = Volume(uuid, nexus_node, pools, 80 * 1024 * 1024)
 
     with pytest.raises(grpc.RpcError) as error:
         v.create()


### PR DESCRIPTION
fix(thin-provisioning): don't leak replicas when wipe_super fails

When the clear method of a pool is not unmap, we wipe the first 8M of a replica after creation.
When using thin provisioning this may fail with ENOSPC, and in this case clean up the created
replica as if we can't even write this much, it's probably not worth using it.

How should we handle this in the control-plane? For now we should probably add a slack of
8M when determining if a pool is usable.

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

ix(thin-provisioning): cap replica size to pool capacity

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

feat: allow permanently faulting a replica with client reason

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>