### PR TITLE
feat: extend nvmf uri with a hostnqn

### DIFF
--- a/io-engine/src/grpc/v0/mayastor_grpc.rs
+++ b/io-engine/src/grpc/v0/mayastor_grpc.rs
@@ -1386,10 +1386,13 @@ impl mayastor_server::Mayastor for MayastorSvc {
                 };
 
                 let device_uri = nexus_lookup(&args.uuid)?
-                    .share_ext(share_protocol, key, args.allowed_hosts)
+                    .share_ext(share_protocol, key, args.allowed_hosts.clone())
                     .await?;
 
-                info!("Published nexus {} under {}", uuid, device_uri);
+                info!(
+                    "Published nexus {} under {} for {:?}",
+                    uuid, device_uri, args.allowed_hosts
+                );
                 Ok(PublishNexusReply {
                     device_uri,
                 })

--- a/io-engine/src/grpc/v1/nexus.rs
+++ b/io-engine/src/grpc/v1/nexus.rs
@@ -689,10 +689,13 @@ impl NexusRpc for NexusService {
                 }
 
                 let device_uri = nexus_lookup(&args.uuid)?
-                    .share_ext(share_protocol, key, args.allowed_hosts)
+                    .share_ext(share_protocol, key, args.allowed_hosts.clone())
                     .await?;
 
-                info!("Published nexus {} under {}", uuid, device_uri);
+                info!(
+                    "Published nexus {} under {} for {:?}",
+                    uuid, device_uri, args.allowed_hosts
+                );
 
                 let nexus = nexus_lookup(&args.uuid)?.into_grpc().await;
 


### PR DESCRIPTION
This will be used when connecting to an nvmf target.

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>