### PR TITLE
feat(nvme): add allowed-hosts control for nvme targets

### DIFF
--- a/io-engine-bench/src/nexus.rs
+++ b/io-engine-bench/src/nexus.rs
@@ -83,6 +83,7 @@ async fn get_children(compose: Arc<ComposeTest>) -> &'static Vec<String> {
                     .share(BdevShareRequest {
                         name: format!("disk{}", disk_index),
                         proto: "nvmf".into(),
+                        ..Default::default()
                     })
                     .await
                     .unwrap();

--- a/io-engine-tests/src/nexus.rs
+++ b/io-engine-tests/src/nexus.rs
@@ -162,6 +162,7 @@ impl NexusBuilder {
                 uuid: self.uuid(),
                 key: String::new(),
                 share: 1,
+                ..Default::default()
             })
             .await
             .map(|r| r.into_inner().nexus.unwrap())

--- a/io-engine-tests/src/replica.rs
+++ b/io-engine-tests/src/replica.rs
@@ -158,6 +158,7 @@ impl ReplicaBuilder {
             .share_replica(ShareReplicaRequest {
                 uuid: self.uuid(),
                 share: 1,
+                ..Default::default()
             })
             .await
             .map(|r| r.into_inner())?;

--- a/io-engine/src/bdev/nexus/nexus_bdev_error.rs
+++ b/io-engine/src/bdev/nexus/nexus_bdev_error.rs
@@ -230,6 +230,8 @@ pub enum Error {
     OperationNotAllowed { reason: String },
     #[snafu(display("Invalid value for nvme reservation: {}", reservation))]
     InvalidReservation { reservation: u8 },
+    #[snafu(display("failed to update share properties {}", name))]
+    UpdateShareProperties { source: CoreError, name: String },
 }
 
 impl From<NvmfError> for Error {

--- a/io-engine/src/bdev/nexus/nexus_share.rs
+++ b/io-engine/src/bdev/nexus/nexus_share.rs
@@ -5,7 +5,7 @@ use std::pin::Pin;
 
 use super::{nexus_err, Error, NbdDisk, Nexus, NexusTarget};
 
-use crate::core::{Protocol, Share, ShareProps};
+use crate::core::{Protocol, Share, ShareProps, UpdateProps};
 
 #[async_trait(? Send)]
 ///
@@ -38,6 +38,18 @@ impl<'n> Share for Nexus<'n> {
             Some(Protocol::Nvmf) => {}
         }
         Ok(self.share_uri().unwrap())
+    }
+
+    async fn update_properties<P: Into<Option<UpdateProps>>>(
+        self: Pin<&mut Self>,
+        props: P,
+    ) -> Result<(), Self::Error> {
+        let name = self.name.clone();
+        self.pin_bdev_mut().update_properties(props).await.context(
+            nexus_err::UpdateShareProperties {
+                name,
+            },
+        )
     }
 
     /// TODO

--- a/io-engine/src/bin/io-engine-client/bdev_cli.rs
+++ b/io-engine/src/bin/io-engine-client/bdev_cli.rs
@@ -225,6 +225,7 @@ async fn share(mut ctx: Context, args: &ArgMatches<'_>) -> crate::Result<()> {
         .share(BdevShareRequest {
             name,
             proto: protocol,
+            ..Default::default()
         })
         .await
         .context(GrpcStatus)?;

--- a/io-engine/src/bin/io-engine-client/bdev_cli.rs
+++ b/io-engine/src/bin/io-engine-client/bdev_cli.rs
@@ -49,6 +49,16 @@ pub fn subcommands<'a, 'b>() -> App<'a, 'b> {
                 .required(false)
                 .possible_values(&["nvmf"])
                 .default_value("nvmf"),
+        )
+        .arg(
+            Arg::with_name("allowed-host")
+                .long("allowed-host")
+                .takes_value(true)
+                .multiple(true)
+                .required(false)
+                .help(
+                    "NQN of hosts which are allowed to connect to the target",
+                ),
         );
 
     let unshare = SubCommand::with_name("unshare")
@@ -219,13 +229,15 @@ async fn share(mut ctx: Context, args: &ArgMatches<'_>) -> crate::Result<()> {
             field: "protocol".to_string(),
         })?
         .to_owned();
+    let allowed_hosts =
+        args.values_of_lossy("allowed-host").unwrap_or_default();
 
     let response = ctx
         .bdev
         .share(BdevShareRequest {
             name,
             proto: protocol,
-            ..Default::default()
+            allowed_hosts,
         })
         .await
         .context(GrpcStatus)?;

--- a/io-engine/src/bin/io-engine-client/nexus_cli.rs
+++ b/io-engine/src/bin/io-engine-client/nexus_cli.rs
@@ -110,7 +110,14 @@ pub fn subcommands<'a, 'b>() -> App<'a, 'b> {
         .arg(Arg::with_name("uuid").required(true).index(1)
             .help("uuid for the nexus"))
         .arg(Arg::with_name("key").required(false).index(2)
-            .help("crypto key to use"));
+            .help("crypto key to use"))
+        .arg(
+            Arg::with_name("allowed-host")
+                .long("allowed-host")
+                .takes_value(true)
+                .multiple(true)
+                .required(false)
+                .help("NQN of hosts which are allowed to connect to the target"));
 
     let unpublish = SubCommand::with_name("unpublish")
         .about("unpublish the nexus")
@@ -749,6 +756,8 @@ async fn nexus_publish(
             .context(GrpcStatus);
         }
     };
