### PR TITLE
chore(v1poolgrpc): changes in error handling for v1 pool operations

### DIFF
--- a/io-engine/src/grpc/v0/mayastor_grpc.rs
+++ b/io-engine/src/grpc/v0/mayastor_grpc.rs
@@ -164,13 +164,26 @@ impl From<LvsError> for Status {
             LvsError::ReplicaShareProtocol {
                 ..
             } => Status::invalid_argument(e.to_string()),
-
             LvsError::Destroy {
                 source, ..
             } => source.into(),
             LvsError::Invalid {
                 ..
             } => Status::invalid_argument(e.to_string()),
+            LvsError::PoolNotFound {
+                ..
+            } => Status::not_found(e.to_string()),
+            LvsError::PoolCreate {
+                source, ..
+            } => {
+                if source == Errno::EEXIST {
+                    Status::already_exists(e.to_string())
+                } else if source == Errno::EINVAL {
+                    Status::invalid_argument(e.to_string())
+                } else {
+                    Status::internal(e.to_string())
+                }
+            }
             LvsError::InvalidBdev {
                 source, ..
             } => source.into(),

--- a/io-engine/src/grpc/v1/pool.rs
+++ b/io-engine/src/grpc/v1/pool.rs
@@ -207,9 +207,12 @@ impl PoolRpc for PoolService {
                         }
                         pool.destroy().await?;
                     } else {
-                        return Err(LvsError::Invalid {
+                        return Err(LvsError::PoolNotFound {
                             source: Errno::EINVAL,
-                            msg: format!("pool {} not found", args.name,),
+                            msg: format!(
+                                "Destroy failed as pool {} was not found",
+                                args.name,
+                            ),
                         });
                     }
                     Ok(())

--- a/io-engine/src/lvs/lvs_error.rs
+++ b/io-engine/src/lvs/lvs_error.rs
@@ -28,6 +28,11 @@ pub enum Error {
         source: BdevError,
         name: String,
     },
+    #[snafu(display("{}", msg))]
+    PoolNotFound {
+        source: Errno,
+        msg: String,
+    },
     InvalidBdev {
         source: BdevError,
         name: String,

--- a/test/python/cross-grpc-version/pool/test_bdd_pool.py
+++ b/test/python/cross-grpc-version/pool/test_bdd_pool.py
@@ -185,7 +185,7 @@ def destroy_pool(v1_mayastor_instance, v0_replica_pools, get_pool_name):
 
 @then("the pool create command should fail")
 def the_pool_create_command_should_fail(create_pool_that_already_exists):
-    assert create_pool_that_already_exists.value.code() == grpc.StatusCode.INTERNAL
+    assert create_pool_that_already_exists.value.code() == grpc.StatusCode.ALREADY_EXISTS
 
 
 @then("the pool should appear in the output list")

--- a/test/python/v1/pool/test_bdd_pool.py
+++ b/test/python/v1/pool/test_bdd_pool.py
@@ -298,12 +298,12 @@ def pool_creation_should_fail(find_pool):
 
 @then("the pool create command should fail")
 def the_pool_create_command_should_fail(create_pool_that_already_exists):
-    assert create_pool_that_already_exists.value.code() == grpc.StatusCode.INTERNAL
+    assert create_pool_that_already_exists.value.code() == grpc.StatusCode.ALREADY_EXISTS
 
 
 @then("the pool destroy command should fail")
 def the_pool_destroy_command_should_fail(destroy_non_existing_pool):
-    assert destroy_non_existing_pool.value.code() == grpc.StatusCode.INVALID_ARGUMENT
+    assert destroy_non_existing_pool.value.code() == grpc.StatusCode.NOT_FOUND
 
 
 @then("the pool should appear in the output list")


### PR DESCRIPTION
Added additional Error variants in lvs error enum for pool operations with more granular tonic status code. This will help Control plane to interpret error and handle accordingly.

Signed-off-by: Abhilash Shetty <abhilash.shetty@datacore.com>