### PR TITLE
fix(nexus): relaxed error unwraps in nexus destroy

### DIFF
--- a/io-engine/src/bdev/nexus/nexus_bdev.rs
+++ b/io-engine/src/bdev/nexus/nexus_bdev.rs
@@ -540,7 +540,7 @@ impl<'n> Nexus<'n> {
     pub async fn destroy(mut self: Pin<&mut Self>) -> Result<(), Error> {
         info!("{:?}: destroying nexus...", self);
 
-        self.as_mut().destroy_shares().await;
+        self.as_mut().destroy_shares().await?;
 
         // wait for all rebuild jobs to be cancelled before proceeding with the
         // destruction of the nexus

--- a/io-engine/src/bdev/nexus/nexus_share.rs
+++ b/io-engine/src/bdev/nexus/nexus_share.rs
@@ -160,13 +160,15 @@ impl<'n> Nexus<'n> {
     }
 
     /// Shutdowns all shares.
-    pub(crate) async fn destroy_shares(mut self: Pin<&mut Self>) {
+    pub(crate) async fn destroy_shares(
+        mut self: Pin<&mut Self>,
+    ) -> Result<(), Error> {
         let _ = self.as_mut().unshare_nexus().await;
         assert_eq!(self.share_handle, None);
 
         // no-op when not shared and will be removed once the old share bits are
-        // gone
-        self.as_mut().unshare().await.unwrap();
+        // gone. Ignore device name provided in case of successful unsharing.
+        self.as_mut().unshare().await.map(|_| ())
     }
 
     /// TODO


### PR DESCRIPTION
This fix eliminates a panic which happens upon unconditional unwrap of the result of NVMe subsystem unsharing, which is done as part of the nexus destroy logic.
Now all errors that occur upon NVMe subsystem shutdown will be propagated to the caller of the Nexus destroy() function.

Signed-off-by: Mikhail Tcymbaliuk <mtzaurus@gmail.com>