### PR TITLE
feat(reactor): freeze detection support for reactors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,6 +44,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-io"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e21f3a490c72b3b0cf44962180e60045de2925d8dff97918f7ee43c8f637c7"
+dependencies = [
+ "autocfg",
+ "concurrent-queue",
+ "futures-lite",
+ "libc",
+ "log",
+ "once_cell",
+ "parking",
+ "polling",
+ "slab",
+ "socket2",
+ "waker-fn",
+ "winapi",
+]
+
+[[package]]
+name = "async-process"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02111fd8655a613c25069ea89fc8d9bb89331fa77486eb3bc059ee757cfa481c"
+dependencies = [
+ "async-io",
+ "autocfg",
+ "blocking",
+ "cfg-if 1.0.0",
+ "event-listener",
+ "futures-lite",
+ "libc",
+ "once_cell",
+ "signal-hook",
+ "winapi",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -80,6 +118,12 @@ dependencies = [
  "quote 1.0.16",
  "syn 1.0.99",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "065374052e7df7ee4047b1160cca5e1467a12351a40b3da123c870ba0b8eda2a"
 
 [[package]]
 name = "atty"
@@ -149,6 +193,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "blocking"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6ccb65d468978a086b69884437ded69a90faab3bbe6e67f242173ea728acccc"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "atomic-waker",
+ "fastrand",
+ "futures-lite",
+ "once_cell",
 ]
 
 [[package]]
@@ -260,6 +318,12 @@ checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
  "nom",
 ]
+
+[[package]]
+name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "cfg-if"
@@ -410,7 +474,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ae5588f6b3c3cb05239e90bd110f257254aecd01e4635400391aeae07497845"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-epoch",
@@ -424,7 +488,7 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aaa7bd5fb665c6864b5f963dd9097905c54125909c7aa94c9e18507cdbe6c53"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-utils",
 ]
 
@@ -434,7 +498,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-epoch",
  "crossbeam-utils",
 ]
@@ -446,7 +510,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1145cf131a2c6ba0615079ab6a638f7e1973ac9c2634fcbeaaad6114246efe8c"
 dependencies = [
  "autocfg",
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-utils",
  "lazy_static",
  "memoffset",
@@ -459,7 +523,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f25d8400f4a7a5778f0e4e52384a48cbd9b5c495d110786187fc750075277a2"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-utils",
 ]
 
@@ -475,7 +539,7 @@ version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "lazy_static",
 ]
 
@@ -639,7 +703,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "dirs-sys-next",
 ]
 
@@ -660,7 +724,7 @@ version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53ecafc952c4528d9b51a458d1a8904b81783feff9fde08ab6ed2545ff396872"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "socket2",
  "winapi",
