### PR TITLE
build!: set openebs as image registry

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -272,7 +272,7 @@ pipeline {
         cleanWs()
         unstash 'source'
 
-        withCredentials([usernamePassword(credentialsId: 'dockerhub', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
+        withCredentials([usernamePassword(credentialsId: 'OPENEBS_DOCKERHUB', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
           sh 'echo $PASSWORD | docker login -u $USERNAME --password-stdin'
         }
         sh './scripts/release.sh'

--- a/nix/pkgs/images/default.nix
+++ b/nix/pkgs/images/default.nix
@@ -58,17 +58,17 @@ let
 in
 {
   mayastor-io-engine = dockerTools.buildImage (ioEngineImageProps // {
-    name = "mayadata/mayastor-io-engine";
+    name = "openebs/mayastor-io-engine";
     contents = [ busybox io-engine mctl ];
   });
 
   mayastor-io-engine-dev = dockerTools.buildImage (ioEngineImageProps // {
-    name = "mayadata/mayastor-io-engine-dev";
+    name = "openebs/mayastor-io-engine-dev";
     contents = [ busybox io-engine-dev ];
   });
 
   mayastor-io-engine-client = dockerTools.buildImage (ioEngineImageProps // {
-    name = "mayadata/mayastor-io-engine-client";
+    name = "openebs/mayastor-io-engine-client";
     contents = [ busybox io-engine ];
     config = { Entrypoint = [ "/bin/io-engine-client" ]; };
   });

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -153,7 +153,7 @@ if [ -n "$OVERRIDE_COMMIT_HASH" ]; then
 fi
 
 for name in $IMAGES; do
-  image_basename="mayadata/${name}"
+  image_basename="openebs/${name}"
   image=$image_basename
   if [ -n "$REGISTRY" ]; then
     image="${REGISTRY}/${image}"


### PR DESCRIPTION
BREAKING CHANGE: Build container images using openebs not mayadata as the registry

Signed-off-by: GlennBullingham <glenn.bullingham@datacore.com>