### PR TITLE
fix(nexus): shutdown nexuses upon graceful shutdown

### DIFF
--- a/mayastor/src/core/env.rs
+++ b/mayastor/src/core/env.rs
@@ -337,7 +337,7 @@ async fn do_shutdown(arg: *mut c_void) {
         warn!("Mayastor stopped non-zero: {}", rc);
     }
 
-    nexus::nexus_children_to_destroying_state().await;
+    nexus::shutdown_nexuses().await;
     crate::lvs::Lvs::export_all().await;
     unsafe {
         spdk_rpc_finish();

--- a/mayastor/tests/persistence.rs
+++ b/mayastor/tests/persistence.rs
@@ -75,9 +75,8 @@ async fn persist_unexpected_restart() {
     let value = response.kvs().first().unwrap().value();
     let nexus_info: NexusInfo = serde_json::from_slice(value).unwrap();
 
-    // Check the persisted nexus info remains unchanged.
-
-    assert!(!nexus_info.clean_shutdown);
+    // Check the persisted nexus info changed to reflect clean shutdown.
+    assert!(nexus_info.clean_shutdown);
 
     let child = child_info(&nexus_info, &uuid(&child1));
     assert!(child.healthy);


### PR DESCRIPTION
Upon graceful I/O agent shutdown all nexuses are now also properly shutdown (clear shutdown flag is set to ‘true’) and persisted in ETCD.

Signed-off-by: Mikhail Tcymbaliuk <mtzaurus@gmail.com>