@@ -759,6 +823,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foreign-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
+dependencies = [
+ "foreign-types-macros",
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-macros"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8469d0d40519bc608ec6863f1cc88f3f1deee15913f2f3b3e573d81ed38cccc"
+dependencies = [
+ "proc-macro2 1.0.43",
+ "quote 1.0.16",
+ "syn 1.0.99",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -847,6 +938,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
 
 [[package]]
+name = "futures-lite"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694489acd39452c77daa48516b894c153f192c3578d5a839b62c58099fcbf48"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "parking",
+ "pin-project-lite",
+ "waker-fn",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -903,9 +1009,19 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d39cd93900197114fa1fcb7ae84ca742095eed9442088988ae74fa744e930e77"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "gettid"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b20f40277dfb8a9dec7e2e945f6d8ff711e733c8f2a2c9b257562764b4c60d"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -1119,7 +1235,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -1129,6 +1245,7 @@ dependencies = [
  "ansi_term",
  "assert_matches",
  "async-channel",
+ "async-process",
  "async-task",
  "async-trait",
  "atty",
@@ -1146,6 +1263,7 @@ dependencies = [
  "etcd-client",
  "function_name",
  "futures",
+ "gettid",
  "hex",
  "http",
  "io-engine-tests",
@@ -1169,6 +1287,7 @@ dependencies = [
  "prost-types",
  "rand",
  "regex",
+ "rstack",
  "run_script",
  "serde",
  "serde_json",
@@ -1374,9 +1493,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.121"
+version = "0.2.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efaa7b300f3b5fe8eb6bf21ce3895e1751d9665086af2d64b42f19701015ff4f"
+checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
 
 [[package]]
 name = "libloading"
@@ -1384,7 +1503,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efbc0f03f9a775e9f6aed295c6a1ba2253c5757a9e03d55c6caa46a681abcddd"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "winapi",
 ]
 
@@ -1433,7 +1552,7 @@ version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -1553,7 +1672,7 @@ checksum = "e4916f159ed8e5de0082076562152a76b7a1f64a01fd9d1e0fea002c37624faf"
 dependencies = [
  "bitflags",
  "cc",
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "memoffset",
 ]
@@ -1636,6 +1755,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
+name = "parking"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
+
+[[package]]
 name = "parking_lot"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1662,7 +1787,7 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "instant",
  "libc",
  "redox_syscall",
@@ -1676,7 +1801,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28141e0cc4143da2443301914478dc976a61ffdb3f043058310c70df2fed8954"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "redox_syscall",
  "smallvec",
@@ -1778,6 +1903,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521fa9638fa597e1dc53e9412a4f9cefb01187ee1f7413076f9e6749e2885ba9"
 dependencies = [
  "plotters-backend",
+]
+
+[[package]]
+name = "polling"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899b00b9c8ab553c743b3e11e87c5c7d423b2a2de229ba95b24a756344748011"
+dependencies = [
+ "autocfg",
+ "cfg-if 1.0.0",
+ "libc",
+ "log",
+ "wepoll-ffi",
+ "winapi",
 ]
 
 [[package]]
@@ -2032,6 +2171,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rstack"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5db35178d78a6c680852a6b48b089100d038c82fde25283a77ee923c3f6f90bd"
+dependencies = [
+ "cfg-if 0.1.10",
+ "libc",
+ "log",
+ "unwind",
+]
+
+[[package]]
 name = "run_script"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2182,7 +2333,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55deaec60f81eefe3cce0dc50bda92d6d8e88f2a27df7c5033b42afeb1ed2676"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpufeatures",
  "digest",
 ]
@@ -2361,7 +2512,7 @@ version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "fastrand",
  "libc",
  "redox_syscall",
@@ -2623,7 +2774,7 @@ version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fce9567bd60a67d08a16488756721ba392f24f29006402881e43b19aac64307"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "log",
  "pin-project-lite",
  "tracing-attributes",
@@ -2774,6 +2925,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
+name = "unwind"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0e0da3c8d6b71dbaf219188cc0e7f9ca3943f3263ca479920338d92d7ea5e07"
+dependencies = [
+ "foreign-types",
+ "libc",
+ "unwind-sys",
+]
+
+[[package]]
+name = "unwind-sys"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d554005b247de226d124a523cae6cd6a4348277071258296dda837cf760e02e7"
+dependencies = [
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "url"
 version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2837,6 +3009,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
+name = "waker-fn"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
+
+[[package]]
 name = "walkdir"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2875,7 +3053,7 @@ version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27370197c907c55e3f1a9fbe26f44e937fe6451368324e009cba39e139dc08ad"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "wasm-bindgen-macro",
 ]
 
@@ -2931,6 +3109,15 @@ checksum = "7b17e741662c70c8bd24ac5c5b18de314a2c26c32bf8346ee1e6f53de919c283"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "wepoll-ffi"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d743fdedc5c64377b5fc2bc036b01c7fd642205a0d96356034ae3404d49eb7fb"
+dependencies = [
+ "cc",
 ]
 
 [[package]]

--- a/ci.nix
+++ b/ci.nix
@@ -53,6 +53,7 @@ mkShell {
     utillinux
     xfsprogs
     gnuplot
+    libunwind
   ] ++ (if (nospdk) then [ libspdk-dev.buildInputs ] else [ libspdk-dev ])
   ++ pkgs.lib.optional (!norust) channel.stable
   ++ pkgs.lib.optional (!norust) channel.nightly;

--- a/io-engine/Cargo.toml
+++ b/io-engine/Cargo.toml
@@ -10,6 +10,8 @@ build = "build.rs"
 [features]
 # Enables fault injection code.
 fault_injection = []
+# Enables diagnostics operations.
+diagnostics = ["async-process", "rstack"]
 
 [[bin]]
 name = "io-engine"
@@ -93,6 +95,9 @@ tracing-log = "0.1.2"
 tracing-subscriber = "0.2.20"
 udev = "0.6.2"
 url = "2.2.2"
+gettid = "0.1.2"
+async-process = { version = "1.5.0", optional = true }
+rstack =  { version = "0.3.2", optional = true }
 
 jsonrpc = { path = "../jsonrpc"}
 mayastor-api = { path = "../rpc/mayastor-api" }

--- a/io-engine/src/core/diagnostics.rs
+++ b/io-engine/src/core/diagnostics.rs
@@ -1,0 +1,102 @@
+use crate::core::{MayastorCliArgs, Reactor};
+use async_process::Command;
+use rstack::TraceOptions;
+use std::env;
+
+/// Get command path from process CLI arguments.
+fn get_io_agent_path() -> String {
+    env::args().next().as_ref().map(String::from).unwrap()
+}
+
+/// Dump stack for current I/O engine instance and log it.
+async fn dump_self_stack() {
+    let pid = std::process::id();
+
+    info!(pid, "Collecting stack for I/O agent process");
+
+    let out = Command::new(get_io_agent_path())
+        .arg("--diagnose-stack")
+        .arg(pid.to_string())
+        .output()
+        .await;
+
+    match out {
+        Err(error) => {
+            error!(
+                %error,
+                "Failed to collect process stack"
+            );
+        }
+        Ok(output) => {
+            let l = String::from_utf8(output.stdout).unwrap();
+            l.split('\n').for_each(|s| {
+                if !s.is_empty() {
+                    if s.starts_with("thread ") {
+                        info!("\n{}", s);
+                    } else {
+                        info!("{}", s);
+                    }
+                }
+            });
+            info!("Process stack collected successfully");
+        }
+    }
+}
+
+/// Dump detailed diagnostic information for the frozen reactor.
+/// As of now print only basic information about the reactor,
+/// in the future might print stack traces too.
+pub fn diagnose_reactor(reactor: &Reactor) {
+    info!(
+        core=reactor.core(),
+        tid=reactor.tid(),
+        state=%reactor.get_state(),
+        "Reactor is frozen"
+    );
+
+    // Spawn a task to perform stack collection.
+    tokio::spawn(async move {
+        dump_self_stack().await;
+    });
+}
+
+/// Collect sracktraces for all stack frames for all threads in target process
+/// and dump it to stdout.
+fn collect_process_stack(pid: u32) -> Result<(), Box<dyn std::error::Error>> {
+    let process = TraceOptions::new()
+        .thread_names(true)
+        .symbols(true)
+        .trace(pid)?;
+
+    for thread in process.threads() {
+        println!(
+            "thread {} - {}",
+            thread.id(),
+            thread.name().unwrap_or("<unknown>")
+        );
+
+        for frame in thread.frames() {
+            match frame.symbol() {
+                Some(symbol) => println!(
+                    "{:#016x} - {} + {:#x}",
+                    frame.ip(),
+                    symbol.name(),
+                    symbol.offset(),
+                ),
+                None => println!("{:#016x} - ???", frame.ip()),
+            }
+        }
+    }
+    println!();
+    Ok(())
+}
+
+/// Process diagnostics-related CLI commands.
+pub fn process_diagnostics_cli(
+    cli: &MayastorCliArgs,
+) -> Option<Result<(), Box<dyn std::error::Error>>> {
+    match cli.diagnose_stack {
+        None => None,
+        Some(pid) => Some(collect_process_stack(pid)),
+    }
+}

--- a/io-engine/src/core/env.rs
+++ b/io-engine/src/core/env.rs
@@ -150,6 +150,20 @@ pub struct MayastorCliArgs {
         env = "API_VERSIONS"
     )]
     pub api_versions: Vec<ApiVersion>,
+    /// Dump stack trace for all threads inside I/O agent process with target
+    /// PID. Available only when diagnostics feature is enabled.
+    #[structopt(long = "diagnose-stack", short = "d", env = "DIAGNOSE_STACK")]
+    #[cfg(feature = "diagnostics")]
+    pub diagnose_stack: Option<u32>,
+    /// Timeout (in seconds) for reactor freeze detection.
+    /// Available only when diagnostics feature is enabled.
+    #[structopt(
+        long = "reactor-freeze-timeout",
+        short = "t",
+        env = "REACTOR_FREEZE_TIMEOUT"
+    )]
+    #[cfg(feature = "diagnostics")]
+    pub reactor_freeze_timeout: Option<u64>,
 }
 
 /// Mayastor features.
