### PR TITLE
chore: partial revert of 4e82abc

### DIFF
--- a/io-engine/src/bdev/nexus/nexus_child.rs
+++ b/io-engine/src/bdev/nexus/nexus_child.rs
@@ -1013,30 +1013,18 @@ impl<'c> NexusChild<'c> {
     }
 
     /// TODO
-    pub(super) fn set_rebuild_job(&mut self, job: RebuildJob<'c>) {
-        assert!(self.rebuild_job.is_none());
-        self.rebuild_job = Some(job);
-    }
-
-    /// TODO
-    pub(super) fn remove_rebuild_job(&mut self) -> Option<RebuildJob<'c>> {
-        self.rebuild_job.take()
+    pub(super) fn remove_rebuild_job(&mut self) -> Option<RebuildJob<'static>> {
+        RebuildJob::remove(&self.name).ok()
     }
 
     /// Return the rebuild job which is rebuilding this child, if rebuilding.
-    pub fn rebuild_job(&self) -> Option<&RebuildJob<'c>> {
-        self.rebuild_job.as_ref()
-    }
-
-    /// Return the rebuild job which is rebuilding this child, if rebuilding.
-    pub fn rebuild_job_mut(&mut self) -> Option<&mut RebuildJob<'c>> {
-        self.rebuild_job.as_mut()
+    pub fn rebuild_job(&self) -> Option<&mut RebuildJob<'c>> {
+        RebuildJob::lookup(&self.name).ok()
     }
 
     /// Return the rebuild progress on this child, if rebuilding.
     pub fn get_rebuild_progress(&self) -> i32 {
-        self.rebuild_job
-            .as_ref()
+        self.rebuild_job()
             .map(|j| j.stats().progress as i32)
             .unwrap_or_else(|| -1)
     }

--- a/io-engine/src/grpc/v1/nexus.rs
+++ b/io-engine/src/grpc/v1/nexus.rs
@@ -509,7 +509,7 @@ impl NexusRpc for NexusService {
                 let uuid = args.uuid.clone();
                 debug!("Removing child {} from nexus {} ...", args.uri, uuid);
                 nexus_lookup(&args.uuid)?.remove_child(&args.uri).await?;
-                info!("Removed child from nexus {}", uuid);
+                info!("Removed child {} from nexus {}", args.uri, uuid);
                 Ok(nexus_lookup(&args.uuid)?.into_grpc().await)
             })?;
 

--- a/io-engine/src/rebuild/rebuild_error.rs
+++ b/io-engine/src/rebuild/rebuild_error.rs
@@ -8,6 +8,8 @@ use spdk_rs::{BdevDescError, DmaError};
 /// Various rebuild errors when interacting with a rebuild job or
 /// encountered during a rebuild copy
 pub enum RebuildError {
+    #[snafu(display("Job {} already exists", job))]
+    JobAlreadyExists { job: String },
     #[snafu(display("Failed to allocate buffer for the rebuild copy"))]
     NoCopyBuffer { source: DmaError },
     #[snafu(display("Failed to validate rebuild job creation parameters"))]

--- a/io-engine/src/rebuild/rebuild_task.rs
+++ b/io-engine/src/rebuild/rebuild_task.rs
@@ -30,7 +30,6 @@ pub(super) struct RebuildTask {
 /// Pool of rebuild tasks and progress tracking
 /// Each task uses a clone of the sender allowing the management task to poll a
 /// single receiver
-#[derive(Debug)]
 pub(super) struct RebuildTasks {
     /// TODO
     pub(super) tasks: Vec<RebuildTask>,
@@ -42,6 +41,16 @@ pub(super) struct RebuildTasks {
     pub(super) total: usize,
     /// TODO
     pub(super) segments_done: u64,
+}
+
+impl std::fmt::Debug for RebuildTasks {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RebuildTasks")
+            .field("active", &self.active)
+            .field("total", &self.total)
+            .field("segments_done", &self.segments_done)
+            .finish()
+    }
 }
 
 impl RebuildTasks {


### PR DESCRIPTION
Some issues where rebuilds are stuck are seen since 4e82abc. We should change the way rebuilds communicate with the nexus/children but since we are nearing a release for now let's partially revert it.

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>