### PR TITLE
fix(nexus): cherry-pick read resubmission fix and replica record duplication in etcd

### DIFF
--- a/io-engine/src/bdev/nexus/nexus_channel.rs
+++ b/io-engine/src/bdev/nexus/nexus_channel.rs
@@ -121,6 +121,11 @@ impl<'n> NexusChannel<'n> {
         self.nexus.as_mut()
     }
 
+    /// Returns the total number of available readers in this channel.
+    pub(crate) fn num_readers(&self) -> usize {
+        self.readers.len()
+    }
+
     /// TODO
     #[inline(always)]
     pub(super) fn for_each_writer<F>(&self, mut f: F) -> Result<(), CoreError>

--- a/io-engine/src/bdev/nexus/nexus_io.rs
+++ b/io-engine/src/bdev/nexus/nexus_io.rs
@@ -273,8 +273,8 @@ impl<'n> NexusBio<'n> {
         )
     }
 
-    /// submit a read operation
-    fn do_readv(&mut self) -> Result<(), CoreError> {
+    /// Submit a Read operation to the next available replica.
+    fn __do_readv_one(&mut self) -> Result<(), CoreError> {
         if let Some(hdl) = self.channel().select_reader() {
             let r = self.submit_read(hdl);
 
@@ -288,7 +288,6 @@ impl<'n> NexusBio<'n> {
                 // start device retire.
                 // TODO: ENOMEM and ENXIO should be handled differently and
                 // device should not be retired in case of ENOMEM.
-
                 let device = hdl.get_device().device_name();
                 error!(
                     "{:?}: read I/O to '{}' submission failed: {:?}",
@@ -301,20 +300,71 @@ impl<'n> NexusBio<'n> {
                         IoSubmissionFailure::Write,
                     ),
                 );
-
-                self.fail();
+                r
             } else {
                 self.ctx_mut().in_flight = 1;
+                r
             }
-            r
         } else {
             error!(
                 "{:?}: read I/O submission failed: no children available",
                 self
             );
 
-            self.fail();
             Err(CoreError::NoDevicesAvailable {})
+        }
+    }
+
+    /// Submit a read operation to the next suitable replica.
+    /// In case of submission error the requiest is transparently resubmitted
+    /// to the next available replica.
+    fn do_readv(&mut self) -> Result<(), CoreError> {
+        match self.__do_readv_one() {
+            Err(e) => {
+                match e {
+                    // No readers available - bail out.
+                    CoreError::NoDevicesAvailable {} => {
+                        self.fail();
+                        Err(e)
+                    }
+                    // Failed to submit Read I/O request to the current replica,
+                    // try to resumbit request to the next available replica.
+                    _ => {
+                        let mut num_readers = self.channel().num_readers();
+
+                        let r = {
+                            if num_readers <= 1 {
+                                // No more readers available (taking into
+                                // account the failed one).
+                                Err(e)
+                            } else {
+                                num_readers -= 1; // Account the failed reader.
+
+                                // Resubmission loop to find a next available
+                                // replica for this Read I/O operation.
+                                loop {
+                                    match self.__do_readv_one() {
+                                        Ok(_) => break Ok(()),
+                                        Err(e) => {
+                                            num_readers -= 1;
+
+                                            if num_readers == 0 {
+                                                break Err(e);
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        };
+
+                        if r.is_err() {
+                            self.fail();
+                        }
+                        r
+                    }
+                }
+            }
+            Ok(_) => Ok(()),
         }
     }
 

--- a/io-engine/src/bdev/nexus/nexus_persistence.rs
+++ b/io-engine/src/bdev/nexus/nexus_persistence.rs
@@ -99,14 +99,25 @@ impl<'n> Nexus<'n> {
                 child_uri,
                 healthy,
             } => {
-                // Add the state of a new child.
-                // This should only be called on adding a new child.
+                // Add the state of a new child. This should only be called
+                // on adding a new child. Take into account that the same child
+                // can be readded again.
                 let child_info = ChildInfo {
                     uuid: NexusChild::uuid(&child_uri)
                         .expect("Failed to get child UUID."),
                     healthy,
                 };
-                nexus_info.children.push(child_info);
+
+                // Check if there is a child with the same UUID already
+                // and update the existing record instead of adding a new one.
+                match nexus_info
+                    .children
+                    .iter()
+                    .position(|r| r.uuid == child_info.uuid)
+                {
+                    Some(idx) => nexus_info.children[idx] = child_info,
+                    None => nexus_info.children.push(child_info),
+                }
             }
             PersistOp::Update {
                 child_uri,


### PR DESCRIPTION
Cherry pick of the following fixes:

fix(nexus): improved request resubmission fr failed read requests
fix(nexus): avoid duplicating replica records when readding replicas