### PR TITLE
feat(reactor): cli arguments for controlling reactor freeze detection

### DIFF
--- a/io-engine/Cargo.toml
+++ b/io-engine/Cargo.toml
@@ -10,8 +10,6 @@ build = "build.rs"
 [features]
 # Enables fault injection code.
 fault_injection = []
-# Enables diagnostics operations.
-diagnostics = ["async-process", "rstack"]
 
 [[bin]]
 name = "io-engine"
@@ -96,8 +94,8 @@ tracing-subscriber = "0.2.20"
 udev = "0.6.2"
 url = "2.2.2"
 gettid = "0.1.2"
-async-process = { version = "1.5.0", optional = true }
-rstack =  { version = "0.3.2", optional = true }
+async-process = { version = "1.5.0" }
+rstack = { version = "0.3.2" }
 
 jsonrpc = { path = "../jsonrpc"}
 mayastor-api = { path = "../rpc/mayastor-api" }

--- a/io-engine/src/core/diagnostics.rs
+++ b/io-engine/src/core/diagnostics.rs
@@ -95,8 +95,5 @@ fn collect_process_stack(pid: u32) -> Result<(), Box<dyn std::error::Error>> {
 pub fn process_diagnostics_cli(
     cli: &MayastorCliArgs,
 ) -> Option<Result<(), Box<dyn std::error::Error>>> {
-    match cli.diagnose_stack {
-        None => None,
-        Some(pid) => Some(collect_process_stack(pid)),
-    }
+    cli.diagnose_stack.map(collect_process_stack)
 }

--- a/io-engine/src/core/env.rs
+++ b/io-engine/src/core/env.rs
@@ -154,18 +154,17 @@ pub struct MayastorCliArgs {
     )]
     pub api_versions: Vec<ApiVersion>,
     /// Dump stack trace for all threads inside I/O agent process with target
-    /// PID. Available only when diagnostics feature is enabled.
+    /// PID.
     #[structopt(long = "diagnose-stack", short = "d", env = "DIAGNOSE_STACK")]
-    #[cfg(feature = "diagnostics")]
     pub diagnose_stack: Option<u32>,
+    /// Enable reactor freeze detection.
+    #[structopt(long)]
+    pub reactor_freeze_detection: bool,
     /// Timeout (in seconds) for reactor freeze detection.
-    /// Available only when diagnostics feature is enabled.
     #[structopt(
         long = "reactor-freeze-timeout",
-        short = "t",
         env = "REACTOR_FREEZE_TIMEOUT"
     )]
-    #[cfg(feature = "diagnostics")]
     pub reactor_freeze_timeout: Option<u64>,
 }
 
@@ -211,11 +210,8 @@ impl Default for MayastorCliArgs {
             registration_endpoint: None,
             nvmf_tgt_interface: None,
             api_versions: vec![ApiVersion::V0, ApiVersion::V1],
-
-            // CLI arguments available only in diagnostics mode.
-            #[cfg(feature = "diagnostics")]
             diagnose_stack: None,
-            #[cfg(feature = "diagnostics")]
+            reactor_freeze_detection: false,
             reactor_freeze_timeout: None,
         }
     }

--- a/io-engine/src/core/mod.rs
+++ b/io-engine/src/core/mod.rs
@@ -42,10 +42,13 @@ pub use env::{
 };
 pub use handle::{BdevHandle, UntypedBdevHandle};
 pub use io_device::IoDevice;
-pub use reactor::{Reactor, ReactorState, Reactors, REACTOR_LIST};
-
-#[cfg(feature = "diagnostics")]
-pub use reactor::reactor_monitor_loop;
+pub use reactor::{
+    reactor_monitor_loop,
+    Reactor,
+    ReactorState,
+    Reactors,
+    REACTOR_LIST,
+};
 
 pub use lock::{
     ProtectedSubsystems,
@@ -66,7 +69,6 @@ mod block_device;
 mod descriptor;
 mod device_events;
 mod device_monitor;
-#[cfg(feature = "diagnostics")]
 pub mod diagnostics;
 mod env;
 mod handle;

--- a/io-engine/src/core/reactor.rs
+++ b/io-engine/src/core/reactor.rs
@@ -637,12 +637,10 @@ impl Future for &'static Reactor {
 }
 
 /// Heartbeat timeout (in seconds) to classify a reactor as frozen.
-#[cfg(feature = "diagnostics")]
 const REACTOR_HEARTBEAT_TIMEOUT: u64 = 3;
 
 /// Monitor health for all reactors: all available reactors are constantly
 /// monitored for liveness.
-#[cfg(feature = "diagnostics")]
 pub async fn reactor_monitor_loop(freeze_timeout: Option<u64>) {
     use std::sync::atomic::{AtomicU64, Ordering};
 

--- a/nix/pkgs/io-engine/cargo-package.nix
+++ b/nix/pkgs/io-engine/cargo-package.nix
@@ -11,6 +11,7 @@
 , libpcap
 , libudev
 , liburing
+, libunwind
 , makeRustPlatform
 , numactl
 , openssl
@@ -74,6 +75,7 @@ let
       numactl
       openssl
       utillinux
+      libunwind
     ];
     cargoLock = {
       lockFile = ../../../Cargo.lock;


### PR DESCRIPTION
Reactor freeze detection is now controlled via CLI arguments rather than via project features, which simplifies its usage. The feature is now always ready to be used but is disabled by default. The following command line arguments were added to manage reactor freeze detection:
  --reactor-freeze-detection   enables reactor freeze detection
  --reactor-freeze-timeout=N   detection timeout (in seconds); 2 seconds
                               default timeout applies if not explicitly
			       overridden by this argument.

Signed-off-by: Mikhail Tcymbaliuk <mtzaurus@gmail.com>