### PR TITLE
fix(nexus): fixing nexus unshare and nvmf error handling

### DIFF
--- a/io-engine/src/bdev/nexus/nexus_bdev_children.rs
+++ b/io-engine/src/bdev/nexus/nexus_bdev_children.rs
@@ -927,9 +927,9 @@ impl<'n> Nexus<'n> {
         }
 
         debug!("{:?}: resuming...", self);
-        let r = self.as_mut().resume().await;
+        let r = self.as_mut().resume().await?;
         debug!("{:?}: resuming ok", self);
-        r
+        Ok(r)
     }
 
     // TODO

--- a/io-engine/src/bdev/nexus/nexus_io_subsystem.rs
+++ b/io-engine/src/bdev/nexus/nexus_io_subsystem.rs
@@ -120,7 +120,13 @@ impl<'n> NexusIoSubsystem<'n> {
                                 subsystem.get_nqn()
                             );
 
-                            subsystem.pause().await.unwrap();
+                            if let Err(e) = subsystem.pause().await {
+                                panic!(
+                                    "Failed to pause subsystem '{}: {}",
+                                    subsystem.get_nqn(),
+                                    e
+                                );
+                            }
 
                             trace!(
                                 "{:?}: subsystem '{}' paused",
@@ -238,7 +244,13 @@ impl<'n> NexusIoSubsystem<'n> {
                                 subsystem.get_nqn()
                             );
 
-                            subsystem.resume().await.unwrap();
+                            if let Err(e) = subsystem.resume().await {
+                                panic!(
+                                    "Failed to resume subsystem '{}: {}",
+                                    subsystem.get_nqn(),
+                                    e
+                                );
+                            }
 
                             trace!(
                                 "{:?}: subsystem '{}' resumed",

--- a/io-engine/src/bdev/nexus/nexus_share.rs
+++ b/io-engine/src/bdev/nexus/nexus_share.rs
@@ -7,7 +7,6 @@ use super::{nexus_err, Error, NbdDisk, Nexus, NexusTarget};
 
 use crate::core::{Protocol, Share, ShareProps, UpdateProps};
 
-#[async_trait(? Send)]
 ///
 /// The sharing of the nexus is different compared to regular bdevs
 /// the Impl of ['Share'] handles this accordingly
@@ -16,6 +15,7 @@ use crate::core::{Protocol, Share, ShareProps, UpdateProps};
 /// endpoints (not targets) however, we want to avoid too many
 /// protocol specifics and for bdevs the need for different endpoints
 /// is not implemented yet as the need for it has not arrived yet.
+#[async_trait(? Send)]
 impl<'n> Share for Nexus<'n> {
     type Error = Error;
     type Output = String;
@@ -24,8 +24,10 @@ impl<'n> Share for Nexus<'n> {
         mut self: Pin<&mut Self>,
         props: Option<ShareProps>,
     ) -> Result<Self::Output, Self::Error> {
-        match self.shared() {
+        let uri = match self.shared() {
             Some(Protocol::Off) | None => {
+                info!("{:?}: sharing NVMF target...", self);
+
                 let name = self.name.clone();
                 self.as_mut()
                     .pin_bdev_mut()
@@ -34,10 +36,19 @@ impl<'n> Share for Nexus<'n> {
                     .context(nexus_err::ShareNvmfNexus {
                         name,
                     })?;
+
+                let uri = self.share_uri().unwrap();
+                info!("{:?}: shared NVMF target as '{}'", self, uri);
+                uri
             }
-            Some(Protocol::Nvmf) => {}
-        }
-        Ok(self.share_uri().unwrap())
+            Some(Protocol::Nvmf) => {
+                let uri = self.share_uri().unwrap();
+                info!("{:?}: already shared as '{}'", self, uri);
+                uri
+            }
+        };
+
+        Ok(uri)
     }
 
     async fn update_properties<P: Into<Option<UpdateProps>>>(
@@ -53,16 +64,19 @@ impl<'n> Share for Nexus<'n> {
     }
 
     /// TODO
-    async fn unshare(
-        self: Pin<&mut Self>,
-    ) -> Result<Self::Output, Self::Error> {
+    async fn unshare(mut self: Pin<&mut Self>) -> Result<(), Self::Error> {
+        info!("{:?}: unsharing nexus bdev...", self);
+
         let name = self.name.clone();
-        self.pin_bdev_mut()
-            .unshare()
-            .await
-            .context(nexus_err::UnshareNexus {
+        self.as_mut().pin_bdev_mut().unshare().await.context(
+            nexus_err::UnshareNexus {
                 name,
-            })
+            },
+        )?;
+
+        info!("{:?}: unshared nexus bdev", self);
+
+        Ok(())
     }
 
     /// TODO
@@ -108,6 +122,7 @@ impl<'n> Nexus<'n> {
     ) -> Result<String, Error> {
         self.share_ext(protocol, key, vec![]).await
     }
+
     /// TODO
     pub async fn share_ext(
         mut self: Pin<&mut Self>,
@@ -183,34 +198,21 @@ impl<'n> Nexus<'n> {
 
     /// TODO
     pub async fn unshare_nexus(mut self: Pin<&mut Self>) -> Result<(), Error> {
-        info!("{:?}: unsharing nexus...", self);
-        unsafe {
-            match self.as_mut().get_unchecked_mut().nexus_target.take() {
-                Some(NexusTarget::NbdDisk(disk)) => {
-                    disk.destroy();
-                }
-                Some(NexusTarget::NexusNvmfTarget) => {
-                    self.as_mut().unshare().await?;
-                }
-                None => {
-                    info!("{:?}: not shared", self);
-                }
+        match unsafe { self.as_mut().get_unchecked_mut().nexus_target.take() } {
+            Some(NexusTarget::NbdDisk(disk)) => {
+                info!("{:?}: destroying NBD device target...", self);
+                disk.destroy();
+            }
+            Some(NexusTarget::NexusNvmfTarget) => {
+                info!("{:?}: unsharing NVMF target...", self);
+            }
+            None => {
+                // Try unshare nexus bdev anyway, just in case it was shared
+                // via bdev API. It is no-op if bdev was not shared.
             }
         }
 
-        Ok(())
-    }
-
-    /// Shutdowns all shares.
-    pub(crate) async fn destroy_shares(
-        mut self: Pin<&mut Self>,
-    ) -> Result<(), Error> {
-        let _ = self.as_mut().unshare_nexus().await;
-        assert_eq!(self.share_handle, None);
-
-        // no-op when not shared and will be removed once the old share bits are
-        // gone. Ignore device name provided in case of successful unsharing.
-        self.as_mut().unshare().await.map(|_| ())
+        self.as_mut().unshare().await
     }
 
     /// TODO

--- a/io-engine/src/core/bdev.rs
+++ b/io-engine/src/core/bdev.rs
@@ -227,21 +227,18 @@ where
     }
 
     /// unshare the bdev regardless of current active share
-    async fn unshare(
-        self: Pin<&mut Self>,
-    ) -> Result<Self::Output, Self::Error> {
+    async fn unshare(self: Pin<&mut Self>) -> Result<(), Self::Error> {
         match self.shared() {
             Some(Protocol::Nvmf) => {
-                if let Some(subsystem) = NvmfSubsystem::nqn_lookup(self.name())
-                {
-                    subsystem.stop().await.context(UnshareNvmf {})?;
-                    subsystem.destroy();
+                if let Some(ss) = NvmfSubsystem::nqn_lookup(self.name()) {
+                    ss.stop().await.context(UnshareNvmf {})?;
+                    ss.destroy();
                 }
             }
             Some(Protocol::Off) | None => {}
         }
 
-        Ok(self.name().to_string())
+        Ok(())
     }
 
     /// returns if the bdev is currently shared

--- a/io-engine/src/core/share.rs
+++ b/io-engine/src/core/share.rs
@@ -180,8 +180,7 @@ pub trait Share: std::fmt::Debug {
     ) -> Result<(), Self::Error>;
 
     /// TODO
-    async fn unshare(self: Pin<&mut Self>)
-        -> Result<Self::Output, Self::Error>;
+    async fn unshare(self: Pin<&mut Self>) -> Result<(), Self::Error>;
 
     /// TODO
     fn shared(&self) -> Option<Protocol>;

--- a/io-engine/src/lvs/lvs_lvol.rs
+++ b/io-engine/src/lvs/lvs_lvol.rs
@@ -201,21 +201,18 @@ impl Share for Lvol {
     }
 
     /// unshare the nvmf target
-    async fn unshare(
-        mut self: Pin<&mut Self>,
-    ) -> Result<Self::Output, Self::Error> {
-        let share =
-            Pin::new(&mut self.as_bdev()).unshare().await.map_err(|e| {
-                Error::LvolUnShare {
-                    source: e,
-                    name: self.name(),
-                }
-            })?;
+    async fn unshare(mut self: Pin<&mut Self>) -> Result<(), Self::Error> {
+        Pin::new(&mut self.as_bdev()).unshare().await.map_err(|e| {
+            Error::LvolUnShare {
+                source: e,
+                name: self.name(),
+            }
+        })?;
 
         self.as_mut().set(PropValue::Shared(false)).await?;
 
         info!("{:?}: unshared ", self);
-        Ok(share)
+        Ok(())
     }
 
     /// return the protocol this bdev is shared under

--- a/io-engine/src/subsys/nvmf/mod.rs
+++ b/io-engine/src/subsys/nvmf/mod.rs
@@ -64,6 +64,12 @@ pub enum Error {
     PgError { msg: String },
     #[snafu(display("Failed to create transport {}", msg))]
     Transport { source: Errno, msg: String },
+    #[snafu(display(
+        "Failed to {} subsystem '{}': subsystem is busy",
+        op,
+        nqn
+    ))]
+    SubsystemBusy { nqn: String, op: String },
     #[snafu(display("Failed nvmf subsystem operation for {} {} error: {}", source.desc(), nqn, msg))]
     Subsystem {
         source: Errno,

--- a/io-engine/src/subsys/nvmf/subsystem.rs
+++ b/io-engine/src/subsys/nvmf/subsystem.rs
@@ -39,6 +39,7 @@ use spdk_rs::libspdk::{
     spdk_nvmf_subsystem_set_mn,
     spdk_nvmf_subsystem_set_sn,
     spdk_nvmf_subsystem_start,
+    spdk_nvmf_subsystem_state_change_done,
     spdk_nvmf_subsystem_stop,
     spdk_nvmf_tgt,
     SPDK_NVMF_SUBTYPE_DISCOVERY,
@@ -519,188 +520,131 @@ impl NvmfSubsystem {
         })
     }
 
+    /// TODO
+    async fn change_state(
+        &self,
+        op: &str,
+        f: impl Fn(
+            *mut spdk_nvmf_subsystem,
+            spdk_nvmf_subsystem_state_change_done,
+            *mut c_void,
+        ) -> i32,
+    ) -> Result<(), Error> {
+        extern "C" fn state_change_cb(
+            _ss: *mut spdk_nvmf_subsystem,
+            arg: *mut c_void,
+            status: i32,
+        ) {
+            let s = unsafe { Box::from_raw(arg as *mut oneshot::Sender<i32>) };
+            s.send(status).unwrap();
+        }
+
+        info!(?self, "Subsystem {} in progress...", op);
+
+        let res = {
+            let mut n = 0;
+
+            let (rc, r) = loop {
+                let (s, r) = oneshot::channel::<i32>();
+
+                let rc = -f(self.0.as_ptr(), Some(state_change_cb), cb_arg(s));
+
+                if rc != libc::EBUSY || n >= 3 {
+                    break (rc, r);
+                }
+
+                n += 1;
+
+                warn!(
+                    "Failed to {} '{}': subsystem is busy, retrying {}...",
+                    op,
+                    self.get_nqn(),
+                    n
+                );
+
+                crate::sleep::mayastor_sleep(std::time::Duration::from_millis(
+                    100,
+                ))
+                .await
+                .unwrap();
+            };
+
+            match rc {
+                0 => r.await.unwrap().to_result(|e| Error::Subsystem {
+                    source: Errno::from_i32(e),
+                    nqn: self.get_nqn(),
+                    msg: format!("{} failed", op),
+                }),
+                libc::EBUSY => Err(Error::SubsystemBusy {
+                    nqn: self.get_nqn(),
+                    op: op.to_owned(),
+                }),
+                e => Err(Error::Subsystem {
+                    source: Errno::from_i32(e),
+                    nqn: self.get_nqn(),
+                    msg: format!("failed to initiate {}", op),
+                }),
+            }
+        };
+
+        if let Err(ref e) = res {
+            error!(?self, "Subsystem {} failed: {}", op, e.to_string());
+        } else {
+            info!(?self, "Subsystem {} completed: Ok", op);
+        }
+
+        res
+    }
+
     /// start the subsystem previously created -- note that we destroy it on
     /// failure to ensure the state is not in limbo and to avoid leaking
     /// resources
     pub async fn start(self) -> Result<String, Error> {
-        extern "C" fn start_cb(
-            ss: *mut spdk_nvmf_subsystem,
-            arg: *mut c_void,
-            status: i32,
-        ) {
-            let s = unsafe { Box::from_raw(arg as *mut oneshot::Sender<i32>) };
-            let ss = NvmfSubsystem::from(ss);
-            if status != 0 {
-                error!(
-                    "Failed start subsystem state {} -- destroying it",
-                    ss.get_nqn()
-                );
-                ss.destroy();
-            }
-
-            s.send(status).unwrap();
-        }
-
         self.add_listener().await?;
 
-        let (s, r) = oneshot::channel::<i32>();
+        if let Err(e) = self
+            .change_state("start", |ss, cb, arg| unsafe {
+                spdk_nvmf_subsystem_start(ss, cb, arg)
+            })
+            .await
+        {
+            error!(
+                "Failed to start subsystem '{}': {}; destroying it",
+                self.get_nqn(),
+                e.to_string(),
+            );
 
-        unsafe {
-            spdk_nvmf_subsystem_start(
-                self.0.as_ptr(),
-                Some(start_cb),
-                cb_arg(s),
-            )
+            self.destroy();
+
+            Err(e)
+        } else {
+            Ok(self.get_nqn())
         }
-        .to_result(|e| Error::Subsystem {
-            source: Errno::from_i32(e),
-            nqn: self.get_nqn(),
-            msg: "out of memory".to_string(),
-        })?;
-
-        r.await.unwrap().to_result(|e| Error::Subsystem {
-            source: Errno::from_i32(e),
-            nqn: self.get_nqn(),
-            msg: "failed to start the subsystem".to_string(),
-        })?;
-
-        debug!(?self, "shared");
-        Ok(self.get_nqn())
     }
 
     /// stop the subsystem
     pub async fn stop(&self) -> Result<(), Error> {
-        extern "C" fn stop_cb(
-            ss: *mut spdk_nvmf_subsystem,
-            arg: *mut c_void,
-            status: i32,
-        ) {
-            let s = unsafe { Box::from_raw(arg as *mut oneshot::Sender<i32>) };
-
-            let ss = NvmfSubsystem::from(ss);
-            if status != 0 {
-                error!(
-                    "Failed change subsystem state {} -- to STOP",
-                    ss.get_nqn()
-                );
-            }
-
-            s.send(status).unwrap();
-        }
-
-        let (s, r) = oneshot::channel::<i32>();
-        debug!("stopping {:?}", self);
-        unsafe {
-            spdk_nvmf_subsystem_stop(self.0.as_ptr(), Some(stop_cb), cb_arg(s))
-        }
-        .to_result(|e| Error::Subsystem {
-            source: Errno::from_i32(e),
-            nqn: self.get_nqn(),
-            msg: "out of memory".to_string(),
-        })?;
-
-        r.await.unwrap().to_result(|e| Error::Subsystem {
-            source: Errno::from_i32(e),
-            nqn: self.get_nqn(),
-            msg: "failed to stop the subsystem".to_string(),
-        })?;
-
-        debug!("stopped {}", self.get_nqn());
-        Ok(())
+        self.change_state("stop", |ss, cb, arg| unsafe {
+            spdk_nvmf_subsystem_stop(ss, cb, arg)
+        })
+        .await
     }
 
     /// transition the subsystem to paused state
     /// intended to be a temporary state while changes are made
     pub async fn pause(&self) -> Result<(), Error> {
-        extern "C" fn pause_cb(
-            ss: *mut spdk_nvmf_subsystem,
-            arg: *mut c_void,
-            status: i32,
-        ) {
-            let s = unsafe { Box::from_raw(arg as *mut oneshot::Sender<i32>) };
-
-            let ss = NvmfSubsystem::from(ss);
-            if status != 0 {
-                error!(
-                    "Failed change subsystem state {} -- to pause",
-                    ss.get_nqn()
-                );
-            }
-
-            s.send(status).unwrap();
-        }
-
-        let (s, r) = oneshot::channel::<i32>();
-
-        unsafe {
-            spdk_nvmf_subsystem_pause(
-                self.0.as_ptr(),
-                1,
-                Some(pause_cb),
-                cb_arg(s),
-            )
-        }
-        .to_result(|e| Error::Subsystem {
-            source: Errno::from_i32(-e),
-            nqn: self.get_nqn(),
-            msg: format!("subsystem_pause returned: {}", e),
-        })?;
-
-        r.await.unwrap().to_result(|e| Error::Subsystem {
-            source: Errno::from_i32(e),
-            nqn: self.get_nqn(),
-            msg: "failed to pause the subsystem".to_string(),
+        self.change_state("pause", |ss, cb, arg| unsafe {
+            spdk_nvmf_subsystem_pause(ss, 1, cb, arg)
         })
+        .await
     }
 
     /// transition the subsystem to active state
     pub async fn resume(&self) -> Result<(), Error> {
-        extern "C" fn resume_cb(
-            ss: *mut spdk_nvmf_subsystem,
-            arg: *mut c_void,
-            status: i32,
-        ) {
-            let s = unsafe { Box::from_raw(arg as *mut oneshot::Sender<i32>) };
-
-            let ss = NvmfSubsystem::from(ss);
-            if status != 0 {
-                error!(
-                    "Failed change subsystem state {} -- to RESUME",
-                    ss.get_nqn()
-                );
-            }
-
-            s.send(status).unwrap();
-        }
-
-        let (s, r) = oneshot::channel::<i32>();
-
-        let mut rc = unsafe {
-            spdk_nvmf_subsystem_resume(
-                self.0.as_ptr(),
-                Some(resume_cb),
-                cb_arg(s),
-            )
-        };
-
-        if rc != 0 {
-            return Err(Error::Subsystem {
-                source: Errno::from_i32(-rc),
-                nqn: self.get_nqn(),
-                msg: format!("subsystem_resume returned: {}", rc),
-            });
-        }
-
-        rc = r.await.unwrap();
-        if rc != 0 {
-            Err(Error::Subsystem {
-                source: Errno::UnknownErrno,
-                nqn: self.get_nqn(),
-                msg: "failed to resume the subsystem".to_string(),
-            })
-        } else {
-            Ok(())
-        }
+        self.change_state("resume", |ss, cb, arg| unsafe {
+            spdk_nvmf_subsystem_resume(ss, cb, arg)
+        })
+        .await
     }
 
     /// get ANA state
@@ -769,9 +713,16 @@ impl NvmfSubsystem {
         let subsystem = unsafe {
             NonNull::new(spdk_nvmf_subsystem_get_first(tgt)).map(NvmfSubsystem)
         };
+
         if let Some(subsystem) = subsystem {
             for s in subsystem.into_iter() {
-                s.stop().await.unwrap();
+                if let Err(e) = s.stop().await {
+                    error!(
+                        "Failed to stop subsystem '{}': {}",
+                        s.get_nqn(),
+                        e.to_string()
+                    );
+                }
             }
         }
     }

--- a/io-engine/src/subsys/nvmf/target.rs
+++ b/io-engine/src/subsys/nvmf/target.rs
@@ -297,7 +297,10 @@ impl Target {
         discovery.allow_any(true);
 
         Reactor::block_on(async {
-            let _ = discovery.start().await.unwrap();
+            let nqn = discovery.get_nqn();
+            if let Err(e) = discovery.start().await {
+                error!("Error starting subsystem '{}': {}", nqn, e.to_string());
+            }
         });
     }
 


### PR DESCRIPTION
NVMF subsystem API and Nexus unshare had some issues with error handling, which could potentially lead to use-after-free.

Signed-off-by: Dmitry Savitskiy <dmitry.savitskiy@datacore.com>