### PR TITLE
fix: re-enable ptpl and allow for not using reservations

### DIFF
--- a/io-engine-tests/src/replica.rs
+++ b/io-engine-tests/src/replica.rs
@@ -134,6 +134,7 @@ impl ReplicaBuilder {
                 size: self.size.unwrap(),
                 thin: self.thin,
                 share: self.share,
+                ..Default::default()
             })
             .await
             .map(|r| r.into_inner())

--- a/io-engine/src/bdev/nexus/nexus_bdev.rs
+++ b/io-engine/src/bdev/nexus/nexus_bdev.rs
@@ -1289,6 +1289,8 @@ async fn nexus_create_internal(
 
     match Nexus::register_instance(&mut nexus_bdev).await {
         Err(Error::NexusIncomplete {
+            name,
+            reason,
             ..
         }) => {
             // We still have code that waits for children to come online,
@@ -1302,7 +1304,8 @@ async fn nexus_create_internal(
                 let _ = device_destroy(child.uri()).await;
             }
             Err(Error::NexusCreate {
-                name: String::from(name),
+                name,
+                reason,
             })
         }
 

--- a/io-engine/src/bdev/nexus/nexus_child.rs
+++ b/io-engine/src/bdev/nexus/nexus_child.rs
@@ -620,6 +620,9 @@ impl<'c> NexusChild<'c> {
         if std::env::var("NEXUS_NVMF_RESV_ENABLE").is_err() {
             return Ok(());
         }
+        if !params.reservations_enabled() {
+            return Ok(());
+        }
         match params.preempt_policy {
             NexusNvmePreemption::ArgKey => {
                 self.reservation_acquire_argkey(params).await?;

--- a/io-engine/src/lvs/lvs_lvol.rs
+++ b/io-engine/src/lvs/lvs_lvol.rs
@@ -157,17 +157,6 @@ impl Share for Lvol {
         mut self: Pin<&mut Self>,
         props: Option<ShareProps>,
     ) -> Result<Self::Output, Self::Error> {
-        let props = Some(match props {
-            Some(props) => props,
-            None => ShareProps::new().with_ptpl(self.ptpl().create().map_err(
-                |source| Error::LvolShare {
-                    source: crate::core::CoreError::Ptpl {
-                        reason: source.to_string(),
-                    },
-                    name: self.name(),
-                },
-            )?),
-        });
         let share = Pin::new(&mut self.as_bdev())
             .share_nvmf(props)
             .await

--- a/io-engine/src/subsys/nvmf/subsystem.rs
+++ b/io-engine/src/subsys/nvmf/subsystem.rs
@@ -369,8 +369,7 @@ impl NvmfSubsystem {
                 source: Errno::from_i32(errno),
                 nqn: self.get_nqn(),
                 msg: format!("failed to add allowed host: {:?}", host),
-            })?;
-        Ok(())
+            })
     }
 
     /// Disallow hosts from connecting to the subsystem.

--- a/io-engine/tests/nexus_io.rs
+++ b/io-engine/tests/nexus_io.rs
@@ -67,8 +67,8 @@ static BDEVNAME11: &str = "aio:///host/tmp/disk1.img?blk_size=512";
 static DISKNAME2: &str = "/tmp/disk2.img";
 static BDEVNAME2: &str = "aio:///host/tmp/disk2.img?blk_size=512";
 
-static PTPL_HOST_DIR: &str = "/tmp/ptpl/";
-static PTPL_CONTAINER_DIR: &str = "/host/tmp/ptpl/";
+static PTPL_HOST_DIR: &str = "/tmp/ptpl";
+static PTPL_CONTAINER_DIR: &str = "/host/tmp/ptpl";
 
 static MAYASTOR: OnceCell<MayastorTest> = OnceCell::new();
 
@@ -124,6 +124,7 @@ async fn nexus_io_multipath() {
             size: 32 * 1024 * 1024,
             thin: false,
             share: 1,
+            ..Default::default()
         })
         .await
         .unwrap();
@@ -350,6 +351,7 @@ async fn nexus_io_resv_acquire() {
             size: 32 * 1024 * 1024,
             thin: false,
             share: 1,
+            ..Default::default()
         })
         .await
         .unwrap();
