### PR TITLE
fix(release): use latest annotated tag only

### DIFF
--- a/nix/lib/version.nix
+++ b/nix/lib/version.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation {
 
   buildCommand = ''
     cd $src
-    vers=`${git}/bin/git -c safe.directory=$src tag --points-at HEAD`
+    vers=$(${git}/bin/git -c safe.directory=$src describe --exact-match 2>/dev/null || echo "")
     if [ -z "$vers" ]; then
       vers=`${git}/bin/git -c safe.directory=$src rev-parse --short=12 HEAD`
     fi

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -16,7 +16,7 @@ dockerhub_tag_exists() {
 
 # Get the tag at the HEAD
 get_tag() {
-  vers=`git tag --points-at HEAD`
+  vers=`git describe --exact-match 2>/dev/null || echo ""`
   echo -n $vers
 }
 get_hash() {


### PR DESCRIPTION
When building the images, there may be the case where 2 tags point at HEAD. In this case, use the latest annotated tag only.

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>