### PR TITLE
feat(nexus): reactor freeze detection is now controlled via cli flags

### DIFF
--- a/io-engine/Cargo.toml
+++ b/io-engine/Cargo.toml
@@ -10,8 +10,6 @@ build = "build.rs"
 [features]
 # Enables fault injection code.
 fault_injection = []
-# Enables diagnostics operations.
-diagnostics = ["async-process", "rstack"]
 
 [[bin]]
 name = "io-engine"
@@ -96,8 +94,8 @@ tracing-subscriber = "0.2.20"
 udev = "0.6.2"
 url = "2.2.2"
 gettid = "0.1.2"
-async-process = { version = "1.5.0", optional = true }
-rstack =  { version = "0.3.2", optional = true }
+async-process = "1.5.0"
+rstack = "0.3.2"
 
 jsonrpc = { path = "../jsonrpc"}
 mayastor-api = { path = "../rpc/mayastor-api" }

--- a/io-engine/src/core/diagnostics.rs
+++ b/io-engine/src/core/diagnostics.rs
@@ -95,8 +95,5 @@ fn collect_process_stack(pid: u32) -> Result<(), Box<dyn std::error::Error>> {
 pub fn process_diagnostics_cli(
     cli: &MayastorCliArgs,
 ) -> Option<Result<(), Box<dyn std::error::Error>>> {
-    match cli.diagnose_stack {
-        None => None,
-        Some(pid) => Some(collect_process_stack(pid)),
-    }
+    cli.diagnose_stack.map(collect_process_stack)
 }

--- a/io-engine/src/core/env.rs
+++ b/io-engine/src/core/env.rs
@@ -151,18 +151,17 @@ pub struct MayastorCliArgs {
     )]
     pub api_versions: Vec<ApiVersion>,
     /// Dump stack trace for all threads inside I/O agent process with target
-    /// PID. Available only when diagnostics feature is enabled.
+    /// PID.
     #[structopt(long = "diagnose-stack", short = "d", env = "DIAGNOSE_STACK")]
-    #[cfg(feature = "diagnostics")]
     pub diagnose_stack: Option<u32>,
+    /// Enable reactor freeze detection.
+    #[structopt(long)]
+    pub reactor_freeze_detection: bool,
     /// Timeout (in seconds) for reactor freeze detection.
-    /// Available only when diagnostics feature is enabled.
     #[structopt(
         long = "reactor-freeze-timeout",
-        short = "t",
         env = "REACTOR_FREEZE_TIMEOUT"
     )]
-    #[cfg(feature = "diagnostics")]
     pub reactor_freeze_timeout: Option<u64>,
 }
 
@@ -207,11 +206,8 @@ impl Default for MayastorCliArgs {
             registration_endpoint: None,
             nvmf_tgt_interface: None,
             api_versions: vec![ApiVersion::V0, ApiVersion::V1],
-
-            // CLI arguments available only in diagnostics mode.
-            #[cfg(feature = "diagnostics")]
             diagnose_stack: None,
-            #[cfg(feature = "diagnostics")]
+            reactor_freeze_detection: false,
             reactor_freeze_timeout: None,
         }
     }

--- a/io-engine/src/core/mod.rs
+++ b/io-engine/src/core/mod.rs
@@ -43,7 +43,6 @@ pub use handle::{BdevHandle, UntypedBdevHandle};
 pub use io_device::IoDevice;
 pub use reactor::{Reactor, ReactorState, Reactors, REACTOR_LIST};
 
-#[cfg(feature = "diagnostics")]
 pub use reactor::reactor_monitor_loop;
 
 pub use runtime::spawn;
@@ -58,7 +57,6 @@ mod block_device;
 mod descriptor;
 mod device_events;
 mod device_monitor;
-#[cfg(feature = "diagnostics")]
 pub mod diagnostics;
 mod env;
 mod handle;

--- a/io-engine/src/core/reactor.rs
+++ b/io-engine/src/core/reactor.rs
@@ -637,12 +637,10 @@ impl Future for &'static Reactor {
 }
 
 /// Heartbeat timeout (in seconds) to classify a reactor as frozen.
-#[cfg(feature = "diagnostics")]
 const REACTOR_HEARTBEAT_TIMEOUT: u64 = 3;
 
 /// Monitor health for all reactors: all available reactors are constantly
 /// monitored for liveness.
-#[cfg(feature = "diagnostics")]
 pub async fn reactor_monitor_loop(freeze_timeout: Option<u64>) {
     use std::sync::atomic::{AtomicU64, Ordering};
 


### PR DESCRIPTION
Reactor freeze detection is now controller directly via CLI arguments rather than via features.

Signed-off-by: Mikhail Tcymbaliuk <mtzaurus@gmail.com>