@@ -193,6 +207,12 @@ impl Default for MayastorCliArgs {
             registration_endpoint: None,
             nvmf_tgt_interface: None,
             api_versions: vec![ApiVersion::V0, ApiVersion::V1],
+
+            // CLI arguments available only in diagnostics mode.
+            #[cfg(feature = "diagnostics")]
+            diagnose_stack: None,
+            #[cfg(feature = "diagnostics")]
+            reactor_freeze_timeout: None,
         }
     }
 }

--- a/io-engine/src/core/mod.rs
+++ b/io-engine/src/core/mod.rs
@@ -42,6 +42,10 @@ pub use env::{
 pub use handle::{BdevHandle, UntypedBdevHandle};
 pub use io_device::IoDevice;
 pub use reactor::{Reactor, ReactorState, Reactors, REACTOR_LIST};
+
+#[cfg(feature = "diagnostics")]
+pub use reactor::reactor_monitor_loop;
+
 pub use runtime::spawn;
 pub use share::{Protocol, Share};
 pub use spdk_rs::{cpu_cores, GenericStatusCode, IoStatus, IoType, NvmeStatus};
@@ -54,6 +58,8 @@ mod block_device;
 mod descriptor;
 mod device_events;
 mod device_monitor;
+#[cfg(feature = "diagnostics")]
+pub mod diagnostics;
 mod env;
 mod handle;
 mod io_device;

--- a/io-engine/src/core/reactor.rs
+++ b/io-engine/src/core/reactor.rs
@@ -62,6 +62,7 @@ use spdk_rs::libspdk::{
 };
 
 use crate::core::{CoreError, Cores};
+use gettid::gettid;
 use nix::errno::Errno;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -114,6 +115,8 @@ pub struct Reactor {
     lcore: u32,
     /// represents the state of the reactor
     flags: Cell<ReactorState>,
+    /// Unique identifier of the thread on which reactor is running.
+    tid: Cell<u64>,
     /// sender and Receiver for sending futures across cores without going
     /// through FFI
     sx: Sender<Pin<Box<dyn Future<Output = ()> + 'static>>>,
@@ -142,10 +145,7 @@ impl Reactors {
             Reactors(
                 Cores::count()
                     .into_iter()
-                    .map(|c| {
-                        debug!("init core: {}", c);
-                        Reactor::new(c)
-                    })
+                    .map(Reactor::new)
                     .collect::<Vec<_>>(),
             )
         });
@@ -288,15 +288,18 @@ impl Reactor {
             incoming: crossbeam::queue::SegQueue::new(),
             lcore: core,
             flags: Cell::new(ReactorState::Init),
+            tid: Cell::new(0),
             sx,
             rx,
         }
     }
 
     /// this function gets called by DPDK
