### PR TITLE
fix(csi-node): cherry-pick wait until filesystem shutdown before disc…

### DIFF
--- a/csi/src/filesystem_vol.rs
+++ b/csi/src/filesystem_vol.rs
@@ -162,13 +162,6 @@ pub async fn unstage_fs_volume(
             ));
         }
 
-        // Sometimes after/during disconnect we get some page write errors,
-        // triggered by a journal update by the JBD2 worker task. We
-        // don't really know how we can "flush" these tasks so at the
-        // moment the best solution we have is to remount the staging path
-        // as RO before we umount it for good, which seems to help.
-        mount::remount(fs_staging_path, true)?;
-
         if let Err(error) = mount::filesystem_unmount(fs_staging_path) {
             return Err(failure!(
                 Code::Internal,
@@ -179,6 +172,8 @@ pub async fn unstage_fs_volume(
                 error
             ));
         }
+
+        mount::wait_fs_shutdown(&device, Some(mount.fstype)).await?;
     }
 
     Ok(())

--- a/csi/src/node.rs
+++ b/csi/src/node.rs
@@ -126,6 +126,8 @@ async fn detach(uuid: &Uuid, errheader: String) -> Result<(), Status> {
             ));
         }
 
+        crate::mount::wait_fs_shutdown(&device_path, None).await?;
+
         if let Err(error) = device.detach().await {
             return Err(failure!(
                 Code::Internal,

--- a/deploy/csi-daemonset.yaml
+++ b/deploy/csi-daemonset.yaml
@@ -30,7 +30,7 @@ spec:
       # the same.
       containers:
       - name: mayastor-csi
-        image: mayadata/mayastor:v1.0.4
+        image: mayadata/mayastor:v1.0.5
         imagePullPolicy: IfNotPresent
         # we need privileged because we mount filesystems and use mknod
         securityContext:

--- a/deploy/mayastor-daemonset.yaml
+++ b/deploy/mayastor-daemonset.yaml
@@ -33,7 +33,7 @@ spec:
         command: ['sh', '-c', 'until nc -vz nats 4222; do echo "Waiting for message bus..."; sleep 1; done;']
       containers:
       - name: mayastor
-        image: mayadata/mayastor:v1.0.4
+        image: mayadata/mayastor:v1.0.5
         imagePullPolicy: IfNotPresent
         env:
         - name: RUST_LOG

--- a/scripts/check-deploy-yamls.sh
+++ b/scripts/check-deploy-yamls.sh
@@ -8,7 +8,7 @@ DEPLOYDIR="$ROOTDIR"/deploy
 
 CORES=2
 PROFILE=release
-TAG=v1.0.4
+TAG=v1.0.5
 
 "$SCRIPTDIR"/generate-deploy-yamls.sh -c "$CORES" -t "$TAG" "$PROFILE"
 


### PR DESCRIPTION
…onnecting

Sometimes after/during disconnect we get some page write errors, triggered by a journal update by the JBD2 worker task.
To get around these, wait until the filesystem&jbd2 is shutdown before disconnecting.

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>