### PR TITLE
fix(csi-node): don't unstage if bind mount exists

### DIFF
--- a/ci.nix
+++ b/ci.nix
@@ -3,7 +3,7 @@ let
   sources = import ./nix/sources.nix;
   pkgs = import sources.nixpkgs {
     overlays =
-      [ (_: _: { inherit sources; }) (import ./nix/mayastor-overlay.nix) ];
+      [ (_: _: { inherit sources; }) (import ./nix/mayastor-overlay.nix { }) ];
   };
 in
 with pkgs;

--- a/csi/src/mount.rs
+++ b/csi/src/mount.rs
@@ -54,6 +54,25 @@ pub fn find_mount(
     found.map(MountInfo::from)
 }
 
+/// Return all mounts for a matching source.
+/// Optionally ignore the given destination path.
+pub(crate) fn find_src_mounts(
+    source: &str,
+    dest_ignore: Option<&str>,
+) -> Vec<MountInfo> {
+    MountIter::new()
+        .unwrap()
+        .flatten()
+        .filter(|mount| {
+            mount.source.to_string_lossy() == source
+                && match dest_ignore {
+                    None => true,
+                    Some(ignore) => ignore != mount.dest.to_string_lossy(),
+                }
+        })
+        .collect()
+}
+
 /// Check if options in "first" are also present in "second",
 /// but exclude values "ro" and "rw" from the comparison.
 pub(super) fn subset(first: &[String], second: &[String]) -> bool {

--- a/default.nix
+++ b/default.nix
@@ -1,5 +1,5 @@
-{
-    crossSystem ? null
+{ crossSystem ? null
+, img_tag ? ""
 }:
 
 let
@@ -7,7 +7,7 @@ let
   pkgs = import sources.nixpkgs {
     overlays = [
       (_: _: { inherit sources; })
-      (import ./nix/mayastor-overlay.nix)
+      (import ./nix/mayastor-overlay.nix { inherit img_tag; })
     ];
     inherit crossSystem;
   };

--- a/nix/mayastor-overlay.nix
+++ b/nix/mayastor-overlay.nix
@@ -1,7 +1,7 @@
+{ img_tag ? "" }:
 self: super: {
-
   fio = super.callPackage ./pkgs/fio { };
-  images = super.callPackage ./pkgs/images { };
+  images = super.callPackage ./pkgs/images { inherit img_tag; };
   libnvme = super.callPackage ./pkgs/libnvme { };
   libspdk = (super.callPackage ./pkgs/libspdk { }).release;
   libspdk-dev = (super.callPackage ./pkgs/libspdk { }).debug;

--- a/nix/pkgs/images/default.nix
+++ b/nix/pkgs/images/default.nix
@@ -17,10 +17,11 @@
 , utillinux
 , writeScriptBin
 , xfsprogs
+, img_tag ? ""
 }:
 let
   versionDrv = import ../../lib/version.nix { inherit lib stdenv git; };
-  version = builtins.readFile "${versionDrv}";
+  version = if lib.stringLength img_tag == 0 then builtins.readFile "${versionDrv}" else img_tag;
   path = lib.makeBinPath [ "/" busybox xfsprogs e2fsprogs utillinux ];
 
   # common props for all mayastor images

--- a/shell.nix
+++ b/shell.nix
@@ -3,7 +3,7 @@ let
   sources = import ./nix/sources.nix;
   pkgs = import sources.nixpkgs {
     overlays =
-      [ (_: _: { inherit sources; }) (import ./nix/mayastor-overlay.nix) ];
+      [ (_: _: { inherit sources; }) (import ./nix/mayastor-overlay.nix { }) ];
   };
 in
 with pkgs;


### PR DESCRIPTION
If an application creates a bind mount for our volume unstaging can be very troublesome as it
leaves the mount in a really bad state.
Even if we reconnect the device, it's very unlikely things won't recover.

This commit adds a check on node_unstage for unknown mounts (as in, not a csi publish mount).
Should there be any we output this as a trace and simply fail the unstage.
It's up to the user to clean up non-csi mounts, otherwise we can never unstage.

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>