### PR TITLE
fix(nvmx): reentrant controller event notification

### DIFF
--- a/io-engine/src/bdev/nexus/nexus_bdev.rs
+++ b/io-engine/src/bdev/nexus/nexus_bdev.rs
@@ -605,6 +605,7 @@ impl<'n> Nexus<'n> {
         if self.children().is_empty() {
             return Err(Error::NexusIncomplete {
                 name,
+                reason: "No child devices".to_string(),
             });
         }
 
@@ -619,6 +620,10 @@ impl<'n> Nexus<'n> {
                 Err(_) => {
                     return Err(Error::NexusIncomplete {
                         name,
+                        reason: format!(
+                            "No block device available for child {}",
+                            child.uri(),
+                        ),
                     })
                 }
             };

--- a/io-engine/src/bdev/nexus/nexus_bdev.rs
+++ b/io-engine/src/bdev/nexus/nexus_bdev.rs
@@ -5,6 +5,7 @@
 //! application needs synchronous mirroring may be required.
 
 use std::{
+    cmp::min,
     convert::TryFrom,
     fmt::{Debug, Display, Formatter},
     marker::PhantomPinned,
@@ -38,6 +39,7 @@ use crate::{
         nexus::{nexus_persistence::PersistentNexusInfo, NexusIoSubsystem},
     },
     core::{
+        partition,
         Bdev,
         BdevHandle,
         CoreError,
@@ -594,6 +596,80 @@ impl<'n> Nexus<'n> {
         );
     }
 
+    /// Configure nexus's block device to match parameters of the child devices.
+    async fn setup_nexus_bdev(mut self: Pin<&mut Self>) -> Result<(), Error> {
+        info!("{:?}: opening nexus children...", self);
+
+        let name = self.name.clone();
+
+        if self.children().is_empty() {
+            return Err(Error::NexusIncomplete {
+                name,
+            });
+        }
+
+        // Determine Nexus block size and data start and end offsets.
+        let mut start_blk = 0;
+        let mut end_blk = 0;
+        let mut blk_size = 0;
+
+        for child in self.children_iter() {
+            let dev = match child.get_device() {
+                Ok(dev) => dev,
+                Err(_) => {
+                    return Err(Error::NexusIncomplete {
+                        name,
+                    })
+                }
+            };
+
+            let nb = dev.num_blocks();
+            let bs = dev.block_len();
+
+            if blk_size == 0 {
+                blk_size = bs;
+            } else if bs != blk_size {
+                return Err(Error::MixedBlockSizes {
+                    name: self.name.clone(),
+                });
+            }
+
+            match partition::calc_data_partition(self.req_size(), nb, bs) {
+                Some((start, end)) => {
+                    if start_blk == 0 {
+                        start_blk = start;
+                        end_blk = end;
+                    } else {
+                        end_blk = min(end_blk, end);
+
+                        if start_blk != start {
+                            return Err(Error::ChildGeometry {
+                                child: child.uri().to_owned(),
+                                name,
+                            });
+                        }
+                    }
+                }
+                None => {
+                    return Err(Error::ChildTooSmall {
+                        child: child.uri().to_owned(),
+                        name,
+                        num_blocks: nb,
+                        block_size: bs,
+                    })
+                }
+            }
+        }
+
+        unsafe {
+            self.as_mut().set_data_ent_offset(start_blk);
+            self.as_mut().set_block_len(blk_size as u32);
+            self.as_mut().set_num_blocks(end_blk - start_blk);
+        }
+
+        Ok(())
+    }
+
     /// Opens the Nexus instance for IO.
     /// Once this function is called, the device is visible and can
     /// be used for IO.
@@ -605,7 +681,7 @@ impl<'n> Nexus<'n> {
 
         info!("{:?}: registering nexus bdev...", nex);
 
-        nex.as_mut().try_open_children().await?;
+        nex.as_mut().setup_nexus_bdev().await?;
 
         // Register the bdev with SPDK and set the callbacks for io channel
         // creation.
@@ -613,40 +689,38 @@ impl<'n> Nexus<'n> {
 
         info!("{:?}: IO device registered", nex);
 
-        match bdev.register_bdev() {
+        if let Err(err) = bdev.register_bdev() {
+            error!(
+                "{:?}: nexus bdev registration failed: {}",
+                nex,
+                err.verbose()
+            );
+            return Err(err).context(nexus_err::RegisterNexus {
+                name: nex.name.clone(),
+            });
+        }
+
+        unsafe { nex.as_mut().unpin_mut().has_io_device = true };
+
+        match nex.as_mut().try_open_children().await {
             Ok(_) => {
-                // Persist the fact that the nexus is now successfully open.
-                // We have to do this before setting the nexus to open so that
-                // nexus list does not return this nexus until it is persisted.
-                nex.persist(PersistOp::Create).await;
-                nex.as_mut().set_state(NexusState::Open);
-                unsafe { nex.as_mut().unpin_mut().has_io_device = true };
-                info!("{:?}: nexus bdev registered successfully", nex);
-                Ok(())
+                info!("{:?}: children opened successfully", nex);
             }
             Err(err) => {
-                error!(
-                    "{:?}: nexus bdev registration failed: {}",
-                    nex,
-                    err.verbose()
-                );
-                unsafe {
-                    for child in nex.as_mut().children_iter_mut() {
-                        if let Err(e) = child.close().await {
-                            error!(
-                                "{:?}: child failed to close: {}",
-                                child,
-                                e.verbose()
-                            );
-                        }
-                    }
-                }
-                nex.as_mut().set_state(NexusState::Closed);
-                Err(err).context(nexus_err::RegisterNexus {
-                    name: nex.name.clone(),
-                })
+                error!("{:?} failed to open children: {}", nex, err.verbose());
+                bdev.unregister_bdev();
+                return Err(err);
             }
-        }
+        };
+
+        // Persist the fact that the nexus is now successfully open.
+        // We have to do this before setting the nexus to open so that
+        // nexus list does not return this nexus until it is persisted.
+        nex.persist(PersistOp::Create).await;
+        nex.as_mut().set_state(NexusState::Open);
+        info!("{:?}: nexus bdev registered successfully", nex);
+
+        Ok(())
     }
 
     /// Destroy the Nexus.

--- a/io-engine/src/bdev/nvmx/controller.rs
+++ b/io-engine/src/bdev/nvmx/controller.rs
@@ -1,13 +1,7 @@
 //!
 //!
 //! This file contains the main structures for a NVMe controller
-use std::{
-    convert::From,
-    fmt,
-    os::raw::c_void,
-    ptr::NonNull,
-    sync::{Arc, Mutex},
-};
+use std::{convert::From, fmt, os::raw::c_void, ptr::NonNull, sync::Arc};
 
 use futures::channel::oneshot;
 use merge::Merge;
@@ -127,7 +121,7 @@ pub struct NvmeController<'a> {
     prchk_flags: u32,
     inner: Option<NvmeControllerInner<'a>>,
     state_machine: ControllerStateMachine,
-    event_dispatcher: Mutex<DeviceEventDispatcher>,
+    event_dispatcher: DeviceEventDispatcher,
     /// Timeout config is accessed by SPDK-driven timeout callback handlers,
     /// so it needs to be a raw pointer. Mutable members are made atomic to
     /// eliminate lock contention between API path and callback path.
@@ -156,7 +150,7 @@ impl<'a> NvmeController<'a> {
             prchk_flags,
             state_machine: ControllerStateMachine::new(name),
             inner: None,
-            event_dispatcher: Mutex::new(DeviceEventDispatcher::new()),
+            event_dispatcher: DeviceEventDispatcher::new(),
             timeout_config: NonNull::new(Box::into_raw(Box::new(
                 TimeoutConfig::new(name),
             )))
@@ -705,14 +699,8 @@ impl<'a> NvmeController<'a> {
     ///
     /// Note: Keep a separate copy of all registered listeners in order to not
     /// invoke them with the lock held.
-    fn notify_listeners(&self, event: DeviceEventType) -> usize {
-        let mut disp = self
-            .event_dispatcher
-            .lock()
-            .expect("event dispatcher lock poisoned");
-
-        disp.dispatch_event(event, &self.name);
-        disp.count()
+    fn notify_listeners(&self, event: DeviceEventType) -> u64 {
+        self.event_dispatcher.dispatch_event(event, &self.name)
     }
 
     /// Register listener to monitor device events related to this controller.
@@ -720,12 +708,7 @@ impl<'a> NvmeController<'a> {
         &self,
         listener: DeviceEventSink,
     ) -> Result<(), CoreError> {
-        let mut listeners = self
-            .event_dispatcher
-            .lock()
-            .expect("event listeners lock poisoned");
-
-        listeners.add_listener(listener);
+        self.event_dispatcher.add_listener(listener);
         debug!("{} added event listener", self.name);
         Ok(())
     }

--- a/io-engine/src/core/device_events.rs
+++ b/io-engine/src/core/device_events.rs
@@ -135,19 +135,38 @@ impl DeviceEventDispatcher {
     /// # Arguments
     ///
     /// * `listener`: Reference to an event listener.
-    pub fn add_listener(&mut self, listener: DeviceEventSink) {
+    pub fn add_listener(&self, listener: DeviceEventSink) {
         self.listeners.lock().unwrap().push(listener.into_weak());
         self.purge();
     }
 
     /// Dispatches an event to all registered listeners.
-    pub fn dispatch_event(&mut self, evt: DeviceEventType, dev_name: &str) {
+    /// Returns the number of listeners notified about target event.
+    pub fn dispatch_event(&self, evt: DeviceEventType, dev_name: &str) -> u64 {
+        let mut listeners = Vec::new();
+
+        // To avoid potential deadlocks we never call the listeners with the
+        // mutex held, just find all suitable listeners and save them
+        // for further invocation.
         self.listeners.lock().unwrap().iter_mut().for_each(|dst| {
             if let Some(p) = dst.upgrade() {
-                p.dispatch_event(evt, dev_name);
+                listeners.push(Arc::clone(&p));
             }
         });
+
+        // Invoke all listeners once the mutex is dropped.
+        let notified = {
+            if !listeners.is_empty() {
+                for l in &listeners {
+                    l.dispatch_event(evt, dev_name);
+                }
+                listeners.len() as u64
+            } else {
+                0
+            }
+        };
         self.purge();
+        notified
     }
 
     /// Returns the number of registered listeners.
@@ -162,7 +181,7 @@ impl DeviceEventDispatcher {
     }
 
     /// Removes all dropped listeners.
-    fn purge(&mut self) {
+    fn purge(&self) {
         self.listeners
             .lock()
             .unwrap()


### PR DESCRIPTION
Current implementation of NVMe controller events could lead to deadlocks, when event listener being notified indirectly triggers the second event notification action for the same NVMe controller, since NVme controller performs event notification under protection of a mutex.
This fix makes event invocation deadlock-free.

Signed-off-by: Mikhail Tcymbaliuk <mtzaurus@gmail.com>