### PR TITLE
ci: fix failures on early shutdown

### DIFF
--- a/io-engine/src/core/env.rs
+++ b/io-engine/src/core/env.rs
@@ -402,10 +402,12 @@ extern "C" fn mayastor_signal_handler(signo: i32) {
     warn!("Received SIGNO: {}", signo);
     SIG_RECEIVED.store(true, SeqCst);
     unsafe {
-        spdk_thread_send_critical_msg(
-            Mthread::primary().as_ptr(),
-            Some(signal_trampoline),
-        );
+        if let Some(mth) = Mthread::primary_safe() {
+            spdk_thread_send_critical_msg(
+                mth.as_ptr(),
+                Some(signal_trampoline),
+            );
+        }
     };
 }
 

--- a/io-engine/src/subsys/nvmf/subsystem.rs
+++ b/io-engine/src/subsys/nvmf/subsystem.rs
@@ -746,13 +746,13 @@ impl NvmfSubsystem {
 
     /// stop all subsystems
     pub async fn stop_all(tgt: *mut spdk_nvmf_tgt) {
-        let ss = unsafe {
-            NvmfSubsystem(
-                NonNull::new(spdk_nvmf_subsystem_get_first(tgt)).unwrap(),
-            )
+        let subsystem = unsafe {
+            NonNull::new(spdk_nvmf_subsystem_get_first(tgt)).map(NvmfSubsystem)
         };
-        for s in ss.into_iter() {
-            s.stop().await.unwrap();
+        if let Some(subsystem) = subsystem {
+            for s in subsystem.into_iter() {
+                s.stop().await.unwrap();
+            }
         }
     }
 

--- a/io-engine/src/subsys/nvmf/target.rs
+++ b/io-engine/src/subsys/nvmf/target.rs
@@ -167,7 +167,7 @@ impl Target {
                 unsafe { spdk_subsystem_init_next(1) }
             }
 
-            _ => panic!("Invalid target state"),
+            TargetState::ShutdownCompleted => {}
         };
     }
 


### PR DESCRIPTION
The first crash was when getting the spdk init thread before the init thread is allocated. The second is when shutting down a target before it has any subsystems.

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>