### PR TITLE
fix(nvmf): cherry-pick - don't enable ANA reporting for lvol replicas

### DIFF
--- a/io-engine/src/bdev/nexus/mod.rs
+++ b/io-engine/src/bdev/nexus/mod.rs
@@ -74,7 +74,7 @@ pub fn register_module() {
     nexus_module::register_module();
 
     use crate::{
-        core::{Share, UntypedBdev},
+        core::{Share, ShareProps, UntypedBdev},
         jsonrpc::{jsonrpc_register, Code, JsonRpcError, Result},
     };
 
@@ -94,7 +94,8 @@ pub fn register_module() {
                     let mut bdev = Pin::new(&mut bdev);
                     match proto.as_str() {
                         "nvmf" => {
-                            bdev.as_mut().share_nvmf(Some((args.cntlid_min, args.cntlid_max)))
+                            let share = ShareProps::new().with_range(Some((args.cntlid_min, args.cntlid_max))).with_ana(true);
+                            bdev.as_mut().share_nvmf(Some(share))
                                 .await
                                 .map_err(|e| {
                                     JsonRpcError {

--- a/io-engine/src/core/mod.rs
+++ b/io-engine/src/core/mod.rs
@@ -46,7 +46,7 @@ pub use reactor::{Reactor, ReactorState, Reactors, REACTOR_LIST};
 pub use reactor::reactor_monitor_loop;
 
 pub use runtime::spawn;
-pub use share::{Protocol, Share};
+pub use share::{Protocol, Share, ShareProps};
 pub use spdk_rs::{cpu_cores, GenericStatusCode, IoStatus, IoType, NvmeStatus};
 pub use thread::Mthread;
 

--- a/io-engine/src/core/share.rs
+++ b/io-engine/src/core/share.rs
@@ -40,13 +40,63 @@ impl Display for Protocol {
     }
 }
 
+/// Share properties when sharing a device.
+#[derive(Default)]
+pub struct ShareProps {
+    /// Controller Id range.
+    cntlid_range: Option<(u16, u16)>,
+    /// Enable ANA reporting.
+    ana: bool,
+    /// Hosts allowed to connect.
+    allowed_hosts: Vec<String>,
+}
+impl ShareProps {
+    /// Returns a new `Self`.
+    pub fn new() -> Self {
+        Self::default()
+    }
+    /// Modify the controller id range.
+    #[must_use]
+    pub fn with_range(mut self, cntlid_range: Option<(u16, u16)>) -> Self {
+        self.cntlid_range = cntlid_range;
+        self
+    }
+    /// Modify the ana reporting.
+    #[must_use]
+    pub fn with_ana(mut self, ana: bool) -> Self {
+        self.ana = ana;
+        self
+    }
+    /// Get the controller id range.
+    pub fn cntlid_range(&self) -> Option<(u16, u16)> {
+        self.cntlid_range
+    }
+    /// Get the ana reporting.
+    pub fn ana(&self) -> bool {
+        self.ana
+    }
+    /// Any host is allowed to connect.
+    pub fn host_any(&self) -> bool {
+        self.allowed_hosts.is_empty()
+    }
+}
+impl From<Option<ShareProps>> for ShareProps {
+    fn from(opts: Option<ShareProps>) -> Self {
+        match opts {
+            None => Self::new(),
+            Some(props) => props,
+        }
+    }
+}
+
 #[async_trait(? Send)]
 pub trait Share: std::fmt::Debug {
     type Error;
     type Output: std::fmt::Display + std::fmt::Debug;
+
     async fn share_nvmf(
         self: Pin<&mut Self>,
-        cntlid_range: Option<(u16, u16)>,
+        props: Option<ShareProps>,
     ) -> Result<Self::Output, Self::Error>;
 
     /// TODO

--- a/io-engine/src/lvs/lvs_lvol.rs
+++ b/io-engine/src/lvs/lvs_lvol.rs
@@ -35,7 +35,7 @@ use super::{Error, Lvs};
 
 use crate::{
     bdev::nexus::Nexus,
-    core::{Bdev, Mthread, Protocol, Share, UntypedBdev},
+    core::{Bdev, Mthread, Protocol, Share, ShareProps, UntypedBdev},
     ffihelper::{
         cb_arg,
         errno_result_from_i32,
@@ -128,10 +128,10 @@ impl Share for Lvol {
     /// share the lvol as a nvmf target
     async fn share_nvmf(
         mut self: Pin<&mut Self>,
-        cntlid_range: Option<(u16, u16)>,
+        props: Option<ShareProps>,
     ) -> Result<Self::Output, Self::Error> {
         let share = Pin::new(&mut self.as_bdev())
-            .share_nvmf(cntlid_range)
+            .share_nvmf(props)
             .await
             .map_err(|e| Error::LvolShare {
                 source: e,

--- a/io-engine/src/subsys/nvmf/subsystem.rs
+++ b/io-engine/src/subsys/nvmf/subsystem.rs
@@ -133,8 +133,8 @@ impl NvmfSubsystem {
             });
         }
         let ss = NvmfSubsystem::new(bdev.name())?;
-        ss.set_ana_reporting(true)?;
-        ss.allow_any(true);
+        ss.set_ana_reporting(false)?;
+        ss.allow_any(false);
         if let Err(e) = ss.add_namespace(bdev) {
             ss.destroy();
             return Err(e);
@@ -203,8 +203,8 @@ impl NvmfSubsystem {
         bdev: &UntypedBdev,
     ) -> Result<Self, Error> {
         let ss = NvmfSubsystem::new(uuid)?;
-        ss.set_ana_reporting(true)?;
-        ss.allow_any(true);
+        ss.set_ana_reporting(false)?;
+        ss.allow_any(false);
         ss.add_namespace(bdev)?;
         Ok(ss)
     }
@@ -270,8 +270,8 @@ impl NvmfSubsystem {
     /// allow any host to connect to the subsystem
     pub fn allow_any(&self, enable: bool) {
         unsafe {
-            spdk_nvmf_subsystem_set_allow_any_host(self.0.as_ptr(), enable)
-        };
+            spdk_nvmf_subsystem_set_allow_any_host(self.0.as_ptr(), enable);
+        }
     }
 
     /// enable Asymmetric Namespace Access (ANA) reporting


### PR DESCRIPTION
We only need ANA reporting on the nexus and having the replicas ANA seems to cause some issues when the nexus connects to them.
Adding a new `ShareProps` which can be used for various share properties - also added a allowed host option which for the moment defaults to any that will likely be helpful to gate access to the targets.

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>