### PR TITLE
feat(nexus): nexus self shutdown

### DIFF
--- a/io-engine/src/bdev/nexus/nexus_bdev.rs
+++ b/io-engine/src/bdev/nexus/nexus_bdev.rs
@@ -13,6 +13,7 @@ use std::{
     pin::Pin,
 };
 
+use crossbeam::atomic::AtomicCell;
 use futures::channel::oneshot;
 use serde::Serialize;
 use snafu::ResultExt;
@@ -263,6 +264,8 @@ pub struct Nexus<'n> {
     /// TODO
     #[allow(dead_code)]
     pub(super) injections: Injections,
+    /// Flag to control shutdown from I/O path.
+    pub(crate) shutdown_requested: AtomicCell<bool>,
     /// Prevent auto-Unpin.
     _pin: PhantomPinned,
 }
@@ -368,6 +371,7 @@ impl<'n> Nexus<'n> {
             nexus_uuid: Default::default(),
             event_sink: None,
             injections: Injections::new(),
+            shutdown_requested: AtomicCell::new(false),
             _pin: Default::default(),
         };
 

--- a/io-engine/src/bdev/nexus/nexus_bdev_children.rs
+++ b/io-engine/src/bdev/nexus/nexus_bdev_children.rs
@@ -933,7 +933,7 @@ impl<'n> Nexus<'n> {
     }
 
     // TODO
-    async fn disconnect_all_channels(
+    pub(crate) async fn disconnect_all_channels(
         &self,
         child_device: String,
     ) -> Result<(), Error> {


### PR DESCRIPTION
Nexus is now automatically shutdown in response to reservation conflicts observed on one of its replicas. This is required to tolerate network partition of source node when switching nexus over.

Signed-off-by: Mikhail Tcymbaliuk <mtzaurus@gmail.com>