### PR TITLE
fix(build): fix arm64 build

### DIFF
--- a/nix/pkgs/libspdk/default.nix
+++ b/nix/pkgs/libspdk/default.nix
@@ -104,9 +104,16 @@ let
 
     hardeningDisable = [ "all" ];
 
-    buildPhase = ''
-      make -j`nproc`
-    '';
+    buildPhase = (if (targetPlatform.config == "aarch64-unknown-linux-gnu") then
+      [
+        "DPDKBUILD_FLAGS=-Dplatform=generic"
+      ]
+    else
+      [ ]
+    ) ++
+    [
+      "make -j`nproc`"
+    ];
 
     installPhase = ''
       echo "installing SPDK to $out"


### PR DESCRIPTION
This fixes arm64 build error below:
"config/arm/meson.build:474:16: ERROR: Problem encountered: Error when getting Arm Implementer ID and part number."

Nix build only support generic platform for Arm64. Need to define "DPDKBUILD_FLAGS=-Dplatform=generic". For details see: https://github.com/NixOS/nixpkgs/commit/5ff289f39e7e3a30298ea7920337480d00988510 
https://github.com/spdk/spdk/issues/2444

close #1201
Signed-off-by: Xinliang Liu <xinliang.liu@linaro.org>