### PR TITLE
fix(ci): add missing release branch subst for tag

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -47,6 +47,7 @@ RM="rm"
 SCRIPTDIR=$(dirname "$0")
 TAG=`get_tag`
 BRANCH=`git rev-parse --abbrev-ref HEAD`
+BRANCH=${BRANCH////-}
 IMAGES=
 UPLOAD=
 SKIP_PUBLISH=


### PR DESCRIPTION
Docker tags can't have '/', so replace them with '-'.
TODO: should interim release tags use v prefix? Then they can be "proper" tags?

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>