### PR TITLE
B2-839 io-engine crashes when sharing bdev via v1 io-engine-client

### DIFF
--- a/io-engine/src/bin/io-engine-client/v1/bdev_cli.rs
+++ b/io-engine/src/bin/io-engine-client/v1/bdev_cli.rs
@@ -44,11 +44,13 @@ pub fn subcommands<'a, 'b>() -> App<'a, 'b> {
         .arg(Arg::with_name("name").required(true).index(1))
         .arg(
             Arg::with_name("protocol")
+                .long("protocol")
                 .short("p")
                 .help("the protocol to used to share the given bdev.")
                 .required(false)
-                .possible_values(&["nvmf"])
-                .default_value("nvmf"),
+                .possible_values(&["Nvmf"])
+                .takes_value(true)
+                .default_value("Nvmf"),
         )
         .arg(
             Arg::with_name("allowed-host")

--- a/io-engine/src/grpc/v1/bdev.rs
+++ b/io-engine/src/grpc/v1/bdev.rs
@@ -153,11 +153,7 @@ impl BdevRpc for BdevService {
                 })
             }
 
-            Err(_) => {
-                return Err(Status::invalid_argument(protocol.to_string()))
-            }
-
-            _ => unreachable!(),
+            _ => return Err(Status::invalid_argument(protocol.to_string())),
         }?;
 
         rx.await


### PR DESCRIPTION
io-engine-client sends the protocol field 'None' to io-engine when the following command is issued which results in io-engine crash

`io-engine-client bdev share abc0`