### PR TITLE
fix(nexus): refactoring nexus child out-of-sync state

### DIFF
--- a/io-engine/src/bdev/nexus/mod.rs
+++ b/io-engine/src/bdev/nexus/mod.rs
@@ -37,7 +37,13 @@ pub use nexus_bdev::{
 };
 pub(crate) use nexus_bdev_error::{nexus_err, Error};
 pub(crate) use nexus_channel::{DrEvent, NexusChannel};
-pub use nexus_child::{ChildError, ChildState, NexusChild, Reason};
+pub use nexus_child::{
+    ChildError,
+    ChildState,
+    ChildSyncState,
+    NexusChild,
+    Reason,
+};
 use nexus_io::{NexusBio, NioCtx};
 use nexus_io_subsystem::{NexusIoSubsystem, NexusPauseState};
 pub use nexus_iter::{

--- a/io-engine/src/bdev/nexus/nexus_channel.rs
+++ b/io-engine/src/bdev/nexus/nexus_channel.rs
@@ -75,7 +75,7 @@ impl<'n> NexusChannel<'n> {
 
         unsafe {
             nexus.as_mut().children_iter_mut()
-                .filter(|c| c.state() == ChildState::Open)
+                .filter(|c| c.is_healthy())
                 .for_each(|c| match (c.get_io_handle(), c.get_io_handle()) {
                     (Ok(w), Ok(r)) => {
                         writers.push(w);
@@ -184,11 +184,11 @@ impl<'n> NexusChannel<'n> {
         let mut writers = Vec::new();
         let mut readers = Vec::new();
 
-        // iterate over all our children which are in the open state
+        // iterate over all our children which are in the healthy state
         unsafe {
             self.nexus_mut()
                 .children_iter_mut()
-                .filter(|c| c.state() == ChildState::Open)
+                .filter(|c| c.is_healthy())
                 .for_each(|c| match (c.get_io_handle(), c.get_io_handle()) {
                     (Ok(w), Ok(r)) => {
                         writers.push(w);
@@ -206,7 +206,7 @@ impl<'n> NexusChannel<'n> {
             unsafe {
                 self.nexus_mut()
                     .children_iter_mut()
-                    .filter(|c| c.rebuilding())
+                    .filter(|c| c.is_rebuilding())
                     .for_each(|c| {
                         if let Ok(hdl) = c.get_io_handle() {
                             writers.push(hdl);

--- a/io-engine/tests/add_child.rs
+++ b/io-engine/tests/add_child.rs
@@ -1,8 +1,5 @@
-#[macro_use]
-extern crate assert_matches;
-
 use io_engine::{
-    bdev::nexus::{nexus_create, nexus_lookup_mut, ChildState, Reason},
+    bdev::nexus::{nexus_create, nexus_lookup_mut},
     core::{MayastorCliArgs, Protocol},
 };
 
@@ -54,10 +51,7 @@ async fn add_child() {
         assert_eq!(nexus.child_count(), 2);
 
         // Expect the added child to be in the out-of-sync state
-        assert_matches!(
-            nexus.child_at(1).state(),
-            ChildState::Faulted(Reason::OutOfSync)
-        );
+        assert!(nexus.child_at(1).is_opened_unsync());
     })
     .await;
 
@@ -94,10 +88,7 @@ async fn add_child() {
         assert_eq!(nexus.child_count(), 2);
 
         // Expect the added child to be in the out-of-sync state
-        assert_matches!(
-            nexus.child_at(1).state(),
-            ChildState::Faulted(Reason::OutOfSync)
-        );
+        assert!(nexus.child_at(1).is_opened_unsync());
     })
     .await;
 


### PR DESCRIPTION
If a nexus child is being rebuilt, and an I/O to that child fails, retire logic won't run because of incorrect handling of out-of-sync child state. This commit fixes how out-of-sync is managed.

Signed-off-by: Dmitry Savitskiy <dmitry.savitskiy@datacore.com>