### PR TITLE
feat(reactor): support for destroying SPDK threads

### DIFF
--- a/io-engine-tests/src/lib.rs
+++ b/io-engine-tests/src/lib.rs
@@ -109,7 +109,7 @@ macro_rules! test_init {
             })
             .init()
         });
-        io_engine::core::Mthread::primary().enter();
+        io_engine::core::Mthread::primary().set_current();
     };
     ($yaml_config:expr) => {
         common::MSTEST.get_or_init(|| {

--- a/io-engine/src/core/env.rs
+++ b/io-engine/src/core/env.rs
@@ -230,7 +230,7 @@ pub static GLOBAL_RC: Lazy<Arc<Mutex<i32>>> =
 pub static SIG_RECEIVED: Lazy<AtomicBool> =
     Lazy::new(|| AtomicBool::new(false));
 
-/// FFI functions that are needed to initialize the environment
+// FFI functions that are needed to initialize the environment
 extern "C" {
     pub fn rte_eal_init(argc: i32, argv: *mut *mut libc::c_char) -> i32;
     pub fn spdk_trace_cleanup();
@@ -854,7 +854,7 @@ impl MayastorEnvironment {
         info!("All cores locked and loaded!");
 
         // ensure we are within the context of a spdk thread from here
-        Mthread::primary().enter();
+        Mthread::primary().set_current();
 
         Reactor::block_on(async {
             let (sender, receiver) = oneshot::channel::<bool>();


### PR DESCRIPTION
Reactors now remove and destroy exited SPDK threads. A check for long SPDK poll was added.

Signed-off-by: Dmitry Savitskiy <dmitry.savitskiy@datacore.com>