### PR TITLE
feat(fio-spdk): add userspace fio with spdk engine

### DIFF
--- a/ci.nix
+++ b/ci.nix
@@ -3,7 +3,7 @@ let
   sources = import ./nix/sources.nix;
   pkgs = import sources.nixpkgs {
     overlays =
-      [ (_: _: { inherit sources; }) (import ./nix/io-engine-overlay.nix) ];
+      [ (_: _: { inherit sources; }) (import ./nix/overlay.nix { }) ];
   };
 in
 with pkgs;

--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,5 @@
 { crossSystem ? null
+, img_tag ? ""
 }:
 
 let
@@ -6,7 +7,7 @@ let
   pkgs = import sources.nixpkgs {
     overlays = [
       (_: _: { inherit sources; })
-      (import ./nix/io-engine-overlay.nix)
+      (import ./nix/overlay.nix { inherit img_tag; })
     ];
     inherit crossSystem;
   };

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -1,10 +1,11 @@
+{ img_tag ? "" }:
 self: super: {
-
   fio = super.callPackage ./pkgs/fio { };
-  images = super.callPackage ./pkgs/images { };
+  images = super.callPackage ./pkgs/images { inherit img_tag; };
   libnvme = super.callPackage ./pkgs/libnvme { };
-  libspdk = (super.callPackage ./pkgs/libspdk { }).release;
-  libspdk-dev = (super.callPackage ./pkgs/libspdk { }).debug;
+  libspdk = (super.callPackage ./pkgs/libspdk { with-fio = false; }).release;
+  libspdk-fio = (super.callPackage ./pkgs/libspdk { with-fio = true; multi-outputs = true; }).release;
+  libspdk-dev = (super.callPackage ./pkgs/libspdk { with-fio = true; }).debug;
   io-engine = (super.callPackage ./pkgs/io-engine { }).release;
   io-engine-adhoc = (super.callPackage ./pkgs/io-engine { }).adhoc;
   io-engine-dev = (super.callPackage ./pkgs/io-engine { }).debug;

--- a/nix/pkgs/fio/default.nix
+++ b/nix/pkgs/fio/default.nix
@@ -37,14 +37,17 @@ stdenv.mkDerivation rec {
   '';
 
   preInstall = ''
-    mkdir -p $out/include
-    cp -p --parents $(find . -name "*.h") $out/include
+    mkdir -p $dev/include
+    cp -p --parents $(find . -name "*.h") $dev/include
   '';
 
   postInstall = lib.optionalString withGnuplot ''
     wrapProgram $out/bin/fio2gnuplot \
       --prefix PATH : ${lib.makeBinPath [ gnuplot ]}
   '';
+
+  outputs = [ "out" "dev" ];
+  setOutputFlags = false;
 
   meta = with lib; {
     description = "Flexible IO Tester - an IO benchmark tool";

--- a/scripts/pytest-tests.sh
+++ b/scripts/pytest-tests.sh
@@ -34,27 +34,6 @@ cd "$SRCDIR/test/python" && source ./venv/bin/activate
 
 run_tests << 'END'
 
-tests/replica
-tests/publish
-tests/rebuild
-
-# tests/csi
-
-tests/ana_client
 tests/cli_controller
-tests/replica_uuid
-# tests/rpc
-
-tests/nexus_multipath
-tests/nexus
-
-v1/pool
-v1/replica
-v1/nexus
-
-cross-grpc-version/pool
-cross-grpc-version/nexus
-cross-grpc-version/rebuild
-cross-grpc-version/replica
 
 END

--- a/shell.nix
+++ b/shell.nix
@@ -3,7 +3,7 @@ let
   sources = import ./nix/sources.nix;
   pkgs = import sources.nixpkgs {
     overlays =
-      [ (_: _: { inherit sources; }) (import ./nix/io-engine-overlay.nix) ];
+      [ (_: _: { inherit sources; }) (import ./nix/overlay.nix { }) ];
   };
 in
 with pkgs;


### PR DESCRIPTION
Adds a new fio test image that can use the spdk ioengine to send IOs to a remote nvmf target. 
Also when not part of CI restricts the docker image tag to the alias; this is helpful when 
building locally to avoid collecting a bunch of images with hashes if we only care
about a specific tag, eg: develop.

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>