-    extern "C" fn poll(core: *mut c_void) -> i32 {
-        debug!("Start polling of reactor {}", core as u32);
-        let reactor = Reactors::get_by_core(core as u32).unwrap();
+    extern "C" fn poll(arg: *mut c_void) -> i32 {
+        let core = arg as u32;
+
+        info!(core, tid = gettid(), "Starting reactor polling loop",);
+        let reactor = Reactors::get_by_core(core).unwrap();
         if reactor.get_state() != ReactorState::Init {
             warn!("calling poll on a reactor who is not in the INIT state");
         }
@@ -432,8 +435,16 @@ impl Reactor {
         self.lcore
     }
 
+    /// Returns system identifier of the thread this reactor is running on.
+    pub fn tid(&self) -> u64 {
+        self.tid.get()
+    }
+
     /// poll this reactor to complete any work that is pending
     pub fn poll_reactor(&self) {
+        // Initialize TID for this reactor.
+        self.tid.set(gettid());
+
         loop {
             match self.get_state() {
                 // running is the default mode for all cores. All cores, except
@@ -620,6 +631,98 @@ impl Future for &'static Reactor {
                 }
                 cx.waker().wake_by_ref();
                 Poll::Pending
+            }
+        }
+    }
+}
+
+/// Heartbeat timeout (in seconds) to classify a reactor as frozen.
+#[cfg(feature = "diagnostics")]
+const REACTOR_HEARTBEAT_TIMEOUT: u64 = 3;
+
+/// Monitor health for all reactors: all available reactors are constantly
+/// monitored for liveness.
+#[cfg(feature = "diagnostics")]
+pub async fn reactor_monitor_loop(freeze_timeout: Option<u64>) {
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    /// Metadata for every reactor being monitored by the reactor monitor.
+    struct ReactorRecord {
+        frozen: bool,
+        reactor: &'static Reactor,
+        reactor_tick: &'static AtomicU64,
+        core: u32,
+    }
+
+    let timeout = freeze_timeout.unwrap_or(REACTOR_HEARTBEAT_TIMEOUT);
+    let num_cores = Cores::count().id() as usize;
+    let mut interval = tokio::time::interval(Duration::from_secs(1));
+    let mut tick: u64 = 0;
+    let mut reactor_state: Vec<ReactorRecord> = Vec::with_capacity(num_cores);
+    static REACTOR_TICKS: OnceCell<Vec<AtomicU64>> = OnceCell::new();
+
+    info!(num_cores, timeout, "Starting reactor health monitor loop");
+
+    // Intialize shared counters for heartbeat futures sent to reactors.
+    let heartbeat_ticks = REACTOR_TICKS.get_or_init(|| {
+        std::iter::repeat_with(|| AtomicU64::new(0))
+            .take(num_cores)
+            .collect::<Vec<AtomicU64>>()
+    });
+
+    // Initialize reactor records.
+    for (id, core) in Cores::count().into_iter().enumerate() {
+        let reactor = Reactors::get_by_core(core)
+            .unwrap_or_else(|| panic!("Can't get reactor for core {}", core));
+        let reactor_tick =
+            heartbeat_ticks.get(id).expect("Failed to get tick item");
+
+        reactor_state.push(ReactorRecord {
+            frozen: false,
+            reactor,
+            reactor_tick,
+            core,
+        });
+    }
+
+    loop {
+        // Schedule heartbeat futures on every reactor, ignoring reactors
+        // which are already frozen.
+        for (id, r) in reactor_state.iter().enumerate() {
+            // For frozen reactors there are already N scheduled heartbeat
+            // futures that haven't resolved yet, so maintain exactly this delta
+            // by just adjusting the tick counter.
+            if r.frozen {
+                heartbeat_ticks[id].fetch_add(1, Ordering::Relaxed);
+            } else {
+                // Send heartbeat future to the reactor.
+                r.reactor.send_future(async move {
+                    heartbeat_ticks[id].fetch_add(1, Ordering::Relaxed);
+                });
+            }
+        }
+
+        // Wait till heartbeat check interval elapses and check ticks
+        // reported by every reactor.
+        interval.tick().await;
+        tick += 1;
+
+        for r in &mut reactor_state {
+            if r.frozen {
+                // Check if all pending heartbeat futures have resolved:
+                // in such a case heartbeat counter adds to the correct
+                // value and mark the reactor as alive.
+                if tick - r.reactor_tick.load(Ordering::Relaxed) == 0 {
+                    info!(core = r.core, "Reactor is healthy again");
+                    r.frozen = false;
+                }
+            } else {
+                // Reactor didn't respond within allowed number of intervals,
+                // assume it is frozen.
+                if tick - r.reactor_tick.load(Ordering::Relaxed) >= timeout {
+                    r.frozen = true;
+                    crate::core::diagnostics::diagnose_reactor(r.reactor);
+                }
             }
         }
     }

--- a/jsonrpc/src/error.rs
+++ b/jsonrpc/src/error.rs
@@ -57,13 +57,17 @@ impl fmt::Display for Error {
             Error::ConnectError {
                 sock,
                 err,
-            } => write!(f, "Error connecting to {}: {}", sock, err),
+            } => {
+                write!(f, "Error connecting to {}: {}", sock, err)
+            }
             Error::IoError(err) => write!(f, "IO error: {}", err),
             Error::ParseError(err) => write!(f, "Invalid json reply: {}", err),
             Error::RpcError {
                 code,
                 msg,
-            } => write!(f, "Json-rpc error {:?}: {}", code, msg),
+            } => {
+                write!(f, "Json-rpc error {:?}: {}", code, msg)
+            }
             Error::GenericError(msg) => write!(f, "{}", msg),
         }
     }

--- a/shell.nix
+++ b/shell.nix
@@ -46,6 +46,7 @@ mkShell {
     python3
     utillinux
     gnuplot
+    libunwind
   ] ++ (if (nospdk) then [ libspdk-dev.buildInputs ] else [ libspdk-dev ]);
 
   LIBCLANG_PATH = io-engine.LIBCLANG_PATH;


### PR DESCRIPTION
This fix introduces reactor heartbeat loop to detect frozen reactors, which is opted by the “diagnostics” feature (not active by default). New CLI command --diagnose-stack is added to allow dumping stack for all threads in running I/O agent, which allows stack trace collection when a frozen reactor is detected.

Signed-off-by: Mikhail Tcymbaliuk <mtzaurus@gmail.com>