### PR TITLE
feat(grpc): per object nexus locking

### DIFF
--- a/io-engine/src/bin/io-engine.rs
+++ b/io-engine/src/bin/io-engine.rs
@@ -10,6 +10,11 @@ use io_engine::{
     bdev::util::uring,
     core::{
         device_monitor_loop,
+        lock::{
+            ProtectedSubsystems,
+            ResourceLockManager,
+            ResourceLockManagerConfig,
+        },
         runtime,
         MayastorCliArgs,
         MayastorEnvironment,
@@ -43,6 +48,11 @@ fn start_tokio_runtime(args: &MayastorCliArgs) {
 
     #[cfg(feature = "diagnostics")]
     let reactor_freeze_timeout = args.reactor_freeze_timeout.clone();
+
+    // Initialize Lock manager.
+    let cfg = ResourceLockManagerConfig::default()
+        .with_subsystem(ProtectedSubsystems::NEXUS, 512);
+    ResourceLockManager::initialize(cfg);
 
     Mthread::spawn_unaffinitized(move || {
         runtime::block_on(async move {

--- a/io-engine/src/core/lock.rs
+++ b/io-engine/src/core/lock.rs
@@ -1,0 +1,189 @@
+use std::{
+    collections::hash_map::DefaultHasher,
+    hash::{Hash, Hasher},
+    time::Duration,
+};
+
+use futures::lock::{Mutex, MutexGuard};
+use once_cell::sync::OnceCell;
+
+/// Common IO engine resource subsystems.
+pub struct ProtectedSubsystems;
+impl ProtectedSubsystems {
+    pub const NEXUS: &'static str = "nexus";
+}
+
+/// Configuration parameters for initialization of the Lock manager.
+#[derive(Debug, Default)]
+pub struct ResourceLockManagerConfig {
+    /// Configs for subsystems: denote id and maximum amount of lockable
+    /// resources.
+    subsystems: Vec<(String, usize)>,
+}
+
+impl ResourceLockManagerConfig {
+    /// Add resource subsystem to the config.
+    /// Panics if another subsystem with the same id already exists.
+    pub fn with_subsystem<T: AsRef<str>>(
+        mut self,
+        id: T,
+        num_objects: usize,
+    ) -> Self {
+        let ids = id.as_ref();
+
+        if self.subsystems.iter().any(|(i, _)| ids.eq(i)) {
+            panic!("Subsystem {} already exists", ids);
+        }
+
+        self.subsystems.push((ids.to_owned(), num_objects));
+        self
+    }
+}
+
+/// Resource subsystem that holds locks for all resources withing this system.
+pub struct ResourceSubsystem {
+    id: String,
+    object_locks: Vec<Mutex<LockStats>>,
+    subsystem_lock: Mutex<LockStats>,
+}
+
+impl ResourceSubsystem {
+    /// Create a new resource subsystem with target id and maximum number of
+    /// objects.
+    fn new(id: String, num_objects: usize) -> Self {
+        let object_locks =
+            std::iter::repeat_with(|| Mutex::new(LockStats::default()))
+                .take(num_objects)
+                .collect::<Vec<_>>();
+
+        Self {
+            id,
+            object_locks,
+            subsystem_lock: Mutex::new(LockStats::default()),
+        }
+    }
+
+    /// Acquire the subsystem lock.
+    pub async fn lock(
+        &self,
+        wait_timeout: Option<Duration>,
+    ) -> Option<ResourceLockGuard<'_>> {
+        acquire_lock(&self.subsystem_lock, wait_timeout).await
+    }
+
+    /// Lock subsystem resource by its ID and obtain a lock guard.
+    pub async fn lock_resource<T: AsRef<str>>(
+        &self,
+        id: T,
+        wait_timeout: Option<Duration>,
+    ) -> Option<ResourceLockGuard<'_>> {
+        // Calculate hash of the object to get the mutex index.
+        let mut hasher = DefaultHasher::new();
+        id.as_ref().hash(&mut hasher);
+        let mutex_id = hasher.finish() as usize % self.object_locks.len();
+
+        acquire_lock(&self.object_locks[mutex_id], wait_timeout).await
+    }
+}
+
+/// Structure that holds per-lock statistics.
+#[derive(Debug, Default)]
+struct LockStats {
+    num_acquires: usize,
+}
+
+/// Lock manager which is used for protecting access to sensitive resources.
+/// The following hierarchical levels of resource protection are supported:
+/// 1) Global - lock manager exposes one single lock which can be used as
+/// the global lock to control access at the topmost level.
+/// 2) Subsystem - Subsystems group resources of the same type (examples are:
+/// "nexus", "pool", etc). Every subsystem exposes the global, per-subsystem
+/// lock to control resource access at the subsystem level.
+/// Example: create/delete nexus operations must be globally serialized,
+/// which can be achieved by locking the "nexus" subsystem.
+/// 3) Resource - control access at per-object level.
+/// Example: control access to a nexus instance whilst modifying nexus state.
+pub struct ResourceLockManager {
+    /// All known resource subsystems with locks.
+    subsystems: Vec<ResourceSubsystem>,
+    /// Global resource lock,
+    mgr_lock: Mutex<LockStats>,
+}
+
+/// Automatically releases the lock once dropped.
+pub struct ResourceLockGuard<'a> {
+    _lock_guard: MutexGuard<'a, LockStats>,
+}
+
+/// Global instance of the resource lock manager.
+static LOCK_MANAGER: OnceCell<ResourceLockManager> = OnceCell::new();
+
+/// Helper function to abstract common lock acquisition logic.
+async fn acquire_lock(
+    lock: &Mutex<LockStats>,
+    wait_timeout: Option<Duration>,
+) -> Option<ResourceLockGuard<'_>> {
+    let mut lock_guard = if let Some(d) = wait_timeout {
+        match tokio::time::timeout(d, lock.lock()).await {
+            Err(_) => return None,
+            Ok(g) => g,
+        }
+    } else {
+        // No timeout, wait for the lock indefinitely.
+        lock.lock().await
+    };
+
+    (*lock_guard).num_acquires += 1;
+
+    Some(ResourceLockGuard {
+        _lock_guard: lock_guard,
+    })
+}
+
+impl ResourceLockManager {
+    /// Initialize instance of the lock manager. This function must be called
+    /// prior to using the lock manager API.
+    pub fn initialize(cfg: ResourceLockManagerConfig) {
+        LOCK_MANAGER.get_or_init(|| {
+            let subsystems = cfg
+                .subsystems
+                .iter()
+                .map(|(id, n)| ResourceSubsystem::new(id.to_owned(), *n))
+                .collect::<Vec<_>>();
+
+            ResourceLockManager {
+                subsystems,
+                mgr_lock: Mutex::new(LockStats::default()),
+            }
+        });
+    }
+
+    /// Acquire the global Lock manager lock.
+    pub async fn lock(
+        &self,
+        wait_timeout: Option<Duration>,
+    ) -> Option<ResourceLockGuard<'_>> {
+        acquire_lock(&self.mgr_lock, wait_timeout).await
+    }
+
+    /// Get resource subsystem by its id.
+    pub fn get_subsystem<T: AsRef<str>>(&self, id: T) -> &ResourceSubsystem {
+        let ids = id.as_ref();
+
+        for s in &self.subsystems {
+            if s.id.eq(ids) {
+                return s;
+            }
+        }
+
+        panic!("Resource subsystem {} doesn't exist", id.as_ref());
+    }
+
+    /// Get global instance of the lock manager. Panics if Lock manager is not
+    /// initialized.
+    pub fn get_instance() -> &'static ResourceLockManager {
+        LOCK_MANAGER.get().expect("Lock Manager is not initialized")
+    }
+}
+
+impl ResourceLockGuard<'_> {}

--- a/io-engine/src/core/mod.rs
+++ b/io-engine/src/core/mod.rs
@@ -47,6 +47,13 @@ pub use reactor::{Reactor, ReactorState, Reactors, REACTOR_LIST};
 #[cfg(feature = "diagnostics")]
 pub use reactor::reactor_monitor_loop;
 
+pub use lock::{
+    ProtectedSubsystems,
+    ResourceLockGuard,
+    ResourceLockManager,
+    ResourceLockManagerConfig,
+    ResourceSubsystem,
+};
 pub use runtime::spawn;
 pub use share::{Protocol, Share, ShareProps};
 pub use spdk_rs::{cpu_cores, GenericStatusCode, IoStatus, IoType, NvmeStatus};
@@ -65,6 +72,7 @@ mod env;
 mod handle;
 mod io_device;
 pub mod io_driver;
+pub mod lock;
 pub mod mempool;
 mod nic;
 pub mod partition;

--- a/io-engine/src/grpc/mod.rs
+++ b/io-engine/src/grpc/mod.rs
@@ -2,11 +2,12 @@ use std::{
     error::Error,
     fmt::{Debug, Display},
     future::Future,
+    time::Duration,
 };
 
 use futures::channel::oneshot::Receiver;
 pub use server::MayastorGrpcServer;
-use tonic::{Response, Status};
+use tonic::{Request, Response, Status};
 
 use crate::{
     bdev_api::BdevError,
@@ -53,10 +54,34 @@ pub mod v1 {
     pub mod replica;
 }
 
+/// Default timeout for gRPC calls, in seconds. Should be enforced in case
+/// no timeout is explicitly provided by the client upon gRPC method invocation.
+pub const DEFAULT_GRPC_TIMEOUT_SEC: u64 = 15;
+
+/// Structure that holds sensitive information about the current gRPC
+/// method being executed.
 #[derive(Debug)]
 pub(crate) struct GrpcClientContext {
+    /// Method arguments.
     pub args: String,
+    /// Method id.
     pub id: String,
+    /// Method timeout.
+    pub timeout: Duration,
+}
+
+impl GrpcClientContext {
+    #[track_caller]
+    pub fn new<T>(req: &Request<T>, fid: &str) -> Self
+    where
+        T: Debug,
+    {
+        Self {
+            timeout: get_request_timeout(req),
+            args: format!("{:?}", req.get_ref()),
+            id: fid.to_string(),
+        }
+    }
 }
 
 /// trait to lock serialize gRPC request outstanding
@@ -100,6 +125,7 @@ macro_rules! default_ip {
         "0.0.0.0"
     };
 }
+
 macro_rules! default_port {
     () => {
         10124
@@ -143,4 +169,65 @@ pub fn node_name(node_name: &Option<String>) -> String {
     node_name.clone().unwrap_or_else(|| {
         std::env::var("HOSTNAME").unwrap_or_else(|_| "mayastor-node".into())
     })
+}
+
+const SECONDS_IN_HOUR: u64 = 60 * 60;
+const SECONDS_IN_MINUTE: u64 = 60;
+
+/// Get gRPC timeout from the request and parse it into a Duration instance.
+/// In case there is no timeout explicitly provided by the gRPC client or
+/// the timeout is malformed, the default timeout is applied.
+pub fn get_request_timeout<T>(req: &Request<T>) -> Duration {
+    match req.metadata().get("grpc-timeout") {
+        Some(v) => {
+            match v.to_str() {
+                // Valid string representation of the timeout exists, parse it.
+                Ok(timeout) => {
+                    // At least one digit for the value + 1 character for unit.
+                    if timeout.len() >= 2 {
+                        let (t_value, t_unit) =
+                            timeout.split_at(timeout.len() - 1);
+                        if let Ok(tv) = t_value.parse() {
+                            return match t_unit {
+                                // Hours
+                                "H" => {
+                                    Duration::from_secs(tv * SECONDS_IN_HOUR)
+                                }
+                                // Minutes
+                                "M" => {
+                                    Duration::from_secs(tv * SECONDS_IN_MINUTE)
+                                }
+                                // Seconds
+                                "S" => Duration::from_secs(tv),
+                                // Milliseconds
+                                "m" => Duration::from_millis(tv),
+                                // Microseconds
+                                "u" => Duration::from_micros(tv),
+                                // Nanoseconds
+                                "n" => Duration::from_nanos(tv),
+                                _ => {
+                                    error!(
+                                        timeout,
+                                        "Unsupported time unit in gRPC timeout, applying default gRPC timeout"
+                                    );
+                                    Duration::from_secs(
+                                        DEFAULT_GRPC_TIMEOUT_SEC,
+                                    )
+                                }
+                            };
+                        }
+                    }
+                    Duration::from_secs(DEFAULT_GRPC_TIMEOUT_SEC)
+                }
+                // Timeout value contains non-ASCII characters and can't
+                // be parsed, apply the default timeout.
+                Err(_) => {
+                    error!("Malformed gRPC timeout provided, applying default gRPC timeout");
+                    Duration::from_secs(DEFAULT_GRPC_TIMEOUT_SEC)
+                }
+            }
+        }
+        // No I/O timeout provided by gRPC client, use the default one.
+        None => Duration::from_secs(DEFAULT_GRPC_TIMEOUT_SEC),
+    }
 }

--- a/io-engine/src/grpc/v0/mayastor_grpc.rs
+++ b/io-engine/src/grpc/v0/mayastor_grpc.rs
@@ -12,6 +12,7 @@ use crate::{
     bdev::{nexus, NvmeControllerState as ControllerState},
     bdev_api::BdevError,
     core::{
+        lock::{ProtectedSubsystems, ResourceLockManager},
         BlockDeviceIoStats,
         CoreError,
         MayastorFeatures,
@@ -61,19 +62,6 @@ struct UnixStream(tokio::net::UnixStream);
 use ::function_name::named;
 use std::{panic::AssertUnwindSafe, pin::Pin};
 use version_info::raw_version_string;
-
-impl GrpcClientContext {
-    #[track_caller]
-    pub fn new<T>(req: &Request<T>, fid: &str) -> Self
-    where
-        T: Debug,
-    {
-        Self {
-            args: format!("{:?}", req.get_ref()),
-            id: fid.to_string(),
-        }
-    }
-}
 
 #[derive(Debug)]
 #[allow(dead_code)]
@@ -130,6 +118,67 @@ impl MayastorSvc {
             name: String::from("CSISvc"),
             interval,
             rw_lock: tokio::sync::RwLock::new(None),
+        }
+    }
+
+    async fn serialized<T, F>(
+        &self,
+        ctx: GrpcClientContext,
+        nexus_uuid: String,
+        global_operation: bool,
+        f: F,
+    ) -> Result<T, Status>
+    where
+        T: Send + 'static,
+        F: core::future::Future<Output = Result<T, Status>> + Send + 'static,
+    {
+        let lock_manager = ResourceLockManager::get_instance();
+        let fut = AssertUnwindSafe(f).catch_unwind();
+
+        // Schedule a Tokio task to detach it from the high-level gRPC future
+        // and avoid task cancellation when the top-level gRPC future is
+        // cancelled.
+        match tokio::spawn(async move {
+            // Grab global operation lock, if requested.
+            let _global_guard = if global_operation {
+                match lock_manager.lock(Some(ctx.timeout)).await {
+                    Some(g) => Some(g),
+                    None => return Err(Status::deadline_exceeded(
+                        "Failed to acquire access to object within given timeout"
+                        .to_string()
+                    )),
+                }
+            } else {
+                None
+            };
+
+            // Grab per-object lock before executing the future.
+            let _resource_guard = match lock_manager
+                .get_subsystem(ProtectedSubsystems::NEXUS)
+                .lock_resource(nexus_uuid, Some(ctx.timeout))
+                .await {
+                    Some(g) => g,
+                    None => return Err(Status::deadline_exceeded(
+                        "Failed to acquire access to object within given timeout"
+                        .to_string()
+                    )),
+                };
+            let r = fut.await;
+
+            match r {
+                Ok(r) => r,
+                Err(_e) => {
+                    warn!("{}: gRPC method panicked, args: {}", ctx.id, ctx.args);
+                    Err(Status::cancelled(format!(
+                        "{}: gRPC method panicked",
+                        ctx.id
+                    )))
+                }
+            }
+        })
+        .await {
+            Ok(r) => r,
+            Err(_) => Err(Status::cancelled("gRPC call cancelled"))
         }
     }
 }
@@ -905,30 +954,29 @@ impl mayastor_server::Mayastor for MayastorSvc {
         &self,
         request: Request<CreateNexusRequest>,
     ) -> GrpcResult<Nexus> {
-        self.locked(
-            GrpcClientContext::new(&request, function_name!()),
-            async move {
-                let args = request.into_inner();
-                let rx = rpc_submit::<_, _, nexus::Error>(async move {
-                    let uuid = args.uuid.clone();
-                    let name = uuid_to_name(&args.uuid)?;
-                    nexus::nexus_create(
-                        &name,
-                        args.size,
-                        Some(&args.uuid),
-                        &args.children,
-                    )
-                    .await?;
-                    let nexus = nexus_lookup(&uuid)?;
-                    info!("Created nexus: '{}'", uuid);
-                    Ok(nexus.to_grpc())
-                })?;
-                rx.await
-                    .map_err(|_| Status::cancelled("cancelled"))?
-                    .map_err(Status::from)
-                    .map(Response::new)
-            },
-        )
+        let ctx = GrpcClientContext::new(&request, function_name!());
+        let args = request.into_inner();
+
+        self.serialized(ctx, args.uuid.clone(), true, async move {
+            let rx = rpc_submit::<_, _, nexus::Error>(async move {
+                let uuid = args.uuid.clone();
+                let name = uuid_to_name(&args.uuid)?;
+                nexus::nexus_create(
+                    &name,
+                    args.size,
+                    Some(&args.uuid),
+                    &args.children,
+                )
+                .await?;
+                let nexus = nexus_lookup(&uuid)?;
+                info!("Created nexus: '{}'", uuid);
+                Ok(nexus.to_grpc())
+            })?;
+            rx.await
+                .map_err(|_| Status::cancelled("cancelled"))?
+                .map_err(Status::from)
+                .map(Response::new)
+        })
         .await
     }
 
@@ -937,52 +985,50 @@ impl mayastor_server::Mayastor for MayastorSvc {
         &self,
         request: Request<CreateNexusV2Request>,
     ) -> GrpcResult<Nexus> {
-        self.locked(
-            GrpcClientContext::new(&request, function_name!()),
-            async move {
-                let args = request.into_inner();
-                let resv_type =
-                    NvmeReservationConv(args.resv_type).try_into()?;
-                let preempt_policy =
-                    NvmePreemptionConv(args.preempt_policy).try_into()?;
-                // If the control plane has supplied a key, use it to store the
-                // NexusInfo.
-                let nexus_info_key = if args.nexus_info_key.is_empty() {
-                    None
-                } else {
-                    Some(args.nexus_info_key.to_string())
-                };
+        let ctx = GrpcClientContext::new(&request, function_name!());
+        let args = request.into_inner();
 
-                let rx = rpc_submit::<_, _, nexus::Error>(async move {
-                    nexus::nexus_create_v2(
-                        &args.name,
-                        args.size,
-                        &args.uuid,
-                        nexus::NexusNvmeParams {
-                            min_cntlid: args.min_cntl_id as u16,
-                            max_cntlid: args.max_cntl_id as u16,
-                            resv_key: args.resv_key,
-                            preempt_key: match args.preempt_key {
-                                0 => None,
-                                k => std::num::NonZeroU64::new(k),
-                            },
-                            resv_type,
-                            preempt_policy,
+        self.serialized(ctx, args.uuid.clone(), true, async move {
+            let resv_type = NvmeReservationConv(args.resv_type).try_into()?;
+            let preempt_policy =
+                NvmePreemptionConv(args.preempt_policy).try_into()?;
+            // If the control plane has supplied a key, use it to store the
+            // NexusInfo.
+            let nexus_info_key = if args.nexus_info_key.is_empty() {
+                None
+            } else {
+                Some(args.nexus_info_key.to_string())
+            };
+
+            let rx = rpc_submit::<_, _, nexus::Error>(async move {
+                nexus::nexus_create_v2(
+                    &args.name,
+                    args.size,
+                    &args.uuid,
+                    nexus::NexusNvmeParams {
+                        min_cntlid: args.min_cntl_id as u16,
+                        max_cntlid: args.max_cntl_id as u16,
+                        resv_key: args.resv_key,
+                        preempt_key: match args.preempt_key {
+                            0 => None,
+                            k => std::num::NonZeroU64::new(k),
                         },
-                        &args.children,
-                        nexus_info_key,
-                    )
-                    .await?;
-                    let nexus = nexus_lookup(&args.name)?;
-                    info!("Created nexus '{}'", &args.name);
-                    Ok(nexus.to_grpc())
-                })?;
-                rx.await
-                    .map_err(|_| Status::cancelled("cancelled"))?
-                    .map_err(Status::from)
-                    .map(Response::new)
-            },
-        )
+                        resv_type,
+                        preempt_policy,
+                    },
+                    &args.children,
+                    nexus_info_key,
+                )
+                .await?;
+                let nexus = nexus_lookup(&args.name)?;
+                info!("Created nexus '{}'", &args.name);
+                Ok(nexus.to_grpc())
+            })?;
+            rx.await
+                .map_err(|_| Status::cancelled("cancelled"))?
+                .map_err(Status::from)
+                .map(Response::new)
+        })
         .await
     }
 
@@ -991,22 +1037,22 @@ impl mayastor_server::Mayastor for MayastorSvc {
         &self,
         request: Request<DestroyNexusRequest>,
     ) -> GrpcResult<Null> {
-        self.locked(
-            GrpcClientContext::new(&request, function_name!()),
-            async move {
-                let rx = rpc_submit::<_, _, nexus::Error>(async move {
-                    let args = request.into_inner();
-                    trace!("{:?}", args);
-                    nexus_destroy(&args.uuid).await?;
-                    Ok(Null {})
-                })?;
+        let ctx = GrpcClientContext::new(&request, function_name!());
+        let args = request.into_inner();
 
-                rx.await
-                    .map_err(|_| Status::cancelled("cancelled"))?
-                    .map_err(Status::from)
-                    .map(Response::new)
-            },
-        )
+        info!("{:?}", ctx);
+        self.serialized(ctx, args.uuid.clone(), true, async move {
+            let rx = rpc_submit::<_, _, nexus::Error>(async move {
+                trace!("{:?}", args);
+                nexus_destroy(&args.uuid).await?;
+                Ok(Null {})
+            })?;
+
+            rx.await
+                .map_err(|_| Status::cancelled("cancelled"))?
+                .map_err(Status::from)
+                .map(Response::new)
+        })
         .await
     }
 
@@ -1015,23 +1061,22 @@ impl mayastor_server::Mayastor for MayastorSvc {
         &self,
         request: Request<ShutdownNexusRequest>,
     ) -> GrpcResult<Null> {
-        self.locked(
-            GrpcClientContext::new(&request, function_name!()),
-            async move {
-                let rx = rpc_submit::<_, _, nexus::Error>(async move {
-                    let args = request.into_inner();
-                    trace!("{:?}", args);
+        let ctx = GrpcClientContext::new(&request, function_name!());
+        let args = request.into_inner();
 
-                    nexus_lookup(&args.uuid)?.shutdown().await?;
-                    Ok(Null {})
-                })?;
+        self.serialized(ctx, args.uuid.clone(), false, async move {
+            let rx = rpc_submit::<_, _, nexus::Error>(async move {
+                trace!("{:?}", args);
 
-                rx.await
-                    .map_err(|_| Status::cancelled("cancelled"))?
-                    .map_err(Status::from)
-                    .map(Response::new)
-            },
-        )
+                nexus_lookup(&args.uuid)?.shutdown().await?;
+                Ok(Null {})
+            })?;
+
+            rx.await
+                .map_err(|_| Status::cancelled("cancelled"))?
+                .map_err(Status::from)
+                .map(Response::new)
+        })
         .await
     }
 
@@ -1086,250 +1131,312 @@ impl mayastor_server::Mayastor for MayastorSvc {
             .map(Response::new)
     }
 
+    #[named]
     async fn add_child_nexus(
         &self,
         request: Request<AddChildNexusRequest>,
     ) -> GrpcResult<Child> {
+        let ctx = GrpcClientContext::new(&request, function_name!());
         let args = request.into_inner();
-        let rx = rpc_submit::<_, _, nexus::Error>(async move {
-            trace!("{:?}", args);
-            let uuid = args.uuid.clone();
-            debug!("Adding child {} to nexus {} ...", args.uri, uuid);
-            let child = nexus_add_child(args).await?;
-            info!("Added child to nexus {}", uuid);
-            Ok(child)
-        })?;
 
-        rx.await
-            .map_err(|_| Status::cancelled("cancelled"))?
-            .map_err(Status::from)
-            .map(Response::new)
+        self.serialized(ctx, args.uuid.clone(), false, async move {
+            let rx = rpc_submit::<_, _, nexus::Error>(async move {
+                trace!("{:?}", args);
+                let uuid = args.uuid.clone();
+                debug!("Adding child {} to nexus {} ...", args.uri, uuid);
+                let child = nexus_add_child(args).await?;
+                info!("Added child to nexus {}", uuid);
+                Ok(child)
+            })?;
+
+            rx.await
+                .map_err(|_| Status::cancelled("cancelled"))?
+                .map_err(Status::from)
+                .map(Response::new)
+        })
+        .await
     }
 
+    #[named]
     async fn remove_child_nexus(
         &self,
         request: Request<RemoveChildNexusRequest>,
     ) -> GrpcResult<Null> {
-        let rx = rpc_submit::<_, _, nexus::Error>(async move {
-            let args = request.into_inner();
-            trace!("{:?}", args);
-            let uuid = args.uuid.clone();
-            debug!("Removing child {} from nexus {} ...", args.uri, uuid);
-            nexus_lookup(&args.uuid)?.remove_child(&args.uri).await?;
-            info!("Removed child from nexus {}", uuid);
-            Ok(Null {})
-        })?;
+        let ctx = GrpcClientContext::new(&request, function_name!());
+        let args = request.into_inner();
 
-        rx.await
-            .map_err(|_| Status::cancelled("cancelled"))?
-            .map_err(Status::from)
-            .map(Response::new)
+        self.serialized(ctx, args.uuid.clone(), false, async move {
+            let rx = rpc_submit::<_, _, nexus::Error>(async move {
+                trace!("{:?}", args);
+                let uuid = args.uuid.clone();
+                debug!("Removing child {} from nexus {} ...", args.uri, uuid);
+                nexus_lookup(&args.uuid)?.remove_child(&args.uri).await?;
+                info!("Removed child from nexus {}", uuid);
+                Ok(Null {})
+            })?;
+
+            rx.await
+                .map_err(|_| Status::cancelled("cancelled"))?
+                .map_err(Status::from)
+                .map(Response::new)
+        })
+        .await
     }
 
+    #[named]
     async fn fault_nexus_child(
         &self,
         request: Request<FaultNexusChildRequest>,
     ) -> GrpcResult<Null> {
-        let rx = rpc_submit::<_, _, nexus::Error>(async move {
-            let args = request.into_inner();
-            trace!("{:?}", args);
-            let uuid = args.uuid.clone();
-            let uri = args.uri.clone();
-            debug!("Faulting child {} on nexus {}", uri, uuid);
-            nexus_lookup(&args.uuid)?
-                .fault_child(&args.uri, nexus::Reason::ByClient)
-                .await?;
-            info!("Faulted child {} on nexus {}", uri, uuid);
-            Ok(Null {})
-        })?;
+        let ctx = GrpcClientContext::new(&request, function_name!());
+        let args = request.into_inner();
 
-        rx.await
-            .map_err(|_| Status::cancelled("cancelled"))?
-            .map_err(Status::from)
-            .map(Response::new)
+        self.serialized(ctx, args.uuid.clone(), false, async move {
+            let rx = rpc_submit::<_, _, nexus::Error>(async move {
+                trace!("{:?}", args);
+                let uuid = args.uuid.clone();
+                let uri = args.uri.clone();
+                debug!("Faulting child {} on nexus {}", uri, uuid);
+                nexus_lookup(&args.uuid)?
+                    .fault_child(&args.uri, nexus::Reason::ByClient)
+                    .await?;
+                info!("Faulted child {} on nexus {}", uri, uuid);
+                Ok(Null {})
+            })?;
+
+            rx.await
+                .map_err(|_| Status::cancelled("cancelled"))?
+                .map_err(Status::from)
+                .map(Response::new)
+        })
+        .await
     }
 
+    #[named]
     async fn inject_nexus_fault(
         &self,
         request: Request<InjectNexusFaultRequest>,
     ) -> GrpcResult<Null> {
-        let rx = rpc_submit::<_, _, nexus::Error>(async move {
-            let args = request.into_inner();
-            trace!("{:?}", args);
-            let uuid = args.uuid.clone();
-            let uri = args.uri.clone();
-            debug!("Injecting fault to nexus '{}': '{}'", uuid, uri);
-            nexus_lookup(&args.uuid)?
-                .inject_add_fault(&args.uri)
-                .await?;
-            info!("Injected fault to nexus '{}': '{}'", uuid, uri);
-            Ok(Null {})
-        })?;
+        let ctx = GrpcClientContext::new(&request, function_name!());
+        let args = request.into_inner();
 
-        rx.await
-            .map_err(|_| Status::cancelled("cancelled"))?
-            .map_err(Status::from)
-            .map(Response::new)
+        self.serialized(ctx, args.uuid.clone(), false, async move {
+            let rx = rpc_submit::<_, _, nexus::Error>(async move {
+                trace!("{:?}", args);
+                let uuid = args.uuid.clone();
+                let uri = args.uri.clone();
+                debug!("Injecting fault to nexus '{}': '{}'", uuid, uri);
+                nexus_lookup(&args.uuid)?
+                    .inject_add_fault(&args.uri)
+                    .await?;
+                info!("Injected fault to nexus '{}': '{}'", uuid, uri);
+                Ok(Null {})
+            })?;
+
+            rx.await
+                .map_err(|_| Status::cancelled("cancelled"))?
+                .map_err(Status::from)
+                .map(Response::new)
+        })
+        .await
     }
 
+    #[named]
     async fn remove_injected_nexus_fault(
         &self,
         request: Request<RemoveInjectedNexusFaultRequest>,
     ) -> GrpcResult<Null> {
-        let rx = rpc_submit::<_, _, nexus::Error>(async move {
-            let args = request.into_inner();
-            trace!("{:?}", args);
-            let uuid = args.uuid.clone();
-            let uri = args.uri.clone();
-            debug!("Removing injected fault to nexus '{}': '{}'", uuid, uri);
-            nexus_lookup(&args.uuid)?
-                .inject_remove_fault(&args.uri)
-                .await?;
-            info!("Removed injected fault to nexus '{}': '{}'", uuid, uri);
-            Ok(Null {})
-        })?;
+        let ctx = GrpcClientContext::new(&request, function_name!());
+        let args = request.into_inner();
 
-        rx.await
-            .map_err(|_| Status::cancelled("cancelled"))?
-            .map_err(Status::from)
-            .map(Response::new)
+        self.serialized(ctx, args.uuid.clone(), false, async move {
+            let rx = rpc_submit::<_, _, nexus::Error>(async move {
+                trace!("{:?}", args);
+                let uuid = args.uuid.clone();
+                let uri = args.uri.clone();
+                debug!(
+                    "Removing injected fault to nexus '{}': '{}'",
+                    uuid, uri
+                );
+                nexus_lookup(&args.uuid)?
+                    .inject_remove_fault(&args.uri)
+                    .await?;
+                info!("Removed injected fault to nexus '{}': '{}'", uuid, uri);
+                Ok(Null {})
+            })?;
+
+            rx.await
+                .map_err(|_| Status::cancelled("cancelled"))?
+                .map_err(Status::from)
+                .map(Response::new)
+        })
+        .await
     }
 
+    #[named]
     async fn list_injected_nexus_faults(
         &self,
         request: Request<ListInjectedNexusFaultsRequest>,
     ) -> GrpcResult<ListInjectedNexusFaultsReply> {
+        let ctx = GrpcClientContext::new(&request, function_name!());
         let args = request.into_inner();
         trace!("{:?}", args);
 
-        let rx = rpc_submit::<_, _, nexus::Error>(async move {
-            let res = nexus_lookup(&args.uuid)?
-                .list_injections()
-                .await?
-                .into_iter()
-                .map(|inj| InjectedFault {
-                    device_name: inj.device_name,
-                    is_active: inj.is_active,
+        self.serialized(ctx, args.uuid.clone(), false, async move {
+            let rx = rpc_submit::<_, _, nexus::Error>(async move {
+                let res = nexus_lookup(&args.uuid)?
+                    .list_injections()
+                    .await?
+                    .into_iter()
+                    .map(|inj| InjectedFault {
+                        device_name: inj.device_name,
+                        is_active: inj.is_active,
+                    })
+                    .collect();
+
+                Ok(ListInjectedNexusFaultsReply {
+                    injections: res,
                 })
-                .collect();
+            })?;
 
-            Ok(ListInjectedNexusFaultsReply {
-                injections: res,
-            })
-        })?;
-
-        rx.await
-            .map_err(|_| Status::cancelled("cancelled"))?
-            .map_err(Status::from)
-            .map(Response::new)
+            rx.await
+                .map_err(|_| Status::cancelled("cancelled"))?
+                .map_err(Status::from)
+                .map(Response::new)
+        })
+        .await
     }
 
+    #[named]
     async fn publish_nexus(
         &self,
         request: Request<PublishNexusRequest>,
     ) -> GrpcResult<PublishNexusReply> {
-        let rx = rpc_submit::<_, _, nexus::Error>(async {
-            let args = request.into_inner();
-            trace!("{:?}", args);
-            let uuid = args.uuid.clone();
-            debug!("Publishing nexus {} ...", uuid);
+        let ctx = GrpcClientContext::new(&request, function_name!());
+        let args = request.into_inner();
 
-            if !args.key.is_empty() && args.key.len() != 16 {
-                return Err(nexus::Error::InvalidKey {});
-            }
+        self.serialized(ctx, args.uuid.clone(), false, async move {
+            let rx = rpc_submit::<_, _, nexus::Error>(async move {
+                trace!("{:?}", args);
+                let uuid = args.uuid.clone();
+                debug!("Publishing nexus {} ...", uuid);
 
-            let key: Option<String> = if args.key.is_empty() {
-                None
-            } else {
-                Some(args.key.clone())
-            };
-
-            let share_protocol = match Protocol::try_from(args.share) {
-                Ok(protocol) => protocol,
-                Err(_) => {
-                    return Err(nexus::Error::InvalidShareProtocol {
-                        sp_value: args.share as i32,
-                    });
+                if !args.key.is_empty() && args.key.len() != 16 {
+                    return Err(nexus::Error::InvalidKey {});
                 }
-            };
 
-            let device_uri =
-                nexus_lookup(&args.uuid)?.share(share_protocol, key).await?;
+                let key: Option<String> = if args.key.is_empty() {
+                    None
+                } else {
+                    Some(args.key.clone())
+                };
 
-            info!("Published nexus {} under {}", uuid, device_uri);
-            Ok(PublishNexusReply {
-                device_uri,
-            })
-        })?;
-        rx.await
-            .map_err(|_| Status::cancelled("cancelled"))?
-            .map_err(Status::from)
-            .map(Response::new)
+                let share_protocol = match Protocol::try_from(args.share) {
+                    Ok(protocol) => protocol,
+                    Err(_) => {
+                        return Err(nexus::Error::InvalidShareProtocol {
+                            sp_value: args.share as i32,
+                        });
+                    }
+                };
+
+                let device_uri = nexus_lookup(&args.uuid)?
+                    .share(share_protocol, key)
+                    .await?;
+
+                info!("Published nexus {} under {}", uuid, device_uri);
+                Ok(PublishNexusReply {
+                    device_uri,
+                })
+            })?;
+            rx.await
+                .map_err(|_| Status::cancelled("cancelled"))?
+                .map_err(Status::from)
+                .map(Response::new)
+        })
+        .await
     }
 
+    #[named]
     async fn unpublish_nexus(
         &self,
         request: Request<UnpublishNexusRequest>,
     ) -> GrpcResult<Null> {
-        let rx = rpc_submit::<_, _, nexus::Error>(async {
-            let args = request.into_inner();
-            trace!("{:?}", args);
-            let uuid = args.uuid.clone();
-            debug!("Unpublishing nexus {} ...", uuid);
-            nexus_lookup(&args.uuid)?.unshare_nexus().await?;
-            info!("Unpublished nexus {}", uuid);
-            Ok(Null {})
-        })?;
+        let ctx = GrpcClientContext::new(&request, function_name!());
+        let args = request.into_inner();
 
-        rx.await
-            .map_err(|_| Status::cancelled("cancelled"))?
-            .map_err(Status::from)
-            .map(Response::new)
+        self.serialized(ctx, args.uuid.clone(), false, async move {
+            let rx = rpc_submit::<_, _, nexus::Error>(async move {
+                trace!("{:?}", args);
+                let uuid = args.uuid.clone();
+                debug!("Unpublishing nexus {} ...", uuid);
+                nexus_lookup(&args.uuid)?.unshare_nexus().await?;
+                info!("Unpublished nexus {}", uuid);
+                Ok(Null {})
+            })?;
+
+            rx.await
+                .map_err(|_| Status::cancelled("cancelled"))?
+                .map_err(Status::from)
+                .map(Response::new)
+        })
+        .await
     }
 
+    #[named]
     async fn get_nvme_ana_state(
         &self,
         request: Request<GetNvmeAnaStateRequest>,
     ) -> GrpcResult<GetNvmeAnaStateReply> {
+        let ctx = GrpcClientContext::new(&request, function_name!());
         let args = request.into_inner();
-        let uuid = args.uuid.clone();
-        debug!("Getting NVMe ANA state for nexus {} ...", uuid);
 
-        let rx = rpc_submit::<_, _, nexus::Error>(async move {
-            let ana_state = nexus_lookup(&args.uuid)?.get_ana_state().await?;
-            info!("Got nexus {} NVMe ANA state {:?}", uuid, ana_state);
-            Ok(GetNvmeAnaStateReply {
-                ana_state: ana_state as i32,
-            })
-        })?;
+        self.serialized(ctx, args.uuid.clone(), false, async move {
+            let rx = rpc_submit::<_, _, nexus::Error>(async move {
+                let uuid = args.uuid.clone();
+                debug!("Getting NVMe ANA state for nexus {} ...", uuid);
+                let ana_state =
+                    nexus_lookup(&args.uuid)?.get_ana_state().await?;
+                info!("Got nexus {} NVMe ANA state {:?}", uuid, ana_state);
+                Ok(GetNvmeAnaStateReply {
+                    ana_state: ana_state as i32,
+                })
+            })?;
 
-        rx.await
-            .map_err(|_| Status::cancelled("cancelled"))?
-            .map_err(Status::from)
-            .map(Response::new)
+            rx.await
+                .map_err(|_| Status::cancelled("cancelled"))?
+                .map_err(Status::from)
+                .map(Response::new)
+        })
+        .await
     }
 
+    #[named]
     async fn set_nvme_ana_state(
         &self,
         request: Request<SetNvmeAnaStateRequest>,
     ) -> GrpcResult<Null> {
+        let ctx = GrpcClientContext::new(&request, function_name!());
         let args = request.into_inner();
-        let uuid = args.uuid.clone();
-        debug!("Setting NVMe ANA state for nexus {} ...", uuid);
 
-        let rx = rpc_submit::<_, _, nexus::Error>(async move {
-            let ana_state = nexus::NvmeAnaState::from_i32(args.ana_state)?;
+        self.serialized(ctx, args.uuid.clone(), false, async move {
+            let rx = rpc_submit::<_, _, nexus::Error>(async move {
+                let uuid = args.uuid.clone();
+                debug!("Setting NVMe ANA state for nexus {} ...", uuid);
+                let ana_state = nexus::NvmeAnaState::from_i32(args.ana_state)?;
 
-            let ana_state =
-                nexus_lookup(&args.uuid)?.set_ana_state(ana_state).await?;
-            info!("Set nexus {} NVMe ANA state {:?}", uuid, ana_state);
-            Ok(Null {})
-        })?;
+                let ana_state =
+                    nexus_lookup(&args.uuid)?.set_ana_state(ana_state).await?;
+                info!("Set nexus {} NVMe ANA state {:?}", uuid, ana_state);
+                Ok(Null {})
+            })?;
 
-        rx.await
-            .map_err(|_| Status::cancelled("cancelled"))?
-            .map_err(Status::from)
-            .map(Response::new)
+            rx.await
+                .map_err(|_| Status::cancelled("cancelled"))?
+                .map_err(Status::from)
+                .map(Response::new)
+        })
+        .await
     }
 
     #[named]
@@ -1337,31 +1444,30 @@ impl mayastor_server::Mayastor for MayastorSvc {
         &self,
         request: Request<ChildNexusRequest>,
     ) -> GrpcResult<Null> {
-        self.locked(
-            GrpcClientContext::new(&request, function_name!()),
-            async move {
-                let rx = rpc_submit::<_, _, nexus::Error>(async move {
-                    let args = request.into_inner();
-                    trace!("{:?}", args);
+        let ctx = GrpcClientContext::new(&request, function_name!());
+        let args = request.into_inner();
 
-                    let nexus = nexus_lookup(&args.uuid)?;
+        self.serialized(ctx, args.uuid.clone(), false, async move {
+            let rx = rpc_submit::<_, _, nexus::Error>(async move {
+                trace!("{:?}", args);
 
-                    match args.action {
-                        0 => nexus.offline_child(&args.uri).await,
-                        1 => nexus.online_child(&args.uri).await,
-                        2 => nexus.retire_child(&args.uri).await,
-                        _ => Err(nexus::Error::InvalidKey {}),
-                    }?;
+                let nexus = nexus_lookup(&args.uuid)?;
 
-                    Ok(Null {})
-                })?;
+                match args.action {
+                    0 => nexus.offline_child(&args.uri).await,
+                    1 => nexus.online_child(&args.uri).await,
+                    2 => nexus.retire_child(&args.uri).await,
+                    _ => Err(nexus::Error::InvalidKey {}),
+                }?;
 
-                rx.await
-                    .map_err(|_| Status::cancelled("cancelled"))?
-                    .map_err(Status::from)
-                    .map(Response::new)
-            },
-        )
+                Ok(Null {})
+            })?;
+
+            rx.await
+                .map_err(|_| Status::cancelled("cancelled"))?
+                .map_err(Status::from)
+                .map(Response::new)
+        })
         .await
     }
 
@@ -1370,25 +1476,24 @@ impl mayastor_server::Mayastor for MayastorSvc {
         &self,
         request: Request<StartRebuildRequest>,
     ) -> GrpcResult<Null> {
-        self.locked(
-            GrpcClientContext::new(&request, function_name!()),
-            async move {
-                let args = request.into_inner();
-                trace!("{:?}", args);
-                let rx = rpc_submit::<_, _, nexus::Error>(async move {
-                    nexus_lookup(&args.uuid)?
-                        .start_rebuild(&args.uri)
-                        .await
-                        .map(|_| {})?;
-                    Ok(Null {})
-                })?;
+        let ctx = GrpcClientContext::new(&request, function_name!());
+        let args = request.into_inner();
 
-                rx.await
-                    .map_err(|_| Status::cancelled("cancelled"))?
-                    .map_err(Status::from)
-                    .map(Response::new)
-            },
-        )
+        self.serialized(ctx, args.uuid.clone(), false, async move {
+            trace!("{:?}", args);
+            let rx = rpc_submit::<_, _, nexus::Error>(async move {
+                nexus_lookup(&args.uuid)?
+                    .start_rebuild(&args.uri)
+                    .await
+                    .map(|_| {})?;
+                Ok(Null {})
+            })?;
+
+            rx.await
+                .map_err(|_| Status::cancelled("cancelled"))?
+                .map_err(Status::from)
+                .map(Response::new)
+        })
         .await
     }
 
@@ -1397,23 +1502,22 @@ impl mayastor_server::Mayastor for MayastorSvc {
         &self,
         request: Request<StopRebuildRequest>,
     ) -> GrpcResult<Null> {
-        self.locked(
-            GrpcClientContext::new(&request, function_name!()),
-            async move {
-                let args = request.into_inner();
-                trace!("{:?}", args);
-                let rx = rpc_submit::<_, _, nexus::Error>(async move {
-                    nexus_lookup(&args.uuid)?.stop_rebuild(&args.uri).await?;
+        let ctx = GrpcClientContext::new(&request, function_name!());
+        let args = request.into_inner();
 
-                    Ok(Null {})
-                })?;
+        self.serialized(ctx, args.uuid.clone(), false, async move {
+            trace!("{:?}", args);
+            let rx = rpc_submit::<_, _, nexus::Error>(async move {
+                nexus_lookup(&args.uuid)?.stop_rebuild(&args.uri).await?;
 
-                rx.await
-                    .map_err(|_| Status::cancelled("cancelled"))?
-                    .map_err(Status::from)
-                    .map(Response::new)
-            },
-        )
+                Ok(Null {})
+            })?;
+
+            rx.await
+                .map_err(|_| Status::cancelled("cancelled"))?
+                .map_err(Status::from)
+                .map(Response::new)
+        })
         .await
     }
 
@@ -1422,22 +1526,21 @@ impl mayastor_server::Mayastor for MayastorSvc {
         &self,
         request: Request<PauseRebuildRequest>,
     ) -> GrpcResult<Null> {
-        self.locked(
-            GrpcClientContext::new(&request, function_name!()),
-            async move {
-                let msg = request.into_inner();
-                let rx = rpc_submit::<_, _, nexus::Error>(async move {
-                    nexus_lookup(&msg.uuid)?.pause_rebuild(&msg.uri).await?;
+        let ctx = GrpcClientContext::new(&request, function_name!());
+        let msg = request.into_inner();
 
-                    Ok(Null {})
-                })?;
+        self.serialized(ctx, msg.uuid.clone(), false, async move {
+            let rx = rpc_submit::<_, _, nexus::Error>(async move {
+                nexus_lookup(&msg.uuid)?.pause_rebuild(&msg.uri).await?;
 
-                rx.await
-                    .map_err(|_| Status::cancelled("cancelled"))?
-                    .map_err(Status::from)
-                    .map(Response::new)
-            },
-        )
+                Ok(Null {})
+            })?;
+
+            rx.await
+                .map_err(|_| Status::cancelled("cancelled"))?
+                .map_err(Status::from)
+                .map(Response::new)
+        })
         .await
     }
 
@@ -1446,21 +1549,20 @@ impl mayastor_server::Mayastor for MayastorSvc {
         &self,
         request: Request<ResumeRebuildRequest>,
     ) -> GrpcResult<Null> {
-        self.locked(
-            GrpcClientContext::new(&request, function_name!()),
-            async move {
-                let msg = request.into_inner();
-                let rx = rpc_submit::<_, _, nexus::Error>(async move {
-                    nexus_lookup(&msg.uuid)?.resume_rebuild(&msg.uri).await?;
-                    Ok(Null {})
-                })?;
+        let ctx = GrpcClientContext::new(&request, function_name!());
+        let msg = request.into_inner();
 
-                rx.await
-                    .map_err(|_| Status::cancelled("cancelled"))?
-                    .map_err(Status::from)
-                    .map(Response::new)
-            },
-        )
+        self.serialized(ctx, msg.uuid.clone(), false, async move {
+            let rx = rpc_submit::<_, _, nexus::Error>(async move {
+                nexus_lookup(&msg.uuid)?.resume_rebuild(&msg.uri).await?;
+                Ok(Null {})
+            })?;
+
+            rx.await
+                .map_err(|_| Status::cancelled("cancelled"))?
+                .map_err(Status::from)
+                .map(Response::new)
+        })
         .await
     }
 
@@ -1469,24 +1571,23 @@ impl mayastor_server::Mayastor for MayastorSvc {
         &self,
         request: Request<RebuildStateRequest>,
     ) -> GrpcResult<RebuildStateReply> {
-        self.locked(
-            GrpcClientContext::new(&request, function_name!()),
-            async move {
-                let args = request.into_inner();
-                let rx = rpc_submit::<_, _, nexus::Error>(async move {
-                    trace!("{:?}", args);
-                    nexus_lookup(&args.uuid)?
-                        .rebuild_state(&args.uri)
-                        .await
-                        .map(RebuildStateReply::from)
-                })?;
+        let ctx = GrpcClientContext::new(&request, function_name!());
+        let args = request.into_inner();
 
-                rx.await
-                    .map_err(|_| Status::cancelled("cancelled"))?
-                    .map_err(Status::from)
-                    .map(Response::new)
-            },
-        )
+        self.serialized(ctx, args.uuid.clone(), false, async move {
+            let rx = rpc_submit::<_, _, nexus::Error>(async move {
+                trace!("{:?}", args);
+                nexus_lookup(&args.uuid)?
+                    .rebuild_state(&args.uri)
+                    .await
+                    .map(RebuildStateReply::from)
+            })?;
+
+            rx.await
+                .map_err(|_| Status::cancelled("cancelled"))?
+                .map_err(Status::from)
+                .map(Response::new)
+        })
         .await
     }
 
@@ -1495,23 +1596,22 @@ impl mayastor_server::Mayastor for MayastorSvc {
         &self,
         request: Request<RebuildStatsRequest>,
     ) -> GrpcResult<RebuildStatsReply> {
-        self.locked(
-            GrpcClientContext::new(&request, function_name!()),
-            async move {
-                let args = request.into_inner();
-                trace!("{:?}", args);
-                let rx = rpc_submit::<_, _, nexus::Error>(async move {
-                    nexus_lookup(&args.uuid)?
-                        .rebuild_stats(&args.uri)
-                        .await
-                        .map(RebuildStatsReply::from)
-                })?;
-                rx.await
-                    .map_err(|_| Status::cancelled("cancelled"))?
-                    .map_err(Status::from)
-                    .map(Response::new)
-            },
-        )
+        let ctx = GrpcClientContext::new(&request, function_name!());
+        let args = request.into_inner();
+
+        self.serialized(ctx, args.uuid.clone(), false, async move {
+            trace!("{:?}", args);
+            let rx = rpc_submit::<_, _, nexus::Error>(async move {
+                nexus_lookup(&args.uuid)?
+                    .rebuild_stats(&args.uri)
+                    .await
+                    .map(RebuildStatsReply::from)
+            })?;
+            rx.await
+                .map_err(|_| Status::cancelled("cancelled"))?
+                .map_err(Status::from)
+                .map(Response::new)
+        })
         .await
     }
 
@@ -1520,46 +1620,51 @@ impl mayastor_server::Mayastor for MayastorSvc {
         &self,
         request: Request<RebuildProgressRequest>,
     ) -> GrpcResult<RebuildProgressReply> {
-        self.locked(
-            GrpcClientContext::new(&request, function_name!()),
-            async move {
-                let args = request.into_inner();
-                trace!("{:?}", args);
-                let rx = rpc_submit::<_, _, nexus::Error>(async move {
-                    nexus_lookup(&args.uuid)?.rebuild_progress(&args.uri).map(
-                        |p| RebuildProgressReply {
-                            progress: p,
-                        },
-                    )
-                })?;
+        let ctx = GrpcClientContext::new(&request, function_name!());
+        let args = request.into_inner();
 
-                rx.await
-                    .map_err(|_| Status::cancelled("cancelled"))?
-                    .map_err(Status::from)
-                    .map(Response::new)
-            },
-        )
+        self.serialized(ctx, args.uuid.clone(), false, async move {
+            trace!("{:?}", args);
+            let rx = rpc_submit::<_, _, nexus::Error>(async move {
+                nexus_lookup(&args.uuid)?
+                    .rebuild_progress(&args.uri)
+                    .map(|p| RebuildProgressReply {
+                        progress: p,
+                    })
+            })?;
+
+            rx.await
+                .map_err(|_| Status::cancelled("cancelled"))?
+                .map_err(Status::from)
+                .map(Response::new)
+        })
         .await
     }
 
+    #[named]
     async fn create_snapshot(
         &self,
         request: Request<CreateSnapshotRequest>,
     ) -> GrpcResult<CreateSnapshotReply> {
-        let rx = rpc_submit::<_, _, nexus::Error>(async {
-            let args = request.into_inner();
-            let uuid = args.uuid.clone();
-            debug!("Creating snapshot on nexus {} ...", uuid);
-            let reply = nexus_lookup(&args.uuid)?.create_snapshot().await?;
-            info!("Created snapshot on nexus {}", uuid);
-            trace!("{:?}", reply);
-            Ok(reply)
-        })?;
+        let ctx = GrpcClientContext::new(&request, function_name!());
+        let args = request.into_inner();
 
-        rx.await
-            .map_err(|_| Status::cancelled("cancelled"))?
-            .map_err(Status::from)
-            .map(Response::new)
+        self.serialized(ctx, args.uuid.clone(), false, async move {
+            let rx = rpc_submit::<_, _, nexus::Error>(async move {
+                let uuid = args.uuid.clone();
+                debug!("Creating snapshot on nexus {} ...", uuid);
+                let reply = nexus_lookup(&args.uuid)?.create_snapshot().await?;
+                info!("Created snapshot on nexus {}", uuid);
+                trace!("{:?}", reply);
+                Ok(reply)
+            })?;
+
+            rx.await
+                .map_err(|_| Status::cancelled("cancelled"))?
+                .map_err(Status::from)
+                .map(Response::new)
+        })
+        .await
     }
 
     async fn list_block_devices(

--- a/io-engine/src/grpc/v1/nexus.rs
+++ b/io-engine/src/grpc/v1/nexus.rs
@@ -3,8 +3,12 @@ use crate::{
         nexus,
         nexus::{nexus_lookup_uuid_mut, NexusChild, NexusStatus, Reason},
     },
-    core::{Protocol, Share},
-    grpc::{rpc_submit, GrpcClientContext, GrpcResult, Serializer},
+    core::{
+        lock::{ProtectedSubsystems, ResourceLockManager},
+        Protocol,
+        Share,
+    },
+    grpc::{rpc_submit, GrpcClientContext, GrpcResult},
     rebuild::{RebuildJob, RebuildState, RebuildStats},
 };
 use futures::FutureExt;
@@ -32,47 +36,6 @@ pub struct NexusService {
     client_context: tokio::sync::Mutex<Option<GrpcClientContext>>,
 }
 
-#[async_trait::async_trait]
-impl<F, T> Serializer<F, T> for NexusService
-where
-    T: Send + 'static,
-    F: core::future::Future<Output = Result<T, Status>> + Send + 'static,
-{
-    async fn locked(&self, ctx: GrpcClientContext, f: F) -> Result<T, Status> {
-        let mut context_guard = self.client_context.lock().await;
-
-        // Store context as a marker of to detect abnormal termination of the
-        // request. Even though AssertUnwindSafe() allows us to
-        // intercept asserts in underlying method strategies, such a
-        // situation can still happen when the high-level future that
-        // represents gRPC call at the highest level (i.e. the one created
-        // by gRPC server) gets cancelled (due to timeout or somehow else).
-        // This can't be properly intercepted by 'locked' function itself in the
-        // first place, so the state needs to be cleaned up properly
-        // upon subsequent gRPC calls.
-        if let Some(c) = context_guard.replace(ctx) {
-            warn!("{}: gRPC method timed out, args: {}", c.id, c.args);
-        }
-
-        let fut = AssertUnwindSafe(f).catch_unwind();
-        let r = fut.await;
-
-        // Request completed, remove the marker.
-        let ctx = context_guard.take().expect("gRPC context disappeared");
-
-        match r {
-            Ok(r) => r,
-            Err(_e) => {
-                warn!("{}: gRPC method panicked, args: {}", ctx.id, ctx.args);
-                Err(Status::cancelled(format!(
-                    "{}: gRPC method panicked",
-                    ctx.id
-                )))
-            }
-        }
-    }
-}
-
 impl Default for NexusService {
     fn default() -> Self {
         Self::new()
@@ -84,6 +47,67 @@ impl NexusService {
         Self {
             name: String::from("NexusService"),
             client_context: tokio::sync::Mutex::new(None),
+        }
+    }
+
+    async fn serialized<T, F>(
+        &self,
+        ctx: GrpcClientContext,
+        nexus_uuid: String,
+        global_operation: bool,
+        f: F,
+    ) -> Result<T, Status>
+    where
+        T: Send + 'static,
+        F: core::future::Future<Output = Result<T, Status>> + Send + 'static,
+    {
+        let lock_manager = ResourceLockManager::get_instance();
+        let fut = AssertUnwindSafe(f).catch_unwind();
+
+        // Schedule a Tokio task to detach it from the high-level gRPC future
+        // and avoid task cancellation when the top-level gRPC future is
+        // cancelled.
+        match tokio::spawn(async move {
+            // Grab global operation lock, if requested.
+            let _global_guard = if global_operation {
+                match lock_manager.lock(Some(ctx.timeout)).await {
+                    Some(g) => Some(g),
+                    None => return Err(Status::deadline_exceeded(
+                        "Failed to acquire access to object within given timeout"
+                        .to_string()
+                    )),
+                }
+            } else {
+                None
+            };
+
+            // Grab per-object lock before executing the future.
+            let _resource_guard = match lock_manager
+                .get_subsystem(ProtectedSubsystems::NEXUS)
+                .lock_resource(nexus_uuid, Some(ctx.timeout))
+                .await {
+                    Some(g) => g,
+                    None => return Err(Status::deadline_exceeded(
+                        "Failed to acquire access to object within given timeout"
+                        .to_string()
+                    )),
+                };
+            let r = fut.await;
+
+            match r {
+                Ok(r) => r,
+                Err(_e) => {
+                    warn!("{}: gRPC method panicked, args: {}", ctx.id, ctx.args);
+                    Err(Status::cancelled(format!(
+                        "{}: gRPC method panicked",
+                        ctx.id
+                    )))
+                }
+            }
+        })
+        .await {
+            Ok(r) => r,
+            Err(_) => Err(Status::cancelled("gRPC call cancelled"))
         }
     }
 }
@@ -292,70 +316,68 @@ impl NexusRpc for NexusService {
         &self,
         request: Request<CreateNexusRequest>,
     ) -> GrpcResult<CreateNexusResponse> {
-        self.locked(
-            GrpcClientContext::new(&request, function_name!()),
-            async move {
-                let args = request.into_inner();
-                trace!("{:?}", args);
-                let resv_type =
-                    NvmeReservationConv(args.resv_type).try_into()?;
-                let preempt_policy =
-                    NvmePreemptionConv(args.preempt_policy).try_into()?;
-                let rx = rpc_submit::<_, _, nexus::Error>(async move {
-                    // check for nexus exists, uuid & name
-                    if let Some(_n) = nexus::nexus_lookup(&args.name) {
-                        return Err(nexus::Error::NameExists {
-                            name: args.name.clone(),
-                        });
-                    }
-                    if let Ok(_n) = nexus_lookup(&args.uuid) {
-                        return Err(nexus::Error::UuidExists {
-                            uuid: args.uuid.clone(),
-                            nexus: args.name.clone(),
-                        });
-                    }
+        let ctx = GrpcClientContext::new(&request, function_name!());
+        let args = request.into_inner();
 
-                    // If the control plane has supplied a key, use it to store
-                    // the NexusInfo.
-                    let nexus_info_key = if args.nexus_info_key.is_empty() {
-                        None
-                    } else {
-                        Some(args.nexus_info_key.to_string())
-                    };
+        self.serialized(ctx, args.uuid.clone(), true, async move {
+            trace!("{:?}", args);
+            let resv_type = NvmeReservationConv(args.resv_type).try_into()?;
+            let preempt_policy =
+                NvmePreemptionConv(args.preempt_policy).try_into()?;
+            let rx = rpc_submit::<_, _, nexus::Error>(async move {
+                // check for nexus exists, uuid & name
+                if let Some(_n) = nexus::nexus_lookup(&args.name) {
+                    return Err(nexus::Error::NameExists {
+                        name: args.name.clone(),
+                    });
+                }
+                if let Ok(_n) = nexus_lookup(&args.uuid) {
+                    return Err(nexus::Error::UuidExists {
+                        uuid: args.uuid.clone(),
+                        nexus: args.name.clone(),
+                    });
+                }
 
-                    nexus::nexus_create_v2(
-                        &args.name,
-                        args.size,
-                        &args.uuid,
-                        nexus::NexusNvmeParams {
-                            min_cntlid: args.min_cntl_id as u16,
-                            max_cntlid: args.max_cntl_id as u16,
-                            resv_key: args.resv_key,
-                            preempt_key: match args.preempt_key {
-                                0 => None,
-                                k => std::num::NonZeroU64::new(k),
-                            },
-                            resv_type,
-                            preempt_policy,
+                // If the control plane has supplied a key, use it to store
+                // the NexusInfo.
+                let nexus_info_key = if args.nexus_info_key.is_empty() {
+                    None
+                } else {
+                    Some(args.nexus_info_key.to_string())
+                };
+
+                nexus::nexus_create_v2(
+                    &args.name,
+                    args.size,
+                    &args.uuid,
+                    nexus::NexusNvmeParams {
+                        min_cntlid: args.min_cntl_id as u16,
+                        max_cntlid: args.max_cntl_id as u16,
+                        resv_key: args.resv_key,
+                        preempt_key: match args.preempt_key {
+                            0 => None,
+                            k => std::num::NonZeroU64::new(k),
                         },
-                        &args.children,
-                        nexus_info_key,
-                    )
-                    .await?;
-                    let nexus = nexus_lookup(&args.uuid)?;
-                    info!("Created nexus {}", &args.name);
-                    Ok(nexus.into_grpc().await)
-                })?;
-                rx.await
-                    .map_err(|_| Status::cancelled("cancelled"))?
-                    .map_err(Status::from)
-                    .map(|nexus| {
-                        Response::new(CreateNexusResponse {
-                            nexus: Some(nexus),
-                        })
+                        resv_type,
+                        preempt_policy,
+                    },
+                    &args.children,
+                    nexus_info_key,
+                )
+                .await?;
+                let nexus = nexus_lookup(&args.uuid)?;
+                info!("Created nexus {}", &args.name);
+                Ok(nexus.into_grpc().await)
+            })?;
+            rx.await
+                .map_err(|_| Status::cancelled("cancelled"))?
+                .map_err(Status::from)
+                .map(|nexus| {
+                    Response::new(CreateNexusResponse {
+                        nexus: Some(nexus),
                     })
-            },
-        )
+                })
+        })
         .await
     }
 
@@ -364,22 +386,21 @@ impl NexusRpc for NexusService {
         &self,
         request: Request<DestroyNexusRequest>,
     ) -> GrpcResult<()> {
-        self.locked(
-            GrpcClientContext::new(&request, function_name!()),
-            async move {
-                let rx = rpc_submit::<_, _, nexus::Error>(async move {
-                    let args = request.into_inner();
-                    trace!("{:?}", args);
-                    nexus_destroy(&args.uuid).await?;
-                    Ok(())
-                })?;
+        let ctx = GrpcClientContext::new(&request, function_name!());
+        let args = request.into_inner();
 
-                rx.await
-                    .map_err(|_| Status::cancelled("cancelled"))?
-                    .map_err(Status::from)
-                    .map(Response::new)
-            },
-        )
+        self.serialized(ctx, args.uuid.clone(), true, async move {
+            let rx = rpc_submit::<_, _, nexus::Error>(async move {
+                trace!("{:?}", args);
+                nexus_destroy(&args.uuid).await?;
+                Ok(())
+            })?;
+
+            rx.await
+                .map_err(|_| Status::cancelled("cancelled"))?
+                .map_err(Status::from)
+                .map(Response::new)
+        })
         .await
     }
 
@@ -388,22 +409,20 @@ impl NexusRpc for NexusService {
         &self,
         request: Request<ShutdownNexusRequest>,
     ) -> GrpcResult<()> {
-        self.locked(
-            GrpcClientContext::new(&request, function_name!()),
-            async move {
-                let rx = rpc_submit::<_, _, nexus::Error>(async move {
-                    let args = request.into_inner();
-                    trace!("{:?}", args);
+        let ctx = GrpcClientContext::new(&request, function_name!());
+        let args = request.into_inner();
 
-                    nexus_lookup(&args.uuid)?.shutdown().await
-                })?;
+        self.serialized(ctx, args.uuid.clone(), false, async move {
+            let rx = rpc_submit::<_, _, nexus::Error>(async move {
+                trace!("{:?}", args);
+                nexus_lookup(&args.uuid)?.shutdown().await
+            })?;
 
-                rx.await
-                    .map_err(|_| Status::cancelled("cancelled"))?
-                    .map_err(Status::from)
-                    .map(Response::new)
-            },
-        )
+            rx.await
+                .map_err(|_| Status::cancelled("cancelled"))?
+                .map_err(Status::from)
+                .map(Response::new)
+        })
         .await
     }
 
@@ -439,276 +458,340 @@ impl NexusRpc for NexusService {
             .map(Response::new)
     }
 
+    #[named]
     async fn add_child_nexus(
         &self,
         request: Request<AddChildNexusRequest>,
     ) -> GrpcResult<AddChildNexusResponse> {
+        let ctx = GrpcClientContext::new(&request, function_name!());
         let args = request.into_inner();
-        let rx = rpc_submit::<_, _, nexus::Error>(async move {
-            trace!("{:?}", args);
-            let uuid = args.uuid.clone();
-            debug!("Adding child {} to nexus {} ...", args.uri, uuid);
-            let nexus = nexus_add_child(args).await?;
-            info!("Added child to nexus {}", uuid);
-            Ok(nexus)
-        })?;
 
-        rx.await
-            .map_err(|_| Status::cancelled("cancelled"))?
-            .map_err(Status::from)
-            .map(|nexus| {
-                Response::new(AddChildNexusResponse {
-                    nexus: Some(nexus),
+        self.serialized(ctx, args.uuid.clone(), false, async move {
+            let rx = rpc_submit::<_, _, nexus::Error>(async move {
+                trace!("{:?}", args);
+                let uuid = args.uuid.clone();
+                debug!("Adding child {} to nexus {} ...", args.uri, uuid);
+                let nexus = nexus_add_child(args).await?;
+                info!("Added child to nexus {}", uuid);
+                Ok(nexus)
+            })?;
+
+            rx.await
+                .map_err(|_| Status::cancelled("cancelled"))?
+                .map_err(Status::from)
+                .map(|nexus| {
+                    Response::new(AddChildNexusResponse {
+                        nexus: Some(nexus),
+                    })
                 })
-            })
+        })
+        .await
     }
 
+    #[named]
     async fn remove_child_nexus(
         &self,
         request: Request<RemoveChildNexusRequest>,
     ) -> GrpcResult<RemoveChildNexusResponse> {
-        let rx = rpc_submit::<_, _, nexus::Error>(async move {
-            let args = request.into_inner();
-            trace!("{:?}", args);
-            let uuid = args.uuid.clone();
-            debug!("Removing child {} from nexus {} ...", args.uri, uuid);
-            nexus_lookup(&args.uuid)?.remove_child(&args.uri).await?;
-            info!("Removed child from nexus {}", uuid);
-            Ok(nexus_lookup(&args.uuid)?.into_grpc().await)
-        })?;
+        let ctx = GrpcClientContext::new(&request, function_name!());
+        let args = request.into_inner();
 
-        rx.await
-            .map_err(|_| Status::cancelled("cancelled"))?
-            .map_err(Status::from)
-            .map(|nexus| {
-                Response::new(RemoveChildNexusResponse {
-                    nexus: Some(nexus),
+        self.serialized(ctx, args.uuid.clone(), false, async move {
+            let rx = rpc_submit::<_, _, nexus::Error>(async move {
+                trace!("{:?}", args);
+                let uuid = args.uuid.clone();
+                debug!("Removing child {} from nexus {} ...", args.uri, uuid);
+                nexus_lookup(&args.uuid)?.remove_child(&args.uri).await?;
+                info!("Removed child from nexus {}", uuid);
+                Ok(nexus_lookup(&args.uuid)?.into_grpc().await)
+            })?;
+
+            rx.await
+                .map_err(|_| Status::cancelled("cancelled"))?
+                .map_err(Status::from)
+                .map(|nexus| {
+                    Response::new(RemoveChildNexusResponse {
+                        nexus: Some(nexus),
+                    })
                 })
-            })
+        })
+        .await
     }
 
+    #[named]
     async fn fault_nexus_child(
         &self,
         request: Request<FaultNexusChildRequest>,
     ) -> GrpcResult<()> {
-        let rx = rpc_submit::<_, _, nexus::Error>(async move {
-            let args = request.into_inner();
-            trace!("{:?}", args);
-            let uuid = args.uuid.clone();
-            let uri = args.uri.clone();
-            debug!("Faulting child {} on nexus {}", uri, uuid);
-            nexus_lookup(&args.uuid)?
-                .fault_child(&args.uri, nexus::Reason::ByClient)
-                .await?;
-            info!("Faulted child {} on nexus {}", uri, uuid);
-            Ok(())
-        })?;
+        let ctx = GrpcClientContext::new(&request, function_name!());
+        let args = request.into_inner();
 
-        rx.await
-            .map_err(|_| Status::cancelled("cancelled"))?
-            .map_err(Status::from)
-            .map(Response::new)
+        self.serialized(ctx, args.uuid.clone(), false, async move {
+            let rx = rpc_submit::<_, _, nexus::Error>(async move {
+                trace!("{:?}", args);
+                let uuid = args.uuid.clone();
+                let uri = args.uri.clone();
+                debug!("Faulting child {} on nexus {}", uri, uuid);
+                nexus_lookup(&args.uuid)?
+                    .fault_child(&args.uri, nexus::Reason::ByClient)
+                    .await?;
+                info!("Faulted child {} on nexus {}", uri, uuid);
+                Ok(())
+            })?;
+
+            rx.await
+                .map_err(|_| Status::cancelled("cancelled"))?
+                .map_err(Status::from)
+                .map(Response::new)
+        })
+        .await
     }
 
+    #[named]
     async fn inject_nexus_fault(
         &self,
         request: Request<InjectNexusFaultRequest>,
     ) -> GrpcResult<()> {
-        let rx = rpc_submit::<_, _, nexus::Error>(async move {
-            let args = request.into_inner();
-            trace!("{:?}", args);
-            let uuid = args.uuid.clone();
-            let uri = args.uri.clone();
-            debug!("Injecting fault to nexus '{}': '{}'", uuid, uri);
-            nexus_lookup(&args.uuid)?
-                .inject_add_fault(&args.uri)
-                .await?;
-            info!("Injectinged fault to nexus '{}': '{}'", uuid, uri);
-            Ok(())
-        })?;
+        let ctx = GrpcClientContext::new(&request, function_name!());
+        let args = request.into_inner();
 
-        rx.await
-            .map_err(|_| Status::cancelled("cancelled"))?
-            .map_err(Status::from)
-            .map(Response::new)
+        self.serialized(ctx, args.uuid.clone(), false, async move {
+            let rx = rpc_submit::<_, _, nexus::Error>(async move {
+                trace!("{:?}", args);
+                let uuid = args.uuid.clone();
+                let uri = args.uri.clone();
+                debug!("Injecting fault to nexus '{}': '{}'", uuid, uri);
+                nexus_lookup(&args.uuid)?
+                    .inject_add_fault(&args.uri)
+                    .await?;
+                info!("Injectinged fault to nexus '{}': '{}'", uuid, uri);
+                Ok(())
+            })?;
+
+            rx.await
+                .map_err(|_| Status::cancelled("cancelled"))?
+                .map_err(Status::from)
+                .map(Response::new)
+        })
+        .await
     }
 
+    #[named]
     async fn remove_injected_nexus_fault(
         &self,
         request: Request<RemoveInjectedNexusFaultRequest>,
     ) -> GrpcResult<()> {
-        let rx = rpc_submit::<_, _, nexus::Error>(async move {
-            let args = request.into_inner();
-            trace!("{:?}", args);
-            let uuid = args.uuid.clone();
-            let uri = args.uri.clone();
-            debug!("Removing injected fault to nexus '{}': '{}'", uuid, uri);
-            nexus_lookup(&args.uuid)?
-                .inject_remove_fault(&args.uri)
-                .await?;
-            info!("Removed injected fault to nexus '{}': '{}'", uuid, uri);
-            Ok(())
-        })?;
+        let ctx = GrpcClientContext::new(&request, function_name!());
+        let args = request.into_inner();
 
-        rx.await
-            .map_err(|_| Status::cancelled("cancelled"))?
-            .map_err(Status::from)
-            .map(Response::new)
+        self.serialized(ctx, args.uuid.clone(), false, async move {
+            let rx = rpc_submit::<_, _, nexus::Error>(async move {
+                trace!("{:?}", args);
+                let uuid = args.uuid.clone();
+                let uri = args.uri.clone();
+                debug!(
+                    "Removing injected fault to nexus '{}': '{}'",
+                    uuid, uri
+                );
+                nexus_lookup(&args.uuid)?
+                    .inject_remove_fault(&args.uri)
+                    .await?;
+                info!("Removed injected fault to nexus '{}': '{}'", uuid, uri);
+                Ok(())
+            })?;
+
+            rx.await
+                .map_err(|_| Status::cancelled("cancelled"))?
+                .map_err(Status::from)
+                .map(Response::new)
+        })
+        .await
     }
 
+    #[named]
     async fn list_injected_nexus_faults(
         &self,
         request: Request<ListInjectedNexusFaultsRequest>,
     ) -> GrpcResult<ListInjectedNexusFaultsReply> {
+        let ctx = GrpcClientContext::new(&request, function_name!());
         let args = request.into_inner();
         trace!("{:?}", args);
 
-        let rx = rpc_submit::<_, _, nexus::Error>(async move {
-            let res = nexus_lookup(&args.uuid)?
-                .list_injections()
-                .await?
-                .into_iter()
-                .map(|inj| InjectedFault {
-                    device_name: inj.device_name,
-                    is_active: inj.is_active,
+        self.serialized(ctx, args.uuid.clone(), false, async move {
+            let rx = rpc_submit::<_, _, nexus::Error>(async move {
+                let res = nexus_lookup(&args.uuid)?
+                    .list_injections()
+                    .await?
+                    .into_iter()
+                    .map(|inj| InjectedFault {
+                        device_name: inj.device_name,
+                        is_active: inj.is_active,
+                    })
+                    .collect();
+
+                Ok(ListInjectedNexusFaultsReply {
+                    injections: res,
                 })
-                .collect();
+            })?;
 
-            Ok(ListInjectedNexusFaultsReply {
-                injections: res,
-            })
-        })?;
-
-        rx.await
-            .map_err(|_| Status::cancelled("cancelled"))?
-            .map_err(Status::from)
-            .map(Response::new)
+            rx.await
+                .map_err(|_| Status::cancelled("cancelled"))?
+                .map_err(Status::from)
+                .map(Response::new)
+        })
+        .await
     }
 
+    #[named]
     async fn publish_nexus(
         &self,
         request: Request<PublishNexusRequest>,
     ) -> GrpcResult<PublishNexusResponse> {
-        let rx = rpc_submit::<_, _, nexus::Error>(async {
-            let args = request.into_inner();
-            trace!("{:?}", args);
-            let uuid = args.uuid.clone();
-            debug!("Publishing nexus {} ...", uuid);
+        let ctx = GrpcClientContext::new(&request, function_name!());
+        let args = request.into_inner();
 
-            if !args.key.is_empty() && args.key.len() != 16 {
-                return Err(nexus::Error::InvalidKey {});
-            }
+        self.serialized(ctx, args.uuid.clone(), false, async move {
+            let rx = rpc_submit::<_, _, nexus::Error>(async move {
+                trace!("{:?}", args);
+                let uuid = args.uuid.clone();
+                debug!("Publishing nexus {} ...", uuid);
 
-            let key: Option<String> = if args.key.is_empty() {
-                None
-            } else {
-                Some(args.key.clone())
-            };
+                if !args.key.is_empty() && args.key.len() != 16 {
+                    return Err(nexus::Error::InvalidKey {});
+                }
 
-            let share_protocol = match Protocol::try_from(args.share) {
-                Ok(protocol) => protocol,
-                Err(_) => {
+                let key: Option<String> = if args.key.is_empty() {
+                    None
+                } else {
+                    Some(args.key.clone())
+                };
+
+                let share_protocol = match Protocol::try_from(args.share) {
+                    Ok(protocol) => protocol,
+                    Err(_) => {
+                        return Err(nexus::Error::InvalidShareProtocol {
+                            sp_value: args.share as i32,
+                        });
+                    }
+                };
+
+                // error out if nbd or iscsi
+                if !matches!(share_protocol, Protocol::Off | Protocol::Nvmf) {
                     return Err(nexus::Error::InvalidShareProtocol {
                         sp_value: args.share as i32,
                     });
                 }
-            };
 
-            // error out if nbd or iscsi
-            if !matches!(share_protocol, Protocol::Off | Protocol::Nvmf) {
-                return Err(nexus::Error::InvalidShareProtocol {
-                    sp_value: args.share as i32,
-                });
-            }
+                let device_uri = nexus_lookup(&args.uuid)?
+                    .share(share_protocol, key)
+                    .await?;
 
-            let device_uri =
-                nexus_lookup(&args.uuid)?.share(share_protocol, key).await?;
+                info!("Published nexus {} under {}", uuid, device_uri);
 
-            info!("Published nexus {} under {}", uuid, device_uri);
+                let nexus = nexus_lookup(&args.uuid)?.into_grpc().await;
 
-            let nexus = nexus_lookup(&args.uuid)?.into_grpc().await;
-
-            Ok(PublishNexusResponse {
-                nexus: Some(nexus),
-            })
-        })?;
-        rx.await
-            .map_err(|_| Status::cancelled("cancelled"))?
-            .map_err(Status::from)
-            .map(Response::new)
+                Ok(PublishNexusResponse {
+                    nexus: Some(nexus),
+                })
+            })?;
+            rx.await
+                .map_err(|_| Status::cancelled("cancelled"))?
+                .map_err(Status::from)
+                .map(Response::new)
+        })
+        .await
     }
 
+    #[named]
     async fn unpublish_nexus(
         &self,
         request: Request<UnpublishNexusRequest>,
     ) -> GrpcResult<UnpublishNexusResponse> {
-        let rx = rpc_submit::<_, _, nexus::Error>(async {
-            let args = request.into_inner();
-            trace!("{:?}", args);
-            let uuid = args.uuid.clone();
-            debug!("Unpublishing nexus {} ...", uuid);
-            nexus_lookup(&args.uuid)?.unshare_nexus().await?;
-            info!("Unpublished nexus {}", uuid);
-            Ok(nexus_lookup(&args.uuid)?.into_grpc().await)
-        })?;
+        let ctx = GrpcClientContext::new(&request, function_name!());
+        let args = request.into_inner();
 
-        rx.await
-            .map_err(|_| Status::cancelled("cancelled"))?
-            .map_err(Status::from)
-            .map(|nexus| {
-                Response::new(UnpublishNexusResponse {
-                    nexus: Some(nexus),
+        self.serialized(ctx, args.uuid.clone(), false, async move {
+            let rx = rpc_submit::<_, _, nexus::Error>(async move {
+                trace!("{:?}", args);
+                let uuid = args.uuid.clone();
+                debug!("Unpublishing nexus {} ...", uuid);
+                nexus_lookup(&args.uuid)?.unshare_nexus().await?;
+                info!("Unpublished nexus {}", uuid);
+                Ok(nexus_lookup(&args.uuid)?.into_grpc().await)
+            })?;
+
+            rx.await
+                .map_err(|_| Status::cancelled("cancelled"))?
+                .map_err(Status::from)
+                .map(|nexus| {
+                    Response::new(UnpublishNexusResponse {
+                        nexus: Some(nexus),
+                    })
                 })
-            })
+        })
+        .await
     }
 
+    #[named]
     async fn get_nvme_ana_state(
         &self,
         request: Request<GetNvmeAnaStateRequest>,
     ) -> GrpcResult<GetNvmeAnaStateResponse> {
+        let ctx = GrpcClientContext::new(&request, function_name!());
         let args = request.into_inner();
-        let uuid = args.uuid.clone();
-        debug!("Getting NVMe ANA state for nexus {} ...", uuid);
 
-        let rx = rpc_submit::<_, _, nexus::Error>(async move {
-            let ana_state = nexus_lookup(&args.uuid)?.get_ana_state().await?;
-            info!("Got nexus {} NVMe ANA state {:?}", uuid, ana_state);
-            Ok(GetNvmeAnaStateResponse {
-                ana_state: ana_state as i32,
-            })
-        })?;
+        self.serialized(ctx, args.uuid.clone(), false, async move {
+            let uuid = args.uuid.clone();
+            debug!("Getting NVMe ANA state for nexus {} ...", uuid);
 
-        rx.await
-            .map_err(|_| Status::cancelled("cancelled"))?
-            .map_err(Status::from)
-            .map(Response::new)
+            let rx = rpc_submit::<_, _, nexus::Error>(async move {
+                let ana_state =
+                    nexus_lookup(&args.uuid)?.get_ana_state().await?;
+                info!("Got nexus {} NVMe ANA state {:?}", uuid, ana_state);
+                Ok(GetNvmeAnaStateResponse {
+                    ana_state: ana_state as i32,
+                })
+            })?;
+
+            rx.await
+                .map_err(|_| Status::cancelled("cancelled"))?
+                .map_err(Status::from)
+                .map(Response::new)
+        })
+        .await
     }
 
+    #[named]
     async fn set_nvme_ana_state(
         &self,
         request: Request<SetNvmeAnaStateRequest>,
     ) -> GrpcResult<SetNvmeAnaStateResponse> {
+        let ctx = GrpcClientContext::new(&request, function_name!());
         let args = request.into_inner();
-        let uuid = args.uuid.clone();
-        debug!("Setting NVMe ANA state for nexus {} ...", uuid);
 
-        let rx = rpc_submit::<_, _, nexus::Error>(async move {
-            let ana_state = nexus::NvmeAnaState::from_i32(args.ana_state)?;
+        self.serialized(ctx, args.uuid.clone(), false, async move {
+            let uuid = args.uuid.clone();
+            debug!("Setting NVMe ANA state for nexus {} ...", uuid);
 
-            let ana_state =
-                nexus_lookup(&args.uuid)?.set_ana_state(ana_state).await?;
-            info!("Set nexus {} NVMe ANA state {:?}", uuid, ana_state);
-            Ok(nexus_lookup(&args.uuid)?.into_grpc().await)
-        })?;
+            let rx = rpc_submit::<_, _, nexus::Error>(async move {
+                let ana_state = nexus::NvmeAnaState::from_i32(args.ana_state)?;
 
-        rx.await
-            .map_err(|_| Status::cancelled("cancelled"))?
-            .map_err(Status::from)
-            .map(|nexus| {
-                Response::new(SetNvmeAnaStateResponse {
-                    nexus: Some(nexus),
+                let ana_state =
+                    nexus_lookup(&args.uuid)?.set_ana_state(ana_state).await?;
+                info!("Set nexus {} NVMe ANA state {:?}", uuid, ana_state);
+                Ok(nexus_lookup(&args.uuid)?.into_grpc().await)
+            })?;
+
+            rx.await
+                .map_err(|_| Status::cancelled("cancelled"))?
+                .map_err(Status::from)
+                .map(|nexus| {
+                    Response::new(SetNvmeAnaStateResponse {
+                        nexus: Some(nexus),
+                    })
                 })
-            })
+        })
+        .await
     }
 
     #[named]
@@ -716,35 +799,33 @@ impl NexusRpc for NexusService {
         &self,
         request: Request<ChildOperationRequest>,
     ) -> GrpcResult<ChildOperationResponse> {
-        self.locked(
-            GrpcClientContext::new(&request, function_name!()),
-            async move {
-                let rx = rpc_submit::<_, _, nexus::Error>(async move {
-                    let args = request.into_inner();
-                    info!("{:?}", args);
+        let ctx = GrpcClientContext::new(&request, function_name!());
+        let args = request.into_inner();
 
-                    let mut nexus = nexus_lookup(&args.nexus_uuid)?;
+        self.serialized(ctx, args.nexus_uuid.clone(), false, async move {
+            let rx = rpc_submit::<_, _, nexus::Error>(async move {
+                info!("{:?}", args);
+                let mut nexus = nexus_lookup(&args.nexus_uuid)?;
 
-                    match args.action {
-                        0 => nexus.as_mut().offline_child(&args.uri).await,
-                        1 => nexus.as_mut().online_child(&args.uri).await,
-                        2 => nexus.as_mut().retire_child(&args.uri).await,
-                        _ => Err(nexus::Error::InvalidKey {}),
-                    }?;
+                match args.action {
+                    0 => nexus.as_mut().offline_child(&args.uri).await,
+                    1 => nexus.as_mut().online_child(&args.uri).await,
+                    2 => nexus.as_mut().retire_child(&args.uri).await,
+                    _ => Err(nexus::Error::InvalidKey {}),
+                }?;
 
-                    Ok(nexus.into_grpc().await)
-                })?;
+                Ok(nexus.into_grpc().await)
+            })?;
 
-                rx.await
-                    .map_err(|_| Status::cancelled("cancelled"))?
-                    .map_err(Status::from)
-                    .map(|n| {
-                        Response::new(ChildOperationResponse {
-                            nexus: Some(n),
-                        })
+            rx.await
+                .map_err(|_| Status::cancelled("cancelled"))?
+                .map_err(Status::from)
+                .map(|n| {
+                    Response::new(ChildOperationResponse {
+                        nexus: Some(n),
                     })
-            },
-        )
+                })
+        })
         .await
     }
 
@@ -753,30 +834,29 @@ impl NexusRpc for NexusService {
         &self,
         request: Request<StartRebuildRequest>,
     ) -> GrpcResult<StartRebuildResponse> {
-        self.locked(
-            GrpcClientContext::new(&request, function_name!()),
-            async move {
-                let args = request.into_inner();
-                info!("{:?}", args);
-                let rx = rpc_submit::<_, _, nexus::Error>(async move {
-                    nexus_lookup(&args.nexus_uuid)?
-                        .start_rebuild(&args.uri)
-                        .await
-                        // todo
-                        .map(|_| {})?;
-                    Ok(nexus_lookup(&args.nexus_uuid)?.into_grpc().await)
-                })?;
+        let ctx = GrpcClientContext::new(&request, function_name!());
+        let args = request.into_inner();
 
-                rx.await
-                    .map_err(|_| Status::cancelled("cancelled"))?
-                    .map_err(Status::from)
-                    .map(|n| {
-                        Response::new(StartRebuildResponse {
-                            nexus: Some(n),
-                        })
+        self.serialized(ctx, args.nexus_uuid.clone(), false, async move {
+            info!("{:?}", args);
+            let rx = rpc_submit::<_, _, nexus::Error>(async move {
+                nexus_lookup(&args.nexus_uuid)?
+                    .start_rebuild(&args.uri)
+                    .await
+                    // todo
+                    .map(|_| {})?;
+                Ok(nexus_lookup(&args.nexus_uuid)?.into_grpc().await)
+            })?;
+
+            rx.await
+                .map_err(|_| Status::cancelled("cancelled"))?
+                .map_err(Status::from)
+                .map(|n| {
+                    Response::new(StartRebuildResponse {
+                        nexus: Some(n),
                     })
-            },
-        )
+                })
+        })
         .await
     }
 
@@ -785,29 +865,28 @@ impl NexusRpc for NexusService {
         &self,
         request: Request<StopRebuildRequest>,
     ) -> GrpcResult<StopRebuildResponse> {
-        self.locked(
-            GrpcClientContext::new(&request, function_name!()),
-            async move {
-                let args = request.into_inner();
-                info!("{:?}", args);
-                let rx = rpc_submit::<_, _, nexus::Error>(async move {
-                    nexus_lookup(&args.nexus_uuid)?
-                        .stop_rebuild(&args.uri)
-                        .await?;
+        let ctx = GrpcClientContext::new(&request, function_name!());
+        let args = request.into_inner();
 
-                    Ok(nexus_lookup(&args.nexus_uuid)?.into_grpc().await)
-                })?;
+        self.serialized(ctx, args.nexus_uuid.clone(), false, async move {
+            info!("{:?}", args);
+            let rx = rpc_submit::<_, _, nexus::Error>(async move {
+                nexus_lookup(&args.nexus_uuid)?
+                    .stop_rebuild(&args.uri)
+                    .await?;
 
-                rx.await
-                    .map_err(|_| Status::cancelled("cancelled"))?
-                    .map_err(Status::from)
-                    .map(|n| {
-                        Response::new(StopRebuildResponse {
-                            nexus: Some(n),
-                        })
+                Ok(nexus_lookup(&args.nexus_uuid)?.into_grpc().await)
+            })?;
+
+            rx.await
+                .map_err(|_| Status::cancelled("cancelled"))?
+                .map_err(Status::from)
+                .map(|n| {
+                    Response::new(StopRebuildResponse {
+                        nexus: Some(n),
                     })
-            },
-        )
+                })
+        })
         .await
     }
 
@@ -816,29 +895,28 @@ impl NexusRpc for NexusService {
         &self,
         request: Request<PauseRebuildRequest>,
     ) -> GrpcResult<PauseRebuildResponse> {
-        self.locked(
-            GrpcClientContext::new(&request, function_name!()),
-            async move {
-                let args = request.into_inner();
-                info!("{:?}", args);
-                let rx = rpc_submit::<_, _, nexus::Error>(async move {
-                    nexus_lookup(&args.nexus_uuid)?
-                        .pause_rebuild(&args.uri)
-                        .await?;
+        let ctx = GrpcClientContext::new(&request, function_name!());
+        let args = request.into_inner();
 
-                    Ok(nexus_lookup(&args.nexus_uuid)?.into_grpc().await)
-                })?;
+        self.serialized(ctx, args.nexus_uuid.clone(), false, async move {
+            info!("{:?}", args);
+            let rx = rpc_submit::<_, _, nexus::Error>(async move {
+                nexus_lookup(&args.nexus_uuid)?
+                    .pause_rebuild(&args.uri)
+                    .await?;
 
-                rx.await
-                    .map_err(|_| Status::cancelled("cancelled"))?
-                    .map_err(Status::from)
-                    .map(|n| {
-                        Response::new(PauseRebuildResponse {
-                            nexus: Some(n),
-                        })
+                Ok(nexus_lookup(&args.nexus_uuid)?.into_grpc().await)
+            })?;
+
+            rx.await
+                .map_err(|_| Status::cancelled("cancelled"))?
+                .map_err(Status::from)
+                .map(|n| {
+                    Response::new(PauseRebuildResponse {
+                        nexus: Some(n),
                     })
-            },
-        )
+                })
+        })
         .await
     }
 
@@ -847,28 +925,27 @@ impl NexusRpc for NexusService {
         &self,
         request: Request<ResumeRebuildRequest>,
     ) -> GrpcResult<ResumeRebuildResponse> {
-        self.locked(
-            GrpcClientContext::new(&request, function_name!()),
-            async move {
-                let args = request.into_inner();
-                info!("{:?}", args);
-                let rx = rpc_submit::<_, _, nexus::Error>(async move {
-                    nexus_lookup(&args.nexus_uuid)?
-                        .resume_rebuild(&args.uri)
-                        .await?;
-                    Ok(nexus_lookup(&args.nexus_uuid)?.into_grpc().await)
-                })?;
+        let ctx = GrpcClientContext::new(&request, function_name!());
+        let args = request.into_inner();
 
-                rx.await
-                    .map_err(|_| Status::cancelled("cancelled"))?
-                    .map_err(Status::from)
-                    .map(|n| {
-                        Response::new(ResumeRebuildResponse {
-                            nexus: Some(n),
-                        })
+        self.serialized(ctx, args.nexus_uuid.clone(), false, async move {
+            info!("{:?}", args);
+            let rx = rpc_submit::<_, _, nexus::Error>(async move {
+                nexus_lookup(&args.nexus_uuid)?
+                    .resume_rebuild(&args.uri)
+                    .await?;
+                Ok(nexus_lookup(&args.nexus_uuid)?.into_grpc().await)
+            })?;
+
+            rx.await
+                .map_err(|_| Status::cancelled("cancelled"))?
+                .map_err(Status::from)
+                .map(|n| {
+                    Response::new(ResumeRebuildResponse {
+                        nexus: Some(n),
                     })
-            },
-        )
+                })
+        })
         .await
     }
 
@@ -877,24 +954,23 @@ impl NexusRpc for NexusService {
         &self,
         request: Request<RebuildStateRequest>,
     ) -> GrpcResult<RebuildStateResponse> {
-        self.locked(
-            GrpcClientContext::new(&request, function_name!()),
-            async move {
-                let args = request.into_inner();
-                info!("{:?}", args);
-                let rx = rpc_submit::<_, _, nexus::Error>(async move {
-                    nexus_lookup(&args.nexus_uuid)?
-                        .rebuild_state(&args.uri)
-                        .await
-                        .map(RebuildStateResponse::from)
-                })?;
+        let ctx = GrpcClientContext::new(&request, function_name!());
+        let args = request.into_inner();
 
-                rx.await
-                    .map_err(|_| Status::cancelled("cancelled"))?
-                    .map_err(Status::from)
-                    .map(Response::new)
-            },
-        )
+        self.serialized(ctx, args.nexus_uuid.clone(), false, async move {
+            info!("{:?}", args);
+            let rx = rpc_submit::<_, _, nexus::Error>(async move {
+                nexus_lookup(&args.nexus_uuid)?
+                    .rebuild_state(&args.uri)
+                    .await
+                    .map(RebuildStateResponse::from)
+            })?;
+
+            rx.await
+                .map_err(|_| Status::cancelled("cancelled"))?
+                .map_err(Status::from)
+                .map(Response::new)
+        })
         .await
     }
 
@@ -903,23 +979,22 @@ impl NexusRpc for NexusService {
         &self,
         request: Request<RebuildStatsRequest>,
     ) -> GrpcResult<RebuildStatsResponse> {
-        self.locked(
-            GrpcClientContext::new(&request, function_name!()),
-            async move {
-                let args = request.into_inner();
-                info!("{:?}", args);
-                let rx = rpc_submit::<_, _, nexus::Error>(async move {
-                    nexus_lookup(&args.nexus_uuid)?
-                        .rebuild_stats(&args.uri)
-                        .await
-                        .map(RebuildStatsResponse::from)
-                })?;
-                rx.await
-                    .map_err(|_| Status::cancelled("cancelled"))?
-                    .map_err(Status::from)
-                    .map(Response::new)
-            },
-        )
+        let ctx = GrpcClientContext::new(&request, function_name!());
+        let args = request.into_inner();
+
+        self.serialized(ctx, args.nexus_uuid.clone(), false, async move {
+            info!("{:?}", args);
+            let rx = rpc_submit::<_, _, nexus::Error>(async move {
+                nexus_lookup(&args.nexus_uuid)?
+                    .rebuild_stats(&args.uri)
+                    .await
+                    .map(RebuildStatsResponse::from)
+            })?;
+            rx.await
+                .map_err(|_| Status::cancelled("cancelled"))?
+                .map_err(Status::from)
+                .map(Response::new)
+        })
         .await
     }
 }

--- a/io-engine/tests/lock.rs
+++ b/io-engine/tests/lock.rs
@@ -1,0 +1,199 @@
+use io_engine::core::lock::{ResourceLockManager, ResourceLockManagerConfig};
+use once_cell::sync::Lazy;
+use std::sync::atomic::{AtomicU64, Ordering};
+use tokio::{
+    sync::oneshot,
+    time::{sleep, Duration},
+};
+
+#[derive(Copy, Clone)]
+enum LockLevel {
+    Global,
+    Subsystem,
+    Resource,
+}
+
+const TEST_SUBSYSTEM: &str = "items";
+const TEST_RESOURCE: &str = "item1";
+
+fn get_lock_manager() -> &'static ResourceLockManager {
+    let cfg =
+        ResourceLockManagerConfig::default().with_subsystem(TEST_SUBSYSTEM, 8);
+    ResourceLockManager::initialize(cfg);
+    ResourceLockManager::get_instance()
+}
+
+// Helper function to test all possible lock levels from 2 tasks
+// that try to simultaneously acquire the same locks.
+async fn test_lock_level(level: LockLevel) {
+    static STEP_COUNT: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+
+    let (tx, rx) = oneshot::channel();
+
+    STEP_COUNT.store(0, Ordering::Relaxed);
+
+    // Task that owns the lock.
+    let h1 = tokio::spawn(async move {
+        let lock_mgr = get_lock_manager();
+
+        // Step 1: acquire lock.
+        let guard = match level {
+            LockLevel::Global => lock_mgr.lock(None).await,
+            LockLevel::Subsystem => {
+                lock_mgr.get_subsystem(TEST_SUBSYSTEM).lock(None).await
+            }
+            LockLevel::Resource => {
+                lock_mgr
+                    .get_subsystem(TEST_SUBSYSTEM)
+                    .lock_resource(TEST_RESOURCE, None)
+                    .await
+            }
+        };
+        assert!(guard.is_some(), "Failed to acquire the lock");
+
+        // Notify that the lock is acquired.
+        tx.send(0).expect("Failed to notify the peer ");
+
+        // Sleep to let the other part of test execute.
+        // Note: the lock is held so the other task must wait.
+        sleep(Duration::from_millis(500)).await;
+
+        // Check that the counter remains unchanged since we're still holding
+        // the lock.
+        assert_eq!(
+            STEP_COUNT.load(Ordering::Relaxed),
+            0,
+            "Protected resource accessed by the other task"
+        );
+
+        // Lock will be automatically released here when lock guard leaves the
+        // scope.
+    });
+
+    // Task that triggers lock contention.
+    let h2 = tokio::spawn(async move {
+        let lock_mgr = get_lock_manager();
+
+        // Wait till the lock is acquired.
+        rx.await
+            .expect("Failed to receive notification that the lock is acquired");
+
+        // Try to grab the lock - we must wait, since the lock is already
+        // acquired.
+        let guard = match level {
+            LockLevel::Global => lock_mgr.lock(None).await,
+            LockLevel::Subsystem => {
+                lock_mgr.get_subsystem(TEST_SUBSYSTEM).lock(None).await
+            }
+            LockLevel::Resource => {
+                lock_mgr
+                    .get_subsystem(TEST_SUBSYSTEM)
+                    .lock_resource(TEST_RESOURCE, None)
+                    .await
+            }
+        };
+        assert!(guard.is_some(), "Failed to acquire the lock");
+
+        // Adjust the counter to denote that lock is acquired.
+        STEP_COUNT.fetch_add(1, Ordering::SeqCst);
+    });
+
+    h1.await.expect("Test task panicked");
+    h2.await.expect("Test task panicked");
+}
+
+// Helper function to test all possible lock levels from 2 tasks
+// that try to simultaneously acquire the same locks.
+async fn test_lock_timed_level(level: LockLevel) {
+    let (tx, rx) = oneshot::channel();
+
+    // Task that owns the lock.
+    let h1 = tokio::spawn(async move {
+        let lock_mgr = get_lock_manager();
+
+        // Step 1: acquire lock.
+        let guard = match level {
+            LockLevel::Global => lock_mgr.lock(None).await,
+            LockLevel::Subsystem => {
+                lock_mgr.get_subsystem(TEST_SUBSYSTEM).lock(None).await
+            }
+            LockLevel::Resource => {
+                lock_mgr
+                    .get_subsystem(TEST_SUBSYSTEM)
+                    .lock_resource(TEST_RESOURCE, None)
+                    .await
+            }
+        };
+        assert!(guard.is_some(), "Failed to acquire the lock");
+
+        // Notify that the lock is acquired.
+        tx.send(0).expect("Failed to notify the peer ");
+
+        // Sleep to let the other part of test execute.
+        // Note: the lock is held so the other task must timeout.
+        sleep(Duration::from_secs(2)).await;
+    });
+
+    // Task that tries to acquire the lock with a timeout lesser
+    // than the time the lock is held.
+    let h2 = tokio::spawn(async move {
+        let lock_mgr = get_lock_manager();
+
+        // Wait till the lock is acquired.
+        rx.await
+            .expect("Failed to receive notification that the lock is acquired");
+
+        let duration = Some(std::time::Duration::from_secs(1));
+        // Try to grab the lock - we must wait, since the lock is already
+        // acquired.
+        let guard = match level {
+            LockLevel::Global => lock_mgr.lock(duration).await,
+            LockLevel::Subsystem => {
+                lock_mgr.get_subsystem(TEST_SUBSYSTEM).lock(duration).await
+            }
+            LockLevel::Resource => {
+                lock_mgr
+                    .get_subsystem(TEST_SUBSYSTEM)
+                    .lock_resource(TEST_RESOURCE, duration)
+                    .await
+            }
+        };
+        assert!(
+            guard.is_none(),
+            "Successfully acquired the lock within timeout"
+        );
+    });
+
+    h1.await.expect("Test task panicked");
+    h2.await.expect("Test task panicked");
+}
+
+#[tokio::test]
+async fn test_lock_global() {
+    test_lock_level(LockLevel::Global).await
+}
+
+#[tokio::test]
+async fn test_lock_subsystem() {
+    test_lock_level(LockLevel::Subsystem).await
+}
+
+#[tokio::test]
+async fn test_lock_resource() {
+    test_lock_level(LockLevel::Resource).await
+}
+
+#[tokio::test]
+async fn test_lock_timed_global() {
+    test_lock_timed_level(LockLevel::Global).await
+}
+
+#[tokio::test]
+async fn test_lock_timed_subsystem() {
+    test_lock_timed_level(LockLevel::Subsystem).await
+}
+
+#[tokio::test]
+async fn test_lock_timed_resource() {
+    test_lock_timed_level(LockLevel::Resource).await
+}


### PR DESCRIPTION
    feat(grpc): per nexus instance locks in grpc api
    
    Nexus gRPC API is now protected on per-nexus basis instead of
    global API serialisation, which provides better scalability.
    
    Generic lock manager implemented to provide common API for
    protecting sensitive resources.
    
    Signed-off-by: Mikhail Tcymbaliuk <mtzaurus@gmail.com>