+    let allowed_hosts =
+        matches.values_of_lossy("allowed-host").unwrap_or_default();
 
     let response = ctx
         .client
@@ -756,7 +765,7 @@ async fn nexus_publish(
             uuid,
             key,
             share: protocol.into(),
-            ..Default::default()
+            allowed_hosts,
         })
         .await
         .context(GrpcStatus)?;

--- a/io-engine/src/bin/io-engine-client/nexus_cli.rs
+++ b/io-engine/src/bin/io-engine-client/nexus_cli.rs
@@ -756,6 +756,7 @@ async fn nexus_publish(
             uuid,
             key,
             share: protocol.into(),
+            ..Default::default()
         })
         .await
         .context(GrpcStatus)?;

--- a/io-engine/src/bin/io-engine-client/replica_cli.rs
+++ b/io-engine/src/bin/io-engine-client/replica_cli.rs
@@ -103,7 +103,14 @@ pub fn subcommands<'a, 'b>() -> App<'a, 'b> {
             Arg::with_name("protocol")
                 .required(true)
                 .index(2)
-                .help("Name of a protocol (nvmf) used for sharing or \"none\" to unshare the replica"));
+                .help("Name of a protocol (nvmf) used for sharing or \"none\" to unshare the replica"))
+        .arg(
+            Arg::with_name("allowed-host")
+                .long("allowed-host")
+                .takes_value(true)
+                .multiple(true)
+                .required(false)
+                .help("NQN of hosts which are allowed to connect to the target"));
 
     SubCommand::with_name("replica")
         .settings(&[
@@ -407,13 +414,15 @@ async fn replica_share(
     let name = matches.value_of("name").unwrap().to_owned();
     let share = parse_replica_protocol(matches.value_of("protocol"))
         .context(GrpcStatus)?;
+    let allowed_hosts =
+        matches.values_of_lossy("allowed-host").unwrap_or_default();
 
     let response = ctx
         .client
         .share_replica(rpc::ShareReplicaRequest {
             uuid: name.clone(),
             share,
-            ..Default::default()
+            allowed_hosts,
         })
         .await
         .context(GrpcStatus)?;

--- a/io-engine/src/bin/io-engine-client/replica_cli.rs
+++ b/io-engine/src/bin/io-engine-client/replica_cli.rs
@@ -413,6 +413,7 @@ async fn replica_share(
         .share_replica(rpc::ShareReplicaRequest {
             uuid: name.clone(),
             share,
+            ..Default::default()
         })
         .await
         .context(GrpcStatus)?;

--- a/io-engine/src/core/mod.rs
+++ b/io-engine/src/core/mod.rs
@@ -55,7 +55,7 @@ pub use lock::{
     ResourceSubsystem,
 };
 pub use runtime::spawn;
-pub use share::{Protocol, PtplProps, Share, ShareProps};
+pub use share::{Protocol, PtplProps, Share, ShareProps, UpdateProps};
 pub use spdk_rs::{cpu_cores, GenericStatusCode, IoStatus, IoType, NvmeStatus};
 pub use thread::Mthread;
 

--- a/io-engine/src/core/mod.rs
+++ b/io-engine/src/core/mod.rs
@@ -227,11 +227,11 @@ pub enum CoreError {
     NvmeIoPassthruFailed {
         opcode: u16,
     },
-    #[snafu(display("failed to share {}", source))]
+    #[snafu(display("failed to share"))]
     ShareNvmf {
         source: NvmfError,
     },
-    #[snafu(display("failed to unshare {}", source))]
+    #[snafu(display("failed to unshare"))]
     UnshareNvmf {
         source: NvmfError,
     },

--- a/io-engine/src/core/share.rs
+++ b/io-engine/src/core/share.rs
@@ -105,7 +105,13 @@ impl ShareProps {
     pub fn host_any(&self) -> bool {
         self.allowed_hosts.is_empty()
     }
-    /// Allowed hosts which can connect to the subsystem.
+    /// Modify the allowed hosts which can connect to the subsystem.
+    #[must_use]
+    pub fn with_allowed_hosts(mut self, hosts: Vec<String>) -> Self {
+        self.allowed_hosts = hosts;
+        self
+    }
+    /// Get the allowed hosts which can connect to the subsystem.
     pub fn allowed_hosts(&self) -> &Vec<String> {
         &self.allowed_hosts
     }

--- a/io-engine/src/core/share.rs
+++ b/io-engine/src/core/share.rs
@@ -105,6 +105,10 @@ impl ShareProps {
     pub fn host_any(&self) -> bool {
         self.allowed_hosts.is_empty()
     }
+    /// Allowed hosts which can connect to the subsystem.
+    pub fn allowed_hosts(&self) -> &Vec<String> {
+        &self.allowed_hosts
+    }
     /// Get the persistence through power loss properties.
     pub fn ptpl(&self) -> &Option<PtplProps> {
         &self.ptpl
@@ -112,6 +116,41 @@ impl ShareProps {
 }
 impl From<Option<ShareProps>> for ShareProps {
     fn from(opts: Option<ShareProps>) -> Self {
+        match opts {
+            None => Self::new(),
+            Some(props) => props,
+        }
+    }
+}
+
+/// Update properties of a shared device.
+#[derive(Default)]
+pub struct UpdateProps {
+    /// Hosts allowed to connect.
+    allowed_hosts: Vec<String>,
+}
+impl UpdateProps {
+    /// Returns a new `Self`.
+    pub fn new() -> Self {
+        Self::default()
+    }
+    /// Any host is allowed to connect.
+    pub fn host_any(&self) -> bool {
+        self.allowed_hosts.is_empty()
+    }
+    /// Add allowed hosts (nqn's) which can connect to the subsystem.
+    #[must_use]
+    pub fn with_allowed_hosts(mut self, hosts: Vec<String>) -> Self {
+        self.allowed_hosts = hosts;
+        self
+    }
+    /// Allowed hosts which can connect to the subsystem.
+    pub fn allowed_hosts(&self) -> &Vec<String> {
+        &self.allowed_hosts
+    }
+}
+impl From<Option<UpdateProps>> for UpdateProps {
+    fn from(opts: Option<UpdateProps>) -> Self {
         match opts {
             None => Self::new(),
             Some(props) => props,
@@ -128,6 +167,11 @@ pub trait Share: std::fmt::Debug {
         self: Pin<&mut Self>,
         props: Option<ShareProps>,
     ) -> Result<Self::Output, Self::Error>;
+
+    async fn update_properties<P: Into<Option<UpdateProps>>>(
+        self: Pin<&mut Self>,
+        props: P,
+    ) -> Result<(), Self::Error>;
 
     /// TODO
     async fn unshare(self: Pin<&mut Self>)

--- a/io-engine/src/grpc/v1/nexus.rs
+++ b/io-engine/src/grpc/v1/nexus.rs
@@ -689,7 +689,7 @@ impl NexusRpc for NexusService {
                 }
 
                 let device_uri = nexus_lookup(&args.uuid)?
-                    .share(share_protocol, key)
+                    .share_ext(share_protocol, key, args.allowed_hosts)
                     .await?;
 
                 info!("Published nexus {} under {}", uuid, device_uri);

--- a/io-engine/src/lvs/lvs_error.rs
+++ b/io-engine/src/lvs/lvs_error.rs
@@ -67,6 +67,11 @@ pub enum Error {
         source: CoreError,
         name: String,
     },
+    #[snafu(display("failed to update share properties lvol {}", name))]
+    UpdateShareProperties {
+        source: CoreError,
+        name: String,
+    },
     #[snafu(display("failed to unshare lvol {}", name))]
     LvolUnShare {
         source: CoreError,

--- a/io-engine/src/lvs/lvs_lvol.rs
+++ b/io-engine/src/lvs/lvs_lvol.rs
@@ -46,6 +46,7 @@ use crate::{
         Share,
         ShareProps,
         UntypedBdev,
+        UpdateProps,
     },
     ffihelper::{
         cb_arg,
@@ -178,6 +179,20 @@ impl Share for Lvol {
         self.as_mut().set(PropValue::Shared(true)).await?;
         info!("{:?}: shared as NVMF", self);
         Ok(share)
+    }
+
+    async fn update_properties<P: Into<Option<UpdateProps>>>(
+        self: Pin<&mut Self>,
+        props: P,
+    ) -> Result<(), Self::Error> {
+        Pin::new(&mut self.as_bdev())
+            .update_properties(props)
+            .await
+            .map_err(|e| Error::UpdateShareProperties {
+                source: e,
+                name: self.name(),
+            })?;
+        Ok(())
     }
 
     /// unshare the nvmf target

--- a/io-engine/src/subsys/nvmf/mod.rs
+++ b/io-engine/src/subsys/nvmf/mod.rs
@@ -76,6 +76,8 @@ pub enum Error {
     Namespace { bdev: String, msg: String },
     #[snafu(display("Failed to find listener for {} {}", nqn, trid))]
     Listener { nqn: String, trid: String },
+    #[snafu(display("Interior nul byte found for host {}", host))]
+    HostCstrNul { host: String },
 }
 
 thread_local! {

--- a/io-engine/tests/block_device_nvmf.rs
+++ b/io-engine/tests/block_device_nvmf.rs
@@ -111,6 +111,7 @@ async fn launch_instance() -> (ComposeTest, String) {
             .share(BdevShareRequest {
                 name: "disk0".into(),
                 proto: "nvmf".into(),
+                ..Default::default()
             })
             .await
             .unwrap();

--- a/io-engine/tests/mayastor_compose_basic.rs
+++ b/io-engine/tests/mayastor_compose_basic.rs
@@ -53,6 +53,7 @@ async fn compose_up_down() {
             .share(BdevShareRequest {
                 name: "disk0".into(),
                 proto: "nvmf".into(),
+                ..Default::default()
             })
             .await
             .unwrap();

--- a/io-engine/tests/nexus_add_remove.rs
+++ b/io-engine/tests/nexus_add_remove.rs
@@ -219,6 +219,7 @@ async fn create_targets() {
             .share(BdevShareRequest {
                 name: "disk0".into(),
                 proto: "nvmf".into(),
+                ..Default::default()
             })
             .await
             .unwrap();

--- a/io-engine/tests/nexus_child_location.rs
+++ b/io-engine/tests/nexus_child_location.rs
@@ -51,6 +51,7 @@ async fn child_location() {
         .share(BdevShareRequest {
             name: "disk0".into(),
             proto: "nvmf".into(),
+            ..Default::default()
         })
         .await
         .unwrap();

--- a/io-engine/tests/nexus_io.rs
+++ b/io-engine/tests/nexus_io.rs
@@ -170,6 +170,7 @@ async fn nexus_io_multipath() {
             uuid: NEXUS_UUID.to_string(),
             key: "".to_string(),
             share: Protocol::Nvmf as i32,
+            ..Default::default()
         })
         .await
         .unwrap();

--- a/io-engine/tests/nvme_device_timeout.rs
+++ b/io-engine/tests/nvme_device_timeout.rs
@@ -89,6 +89,7 @@ async fn test_io_timeout(action_on_timeout: DeviceTimeoutAction) {
             .share(BdevShareRequest {
                 name: "disk0".into(),
                 proto: "nvmf".into(),
+                ..Default::default()
             })
             .await
             .unwrap();
@@ -277,6 +278,7 @@ async fn io_timeout_ignore() {
             .share(BdevShareRequest {
                 name: "disk0".into(),
                 proto: "nvmf".into(),
+                ..Default::default()
             })
             .await
             .unwrap();

--- a/io-engine/tests/nvmf.rs
+++ b/io-engine/tests/nvmf.rs
@@ -150,6 +150,7 @@ async fn nvmf_set_target_interface() {
             .share(BdevShareRequest {
                 name: "disk0".into(),
                 proto: "nvmf".into(),
+                ..Default::default()
             })
             .await
             .unwrap()

--- a/io-engine/tests/persistence.rs
+++ b/io-engine/tests/persistence.rs
@@ -201,6 +201,7 @@ async fn persist_io_failure() {
         .share(BdevShareRequest {
             name: "disk0".to_string(),
             proto: "nvmf".to_string(),
+            ..Default::default()
         })
         .await
         .expect("Failed to share");
@@ -436,6 +437,7 @@ async fn publish_nexus(hdl: &mut RpcHandle, uuid: &str) -> String {
             uuid: uuid.to_string(),
             key: "".to_string(),
             share: ShareProtocolNexus::NexusNvmf as i32,
+            ..Default::default()
         })
         .await
         .expect("Failed to publish nexus")
@@ -456,6 +458,7 @@ async fn create_and_share_bdevs(hdl: &mut RpcHandle, uuid: &str) -> String {
         .share(BdevShareRequest {
             name: "disk0".into(),
             proto: "nvmf".into(),
+            ..Default::default()
         })
         .await
         .unwrap();

--- a/io-engine/tests/replica_snapshot.rs
+++ b/io-engine/tests/replica_snapshot.rs
@@ -126,6 +126,7 @@ async fn replica_snapshot() {
         .share_replica(ShareReplicaRequest {
             uuid: format!("{}-snap-{}", UUID1, t),
             share: ShareProtocolReplica::ReplicaNvmf as i32,
+            ..Default::default()
         })
         .await
         .unwrap();

--- a/io-engine/tests/replica_timeout.rs
+++ b/io-engine/tests/replica_timeout.rs
@@ -66,6 +66,7 @@ async fn replica_stop_cont() {
             .share(BdevShareRequest {
                 name: "disk0".into(),
                 proto: "nvmf".into(),
+                ..Default::default()
             })
             .await
             .unwrap();

--- a/io-engine/tests/replica_uri.rs
+++ b/io-engine/tests/replica_uri.rs
@@ -107,6 +107,7 @@ async fn replica_uri() {
         .share_replica(ShareReplicaRequest {
             uuid: VOLUME_UUID.to_string(),
             share: ShareProtocolReplica::ReplicaNvmf as i32,
+            ..Default::default()
         })
         .await;
     info!("Replica: {:?}", replica_uri);
@@ -118,6 +119,7 @@ async fn replica_uri() {
         .share_replica(ShareReplicaRequest {
             uuid: VOLUME_UUID.to_string(),
             share: ShareProtocolReplica::ReplicaNone as i32,
+            ..Default::default()
         })
         .await;
     info!("Replica: {:?}", replica_uri);

--- a/io-engine/tests/reset.rs
+++ b/io-engine/tests/reset.rs
@@ -44,6 +44,7 @@ async fn nexus_reset_mirror() {
                 .share(BdevShareRequest {
                     name: "disk0".into(),
                     proto: "nvmf".into(),
+                    ..Default::default()
                 })
                 .await
                 .unwrap()

--- a/scripts/cargo-test.sh
+++ b/scripts/cargo-test.sh
@@ -19,6 +19,8 @@ echo "running cargo-test..."
 echo "rustc version:"
 rustc --version
 
+$SCRIPTDIR/clean-cargo-tests.sh
+
 set -euxo pipefail
 export PATH=$PATH:${HOME}/.cargo/bin
 ( cd jsonrpc && cargo test )

--- a/scripts/clean-cargo-tests.sh
+++ b/scripts/clean-cargo-tests.sh
@@ -1,0 +1,7 @@
+SCRIPT_DIR="$(dirname "$0")"
+ROOT_DIR=$(realpath "$SCRIPT_DIR/..")
+
+# Kill's processes running off the workspace cargo binary location
+ps aux | grep "$ROOT_DIR/target" | grep -v sudo | head -n -1 | awk '{ print $2 }' | xargs -I% kill -9 %
+
+exit 0

--- a/scripts/grpc-test.sh
+++ b/scripts/grpc-test.sh
@@ -5,11 +5,11 @@ set -euxo pipefail
 export PATH="$PATH:${HOME}/.cargo/bin"
 export npm_config_jobs=$(nproc)
 
+$(dirname "$0")/clean-cargo-tests.sh
+
 cargo build --all
 cd "$(dirname "$0")/../test/grpc"
 npm install
-
-sudo pkill io-engine || true
 
 for ts in cli replica nexus rebuild; do
   ./node_modules/mocha/bin/mocha test_${ts}.js \


### PR DESCRIPTION
This allows us to control which hosts (nqn's) are allowed to connect to our nvmf targets. In addition, we also disconnect previously allowed devices which are no longer allowed.

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>