### PR TITLE
fix(nexus): shutdown nexuses upon graceful shutdown

### DIFF
--- a/io-engine/src/bdev/nexus/mod.rs
+++ b/io-engine/src/bdev/nexus/mod.rs
@@ -123,12 +123,17 @@ pub fn register_module() {
 
 /// called during shutdown so that all nexus children are in Destroying state
 /// so that a possible remove event from SPDK also results in bdev removal
-pub async fn nexus_children_to_destroying_state() {
-    info!("Setting all nexus children to destroying state...");
-    for nexus in nexus_iter() {
-        for child in nexus.children_iter() {
-            child.set_state(nexus_child::ChildState::Destroying);
+pub async fn shutdown_nexuses() {
+    info!("Shutting down nexuses...");
+    for mut nexus in nexus_iter_mut() {
+        // Destroy nexus and persist its state in the ETCd.
+        if let Err(error) = nexus.as_mut().destroy().await {
+            error!(
+                name=nexus.name,
+                %error,
+                "Failed to destroy nexus"
+            );
         }
     }
-    info!("Setting all nexus children to destroying state done");
+    info!("All nexus have been shutdown.");
 }

--- a/io-engine/src/core/env.rs
+++ b/io-engine/src/core/env.rs
@@ -358,7 +358,7 @@ async fn do_shutdown(arg: *mut c_void) {
         warn!("Mayastor stopped non-zero: {}", rc);
     }
 
-    nexus::nexus_children_to_destroying_state().await;
+    nexus::shutdown_nexuses().await;
     crate::lvs::Lvs::export_all().await;
     unsafe {
         spdk_rpc_finish();

--- a/io-engine/tests/persistence.rs
+++ b/io-engine/tests/persistence.rs
@@ -84,9 +84,9 @@ async fn persist_unexpected_restart() {
     let value = response.kvs().first().unwrap().value();
     let nexus_info: NexusInfo = serde_json::from_slice(value).unwrap();
 
-    // Check the persisted nexus info remains unchanged.
+    // Check the persisted nexus info changed to reflect clean shutdown.
 
-    assert!(!nexus_info.clean_shutdown);
+    assert!(nexus_info.clean_shutdown);
 
     let child = child_info(&nexus_info, &uuid(&child1));
     assert!(child.healthy);

--- a/test/grpc/test_rebuild.js
+++ b/test/grpc/test_rebuild.js
@@ -297,9 +297,6 @@ describe('rebuild tests', function () {
     });
 
     afterEach(async () => {
-      await client.stopRebuild().sendMessage(rebuildArgs);
-      // TODO: Check for rebuild stop rather than sleeping
-      await sleep(250); // Give time for the rebuild to stop
       await client.removeChildNexus().sendMessage(rebuildArgs);
     });
 
@@ -338,9 +335,6 @@ describe('rebuild tests', function () {
     });
 
     afterEach(async () => {
-      await client.stopRebuild().sendMessage(rebuildArgs);
-      // TODO: Check for rebuild stop rather than sleeping
-      await sleep(250); // Give time for the rebuild to stop
       await client.removeChildNexus().sendMessage(rebuildArgs);
     });
 
@@ -373,7 +367,6 @@ describe('rebuild tests', function () {
     });
 
     afterEach(async () => {
-      await client.stopRebuild().sendMessage(rebuildArgs);
       await client.removeChildNexus().sendMessage(rebuildArgs);
     });
 
@@ -402,6 +395,7 @@ describe('rebuild tests', function () {
     beforeEach(async () => {
       await client.addChildNexus().sendMessage(addChildArgs);
       await client.startRebuild().sendMessage(rebuildArgs);
+      await sleep(250); // Give some time for rebuild to start.
       await client.childOperation().sendMessage(childOfflineArgs);
       await sleep(250); // Allow time for the child to go offline
     });


### PR DESCRIPTION
Upon graceful I/O agent shutdown all nexuses are now also properly shutdown (clear shutdown flag is set to ‘true’) and persisted in ETCD.

Signed-off-by: Mikhail Tcymbaliuk <mtzaurus@gmail.com>