### PR TITLE
ci: cherry-pick fixes to release 2.0 branch

### DIFF
--- a/io-engine-tests/src/compose/rpc/v0.rs
+++ b/io-engine-tests/src/compose/rpc/v0.rs
@@ -96,6 +96,7 @@ impl<'a> GrpcConnect<'a> {
                 .await?,
             );
         }
+        handles.sort_by(|a, b| b.name.cmp(&a.name));
 
         Ok(handles)
     }

--- a/io-engine/src/bdev/nexus/mod.rs
+++ b/io-engine/src/bdev/nexus/mod.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::vec_box)]
 
+use crate::core::VerboseError;
 use futures::{future::Future, FutureExt};
 use std::pin::Pin;
 
@@ -129,8 +130,8 @@ pub async fn shutdown_nexuses() {
         // Destroy nexus and persist its state in the ETCd.
         if let Err(error) = nexus.as_mut().destroy().await {
             error!(
-                name=nexus.name,
-                %error,
+                name = nexus.name,
+                error = error.verbose(),
                 "Failed to destroy nexus"
             );
         }

--- a/io-engine/src/bdev/nexus/nexus_bdev_error.rs
+++ b/io-engine/src/bdev/nexus/nexus_bdev_error.rs
@@ -11,7 +11,7 @@ use super::{
 
 use crate::{
     bdev_api::BdevError,
-    core::CoreError,
+    core::{CoreError, VerboseError},
     rebuild::RebuildError,
     subsys::NvmfError,
 };
@@ -275,7 +275,10 @@ impl From<Error> for tonic::Status {
             Error::ChildNotFound {
                 ..
             } => Status::not_found(e.to_string()),
-            e => Status::new(Code::Internal, e.to_string()),
+            Error::RebuildJobNotFound {
+                ..
+            } => Status::not_found(e.to_string()),
+            e => Status::new(Code::Internal, e.verbose()),
         }
     }
 }

--- a/scripts/grpc-test.sh
+++ b/scripts/grpc-test.sh
@@ -9,6 +9,8 @@ cargo build --all
 cd "$(dirname "$0")/../test/grpc"
 npm install
 
+sudo pkill io-engine || true
+
 for ts in cli replica nexus rebuild; do
   ./node_modules/mocha/bin/mocha test_${ts}.js \
       --reporter ./multi_reporter.js \

--- a/test/grpc/test_rebuild.js
+++ b/test/grpc/test_rebuild.js
@@ -108,8 +108,38 @@ describe('rebuild tests', function () {
   }
 
   async function checkRebuildState (expected) {
-    const res = await client.getRebuildState().sendMessage(rebuildArgs);
-    assert.equal(res.state, expected);
+    try {
+      const res = await client.getRebuildState().sendMessage(rebuildArgs);
+      assert.equal(res.state, expected);
+    } catch (e) {
+      if (expected === 'stopped' && e.code === grpc.status.NOT_FOUND) {
+        // this is ok, when stopped it gets removed
+      } else {
+        throw e;
+      }
+    }
+  }
+
+  async function untilChildStatus (state, sleepMs = 200, retries = 10) {
+    const promise = () => checkState(ObjectType.DESTINATION_CHILD, state);
+    await retryPromiseFn(promise, sleepMs, retries);
+  }
+
+  async function untilRebuildState (state, sleepMs = 200, retries = 10) {
+    const promise = () => checkRebuildState(state);
+    await retryPromiseFn(promise, sleepMs, retries);
+  }
+
+  async function retryPromiseFn (promiseFn, sleepMs, retries) {
+    try {
+      return await promiseFn();
+    } catch (e) {
+      if (retries > 0) {
+        await sleep(sleepMs);
+        return retryPromiseFn(promiseFn, retries - 1);
+      }
+      throw e;
+    }
   }
 
   async function checkRebuildStats () {
@@ -247,8 +277,7 @@ describe('rebuild tests', function () {
       await client.addChildNexus().sendMessage(addChildArgs);
       await client.startRebuild().sendMessage(rebuildArgs);
       await client.stopRebuild().sendMessage(rebuildArgs);
-      // TODO: Check for rebuild stop rather than sleeping
-      await sleep(250); // Give time for the rebuild to stop
+      await untilRebuildState('stopped');
     });
 
     afterEach(async () => {
@@ -293,7 +322,7 @@ describe('rebuild tests', function () {
       await client.addChildNexus().sendMessage(addChildArgs);
       await client.startRebuild().sendMessage(rebuildArgs);
       await client.pauseRebuild().sendMessage(rebuildArgs);
-      await sleep(250); // Give time for the rebuild to pause
+      await untilRebuildState('paused');
     });
 
     afterEach(async () => {
@@ -330,7 +359,7 @@ describe('rebuild tests', function () {
       await client.addChildNexus().sendMessage(addChildArgs);
       await client.startRebuild().sendMessage(rebuildArgs);
       await client.pauseRebuild().sendMessage(rebuildArgs);
-      await sleep(250); // Give time for the rebuild to pause
+      await untilRebuildState('paused');
       await client.resumeRebuild().sendMessage(rebuildArgs);
     });
 
@@ -395,9 +424,9 @@ describe('rebuild tests', function () {
     beforeEach(async () => {
       await client.addChildNexus().sendMessage(addChildArgs);
       await client.startRebuild().sendMessage(rebuildArgs);
-      await sleep(250); // Give some time for rebuild to start.
+      await untilRebuildState('running');
       await client.childOperation().sendMessage(childOfflineArgs);
-      await sleep(250); // Allow time for the child to go offline
+      await untilChildStatus('CHILD_DEGRADED');
     });
 
     afterEach(async () => {


### PR DESCRIPTION
test(nvme): sort the container handles

Otherwise tests might yield surprising results, as we'd be calling the wrong instance in
 tests where we use arrays indexes..

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

ci: fix nodejs test by using retry function

Use the retry patter with a high timeout instead of simply sleeping..

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>