@@ -502,6 +504,8 @@ async fn nexus_io_resv_preempt() {
     common::delete_file(&[DISKNAME1.into(), PTPL_HOST_DIR.into()]);
     common::truncate_file(DISKNAME1, 64 * 1024);
 
+    let ptpl_dir = |ms| format!("{}/{}", PTPL_CONTAINER_DIR, ms);
+
     let test = Builder::new()
         .name("nexus_io_resv_preempt_test")
         .network("10.1.0.0/16")
@@ -511,7 +515,7 @@ async fn nexus_io_resv_preempt() {
             Binary::from_dbg("io-engine")
                 .with_env("NEXUS_NVMF_RESV_ENABLE", "1")
                 .with_env("MAYASTOR_NVMF_HOSTID", HOSTID1)
-                .with_args(vec!["--ptpl-dir", PTPL_CONTAINER_DIR])
+                .with_args(vec!["--ptpl-dir", ptpl_dir("ms2").as_str()])
                 .with_bind("/tmp", "/host/tmp"),
         )
         .add_container_bin(
@@ -519,7 +523,7 @@ async fn nexus_io_resv_preempt() {
             Binary::from_dbg("io-engine")
                 .with_env("NEXUS_NVMF_RESV_ENABLE", "1")
                 .with_env("MAYASTOR_NVMF_HOSTID", HOSTID2)
-                .with_args(vec!["--ptpl-dir", PTPL_CONTAINER_DIR])
+                .with_args(vec!["--ptpl-dir", ptpl_dir("ms1").as_str()])
                 .with_bind("/tmp", "/host/tmp"),
         )
         .with_clean(true)
@@ -552,6 +556,7 @@ async fn nexus_io_resv_preempt() {
             size: 32 * 1024 * 1024,
             thin: false,
             share: 1,
+            ..Default::default()
         })
         .await
         .unwrap();
@@ -796,6 +801,7 @@ async fn nexus_io_resv_preempt_tabled() {
             size: 32 * 1024 * 1024,
             thin: false,
             share: 1,
+            ..Default::default()
         })
         .await
         .unwrap();
@@ -1022,6 +1028,7 @@ async fn nexus_io_write_zeroes() {
             size: 32 * 1024 * 1024,
             thin: false,
             share: 1,
+            ..Default::default()
         })
         .await
         .unwrap();

--- a/io-engine/tests/nexus_with_local.rs
+++ b/io-engine/tests/nexus_with_local.rs
@@ -60,6 +60,7 @@ async fn create_replicas(h: &mut RpcHandle) {
             size: 8 * 1024 * 1024,
             thin: false,
             share: 1,
+            ..Default::default()
         })
         .await
         .unwrap();

--- a/io-engine/tests/replica_snapshot.rs
+++ b/io-engine/tests/replica_snapshot.rs
@@ -77,6 +77,7 @@ async fn replica_snapshot() {
             size: 64 * 1024 * 1024,
             thin: false,
             share: ShareProtocolReplica::ReplicaNvmf as i32,
+            ..Default::default()
         })
         .await
         .unwrap();

--- a/io-engine/tests/replica_uri.rs
+++ b/io-engine/tests/replica_uri.rs
@@ -77,6 +77,7 @@ async fn replica_uri() {
             size: VOLUME_SIZE_B,
             thin: false,
             share: ShareProtocolReplica::ReplicaNvmf as i32,
+            ..Default::default()
         })
         .await
         .unwrap()
@@ -93,6 +94,7 @@ async fn replica_uri() {
             size: VOLUME_SIZE_B,
             thin: false,
             share: ShareProtocolReplica::ReplicaNone as i32,
+            ..Default::default()
         })
         .await
         .unwrap()

--- a/scripts/clean-cargo-tests.sh
+++ b/scripts/clean-cargo-tests.sh
@@ -2,6 +2,6 @@ SCRIPT_DIR="$(dirname "$0")"
 ROOT_DIR=$(realpath "$SCRIPT_DIR/..")
 
 # Kill's processes running off the workspace cargo binary location
-ps aux | grep "$ROOT_DIR/target" | grep -v sudo | head -n -1 | awk '{ print $2 }' | xargs -I% kill -9 %
+ps aux | grep "$ROOT_DIR/target" | grep -v sudo | head -n -1 | awk '{ print $2 }' | xargs -I% sudo kill -9 %
 
 exit 0

--- a/scripts/grpc-test.sh
+++ b/scripts/grpc-test.sh
@@ -11,6 +11,8 @@ cargo build --all
 cd "$(dirname "$0")/../test/grpc"
 npm install
 
+sudo pkill io-engine || true
+
 for ts in cli replica nexus rebuild; do
   ./node_modules/mocha/bin/mocha test_${ts}.js \
       --reporter ./multi_reporter.js \

--- a/test/grpc/test_nexus.js
+++ b/test/grpc/test_nexus.js
@@ -792,6 +792,7 @@ describe('nexus', function () {
         minCntlId: 1,
         maxCntlId: 0xffef,
         resvKey: 0,
+        preemptKey: 1,
         children: [
           'malloc:///malloc1?size_mb=64'
         ]


### PR DESCRIPTION
chore: allow for not using reservations

This gives back control to the api client.
To do this, set the reservation parameters to "0".

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

fix(nvme-resv): setup ptpl from the caller side

Previously this was done incorrectly only when props was None.
It's better to leave it for the caller to decide.