### PR TITLE
feat(nvme-resv): add nvme reservation persistence through powerloss

### DIFF
--- a/io-engine-tests/src/nvme.rs
+++ b/io-engine-tests/src/nvme.rs
@@ -92,6 +92,7 @@ pub fn nvme_connect(
         .args(&["-t", "tcp"])
         .args(&["-a", target_addr])
         .args(&["-s", "8420"])
+        .args(&["-c", "1"])
         .args(&["-n", nqn])
         .status()
         .unwrap();

--- a/io-engine/src/bdev/nexus/mod.rs
+++ b/io-engine/src/bdev/nexus/mod.rs
@@ -51,6 +51,7 @@ pub(crate) use nexus_module::{NexusModule, NEXUS_MODULE_NAME};
 pub(crate) use nexus_nbd::{NbdDisk, NbdError};
 pub(crate) use nexus_persistence::PersistOp;
 pub use nexus_persistence::{ChildInfo, NexusInfo};
+pub(crate) use nexus_share::NexusPtpl;
 
 /// TODO
 #[derive(Deserialize)]
@@ -132,7 +133,7 @@ pub async fn shutdown_nexuses() {
     info!("Shutting down nexuses...");
     for mut nexus in nexus_iter_mut() {
         // Destroy nexus and persist its state in the ETCd.
-        if let Err(error) = nexus.as_mut().destroy().await {
+        if let Err(error) = nexus.as_mut().destroy_ext(true).await {
             error!(
                 name = nexus.name,
                 error = error.verbose(),

--- a/io-engine/src/bdev/nexus/nexus_child.rs
+++ b/io-engine/src/bdev/nexus/nexus_child.rs
@@ -30,10 +30,13 @@ use crate::{
     rebuild::RebuildJob,
 };
 
-use crate::bdev::nexus::{
-    nexus_bdev::NexusNvmePreemption,
-    NexusNvmeParams,
-    NvmeReservation,
+use crate::{
+    bdev::nexus::{
+        nexus_bdev::NexusNvmePreemption,
+        NexusNvmeParams,
+        NvmeReservation,
+    },
+    core::MayastorEnvironment,
 };
 use spdk_rs::{
     libspdk::{
@@ -320,7 +323,10 @@ impl<'c> NexusChild<'c> {
             0,
             new_key,
             nvme_reservation_register_action::REPLACE_KEY,
-            nvme_reservation_register_cptpl::NO_CHANGES,
+            match MayastorEnvironment::global_or_default().ptpl_dir() {
+                Some(_) => nvme_reservation_register_cptpl::PERSIST_POWER_LOSS,
+                None => nvme_reservation_register_cptpl::CLEAR_POWER_ON,
+            },
         )
         .await?;
         info!("{:?}: registered key {:0x}h", self, new_key);

--- a/io-engine/src/bdev/nexus/nexus_persistence.rs
+++ b/io-engine/src/bdev/nexus/nexus_persistence.rs
@@ -5,10 +5,10 @@ use std::time::Duration;
 
 /// Information associated with the persisted NexusInfo structure.
 pub struct PersistentNexusInfo {
-    // Structure that is written to the persistent store.
+    /// Structure that is written to the persistent store.
     inner: NexusInfo,
-    // Key to use to persist the NexusInfo structure.
-    // If `Some` the key has been supplied by the control plane.
+    /// Key to use to persist the NexusInfo structure.
+    /// If `Some` the key has been supplied by the control plane.
     key: Option<String>,
 }
 

--- a/io-engine/src/core/bdev.rs
+++ b/io-engine/src/core/bdev.rs
@@ -181,9 +181,12 @@ where
         props: Option<ShareProps>,
     ) -> Result<Self::Output, Self::Error> {
         let me = unsafe { self.get_unchecked_mut() };
-
-        let subsystem = NvmfSubsystem::try_from(me).context(ShareNvmf {})?;
         let props = ShareProps::from(props);
+
+        let ptpl = props.ptpl().as_ref().map(|ptpl| ptpl.path());
+        let subsystem =
+            NvmfSubsystem::try_from_with(me, ptpl).context(ShareNvmf {})?;
+
         if let Some((cntlid_min, cntlid_max)) = props.cntlid_range() {
             subsystem
                 .set_cntlid_range(cntlid_min, cntlid_max)

--- a/io-engine/src/core/mod.rs
+++ b/io-engine/src/core/mod.rs
@@ -55,7 +55,7 @@ pub use lock::{
     ResourceSubsystem,
 };
 pub use runtime::spawn;
-pub use share::{Protocol, Share, ShareProps};
+pub use share::{Protocol, PtplProps, Share, ShareProps};
 pub use spdk_rs::{cpu_cores, GenericStatusCode, IoStatus, IoType, NvmeStatus};
 pub use thread::Mthread;
 
@@ -253,6 +253,13 @@ pub enum CoreError {
     },
     #[snafu(display("No devices available for I/O"))]
     NoDevicesAvailable {},
+    #[snafu(display(
+        "NVMe persistence through power-loss failure: {}",
+        reason
+    ))]
+    Ptpl {
+        reason: String,
+    },
 }
 
 /// Logical volume layer failure.

--- a/io-engine/src/core/share.rs
+++ b/io-engine/src/core/share.rs
@@ -40,6 +40,24 @@ impl Display for Protocol {
     }
 }
 
+/// Persist Through Power Loss properties
+pub struct PtplProps {
+    /// The path to the json file where the reservations will be stored.
+    file: std::path::PathBuf,
+}
+impl PtplProps {
+    /// Create a new `Self` with the given json file path.
+    pub fn new(file: std::path::PathBuf) -> Self {
+        Self {
+            file,
+        }
+    }
+    /// Get the json file path.
+    pub fn path(&self) -> &std::path::PathBuf {
+        &self.file
+    }
+}
+
 /// Share properties when sharing a device.
 #[derive(Default)]
 pub struct ShareProps {
@@ -49,6 +67,8 @@ pub struct ShareProps {
     ana: bool,
     /// Hosts allowed to connect.
     allowed_hosts: Vec<String>,
+    /// Persistent-Power-Loss settings.
+    ptpl: Option<PtplProps>,
 }
 impl ShareProps {
     /// Returns a new `Self`.
@@ -67,6 +87,12 @@ impl ShareProps {
         self.ana = ana;
         self
     }
+    /// Modify the ptpl properties.
+    #[must_use]
+    pub fn with_ptpl<P: Into<Option<PtplProps>>>(mut self, ptpl: P) -> Self {
+        self.ptpl = ptpl.into();
+        self
+    }
     /// Get the controller id range.
     pub fn cntlid_range(&self) -> Option<(u16, u16)> {
         self.cntlid_range
@@ -78,6 +104,10 @@ impl ShareProps {
     /// Any host is allowed to connect.
     pub fn host_any(&self) -> bool {
         self.allowed_hosts.is_empty()
+    }
+    /// Get the persistence through power loss properties.
+    pub fn ptpl(&self) -> &Option<PtplProps> {
+        &self.ptpl
     }
 }
 impl From<Option<ShareProps>> for ShareProps {

--- a/io-engine/src/grpc/v0/nexus_grpc.rs
+++ b/io-engine/src/grpc/v0/nexus_grpc.rs
@@ -12,10 +12,12 @@ use crate::{
             ChildState,
             Nexus,
             NexusChild,
+            NexusPtpl,
             NexusStatus,
             NvmeAnaState,
             Reason,
         },
+        PtplFileOps,
     },
     core::{Protocol, Share},
     rebuild::RebuildJob,
@@ -228,10 +230,13 @@ pub async fn nexus_destroy(uuid: &str) -> Result<(), nexus::Error> {
     if let Ok(n) = nexus_lookup(uuid) {
         let result = n.destroy().await;
         if result.is_ok() {
-            info!("Destroyed nexus: '{}'", uuid)
+            info!("Destroyed nexus: '{}'", uuid);
         } else {
             return result;
         }
-    };
+    } else if let Ok(uuid) = Uuid::parse_str(uuid) {
+        NexusPtpl::new(uuid).destroy().ok();
+    }
+
     Ok(())
 }

--- a/nix/pkgs/libspdk/default.nix
+++ b/nix/pkgs/libspdk/default.nix
@@ -54,13 +54,13 @@ let
   # 7. Copy SHA256 from 'got' of the error message to 'sha256' field.
   # 8. 'nix-shell' build must now succeed.
   drvAttrs = rec {
-    version = "22.05-1c23be9f7";
+    version = "22.05-1832390a5";
 
     src = fetchFromGitHub {
       owner = "openebs";
       repo = "spdk";
-      rev = "1c23be9f750a56fe2d6d392857978d8c95aaac66";
-      sha256 = "sha256-zaJzLGCAi1pvVCgIUlPuYvBo3s91JTWjJTdXcON65bU=";
+      rev = "1832390a5a9cd2aed6046791d01712c931600469";
+      sha256 = "sha256-oHWEnM01H52/yrpX987YBoC+eH3J9XZ+COFofHfZ/E0=";
       fetchSubmodules = true;
     };
 


### PR DESCRIPTION
Enable Persistence Through Power Loss which is setup with SPDK when creating a namespace.
The base directory is specified via a cli argument, eg: /host/tmp/ptpl
Each resource gets its own entry within the base, eg:

```
├── nexus
│   ├── e0be2258-f2ac-4691-a607-a91e7145abe4.json
└── pool
    ├── 0b1c02c1-2840-469b-b101-105b0120f663
    │   └── replica
    │       └── 50a1e576-d475-4f66-9929-12ddbabbd0a8.json
    ├── 14d860af-4e8b-48e8-9328-88672f0d6fd0
    │   └── replica
    │       └── 207b1b37-df8a-4a24-9f4a-54a2988cc884.json
    └── 177197c0-c2dc-4a34-bdf7-1d3423e7f35e
        └── replica
            └── 7f49aca4-70ed-4a68-9d10-c8269bdcf98a.json
```

To achieve this we've added a new trait `PtplFileOps` which any resource can implement. The `Share` trait is then enhanced to include a new `PtplProps` which includes the full path for the ptpl json file.

When a resource is deleted, we have to delete the file as well.

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>