### PR TITLE
refactor: remove unsafe constructs from rebuild

### DIFF
--- a/io-engine-tests/src/lib.rs
+++ b/io-engine-tests/src/lib.rs
@@ -425,7 +425,7 @@ pub fn get_device_size(nexus_device: &str) -> u64 {
 }
 
 /// Waits for the rebuild to reach `state`, up to `timeout`
-pub fn wait_for_rebuild(
+pub async fn wait_for_rebuild(
     dst_uri: String,
     state: RebuildState,
     timeout: Duration,
@@ -435,10 +435,10 @@ pub fn wait_for_rebuild(
         Ok(job) => job,
         Err(_) => return,
     };
-    job.stats();
+    job.stats().await;
 
     let mut curr_state = job.state();
-    let ch = job.notify_chan.1.clone();
+    let ch = job.notify_chan();
     let cname = dst_uri.clone();
     let t = Mthread::spawn_unaffinitized(move || {
         let now = std::time::Instant::now();
@@ -465,7 +465,7 @@ pub fn wait_for_rebuild(
     });
     reactor_poll!(r);
     if let Ok(job) = RebuildJob::lookup(&dst_uri) {
-        job.stats();
+        job.stats().await;
     }
     t.join().unwrap().unwrap();
 }

--- a/io-engine/src/bdev/nexus/nexus_child.rs
+++ b/io-engine/src/bdev/nexus/nexus_child.rs
@@ -1041,20 +1041,23 @@ impl<'c> NexusChild<'c> {
     }
 
     /// TODO
-    pub(super) fn remove_rebuild_job(&mut self) -> Option<RebuildJob<'static>> {
+    pub(super) fn remove_rebuild_job(
+        &mut self,
+    ) -> Option<std::sync::Arc<RebuildJob>> {
         RebuildJob::remove(&self.name).ok()
     }
 
     /// Return the rebuild job which is rebuilding this child, if rebuilding.
-    pub fn rebuild_job(&self) -> Option<&mut RebuildJob<'c>> {
+    pub fn rebuild_job(&self) -> Option<std::sync::Arc<RebuildJob>> {
         RebuildJob::lookup(&self.name).ok()
     }
 
     /// Return the rebuild progress on this child, if rebuilding.
-    pub fn get_rebuild_progress(&self) -> i32 {
-        self.rebuild_job()
-            .map(|j| j.stats().progress as i32)
-            .unwrap_or_else(|| -1)
+    pub async fn get_rebuild_progress(&self) -> i32 {
+        match self.rebuild_job() {
+            Some(j) => j.stats().await.progress as i32,
+            None => -1,
+        }
     }
 
     /// Determine if a child is local to the nexus (i.e. on the same node).

--- a/io-engine/src/rebuild/mod.rs
+++ b/io-engine/src/rebuild/mod.rs
@@ -1,10 +1,21 @@
+mod rebuild_descriptor;
 mod rebuild_error;
 mod rebuild_job;
+mod rebuild_job_backend;
+mod rebuild_record;
 mod rebuild_state;
 mod rebuild_task;
 
+use rebuild_descriptor::RebuildDescriptor;
 pub use rebuild_error::RebuildError;
-pub use rebuild_job::{RebuildJob, RebuildRecord};
+pub use rebuild_job::RebuildJob;
+use rebuild_job::RebuildOperation;
+use rebuild_job_backend::{
+    RebuildFBendChan,
+    RebuildJobBackend,
+    RebuildJobRequest,
+};
+pub use rebuild_record::RebuildRecord;
 pub use rebuild_state::RebuildState;
 use rebuild_state::RebuildStates;
 use rebuild_task::{RebuildTask, RebuildTasks, TaskResult};
@@ -33,19 +44,20 @@ impl Within<u64> for std::ops::Range<u64> {
 }
 
 /// Rebuild statistics.
+#[derive(Default, Debug, Clone)]
 pub struct RebuildStats {
-    /// total number of blocks to recover
+    /// Total number of blocks to recover.
     pub blocks_total: u64,
-    /// number of blocks recovered
+    /// Number of blocks recovered.
     pub blocks_recovered: u64,
-    /// rebuild progress in %
+    /// Rebuild progress in %.
     pub progress: u64,
-    /// granularity of each recovery copy in blocks
+    /// Granularity of each recovery copy in blocks.
     pub segment_size_blks: u64,
-    /// size in bytes of each block
+    /// Size in bytes of each block.
     pub block_size: u64,
-    /// total number of concurrent rebuild tasks
+    /// Total number of concurrent rebuild tasks.
     pub tasks_total: u64,
-    /// number of current active tasks
+    /// Number of current active tasks.
     pub tasks_active: u64,
 }

--- a/io-engine/src/rebuild/rebuild_descriptor.rs
+++ b/io-engine/src/rebuild/rebuild_descriptor.rs
@@ -1,0 +1,64 @@
+use snafu::ResultExt;
+
+use super::rebuild_error::{NoBdevHandle, RebuildError};
+use crate::core::{BlockDeviceDescriptor, BlockDeviceHandle, DescriptorGuard};
+
+/// Contains all descriptors and their associated information which allows the
+/// tasks to copy/rebuild data from source to destination.
+pub(super) struct RebuildDescriptor {
+    /// The block size of the src and dst.
+    /// todo: allow for differences?
+    pub(super) block_size: u64,
+    /// The range of the entire rebuild.
+    pub(super) range: std::ops::Range<u64>,
+    /// Segment size in blocks (number of segments divided by device block
+    /// size).
+    pub(super) segment_size_blks: u64,
+    /// Source URI of the healthy child to rebuild from.
+    pub src_uri: String,
+    /// Target URI of the out of sync child to rebuild.
+    pub dst_uri: String,
+    /// Pre-opened descriptor for the source block device.
+    #[allow(clippy::non_send_fields_in_send_ty)]
+    pub(super) src_descriptor: Box<dyn BlockDeviceDescriptor>,
+    /// Pre-opened descriptor for destination block device.
+    #[allow(clippy::non_send_fields_in_send_ty)]
+    pub(super) dst_descriptor: Box<dyn BlockDeviceDescriptor>,
+    /// Nexus Descriptor so we can lock its ranges when rebuilding a segment.
+    pub(super) nexus_descriptor: DescriptorGuard<()>,
+}
+
+impl RebuildDescriptor {
+    /// Return the size of the segment to be copied.
+    pub(super) fn get_segment_size_blks(&self, blk: u64) -> u64 {
+        // Adjust the segments size for the last segment
+        if (blk + self.segment_size_blks) > self.range.end {
+            return self.range.end - blk;
+        }
+        self.segment_size_blks
+    }
+    /// Get a `BlockDeviceHandle` for the source.
+    pub(super) async fn src_io_handle(
+        &self,
+    ) -> Result<Box<dyn BlockDeviceHandle>, RebuildError> {
+        Self::io_handle(&*self.src_descriptor).await
+    }
+    /// Get a `BlockDeviceHandle` for the destination.
+    pub(super) async fn dst_io_handle(
+        &self,
+    ) -> Result<Box<dyn BlockDeviceHandle>, RebuildError> {
+        Self::io_handle(&*self.dst_descriptor).await
+    }
+
+    /// Get a `BlockDeviceHandle` for the given block device descriptor.
+    pub(super) async fn io_handle(
+        descriptor: &dyn BlockDeviceDescriptor,
+    ) -> Result<Box<dyn BlockDeviceHandle>, RebuildError> {
+        descriptor
+            .get_io_handle_nonblock()
+            .await
+            .context(NoBdevHandle {
+                bdev: descriptor.get_device().device_name(),
+            })
+    }
+}

--- a/io-engine/src/rebuild/rebuild_error.rs
+++ b/io-engine/src/rebuild/rebuild_error.rs
@@ -1,5 +1,6 @@
-use crate::{bdev_api::BdevError, core::CoreError};
 use snafu::Snafu;
+
+use crate::{bdev_api::BdevError, core::CoreError};
 use spdk_rs::{BdevDescError, DmaError};
 
 #[derive(Debug, Snafu, Clone)]
@@ -60,4 +61,10 @@ pub enum RebuildError {
     },
     #[snafu(display("Failed to get bdev name from URI {}", uri))]
     BdevInvalidUri { source: BdevError, uri: String },
+    #[snafu(display("The rebuild frontend has been dropped"))]
+    FrontendGone,
+    #[snafu(display("The rebuild backend has been dropped"))]
+    BackendGone,
+    #[snafu(display("The rebuild task pool channel is unexpectedly closed with {} active tasks", active))]
+    RebuildTasksChannel { active: usize },
 }

--- a/io-engine/src/rebuild/rebuild_job.rs
+++ b/io-engine/src/rebuild/rebuild_job.rs
@@ -1,56 +1,22 @@
+use std::{collections::HashMap, sync::Arc};
+
 use chrono::{DateTime, Utc};
-use crossbeam::channel::{unbounded, Receiver, Sender};
-use futures::channel::{mpsc, oneshot};
-use snafu::ResultExt;
-use std::fmt;
-
-use spdk_rs::{DmaBuf, LbaRange};
-
-use crate::{
-    bdev::{device_open, nexus::nexus_iter, Nexus},
-    bdev_api::bdev_get_name,
-    core::{
-        Bdev,
-        BlockDevice,
-        BlockDeviceDescriptor,
-        BlockDeviceHandle,
-        CoreError,
-        DescriptorGuard,
-        Reactors,
-        ReadMode,
-        VerboseError,
-    },
-};
+use futures::channel::oneshot;
+use once_cell::sync::OnceCell;
 
 use super::{
-    rebuild_error::*,
     RebuildError,
+    RebuildJobRequest,
     RebuildState,
     RebuildStates,
     RebuildStats,
-    RebuildTask,
-    RebuildTasks,
-    TaskResult,
-    Within,
-    SEGMENT_SIZE,
-    SEGMENT_TASKS,
 };
-
-use once_cell::sync::OnceCell;
+use crate::core::{Reactors, VerboseError};
 use spdk_rs::Thread;
-use std::{cell::UnsafeCell, collections::HashMap};
 
-unsafe impl Sync for RebuildInstances {}
-unsafe impl Send for RebuildInstances {}
-
-/// Global list of rebuild jobs using a static OnceCell
-pub(crate) struct RebuildInstances {
-    inner: UnsafeCell<HashMap<String, Box<RebuildJob<'static>>>>,
-}
-
+/// Operations used to control the state of the job.
 #[derive(Debug)]
-/// Operations used to control the state of the job
-enum RebuildOperation {
+pub(super) enum RebuildOperation {
     /// Client Operations
     ///
     /// Starts the job for the first time
@@ -75,242 +41,94 @@ impl std::fmt::Display for RebuildOperation {
     }
 }
 
-/// A rebuild record is a lightweight extract of rebuild job that is maintained
-/// for the statistics.
-pub struct RebuildRecord {
-    /// source URI of the healthy child to rebuild from
-    pub src_uri: String,
-    /// target URI of the out of sync child in need of a rebuild
-    pub dst_uri: String,
-    /// Was this a partial rebuild?
-    pub partial_rebuild: bool,
-    /// What state this rebuild job ended up in
-    pub state: RebuildState,
-    /// Size of rebuilt data: Equal to replica size for full rebuilds,
-    /// and lesser(or possibly equal) for partial rebuilds
-    pub rebuilt_data_size: u64,
-    /// Start time of this rebuild
-    pub start: DateTime<Utc>,
-    /// End time of this rebuild
-    pub end: DateTime<Utc>,
-}
-
-impl From<RebuildJob<'_>> for RebuildRecord {
-    fn from(job: RebuildJob) -> Self {
-        RebuildRecord {
-            src_uri: job.src_uri.to_string(),
-            dst_uri: job.dst_uri.to_string(),
-            // TODO: Set boolean correctly after partial rebuild changes
-            partial_rebuild: false,
-            state: job.state(),
-            // TODO: Set data size correctly after partial rebuild changes
-            rebuilt_data_size: 0,
-            start: job.start,
-            end: Utc::now(),
-        }
-    }
-}
-
 /// A rebuild job is responsible for managing a rebuild (copy) which reads
-/// from source_hdl and writes into destination_hdl from specified start to end
-pub struct RebuildJob<'n> {
-    /// name of the nexus associated with the rebuild job
+/// from source_hdl and writes into destination_hdl from specified start to end.
+/// This is a frontend interface that communicates with a backend runner which
+/// is the one responsible for the read/writing of the data.
+#[derive(Debug)]
+pub struct RebuildJob {
+    /// Name of the nexus associated with the rebuild job.
     pub nexus_name: String,
-    /// descriptor for the nexus
-    pub(super) nexus_descriptor: DescriptorGuard<Nexus<'n>>,
-    /// source URI of the healthy child to rebuild from
-    pub src_uri: String,
-    /// target URI of the out of sync child in need of a rebuild
-    pub dst_uri: String,
-    /// TODO
-    pub(super) block_size: u64,
-    /// TODO
-    pub(super) range: std::ops::Range<u64>,
-    /// TODO
-    pub(super) next: u64,
-    /// Segment size in blocks (number of segments divided by device block
-    /// size).
-    pub(super) segment_size_blks: u64,
-    /// TODO
-    pub(super) task_pool: RebuildTasks,
-    /// TODO
-    pub(super) notify_fn: fn(String, String) -> (),
-    /// channel used to signal rebuild update
-    pub notify_chan: (Sender<RebuildState>, Receiver<RebuildState>),
-    /// current state of the rebuild job
-    pub(super) states: RebuildStates,
-    /// channel list which allows the await of the rebuild
-    pub(super) complete_chan: Vec<oneshot::Sender<RebuildState>>,
-    /// rebuild copy error, if any
-    pub error: Option<RebuildError>,
-    /// Start time of this rebuild job
-    pub start: DateTime<Utc>,
-
-    // Pre-opened descriptors for source/destination block device.
-    #[allow(clippy::non_send_fields_in_send_ty)]
-    pub(super) src_descriptor: Box<dyn BlockDeviceDescriptor>,
-    #[allow(clippy::non_send_fields_in_send_ty)]
-    pub(super) dst_descriptor: Box<dyn BlockDeviceDescriptor>,
+    /// Source URI of the healthy child to rebuild from.
+    src_uri: String,
+    /// Target URI of the out of sync child in need of a rebuild.
+    pub(crate) dst_uri: String,
+    comms: super::RebuildFBendChan,
+    /// Current state of the rebuild job.
+    states: Arc<parking_lot::RwLock<RebuildStates>>,
+    /// Channel used to Notify rebuild updates when the state changes.
+    notify_chan: crossbeam::channel::Receiver<RebuildState>,
+    /// Start time of this rebuild job.
+    start_time: DateTime<Utc>,
+    /// Channel used to Notify when rebuild completes.
+    complete_chan:
+        std::sync::Weak<parking_lot::Mutex<Vec<oneshot::Sender<RebuildState>>>>,
 }
 
-// TODO: is `RebuildJob` really a Send type?
-unsafe impl Send for RebuildJob<'_> {}
-
-impl<'n> fmt::Debug for RebuildJob<'n> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("RebuildJob")
-            .field("nexus", &self.nexus_name)
-            .field("source", &self.src_uri)
-            .field("destination", &self.dst_uri)
-            .finish()
-    }
-}
-
-impl<'n> RebuildJob<'n> {
+impl RebuildJob {
     /// Creates a new RebuildJob which rebuilds from source URI to target URI
     /// from start to end (of the data partition); notify_fn callback is called
     /// when the rebuild state is updated - with the nexus and destination
-    /// URI as arguments
+    /// URI as arguments.
     pub async fn new(
         nexus_name: &str,
         src_uri: &str,
         dst_uri: &str,
         range: std::ops::Range<u64>,
         notify_fn: fn(String, String) -> (),
-    ) -> Result<RebuildJob<'n>, RebuildError> {
-        let src_descriptor = device_open(
-            &bdev_get_name(src_uri).context(BdevInvalidUri {
-                uri: src_uri.to_string(),
-            })?,
-            false,
+    ) -> Result<Self, RebuildError> {
+        let backend = super::RebuildJobBackend::new(
+            nexus_name, src_uri, dst_uri, range, notify_fn,
         )
-        .map_err(|e| RebuildError::BdevNotFound {
-            source: e,
-            bdev: src_uri.to_string(),
-        })?;
-
-        let dst_descriptor = device_open(
-            &bdev_get_name(dst_uri).context(BdevInvalidUri {
-                uri: dst_uri.to_string(),
-            })?,
-            true,
-        )
-        .map_err(|e| RebuildError::BdevNotFound {
-            source: e,
-            bdev: dst_uri.to_string(),
-        })?;
-
-        let source_hdl = Self::get_io_handle(&*src_descriptor).await?;
-        let destination_hdl = Self::get_io_handle(&*dst_descriptor).await?;
-
-        if !Self::validate(
-            source_hdl.get_device(),
-            destination_hdl.get_device(),
-            &range,
-        ) {
-            return Err(RebuildError::InvalidParameters {});
+        .await?;
+        let frontend = Self {
+            nexus_name: backend.nexus_name.clone(),
+            src_uri: backend.src_uri.clone(),
+            dst_uri: backend.dst_uri.clone(),
+            states: backend.states.clone(),
+            comms: backend.info_chan.clone(),
+            complete_chan: Arc::downgrade(&backend.complete_chan),
+            notify_chan: backend.notify_chan.1.clone(),
+            start_time: Utc::now(),
         };
-
-        // validation passed, block size is the same for both
-        let block_size = destination_hdl.get_device().block_len();
-        let segment_size_blks = SEGMENT_SIZE / block_size;
-
-        let mut tasks = RebuildTasks {
-            tasks: Vec::new(),
-            // only sending one message per channel at a time so we don't need
-            // the extra buffer
-            channel: mpsc::channel(0),
-            active: 0,
-            total: SEGMENT_TASKS,
-            segments_done: 0,
-        };
-
-        for _ in 0 .. tasks.total {
-            let copy_buffer = destination_hdl
-                .dma_malloc(segment_size_blks * block_size)
-                .context(NoCopyBuffer {})?;
-            tasks.tasks.push(RebuildTask {
-                buffer: copy_buffer,
-                sender: tasks.channel.0.clone(),
-                error: None,
-            });
-        }
-
-        let nexus_descriptor = Bdev::<Nexus>::open_by_name(nexus_name, false)
-            .context(BdevNotFound {
-            bdev: nexus_name.to_string(),
-        })?;
-
-        Ok(Self {
-            nexus_name: nexus_name.to_string(),
-            nexus_descriptor,
-            src_uri: src_uri.to_string(),
-            dst_uri: dst_uri.to_string(),
-            next: range.start,
-            range,
-            block_size,
-            segment_size_blks,
-            task_pool: tasks,
-            notify_fn,
-            notify_chan: unbounded::<RebuildState>(),
-            states: Default::default(),
-            complete_chan: Vec::new(),
-            error: None,
-            start: Utc::now(),
-            src_descriptor,
-            dst_descriptor,
-        })
+        // kick off the rebuild task where it will "live" and await for commands
+        backend.schedule().await;
+        Ok(frontend)
     }
 
-    /// Get the rebuild job instances container, we ensure that this can only
-    /// ever be called on a properly allocated thread
-    fn get_instances() -> &'static mut HashMap<String, Box<RebuildJob<'static>>>
-    {
-        if !Thread::is_spdk_thread() {
-            panic!("not called from SPDK thread")
-        }
-
-        static REBUILD_INSTANCES: OnceCell<RebuildInstances> = OnceCell::new();
-
-        let global_instances =
-            REBUILD_INSTANCES.get_or_init(|| RebuildInstances {
-                inner: UnsafeCell::new(HashMap::new()),
-            });
-
-        unsafe { &mut *global_instances.inner.get() }
+    /// Returns number of all rebuild jobs on the system.
+    pub fn count() -> usize {
+        Self::get_instances().len()
     }
 
     /// Lookup a rebuild job by its destination uri then remove and drop it.
-    pub fn remove(name: &str) -> Result<RebuildJob<'static>, RebuildError> {
+    pub fn remove(name: &str) -> Result<Arc<Self>, RebuildError> {
         match Self::get_instances().remove(name) {
-            Some(job) => Ok(*job),
+            Some(job) => Ok(job),
             None => Err(RebuildError::JobNotFound {
                 job: name.to_owned(),
             }),
         }
     }
 
-    /// Stores a rebuild job in the rebuild job list
+    /// Stores a rebuild job in the rebuild job list.
     pub fn store(self) -> Result<(), RebuildError> {
-        let rebuild_list = Self::get_instances();
+        let mut rebuild_list = Self::get_instances();
 
         if rebuild_list.contains_key(&self.dst_uri) {
             Err(RebuildError::JobAlreadyExists {
                 job: self.dst_uri,
             })
         } else {
-            let _ = rebuild_list
-                .insert(self.dst_uri.clone(), Box::new(self.into_static()));
+            let _ = rebuild_list.insert(self.dst_uri.clone(), Arc::new(self));
             Ok(())
         }
     }
 
-    /// Lookup a rebuild job by its destination uri and return it
-    pub fn lookup<'a>(
-        dst_uri: &str,
-    ) -> Result<&'a mut RebuildJob<'a>, RebuildError> {
-        if let Some(job) = Self::get_instances().get_mut(dst_uri) {
-            Ok(Self::from_static(job))
+    /// Lookup a rebuild job by its destination uri and return it.
+    pub fn lookup(dst_uri: &str) -> Result<Arc<Self>, RebuildError> {
+        if let Some(job) = Self::get_instances().get(dst_uri) {
+            Ok(job.clone())
         } else {
             Err(RebuildError::JobNotFound {
                 job: dst_uri.to_owned(),
@@ -319,12 +137,12 @@ impl<'n> RebuildJob<'n> {
     }
 
     /// Lookup all rebuilds jobs with name as its source.
-    pub fn lookup_src<'a>(src_uri: &str) -> Vec<&'a mut RebuildJob<'a>> {
+    pub fn lookup_src(src_uri: &str) -> Vec<Arc<Self>> {
         Self::get_instances()
             .iter_mut()
             .filter_map(|j| {
                 if j.1.src_uri == src_uri {
-                    Some(Self::from_static(j.1.as_mut()))
+                    Some(j.1.clone())
                 } else {
                     None
                 }
@@ -332,467 +150,104 @@ impl<'n> RebuildJob<'n> {
             .collect()
     }
 
-    /// TODO
-    fn into_static(self) -> RebuildJob<'static> {
-        unsafe { std::mem::transmute::<_, RebuildJob<'static>>(self) }
-    }
-
-    /// TODO
-    fn from_static<'a>(
-        job: &mut RebuildJob<'static>,
-    ) -> &'a mut RebuildJob<'a> {
-        unsafe { std::mem::transmute::<_, &'a mut RebuildJob<'a>>(job) }
-    }
-
-    /// Returns number of all rebuild jobs on the system.
-    pub fn count() -> usize {
-        nexus_iter().fold(0, |acc, n| acc + n.count_rebuild_jobs())
-    }
-
-    /// State of the rebuild job
-    pub fn state(&self) -> RebuildState {
-        self.states.current
-    }
-
-    /// Error description
-    pub fn error_desc(&self) -> String {
-        match self.error.as_ref() {
-            Some(e) => e.verbose(),
-            _ => "".to_string(),
-        }
-    }
-
-    // Runs the management async task that kicks off N rebuild copy tasks and
-    // awaits each completion. When any task completes it kicks off another
-    // until the bdev is fully rebuilt
-    async fn run(&mut self) {
-        self.start_all_tasks();
-        while self.task_pool.active > 0 {
-            match self.await_one_task().await {
-                Some(r) => match r.error {
-                    None => {
-                        match self.states.pending {
-                            None | Some(RebuildState::Running) => {
-                                self.start_task_by_id(r.id);
-                            }
-                            _ => {
-                                // await all active tasks as we might still have
-                                // ongoing IO. do we need a timeout?
-                                self.await_all_tasks().await;
-                                break;
-                            }
-                        }
-                    }
-                    Some(e) => {
-                        error!("Failed to rebuild segment id {} block {} with error: {}", r.id, r.blk, e);
-                        self.fail();
-                        self.await_all_tasks().await;
-                        self.error = Some(e);
-                        break;
-                    }
-                },
-                None => {
-                    // all senders have disconnected, out of place termination?
-                    error!("Out of place termination with potentially {} active tasks", self.task_pool.active);
-                    let _ = self.terminate();
-                    break;
-                }
-            }
-        }
-        self.reconcile();
-    }
-
-    /// Return the size of the segment to be copied.
-    fn get_segment_size_blks(&self, blk: u64) -> u64 {
-        // Adjust the segments size for the last segment
-        if (blk + self.segment_size_blks) > self.range.end {
-            return self.range.end - blk;
-        }
-        self.segment_size_blks
-    }
-
-    /// Copies one segment worth of data from source into destination. During
-    /// this time the LBA range being copied is locked so that there cannot be
-    /// front end I/O to the same LBA range.
-    ///
-    /// # Safety
-    ///
-    /// The lock and unlock functions internally reference the RangeContext as a
-    /// raw pointer, so rust cannot correctly manage its lifetime. The
-    /// RangeContext MUST NOT be dropped until after the lock and unlock have
-    /// completed.
-    ///
-    /// The use of RangeContext here is safe because it is stored on the stack
-    /// for the duration of the calls to lock and unlock.
-    async fn locked_copy_one(
-        &mut self,
-        id: usize,
-        blk: u64,
-    ) -> Result<(), RebuildError> {
-        let len = self.get_segment_size_blks(blk);
-        // The nexus children have metadata and data partitions, whereas the
-        // nexus has a data partition only. Because we are locking the range on
-        // the nexus, we need to calculate the offset from the start of the data
-        // partition.
-        let r = LbaRange::new(blk - self.range.start, len);
-
-        // Wait for LBA range to be locked.
-        // This prevents other I/Os being issued to this LBA range whilst it is
-        // being rebuilt.
-        let lock = self.nexus_descriptor.lock_lba_range(r).await.context(
-            RangeLockFailed {
-                blk,
-                len,
-            },
-        )?;
-
-        // Perform the copy
-        let result = self.copy_one(id, blk).await;
-
-        // Wait for the LBA range to be unlocked.
-        // This allows others I/Os to be issued to this LBA range once again.
-        self.nexus_descriptor.unlock_lba_range(lock).await.context(
-            RangeUnlockFailed {
-                blk,
-                len,
-            },
-        )?;
-
-        result
-    }
-
-    /// Copies one segment worth of data from source into destination.
-    async fn copy_one(
-        &mut self,
-        id: usize,
-        blk: u64,
-    ) -> Result<(), RebuildError> {
-        let mut copy_buffer: DmaBuf;
-        let mut source_hdl = Self::get_io_handle(&*self.src_descriptor).await?;
-        let destination_hdl =
-            Self::get_io_handle(&*self.dst_descriptor).await?;
-
-        let copy_buffer = if self.get_segment_size_blks(blk)
-            == self.segment_size_blks
-        {
-            &mut self.task_pool.tasks[id].buffer
-        } else {
-            let segment_size_blks = self.range.end - blk;
-
-            trace!(
-                    "Adjusting last segment size from {} to {}. offset: {}, range: {:?}",
-                    self.segment_size_blks, segment_size_blks, blk, self.range,
-                );
-
-            copy_buffer = destination_hdl
-                .dma_malloc(segment_size_blks * self.block_size)
-                .context(NoCopyBuffer {})?;
-
-            &mut copy_buffer
-        };
-
-        source_hdl.set_read_mode(ReadMode::UnwrittenFail);
-
-        let res = source_hdl.read_at(blk * self.block_size, copy_buffer).await;
-
-        if let Err(CoreError::ReadingUnallocatedBlock {
-            ..
-        }) = res
-        {
-            return Ok(());
-        }
-
-        res.context(ReadIoFailed {
-            bdev: &self.src_uri,
-        })?;
-
-        destination_hdl
-            .write_at(blk * self.block_size, copy_buffer)
-            .await
-            .context(WriteIoFailed {
-                bdev: &self.dst_uri,
-            })?;
-
-        Ok(())
-    }
-
-    /// TODO
-    async fn get_io_handle(
-        descriptor: &dyn BlockDeviceDescriptor,
-    ) -> Result<Box<dyn BlockDeviceHandle>, RebuildError> {
-        descriptor.get_io_handle_nonblock().await.map_err(|e| {
-            RebuildError::NoBdevHandle {
-                source: e,
-                bdev: descriptor.get_device().device_name(),
-            }
-        })
-    }
-
-    /// TODO
-    fn notify(&mut self) {
-        self.stats();
-        self.send_notify();
-    }
-
-    /// Calls the job's registered notify fn callback and notify sender channel
-    fn send_notify(&mut self) {
-        // should this return a status before we notify the sender channel?
-        (self.notify_fn)(self.nexus_name.clone(), self.dst_uri.clone());
-        if let Err(e) = self.notify_chan.0.send(self.state()) {
-            error!("Rebuild Job {} of nexus {} failed to send complete via the unbound channel with err {}", self.dst_uri, self.nexus_name, e);
-        }
-    }
-
-    /// Check if the source and destination block devices are compatible for
-    /// rebuild
-    fn validate(
-        source: &dyn BlockDevice,
-        destination: &dyn BlockDevice,
-        range: &std::ops::Range<u64>,
-    ) -> bool {
-        // todo: make sure we don't overwrite the labels
-        let data_partition_start = 0;
-        range.within(data_partition_start .. source.num_blocks())
-            && range.within(data_partition_start .. destination.num_blocks())
-            && source.block_len() == destination.block_len()
-    }
-
-    /// Reconciles the pending state to the current and clear the pending.
-    fn reconcile(&mut self) {
-        let old = self.state();
-        let new = self.states.reconcile();
-
-        if old != new {
-            info!(
-                "Rebuild job {}: changing state from {:?} to {:?}",
-                self.dst_uri, old, new
-            );
-            self.notify();
-        }
-    }
-
-    /// Reconciles to state if it's the same as the pending value.
-    fn reconcile_to_state(&mut self, state: RebuildState) -> bool {
-        if self.states.pending_equals(state) {
-            self.reconcile();
-            true
-        } else {
-            false
-        }
-    }
-
-    /// TODO
-    fn schedule(&self) {
-        match self.state() {
-            RebuildState::Paused | RebuildState::Init => {
-                let dst_uri = self.dst_uri.clone();
-                Reactors::master().send_future(async move {
-                    let job = match RebuildJob::lookup(&dst_uri) {
-                        Ok(job) => job,
-                        Err(_) => {
-                            return error!(
-                                "Failed to find and start the rebuild job {}",
-                                dst_uri
-                            );
-                        }
-                    };
-
-                    if job.reconcile_to_state(RebuildState::Running) {
-                        job.run().await;
-                    }
-                });
-            }
-            _ => {}
-        }
-    }
-
-    /// Collects statistics from the job
-    pub fn stats(&self) -> RebuildStats {
-        let blocks_total = self.range.end - self.range.start;
-
-        // segment size may not be aligned to the total size
-        let blocks_recovered = std::cmp::min(
-            self.task_pool.segments_done * self.segment_size_blks,
-            blocks_total,
-        );
-
-        let progress = (blocks_recovered * 100) / blocks_total;
-
-        info!(
-            "State: {}, Src: {}, Dst: {}, range: {:?}, next: {}, \
-             block_size: {}, segment_sz: {}, recovered_blks: {}, progress: {}%, TaskPool: {:?}",
-            self.state(),
-            self.src_uri,
-            self.dst_uri,
-            self.range,
-            self.next,
-            self.block_size,
-            self.segment_size_blks,
-            blocks_recovered,
-            progress,
-            self.task_pool,
-        );
-
-        RebuildStats {
-            blocks_total,
-            blocks_recovered,
-            progress,
-            segment_size_blks: self.segment_size_blks,
-            block_size: self.block_size,
-            tasks_total: self.task_pool.total as u64,
-            tasks_active: self.task_pool.active as u64,
-        }
-    }
-
     /// Schedules the job to start in a future and returns a complete channel
     /// which can be waited on.
     pub fn start(
-        &mut self,
+        &self,
     ) -> Result<oneshot::Receiver<RebuildState>, RebuildError> {
         self.exec_client_op(RebuildOperation::Start)?;
-        let end_channel = oneshot::channel();
-        self.complete_chan.push(end_channel.0);
-        Ok(end_channel.1)
+        self.add_completion_listener()
     }
 
     /// Stops the job which then triggers the completion hooks.
-    pub fn stop(&mut self) -> Result<(), RebuildError> {
+    pub fn stop(&self) -> Result<(), RebuildError> {
         self.exec_client_op(RebuildOperation::Stop)
     }
 
     /// Pauses the job which can then be later resumed.
-    pub fn pause(&mut self) -> Result<(), RebuildError> {
+    pub fn pause(&self) -> Result<(), RebuildError> {
         self.exec_client_op(RebuildOperation::Pause)
     }
 
     /// Resumes a previously paused job
     /// this could be used to mitigate excess load on the source bdev, eg
     /// too much contention with frontend IO.
-    pub fn resume(&mut self) -> Result<(), RebuildError> {
+    pub fn resume(&self) -> Result<(), RebuildError> {
         self.exec_client_op(RebuildOperation::Resume)
     }
 
     /// Forcefully terminates the job, overriding any pending client operation
     /// returns an async channel which can be used to await for termination/
-    pub fn terminate(&mut self) -> oneshot::Receiver<RebuildState> {
+    pub fn terminate(&self) -> oneshot::Receiver<RebuildState> {
         self.exec_internal_op(RebuildOperation::Stop).ok();
-        let end_channel = oneshot::channel();
-        self.complete_chan.push(end_channel.0);
-        end_channel.1
+        self.add_completion_listener()
+            .unwrap_or_else(|_| oneshot::channel().1)
     }
 
-    /// Fails the job, overriding any pending client operation
-    fn fail(&mut self) {
-        self.exec_internal_op(RebuildOperation::Fail).ok();
+    /// Get the rebuild stats.
+    pub async fn stats(&self) -> RebuildStats {
+        let (s, r) = oneshot::channel::<RebuildStats>();
+        self.comms.send(RebuildJobRequest::Stats(s)).await.ok();
+        r.await.unwrap_or_default()
     }
 
-    /// Completes the job, overriding any pending operation
-    fn complete(&mut self) {
-        self.exec_internal_op(RebuildOperation::Complete).ok();
+    /// Get the last error.
+    pub fn error(&self) -> Option<RebuildError> {
+        self.states.read().error.clone()
     }
-
-    /// TODO
-    fn start_all_tasks(&mut self) {
-        assert_eq!(
-            self.task_pool.active, 0,
-            "{} active tasks",
-            self.task_pool.active
-        );
-
-        for n in 0 .. self.task_pool.total {
-            self.next = match self.send_segment_task(n) {
-                Some(next) => {
-                    self.task_pool.active += 1;
-                    next
-                }
-                None => break, /* we've already got enough tasks to rebuild
-                                * the bdev */
-            };
+    /// Get the last error description.
+    pub fn error_desc(&self) -> String {
+        match self.error() {
+            Some(e) => e.verbose(),
+            _ => "".to_string(),
         }
     }
 
-    /// TODO
-    fn start_task_by_id(&mut self, id: usize) {
-        match self.send_segment_task(id) {
-            Some(next) => {
-                self.task_pool.active += 1;
-                self.next = next;
-            }
-            None => {
-                if self.task_pool.active == 0 {
-                    self.complete();
-                }
-            }
-        };
+    /// Gets the current rebuild state.
+    pub fn state(&self) -> RebuildState {
+        self.states.read().current
     }
 
-    /// TODO
-    async fn await_one_task(&mut self) -> Option<TaskResult> {
-        self.task_pool.await_one_task().await
+    /// Get a channel to listen on for rebuild notifications.
+    pub fn notify_chan(&self) -> crossbeam::channel::Receiver<RebuildState> {
+        self.notify_chan.clone()
     }
 
-    /// TODO
-    async fn await_all_tasks(&mut self) {
-        debug!(
-            "Awaiting all active tasks({}) for rebuild {}",
-            self.task_pool.active, self.dst_uri
-        );
-
-        while self.task_pool.active > 0 {
-            if self.await_one_task().await.is_none() {
-                error!("Failed to wait for {} rebuild tasks due mpsc channel failure.", self.task_pool.active);
-                self.fail();
-                return;
-            }
-        }
-        debug!("Finished awaiting all tasks for rebuild {}", self.dst_uri);
+    /// Get the uri of the rebuild source.
+    pub fn src_uri(&self) -> &str {
+        &self.src_uri
+    }
+    /// Get the uri of the rebuild destination.
+    pub fn dst_uri(&self) -> &str {
+        &self.dst_uri
+    }
+    /// Start time of this rebuild job.
+    pub fn start_time(&self) -> DateTime<Utc> {
+        self.start_time
     }
 
-    /// Sends one segment worth of data in a reactor future and notifies the
-    /// management channel. Returns the next segment offset to rebuild, if any.
-    fn send_segment_task(&self, id: usize) -> Option<u64> {
-        if self.next >= self.range.end {
-            None
-        } else {
-            let blk = self.next;
-            let next = std::cmp::min(
-                self.next + self.segment_size_blks,
-                self.range.end,
-            );
-            let dst_uri = self.dst_uri.clone();
+    /// Get the rebuild job instances container, we ensure that this can only
+    /// ever be called on a properly allocated thread
+    fn get_instances<'a>() -> parking_lot::MutexGuard<'a, RebuildJobInstances> {
+        assert!(Thread::is_spdk_thread(), "not called from SPDK thread");
 
-            Reactors::current().send_future(async move {
-                let job = Self::lookup(&dst_uri).unwrap();
+        static REBUILD_INSTANCES: OnceCell<
+            parking_lot::Mutex<RebuildJobInstances>,
+        > = OnceCell::new();
 
-                let r = TaskResult {
-                    blk,
-                    id,
-                    error: job.locked_copy_one(id, blk).await.err(),
-                };
-
-                let task = &mut job.task_pool.tasks[id];
-                if let Err(e) = task.sender.start_send(r) {
-                    error!("Failed to notify job of segment id: {} blk: {} completion, err: {}", id, blk, e.verbose());
-                }
-            });
-
-            Some(next)
-        }
+        REBUILD_INSTANCES
+            .get_or_init(|| parking_lot::Mutex::new(HashMap::new()))
+            .lock()
     }
-}
 
-impl<'n> RebuildJob<'n> {
     /// Client operations are now allowed to skip over previous operations.
-    fn exec_client_op(
-        &mut self,
-        op: RebuildOperation,
-    ) -> Result<(), RebuildError> {
+    fn exec_client_op(&self, op: RebuildOperation) -> Result<(), RebuildError> {
         self.exec_op(op, false)
     }
 
-    /// TODO.
+    /// Internal operations can bypass previous pending operations.
     fn exec_internal_op(
-        &mut self,
+        &self,
         op: RebuildOperation,
     ) -> Result<(), RebuildError> {
         self.exec_op(op, true)
@@ -800,90 +255,41 @@ impl<'n> RebuildJob<'n> {
 
     /// Single state machine where all operations are handled.
     fn exec_op(
-        &mut self,
+        &self,
         op: RebuildOperation,
         override_pending: bool,
     ) -> Result<(), RebuildError> {
-        type S = RebuildState;
-        let e = RebuildError::OpError {
-            operation: op.to_string(),
-            state: self.states.to_string(),
-        };
-
-        trace!(
-            "Executing operation {} with override {}",
-            op,
-            override_pending
-        );
-
-        match op {
-            RebuildOperation::Start => {
-                match self.state() {
-                    // start only allowed when... starting
-                    S::Stopped | S::Paused | S::Failed | S::Completed => Err(e),
-                    // for idempotence sake
-                    S::Running => Ok(()),
-                    S::Init => {
-                        self.states.set_pending(S::Running, false)?;
-                        self.schedule();
-                        Ok(())
-                    }
-                }
-            }
-            RebuildOperation::Stop => {
-                match self.state() {
-                    // We're already stopping anyway, so all is well
-                    S::Failed | S::Completed => Err(e),
-                    // for idempotence sake
-                    S::Stopped => Ok(()),
-                    S::Running => {
-                        self.states
-                            .set_pending(S::Stopped, override_pending)?;
-                        Ok(())
-                    }
-                    S::Init | S::Paused => {
-                        self.states
-                            .set_pending(S::Stopped, override_pending)?;
-
-                        // The rebuild is not running so we need to reconcile
-                        self.reconcile();
-                        Ok(())
-                    }
-                }
-            }
-            RebuildOperation::Pause => match self.state() {
-                S::Stopped | S::Failed | S::Completed => Err(e),
-                S::Init | S::Running | S::Paused => {
-                    self.states.set_pending(S::Paused, false)?;
-                    Ok(())
-                }
-            },
-            RebuildOperation::Resume => match self.state() {
-                S::Init | S::Stopped | S::Failed | S::Completed => Err(e),
-                S::Running | S::Paused => {
-                    self.states.set_pending(S::Running, false)?;
-                    self.schedule();
-                    Ok(())
-                }
-            },
-            RebuildOperation::Fail => match self.state() {
-                S::Init | S::Stopped | S::Paused | S::Completed => Err(e),
-                // for idempotence sake
-                S::Failed => Ok(()),
-                S::Running => {
-                    self.states.set_pending(S::Failed, override_pending)?;
-                    Ok(())
-                }
-            },
-            RebuildOperation::Complete => match self.state() {
-                S::Init | S::Paused | S::Stopped | S::Failed | S::Completed => {
-                    Err(e)
-                }
-                S::Running => {
-                    self.states.set_pending(S::Completed, override_pending)?;
-                    Ok(())
-                }
-            },
+        let wake_up = self.states.write().exec_op(op, override_pending)?;
+        if wake_up {
+            self.wake_up();
         }
+        Ok(())
+    }
+
+    fn wake_up(&self) {
+        let sender = self.comms.send_clone();
+        Reactors::master().send_future(async move {
+            if let Err(error) = sender.send(RebuildJobRequest::WakeUp).await {
+                error!(
+                    ?error,
+                    "Failed to wake up rebuild backend, it has been dropped"
+                );
+            }
+        });
+    }
+
+    fn add_completion_listener(
+        &self,
+    ) -> Result<oneshot::Receiver<RebuildState>, RebuildError> {
+        let (sender, receiver) = oneshot::channel();
+        let list = match self.complete_chan.upgrade() {
+            None => Err(RebuildError::BackendGone),
+            Some(chan) => Ok(chan),
+        }?;
+        list.lock().push(sender);
+        Ok(receiver)
     }
 }
+
+/// List of rebuild jobs indexed by the destination's replica uri.
+type RebuildJobInstances = HashMap<String, Arc<RebuildJob>>;

--- a/io-engine/src/rebuild/rebuild_job_backend.rs
+++ b/io-engine/src/rebuild/rebuild_job_backend.rs
@@ -1,0 +1,532 @@
+use crossbeam::channel::{unbounded, Receiver, Sender};
+use futures::{
+    channel::{mpsc, oneshot},
+    FutureExt,
+    StreamExt,
+};
+use snafu::ResultExt;
+use std::sync::Arc;
+
+use super::{
+    rebuild_error::{BdevInvalidUri, BdevNotFound, NoCopyBuffer},
+    RebuildDescriptor,
+    RebuildError,
+    RebuildState,
+    RebuildStates,
+    RebuildStats,
+    RebuildTask,
+    RebuildTasks,
+    TaskResult,
+    Within,
+    SEGMENT_SIZE,
+    SEGMENT_TASKS,
+};
+use crate::{
+    bdev::device_open,
+    bdev_api::bdev_get_name,
+    core::{BlockDevice, Reactors, UntypedBdev},
+};
+
+/// Request between frontend and backend.
+#[derive(Debug)]
+pub(super) enum RebuildJobRequest {
+    /// Wake up the rebuild backend to check for latest state information.
+    WakeUp,
+    /// Get the rebuild stats from the backend.
+    Stats(oneshot::Sender<RebuildStats>),
+}
+
+/// Channel to share information between frontend and backend.
+#[derive(Debug, Clone)]
+pub(super) struct RebuildFBendChan {
+    sender: async_channel::Sender<RebuildJobRequest>,
+    receiver: async_channel::Receiver<RebuildJobRequest>,
+}
+impl RebuildFBendChan {
+    fn new() -> Self {
+        let (sender, receiver) = async_channel::unbounded();
+        Self {
+            sender,
+            receiver,
+        }
+    }
+    /// Forward the given request to the backend job.
+    pub(super) async fn send(
+        &self,
+        req: RebuildJobRequest,
+    ) -> Result<(), RebuildError> {
+        self.sender
+            .send(req)
+            .await
+            .map_err(|_| RebuildError::BackendGone)
+    }
+    /// Get a clone of the sender channel.
+    pub(super) fn send_clone(
+        &self,
+    ) -> async_channel::Sender<RebuildJobRequest> {
+        self.sender.clone()
+    }
+    async fn recv(&mut self) -> Result<RebuildJobRequest, RebuildError> {
+        self.receiver
+            .recv()
+            .await
+            .map_err(|_| RebuildError::FrontendGone {})
+    }
+    /// Get a clone of the receive channel.
+    fn recv_clone(&self) -> async_channel::Receiver<RebuildJobRequest> {
+        self.receiver.clone()
+    }
+}
+
+/// A rebuild job is responsible for managing a rebuild (copy) which reads
+/// from source_hdl and writes into destination_hdl from specified start to end.
+pub(super) struct RebuildJobBackend {
+    /// Name of the nexus associated with the rebuild job.
+    pub nexus_name: String,
+    /// Source URI of the healthy child to rebuild from.
+    pub src_uri: String,
+    /// Target URI of the out of sync child in need of a rebuild.
+    pub dst_uri: String,
+    /// The next block to be rebuilt.
+    pub(super) next: u64,
+    /// A pool of tasks which perform the actual data rebuild.
+    pub(super) task_pool: RebuildTasks,
+    /// Notification as a `fn` callback.
+    pub(super) notify_fn: fn(String, String) -> (),
+    /// Channel used to signal rebuild update.
+    pub notify_chan: (Sender<RebuildState>, Receiver<RebuildState>),
+    /// Current state of the rebuild job.
+    pub(super) states: Arc<parking_lot::RwLock<RebuildStates>>,
+    /// Channel list which allows the await of the rebuild.
+    pub(super) complete_chan:
+        Arc<parking_lot::Mutex<Vec<oneshot::Sender<RebuildState>>>>,
+    /// Channel to share information between frontend and backend.
+    pub(super) info_chan: RebuildFBendChan,
+    /// All the rebuild related descriptors.
+    pub(super) descriptor: Arc<RebuildDescriptor>,
+}
+
+impl std::fmt::Debug for RebuildJobBackend {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RebuildJob")
+            .field("nexus", &self.nexus_name)
+            .field("source", &self.src_uri)
+            .field("destination", &self.dst_uri)
+            .finish()
+    }
+}
+
+impl RebuildJobBackend {
+    /// Creates a new RebuildJob which rebuilds from source URI to target URI
+    /// from start to end (of the data partition); notify_fn callback is called
+    /// when the rebuild state is updated - with the nexus and destination
+    /// URI as arguments.
+    pub async fn new(
+        nexus_name: &str,
+        src_uri: &str,
+        dst_uri: &str,
+        range: std::ops::Range<u64>,
+        notify_fn: fn(String, String) -> (),
+    ) -> Result<Self, RebuildError> {
+        let src_descriptor = device_open(
+            &bdev_get_name(src_uri).context(BdevInvalidUri {
+                uri: src_uri.to_string(),
+            })?,
+            false,
+        )
+        .map_err(|e| RebuildError::BdevNotFound {
+            source: e,
+            bdev: src_uri.to_string(),
+        })?;
+
+        let dst_descriptor = device_open(
+            &bdev_get_name(dst_uri).context(BdevInvalidUri {
+                uri: dst_uri.to_string(),
+            })?,
+            true,
+        )
+        .map_err(|e| RebuildError::BdevNotFound {
+            source: e,
+            bdev: dst_uri.to_string(),
+        })?;
+
+        let source_hdl = RebuildDescriptor::io_handle(&*src_descriptor).await?;
+        let destination_hdl =
+            RebuildDescriptor::io_handle(&*dst_descriptor).await?;
+
+        if !Self::validate(
+            source_hdl.get_device(),
+            destination_hdl.get_device(),
+            &range,
+        ) {
+            return Err(RebuildError::InvalidParameters {});
+        };
+
+        // validation passed, block size is the same for both
+        let block_size = destination_hdl.get_device().block_len();
+        let segment_size_blks = SEGMENT_SIZE / block_size;
+
+        let mut tasks = RebuildTasks {
+            tasks: Default::default(),
+            // only sending one message per channel at a time so we don't need
+            // the extra buffer
+            channel: mpsc::channel(0),
+            active: 0,
+            total: SEGMENT_TASKS,
+            segments_done: Default::default(),
+        };
+
+        for _ in 0 .. tasks.total {
+            let copy_buffer = destination_hdl
+                .dma_malloc(segment_size_blks * block_size)
+                .context(NoCopyBuffer {})?;
+            tasks.push(RebuildTask {
+                buffer: copy_buffer,
+                sender: tasks.channel.0.clone(),
+                error: None,
+            });
+        }
+
+        let nexus_descriptor = UntypedBdev::open_by_name(nexus_name, false)
+            .context(BdevNotFound {
+                bdev: nexus_name.to_string(),
+            })?;
+
+        Ok(Self {
+            nexus_name: nexus_name.to_string(),
+            src_uri: src_uri.to_string(),
+            dst_uri: dst_uri.to_string(),
+            task_pool: tasks,
+            next: range.start,
+            notify_fn,
+            notify_chan: unbounded::<RebuildState>(),
+            states: Default::default(),
+            complete_chan: Default::default(),
+            info_chan: RebuildFBendChan::new(),
+            descriptor: Arc::new(RebuildDescriptor {
+                src_uri: src_uri.to_string(),
+                dst_uri: dst_uri.to_string(),
+                range,
+                block_size,
+                segment_size_blks,
+                src_descriptor,
+                dst_descriptor,
+                nexus_descriptor,
+            }),
+        })
+    }
+
+    /// State of the rebuild job
+    fn state(&self) -> RebuildState {
+        self.states.read().current
+    }
+
+    /// Reply back to the requester with the rebuild statistics.
+    async fn reply_stats(
+        &mut self,
+        requester: oneshot::Sender<RebuildStats>,
+    ) -> Result<(), RebuildStats> {
+        requester.send(self.stats())?;
+        Ok(())
+    }
+
+    /// Moves the rebuild job runner and runs until completion.
+    pub(super) async fn schedule(self) {
+        let mut job = self;
+        Reactors::master().send_future(async move { job.run().await });
+    }
+
+    /// Runs the management async task and listens for requests from the
+    /// frontend side of the rebuild, example: get statistics.
+    async fn run(&mut self) {
+        while !self.reconcile().done() {
+            if !self.state().running() {
+                match self.info_chan.recv().await {
+                    Ok(RebuildJobRequest::WakeUp) => {}
+                    Ok(RebuildJobRequest::Stats(reply)) => {
+                        self.reply_stats(reply).await.ok();
+                    }
+                    Err(error) => {
+                        self.fail_with(error);
+                    }
+                }
+                continue;
+            }
+
+            self.start_all_tasks();
+
+            let mut recv = self.info_chan.recv_clone();
+            while self.task_pool.running() {
+                futures::select! {
+                    message = recv.next() => match message {
+                        Some(RebuildJobRequest::WakeUp) => { }
+                        Some(RebuildJobRequest::Stats(reply)) => {
+                            self.reply_stats(reply).await.ok();
+                        }
+                        None => {
+                            // The frontend is gone (dropped), this should not happen, but let's
+                            // be defensive and simply cancel the rebuild.
+                            self.fail_with(RebuildError::FrontendGone);
+                            self.manage_tasks().await;
+                            break;
+                        }
+                    },
+                    _ = self.manage_tasks().fuse() => {},
+                }
+            }
+        }
+    }
+
+    /// Runs the management async task that kicks off N rebuild copy tasks and
+    /// awaits each completion. When any task completes it kicks off another
+    /// until the destination is fully rebuilt.
+    async fn manage_tasks(&mut self) {
+        while self.task_pool.active > 0 {
+            match self.await_one_task().await {
+                Some(r) => match r.error {
+                    None => {
+                        let state = self.states.read().clone();
+                        match state.pending {
+                            None | Some(RebuildState::Running) => {
+                                self.start_task_by_id(r.id);
+                            }
+                            _ => {
+                                // await all active tasks as we might still have
+                                // ongoing IO. do we need a timeout?
+                                self.await_all_tasks().await;
+                                break;
+                            }
+                        }
+                    }
+                    Some(e) => {
+                        error!("Failed to rebuild segment id {} block {} with error: {}", r.id, r.blk, e);
+                        self.fail_with(e);
+                        self.await_all_tasks().await;
+                        break;
+                    }
+                },
+                None => {
+                    // all senders have disconnected, out of place termination?
+                    self.task_sync_fail();
+                    break;
+                }
+            }
+        }
+    }
+
+    /// Log the statistics and send a notification to the listeners.
+    fn notify(&mut self) {
+        self.stats();
+        self.send_notify();
+    }
+
+    /// Calls the job's registered notify fn callback and notify sender channel
+    fn send_notify(&mut self) {
+        // should this return a status before we notify the sender channel?
+        (self.notify_fn)(self.nexus_name.clone(), self.dst_uri.clone());
+        if let Err(e) = self.notify_chan.0.send(self.state()) {
+            error!("Rebuild Job {} of nexus {} failed to send complete via the unbound channel with err {}", self.dst_uri, self.nexus_name, e);
+        }
+    }
+
+    /// Check if the source and destination block devices are compatible for
+    /// rebuild
+    fn validate(
+        source: &dyn BlockDevice,
+        destination: &dyn BlockDevice,
+        range: &std::ops::Range<u64>,
+    ) -> bool {
+        // todo: make sure we don't overwrite the labels
+        let data_partition_start = 0;
+        range.within(data_partition_start .. source.num_blocks())
+            && range.within(data_partition_start .. destination.num_blocks())
+            && source.block_len() == destination.block_len()
+    }
+
+    /// Reconciles the pending state to the current and clear the pending.
+    fn reconcile(&mut self) -> RebuildState {
+        let (old, new) = {
+            let mut state = self.states.write();
+            let old = state.current;
+            let new = state.reconcile();
+            (old, new)
+        };
+
+        if old != new {
+            info!(
+                "Rebuild job {}: changing state from {:?} to {:?}",
+                self.dst_uri, old, new
+            );
+            self.notify();
+        }
+
+        new
+    }
+
+    /// Collects statistics from the job
+    pub fn stats(&self) -> RebuildStats {
+        let blocks_total =
+            self.descriptor.range.end - self.descriptor.range.start;
+
+        // segment size may not be aligned to the total size
+        let blocks_recovered = std::cmp::min(
+            self.task_pool.segments_done * self.descriptor.segment_size_blks,
+            blocks_total,
+        );
+
+        let progress = (blocks_recovered * 100) / blocks_total;
+
+        info!(
+            "State: {}, Nexus: {}, Src: {}, Dst: {}, range: {:?}, next: {}, \
+            block_size: {}, segment_sz: {}, recovered_blks: {}, progress: {}%, TaskPool: {:?}",
+            self.state(),
+            self.nexus_name,
+            self.src_uri,
+            self.dst_uri,
+            self.descriptor.range,
+            self.next,
+            self.descriptor.block_size,
+            self.descriptor.segment_size_blks,
+            blocks_recovered,
+            progress,
+            self.task_pool,
+        );
+
+        RebuildStats {
+            blocks_total,
+            blocks_recovered,
+            progress,
+            segment_size_blks: self.descriptor.segment_size_blks,
+            block_size: self.descriptor.block_size,
+            tasks_total: self.task_pool.total as u64,
+            tasks_active: self.task_pool.active as u64,
+        }
+    }
+
+    /// Fails the job, overriding any pending client operation
+    fn fail(&self) {
+        self.exec_internal_op(super::RebuildOperation::Fail).ok();
+    }
+
+    /// Fails the job, with the given error.
+    fn fail_with<E: Into<Option<RebuildError>>>(&mut self, error: E) {
+        self.fail();
+        self.states.write().error = error.into();
+    }
+
+    fn task_sync_fail(&mut self) {
+        let active = self.task_pool.active;
+        error!(
+            "Failed to wait for {} rebuild tasks due to task channel failure",
+            active
+        );
+        self.fail_with(RebuildError::RebuildTasksChannel {
+            active,
+        });
+    }
+
+    /// Completes the job, overriding any pending operation
+    fn complete(&self) {
+        self.exec_internal_op(super::RebuildOperation::Complete)
+            .ok();
+    }
+
+    /// Internal operations can bypass previous pending operations.
+    fn exec_internal_op(
+        &self,
+        op: super::RebuildOperation,
+    ) -> Result<bool, RebuildError> {
+        self.states.write().exec_op(op, true)
+    }
+
+    /// Kicks off all rebuild tasks in the background, or as many as necessary
+    /// to complete the rebuild.
+    fn start_all_tasks(&mut self) {
+        assert_eq!(
+            self.task_pool.active, 0,
+            "{} active tasks",
+            self.task_pool.active
+        );
+
+        for n in 0 .. self.task_pool.total {
+            if !self.start_task_by_id(n) {
+                break;
+            }
+        }
+        // Nothing to rebuild, in case we paused but the rebuild is complete
+        if self.task_pool.active == 0 {
+            self.complete();
+        }
+
+        self.stats();
+    }
+
+    /// Tries to kick off a task by its identifier and returns result.
+    /// todo: there's no need to use id's, just use a task from the pool.
+    fn start_task_by_id(&mut self, id: usize) -> bool {
+        match self.send_segment_task(id) {
+            Some(next) => {
+                self.task_pool.active += 1;
+                self.next = next;
+                true
+            }
+            // we've already got enough tasks to rebuild the destination
+            None => {
+                if self.task_pool.active == 0 {
+                    self.complete();
+                }
+                false
+            }
+        }
+    }
+
+    /// Awaits for one rebuild task to complete and collect the task's result.
+    async fn await_one_task(&mut self) -> Option<TaskResult> {
+        self.task_pool.await_one_task().await
+    }
+
+    /// Awaits for all active rebuild tasks to complete.
+    async fn await_all_tasks(&mut self) {
+        debug!(
+            "Awaiting all active tasks({}) for rebuild {}",
+            self.task_pool.active, self.dst_uri
+        );
+
+        while self.task_pool.active > 0 {
+            if self.await_one_task().await.is_none() {
+                // this should never happen, but just in case..
+                self.task_sync_fail();
+                return;
+            }
+        }
+        debug!("Finished awaiting all tasks for rebuild {}", self.dst_uri);
+    }
+
+    /// Sends one segment worth of data in a reactor future and notifies the
+    /// management channel. Returns the next segment offset to rebuild, if any.
+    fn send_segment_task(&mut self, id: usize) -> Option<u64> {
+        if self.next >= self.descriptor.range.end {
+            None
+        } else {
+            let blk = self.next;
+            let next = std::cmp::min(
+                self.next + self.descriptor.segment_size_blks,
+                self.descriptor.range.end,
+            );
+
+            self.task_pool
+                .send_segment(id, blk, self.descriptor.clone());
+
+            Some(next)
+        }
+    }
+}
+
+impl Drop for RebuildJobBackend {
+    fn drop(&mut self) {
+        tracing::warn!(
+            "RebuildJobBackend being dropped with done({})",
+            self.state().done()
+        );
+    }
+}

--- a/io-engine/src/rebuild/rebuild_record.rs
+++ b/io-engine/src/rebuild/rebuild_record.rs
@@ -1,0 +1,39 @@
+use super::{RebuildJob, RebuildState};
+use chrono::{DateTime, Utc};
+use std::sync::Arc;
+
+/// A rebuild record is a lightweight extract of rebuild job that is maintained
+/// for the statistics.
+pub struct RebuildRecord {
+    /// Source URI of the healthy child to rebuild from.
+    pub src_uri: String,
+    /// Target URI of the out of sync child in need of a rebuild.
+    pub dst_uri: String,
+    /// Was this a partial rebuild?
+    pub partial_rebuild: bool,
+    /// What state this rebuild job ended up in.
+    pub state: RebuildState,
+    /// Size of rebuilt data: Equal to replica size for full rebuilds,
+    /// and lesser(or possibly equal) for partial rebuilds.
+    pub rebuilt_data_size: u64,
+    /// Start time of this rebuild.
+    pub start: DateTime<Utc>,
+    /// End time of this rebuild.
+    pub end: DateTime<Utc>,
+}
+
+impl From<Arc<RebuildJob>> for RebuildRecord {
+    fn from(job: Arc<RebuildJob>) -> Self {
+        RebuildRecord {
+            src_uri: job.src_uri().to_string(),
+            dst_uri: job.dst_uri().to_string(),
+            // TODO: Set boolean correctly after partial rebuild changes
+            partial_rebuild: false,
+            state: job.state(),
+            // TODO: Set data size correctly after partial rebuild changes
+            rebuilt_data_size: 0,
+            start: job.start_time(),
+            end: Utc::now(),
+        }
+    }
+}

--- a/io-engine/src/rebuild/rebuild_state.rs
+++ b/io-engine/src/rebuild/rebuild_state.rs
@@ -1,5 +1,4 @@
-use super::RebuildError;
-use std::fmt;
+use super::{RebuildError, RebuildOperation};
 
 /// Allowed states for a rebuild job.
 #[derive(Debug, PartialEq, Copy, Clone)]
@@ -20,8 +19,8 @@ pub enum RebuildState {
     Completed,
 }
 
-impl fmt::Display for RebuildState {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+impl std::fmt::Display for RebuildState {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match *self {
             RebuildState::Init => write!(f, "init"),
             RebuildState::Running => write!(f, "running"),
@@ -38,15 +37,24 @@ impl RebuildState {
     pub fn done(self) -> bool {
         matches!(self, Self::Stopped | Self::Failed | Self::Completed)
     }
+    /// Chugging along and rebuilding segments.
+    pub fn running(&self) -> bool {
+        matches!(self, Self::Running)
+    }
 }
 
-/// TODO
-#[derive(Debug, Default)]
+/// Rebuild state information containing the current and pending states.
+/// The pending state is used when trying to move to the desired state, eg:
+/// stopping a rebuild but the rebuild cannot be stopped right away if it has
+/// ongoing active tasks.
+#[derive(Debug, Default, Clone)]
 pub(super) struct RebuildStates {
-    /// Current state of the rebuild job
+    /// Current state of the rebuild job.
     pub current: RebuildState,
-    /// Pending state for the rebuild job
+    /// Pending state for the rebuild job.
     pub(super) pending: Option<RebuildState>,
+    /// Last rebuild error, if any.
+    pub(super) error: Option<RebuildError>,
 }
 
 impl std::fmt::Display for RebuildStates {
@@ -86,18 +94,94 @@ impl RebuildStates {
         }
     }
 
-    /// a change to `state` is pending
-    pub(super) fn pending_equals(&self, state: RebuildState) -> bool {
-        self.pending == Some(state)
-    }
-
-    /// reconcile the pending state into the current state
+    /// Reconcile the pending state into the current state.
     pub(super) fn reconcile(&mut self) -> RebuildState {
-        if let Some(pending) = self.pending {
+        if let Some(pending) = self.pending.take() {
             self.current = pending;
-            self.pending = None;
         }
 
         self.current
+    }
+
+    /// Single state machine where all operations are handled.
+    /// Returns bool indicating whether a change has happened or not.
+    pub(super) fn exec_op(
+        &mut self,
+        op: RebuildOperation,
+        override_pending: bool,
+    ) -> Result<bool, RebuildError> {
+        type S = RebuildState;
+        let e = RebuildError::OpError {
+            operation: op.to_string(),
+            state: self.to_string(),
+        };
+
+        debug!(
+            "Executing operation {} with override {}, {:?}",
+            op, override_pending, self
+        );
+
+        match op {
+            RebuildOperation::Start => {
+                match self.current {
+                    // start only allowed when... starting
+                    S::Stopped | S::Paused | S::Failed | S::Completed => Err(e),
+                    // for idempotence sake
+                    S::Running => Ok(false),
+                    S::Init => {
+                        self.set_pending(S::Running, false)?;
+                        Ok(true)
+                    }
+                }
+            }
+            RebuildOperation::Stop => {
+                match self.current {
+                    // We're already stopping anyway, so all is well
+                    S::Failed | S::Completed => Err(e),
+                    // for idempotence sake
+                    S::Stopped => Ok(false),
+                    S::Running => {
+                        self.set_pending(S::Stopped, override_pending)?;
+                        Ok(false)
+                    }
+                    S::Init | S::Paused => {
+                        self.set_pending(S::Stopped, override_pending)?;
+                        Ok(true)
+                    }
+                }
+            }
+            RebuildOperation::Pause => match self.current {
+                S::Stopped | S::Failed | S::Completed => Err(e),
+                S::Init | S::Running | S::Paused => {
+                    self.set_pending(S::Paused, false)?;
+                    Ok(false)
+                }
+            },
+            RebuildOperation::Resume => match self.current {
+                S::Init | S::Stopped | S::Failed | S::Completed => Err(e),
+                S::Running | S::Paused => {
+                    self.set_pending(S::Running, false)?;
+                    Ok(true)
+                }
+            },
+            RebuildOperation::Fail => match self.current {
+                S::Init | S::Stopped | S::Paused | S::Completed => Err(e),
+                // for idempotence sake
+                S::Failed => Ok(false),
+                S::Running => {
+                    self.set_pending(S::Failed, override_pending)?;
+                    Ok(false)
+                }
+            },
+            RebuildOperation::Complete => match self.current {
+                S::Init | S::Paused | S::Stopped | S::Failed | S::Completed => {
+                    Err(e)
+                }
+                S::Running => {
+                    self.set_pending(S::Completed, override_pending)?;
+                    Ok(false)
+                }
+            },
+        }
     }
 }

--- a/io-engine/src/rebuild/rebuild_task.rs
+++ b/io-engine/src/rebuild/rebuild_task.rs
@@ -1,45 +1,173 @@
-use super::RebuildError;
-use futures::{channel::mpsc, StreamExt};
-use spdk_rs::DmaBuf;
+use futures::{channel::mpsc, stream::FusedStream, SinkExt, StreamExt};
+use snafu::ResultExt;
 
-/// Result returned by each segment task worker
-/// used to communicate with the management task indicating that the
-/// segment task worker is ready to copy another segment
+use super::{
+    rebuild_error::{
+        NoCopyBuffer,
+        RangeLockFailed,
+        RangeUnlockFailed,
+        ReadIoFailed,
+        WriteIoFailed,
+    },
+    RebuildDescriptor,
+    RebuildError,
+};
+use crate::core::{CoreError, Reactors, ReadMode, VerboseError};
+use spdk_rs::{DmaBuf, LbaRange};
+
+/// Result returned by each segment task worker.
+/// Used to communicate with the management task indicating that the
+/// segment task worker is ready to copy another segment.
 #[derive(Debug, Clone)]
 pub(super) struct TaskResult {
-    /// block that was being rebuilt
-    pub(super) blk: u64,
-    /// id of the task
+    /// Id of the rebuild task.
     pub(super) id: usize,
-    /// encountered error, if any
+    /// Block that was being rebuilt.
+    pub(super) blk: u64,
+    /// Encountered error, if any.
     pub(super) error: Option<RebuildError>,
 }
 
-/// Each rebuild task needs a unique buffer to read/write from source to target
-/// A mpsc channel is used to communicate with the management task
+/// Each rebuild task needs a unique buffer to read/write from source to target.
+/// An mpsc channel is used to communicate with the management task.
 #[derive(Debug)]
 pub(super) struct RebuildTask {
-    /// TODO
+    /// The pre-allocated `DmaBuf` used to read/write.
     pub(super) buffer: DmaBuf,
-    /// TODO
+    /// The channel used to notify when the task completes/fails.
     pub(super) sender: mpsc::Sender<TaskResult>,
-    /// TODO
+    /// Last error seen by this particular task.
     pub(super) error: Option<TaskResult>,
 }
 
-/// Pool of rebuild tasks and progress tracking
+impl RebuildTask {
+    /// Copies one segment worth of data from source into destination. During
+    /// this time the LBA range being copied is locked so that there cannot be
+    /// front end I/O to the same LBA range.
+    ///
+    /// # Safety
+    ///
+    /// The lock and unlock functions internally reference the RangeContext as a
+    /// raw pointer, so rust cannot correctly manage its lifetime. The
+    /// RangeContext MUST NOT be dropped until after the lock and unlock have
+    /// completed.
+    ///
+    /// The use of RangeContext here is safe because it is stored on the stack
+    /// for the duration of the calls to lock and unlock.
+    async fn locked_copy_one(
+        &mut self,
+        blk: u64,
+        descriptor: &RebuildDescriptor,
+    ) -> Result<(), RebuildError> {
+        let len = descriptor.get_segment_size_blks(blk);
+        // The nexus children have metadata and data partitions, whereas the
+        // nexus has a data partition only. Because we are locking the range on
+        // the nexus, we need to calculate the offset from the start of the data
+        // partition.
+        let r = LbaRange::new(blk - descriptor.range.start, len);
+
+        // Wait for LBA range to be locked.
+        // This prevents other I/Os being issued to this LBA range whilst it is
+        // being rebuilt.
+        let lock = descriptor
+            .nexus_descriptor
+            .lock_lba_range(r)
+            .await
+            .context(RangeLockFailed {
+                blk,
+                len,
+            })?;
+
+        // Perform the copy
+        let result = self.copy_one(blk, descriptor).await;
+
+        // Wait for the LBA range to be unlocked.
+        // This allows others I/Os to be issued to this LBA range once again.
+        descriptor
+            .nexus_descriptor
+            .unlock_lba_range(lock)
+            .await
+            .context(RangeUnlockFailed {
+                blk,
+                len,
+            })?;
+
+        result
+    }
+
+    /// Copies one segment worth of data from source into destination.
+    async fn copy_one(
+        &mut self,
+        blk: u64,
+        descriptor: &RebuildDescriptor,
+    ) -> Result<(), RebuildError> {
+        let mut copy_buffer: DmaBuf;
+        let mut source_hdl = descriptor.src_io_handle().await?;
+        let destination_hdl = descriptor.dst_io_handle().await?;
+
+        let copy_buffer = if descriptor.get_segment_size_blks(blk)
+            == descriptor.segment_size_blks
+        {
+            &mut self.buffer
+        } else {
+            let segment_size_blks = descriptor.range.end - blk;
+
+            trace!(
+                    "Adjusting last segment size from {} to {}. offset: {}, range: {:?}",
+                    descriptor.segment_size_blks, segment_size_blks, blk, descriptor.range,
+                );
+
+            copy_buffer = destination_hdl
+                .dma_malloc(segment_size_blks * descriptor.block_size)
+                .context(NoCopyBuffer {})?;
+
+            &mut copy_buffer
+        };
+
+        source_hdl.set_read_mode(ReadMode::UnwrittenFail);
+
+        let res = source_hdl
+            .read_at(blk * descriptor.block_size, copy_buffer)
+            .await;
+
+        if let Err(CoreError::ReadingUnallocatedBlock {
+            ..
+        }) = res
+        {
+            return Ok(());
+        }
+
+        res.context(ReadIoFailed {
+            bdev: &descriptor.src_uri,
+        })?;
+
+        destination_hdl
+            .write_at(blk * descriptor.block_size, copy_buffer)
+            .await
+            .context(WriteIoFailed {
+                bdev: &descriptor.dst_uri,
+            })?;
+
+        Ok(())
+    }
+}
+
+/// Pool of rebuild tasks and progress tracking.
 /// Each task uses a clone of the sender allowing the management task to poll a
-/// single receiver
+/// single receiver.
 pub(super) struct RebuildTasks {
-    /// TODO
-    pub(super) tasks: Vec<RebuildTask>,
-    /// TODO
+    /// All tasks managed by this entity.
+    /// Each task can run off on its own, and thus why each is protected
+    /// by a lock.
+    pub(super) tasks: Vec<std::sync::Arc<parking_lot::Mutex<RebuildTask>>>,
+    /// The channel is used to communicate with the tasks.
     pub(super) channel: (mpsc::Sender<TaskResult>, mpsc::Receiver<TaskResult>),
-    /// TODO
+    /// How many active tasks at present.
     pub(super) active: usize,
-    /// TODO
+    /// How many tasks in total.
     pub(super) total: usize,
-    /// TODO
+    /// How many segments have been rebuilt so far.
+    /// In other words, how many rebuild tasks have successfully completed.
     pub(super) segments_done: u64,
 }
 
@@ -54,16 +182,49 @@ impl std::fmt::Debug for RebuildTasks {
 }
 
 impl RebuildTasks {
-    /// TODO
+    /// Add the given `RebuildTask` to the task pool.
+    pub(super) fn push(&mut self, task: RebuildTask) {
+        self.tasks
+            .push(std::sync::Arc::new(parking_lot::Mutex::new(task)));
+    }
+    /// Check if there's at least one task still running.
+    pub(super) fn running(&self) -> bool {
+        self.active > 0 && !self.channel.1.is_terminated()
+    }
+    /// Await for one task to complete and update the task complete count.
     pub(super) async fn await_one_task(&mut self) -> Option<TaskResult> {
         self.channel.1.next().await.map(|f| {
             self.active -= 1;
             if f.error.is_none() {
                 self.segments_done += 1;
-            } else {
-                self.tasks[f.id].error = Some(f.clone());
             }
             f
         })
+    }
+    /// Schedules the run of a task by its id. It will copy the segment size
+    /// starting at the given block address from source to destination.
+    /// todo: don't use a specific task, simply get the next from the pool.
+    pub(super) fn send_segment(
+        &mut self,
+        id: usize,
+        blk: u64,
+        descriptor: std::sync::Arc<RebuildDescriptor>,
+    ) {
+        let task = self.tasks[id].clone();
+
+        Reactors::current().send_future(async move {
+            // No other thread/task will acquire the mutex at the same time.
+            let mut task = task.lock();
+            let result = task.locked_copy_one(blk, &descriptor).await;
+            let error = TaskResult {
+                id,
+                blk,
+                error: result.err(),
+            };
+            task.error = Some(error.clone());
+            if let Err(e) = task.sender.send(error).await {
+                error!("Failed to notify job of segment id: {} blk: {} completion, err: {}", id, blk, e.verbose());
+            }
+        });
     }
 }


### PR DESCRIPTION
The previous rebuild code was making some assumptions about the way the rebuild job runs. The code is ever run in the master reactor, so there can never be two tasks concurrently touching the rebuild job - however with time seems in certain cases between awaits the rebuild job may be reused which is likely bad and could explain some weird issues we've seen with rebuild as of late.

This change removes the unsoundness of the rebuild at the cost of a few locks and channels. However these probably won't affect the rebuild performance much as they will be largely uncontended.
The rebuild job is kind of split into frontend and backend. The backend is where the rebuild actually happens and we have a channel used to communicate between frontend and backend.

This change also allows to, in the future, have dedicated cores just for rebuilds for example.

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>