### PR TITLE
fix: remove host path from csi daemonset

### DIFF
--- a/chart/templates/csi-daemonset.yaml
+++ b/chart/templates/csi-daemonset.yaml
@@ -62,8 +62,6 @@ spec:
           mountPath: /sys
         - name: run-udev
           mountPath: /run/udev
-        - name: host-root
-          mountPath: /host
         - name: plugin-dir
           mountPath: /csi
         - name: kubelet-dir
@@ -110,10 +108,6 @@ spec:
       - name: run-udev
         hostPath:
           path: /run/udev
-          type: Directory
-      - name: host-root
-        hostPath:
-          path: /
           type: Directory
       - name: registration-dir
         hostPath:

--- a/deploy/csi-daemonset.yaml
+++ b/deploy/csi-daemonset.yaml
@@ -62,8 +62,6 @@ spec:
           mountPath: /sys
         - name: run-udev
           mountPath: /run/udev
-        - name: host-root
-          mountPath: /host
         - name: plugin-dir
           mountPath: /csi
         - name: kubelet-dir
@@ -110,10 +108,6 @@ spec:
       - name: run-udev
         hostPath:
           path: /run/udev
-          type: Directory
-      - name: host-root
-        hostPath:
-          path: /
           type: Directory
       - name: registration-dir
         hostPath:


### PR DESCRIPTION
This interferes with the "unknown" mount finder and we no longer need the host path anyway. todo: wa this even when such a thing happens

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>