### PR TITLE
fix(grpc-socket): use socketAddr type instead of string

### DIFF
--- a/io-engine/src/bin/io-engine.rs
+++ b/io-engine/src/bin/io-engine.rs
@@ -37,14 +37,7 @@ fn start_tokio_runtime(args: &MayastorCliArgs) {
     let registration_addr = args.registration_endpoint.clone();
     let rpc_address = args.rpc_address.clone();
     let api_versions = args.api_versions.clone();
-    // In case we do not have the node-name provided we would set the node name
-    // as the hostname(env always present), because the csi-controller adds
-    // the hostname in allowed nodes in the topology and in case there is
-    // mismatch, for ex, in case of EKS clusters where hostname and
-    // node name differ volume wont be created, so we set it to hostname.
-    let node_name = args.node_name.clone().unwrap_or_else(|| {
-        env::var("HOSTNAME").unwrap_or_else(|_| "mayastor-node".into())
-    });
+    let node_name = grpc::node_name(&args.node_name);
 
     let persistent_store_endpoint = args.persistent_store_endpoint.clone();
 
@@ -63,6 +56,7 @@ fn start_tokio_runtime(args: &MayastorCliArgs) {
 
             futures.push(
                 grpc::MayastorGrpcServer::run(
+                    &node_name,
                     grpc_address,
                     rpc_address,
                     api_versions.clone(),

--- a/io-engine/src/bin/nvmet.rs
+++ b/io-engine/src/bin/nvmet.rs
@@ -26,6 +26,7 @@ extern crate tracing;
 const NEXUS: &str = "nexus-e1e27668-fbe1-4c8a-9108-513f6e44d342";
 
 fn start_tokio_runtime(args: &MayastorCliArgs) {
+    let node_name = grpc::node_name(&args.node_name);
     let grpc_endpoint = grpc::endpoint(args.grpc_endpoint.clone());
     let rpc_address = args.rpc_address.clone();
     let api_versions = args.api_versions.clone();
@@ -40,6 +41,7 @@ fn start_tokio_runtime(args: &MayastorCliArgs) {
             .unwrap();
 
         let futures = vec![grpc::MayastorGrpcServer::run(
+            &node_name,
             grpc_endpoint,
             rpc_address,
             api_versions,

--- a/io-engine/src/core/env.rs
+++ b/io-engine/src/core/env.rs
@@ -876,6 +876,7 @@ impl MayastorEnvironment {
         F: FnOnce() + 'static,
     {
         type FutureResult = Result<(), ()>;
+        let node_name = self.node_name.clone();
         let grpc_endpoint = self.grpc_endpoint;
         let rpc_addr = self.rpc_addr.clone();
         let api_versions = self.api_versions.clone();
@@ -893,6 +894,7 @@ impl MayastorEnvironment {
             > = Vec::new();
             if let Some(grpc_endpoint) = grpc_endpoint {
                 futures.push(Box::pin(grpc::MayastorGrpcServer::run(
+                    &node_name,
                     grpc_endpoint,
                     rpc_addr,
                     api_versions,

--- a/io-engine/src/grpc/mod.rs
+++ b/io-engine/src/grpc/mod.rs
@@ -133,3 +133,14 @@ pub fn endpoint(endpoint: String) -> std::net::SocketAddr {
     .parse()
     .expect("Invalid gRPC endpoint")
 }
+
+/// In case we do not have the node-name provided we would set the node name
+/// as the hostname(env always present), because the csi-controller adds
+/// the hostname in allowed nodes in the topology and in case there is
+/// mismatch, for ex, in case of EKS clusters where hostname and
+/// node name differ volume wont be created, so we set it to hostname.
+pub fn node_name(node_name: &Option<String>) -> String {
+    node_name.clone().unwrap_or_else(|| {
+        std::env::var("HOSTNAME").unwrap_or_else(|_| "mayastor-node".into())
+    })
+}

--- a/io-engine/src/grpc/server.rs
+++ b/io-engine/src/grpc/server.rs
@@ -32,6 +32,7 @@ pub struct MayastorGrpcServer;
 
 impl MayastorGrpcServer {
     pub async fn run(
+        node_name: &str,
         endpoint: std::net::SocketAddr,
         rpc_addr: String,
         api_versions: Vec<ApiVersion>,
@@ -59,10 +60,13 @@ impl MayastorGrpcServer {
             .add_optional_service(enable_v1.map(|_| {
                 v1::replica::ReplicaRpcServer::new(ReplicaService::new())
             }))
-            .add_optional_service(
-                enable_v1
-                    .map(|_| v1::host::HostRpcServer::new(HostService::new())),
-            )
+            .add_optional_service(enable_v1.map(|_| {
+                v1::host::HostRpcServer::new(HostService::new(
+                    node_name,
+                    endpoint,
+                    api_versions,
+                ))
+            }))
             .add_optional_service(
                 enable_v1.map(|_| {
                     v1::nexus::NexusRpcServer::new(NexusService::new())


### PR DESCRIPTION
In case the grpc port is not specified we were sending the endpoint with only an ip address. Switch to a socketAddr to make we always use a port.

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>