### PR TITLE
Idempotency fixes

### DIFF
--- a/io-engine-tests/src/nexus.rs
+++ b/io-engine-tests/src/nexus.rs
@@ -245,6 +245,7 @@ pub async fn list_nexuses(rpc: SharedRpcHandle) -> Result<Vec<Nexus>, Status> {
         .nexus
         .list_nexus(ListNexusOptions {
             name: None,
+            uuid: None,
         })
         .await
         .map(|r| r.into_inner().nexus_list)

--- a/io-engine-tests/src/pool.rs
+++ b/io-engine-tests/src/pool.rs
@@ -102,6 +102,7 @@ pub async fn list_pools(rpc: SharedRpcHandle) -> Result<Vec<Pool>, Status> {
         .list_pools(ListPoolOptions {
             name: None,
             pooltype: None,
+            uuid: None,
         })
         .await
         .map(|r| r.into_inner().pools)

--- a/io-engine-tests/src/replica.rs
+++ b/io-engine-tests/src/replica.rs
@@ -190,6 +190,7 @@ pub async fn list_replicas(
         .list_replicas(ListReplicaOptions {
             name: None,
             poolname: None,
+            uuid: None,
         })
         .await
         .map(|r| r.into_inner().replicas)

--- a/io-engine/src/bdev/dev.rs
+++ b/io-engine/src/bdev/dev.rs
@@ -102,6 +102,11 @@ pub fn device_lookup(name: &str) -> Option<Box<dyn BlockDevice>> {
     nvmx::lookup_by_name(name).or_else(|| SpdkBlockDevice::lookup_by_name(name))
 }
 
+/// Lookup up device name by its uri.
+pub fn device_name(uri: &str) -> Result<String, BdevError> {
+    Ok(uri::parse(uri)?.get_name())
+}
+
 pub async fn device_create(uri: &str) -> Result<String, BdevError> {
     uri::parse(uri)?.create().await
 }

--- a/io-engine/src/bdev/nexus/nexus_bdev_error.rs
+++ b/io-engine/src/bdev/nexus/nexus_bdev_error.rs
@@ -249,13 +249,16 @@ impl From<NvmfError> for Error {
 impl From<Error> for tonic::Status {
     fn from(e: Error) -> Self {
         match e {
-            Error::NexusNotFound {
-                ..
-            } => Status::not_found(e.to_string()),
             Error::InvalidUuid {
                 ..
             } => Status::invalid_argument(e.to_string()),
             Error::InvalidKey {
+                ..
+            } => Status::invalid_argument(e.to_string()),
+            Error::InvalidShareProtocol {
+                ..
+            } => Status::invalid_argument(e.to_string()),
+            Error::InvalidReservation {
                 ..
             } => Status::invalid_argument(e.to_string()),
             Error::AlreadyShared {
@@ -276,10 +279,19 @@ impl From<Error> for tonic::Status {
             Error::ChildGeometry {
                 ..
             } => Status::invalid_argument(e.to_string()),
+            Error::ChildTooSmall {
+                ..
+            } => Status::invalid_argument(e.to_string()),
             Error::OpenChild {
                 ..
             } => Status::invalid_argument(e.to_string()),
+            Error::OperationNotAllowed {
+                ..
+            } => Status::failed_precondition(e.to_string()),
             Error::DestroyLastChild {
+                ..
+            } => Status::failed_precondition(e.to_string()),
+            Error::DestroyLastHealthyChild {
                 ..
             } => Status::failed_precondition(e.to_string()),
             Error::ChildNotFound {
@@ -288,12 +300,15 @@ impl From<Error> for tonic::Status {
             Error::RebuildJobNotFound {
                 ..
             } => Status::not_found(e.to_string()),
-            Error::OperationNotAllowed {
+            Error::NexusNotFound {
                 ..
-            } => Status::failed_precondition(e.to_string()),
-            Error::ChildTooSmall {
+            } => Status::not_found(e.to_string()),
+            Error::ChildAlreadyExists {
                 ..
-            } => Status::invalid_argument(e.to_string()),
+            } => Status::already_exists(e.to_string()),
+            Error::NameExists {
+                ..
+            } => Status::already_exists(e.to_string()),
             e => Status::new(Code::Internal, e.verbose()),
         }
     }

--- a/io-engine/src/bin/io-engine-client/v0/nexus_cli.rs
+++ b/io-engine/src/bin/io-engine-client/v0/nexus_cli.rs
@@ -690,6 +690,7 @@ async fn nexus_children_2(
         .nexus
         .list_nexus(v1::nexus::ListNexusOptions {
             name: None,
+            uuid: None,
         })
         .await
         .context(GrpcStatus)?;

--- a/io-engine/src/bin/io-engine-client/v1/nexus_cli.rs
+++ b/io-engine/src/bin/io-engine-client/v1/nexus_cli.rs
@@ -434,6 +434,7 @@ async fn nexus_destroy(
         .nexus
         .list_nexus(v1::nexus::ListNexusOptions {
             name: None,
+            uuid: None,
         })
         .await
         .context(GrpcStatus)?;
@@ -464,6 +465,7 @@ async fn nexus_list(
         .nexus
         .list_nexus(v1::nexus::ListNexusOptions {
             name: None,
+            uuid: None,
         })
         .await
         .context(GrpcStatus)?;
@@ -540,6 +542,7 @@ async fn nexus_children_2(
         .nexus
         .list_nexus(v1::nexus::ListNexusOptions {
             name: None,
+            uuid: None,
         })
         .await
         .context(GrpcStatus)?;

--- a/io-engine/src/bin/io-engine-client/v1/pool_cli.rs
+++ b/io-engine/src/bin/io-engine-client/v1/pool_cli.rs
@@ -152,6 +152,7 @@ async fn list(
         .list_pools(v1rpc::pool::ListPoolOptions {
             name: None,
             pooltype: None,
+            uuid: None,
         })
         .await
         .context(GrpcStatus)?;

--- a/io-engine/src/bin/io-engine-client/v1/replica_cli.rs
+++ b/io-engine/src/bin/io-engine-client/v1/replica_cli.rs
@@ -59,54 +59,6 @@ pub fn subcommands<'a, 'b>() -> App<'a, 'b> {
                 ),
         );
 
-    // let create_v2 = SubCommand::with_name("create2")
-    //            .about("Create replica on pool")
-    //            .arg(
-    //                Arg::with_name("pool")
-    //                    .required(true)
-    //                    .index(1)
-    //                    .help("Storage pool name"))
-    //            .arg(
-    //                Arg::with_name("name")
-    //                    .required(true)
-    //                    .index(2)
-    //                    .help("Replica name"))
-    //            .arg(
-    //                Arg::with_name("uuid")
-    //                    .required(true).index(3)
-    //                    .help("Unique replica uuid"))
-    //            .arg(
-    //                Arg::with_name("protocol")
-    //                    .short("p")
-    //                    .long("protocol")
-    //                    .takes_value(true)
-    //                    .value_name("PROTOCOL")
-    //                    .help("Name of a protocol (nvmf) used for sharing the
-    // replica (default none)"))            .arg(
-    //                Arg::with_name("size")
-    //                    .short("s")
-    //                    .long("size")
-    //                    .takes_value(true)
-    //                    .required(true)
-    //                    .value_name("NUMBER")
-    //                    .help("Size of the replica"))
-    //            .arg(
-    //                Arg::with_name("thin")
-    //                    .short("t")
-    //                    .long("thin")
-    //                    .takes_value(false)
-    //                    .help("Whether replica is thin provisioned (default
-    // false)"))            .arg(
-    //                Arg::with_name("allowed-host")
-    //                    .long("allowed-host")
-    //                    .takes_value(true)
-    //                    .multiple(true)
-    //                    .required(false)
-    //                    .help(
-    //                        "NQN of hosts which are allowed to connect to the
-    // target",                    ),
-    //            );
-
     let destroy = SubCommand::with_name("destroy")
         .about("Destroy replica")
         .arg(
@@ -222,13 +174,14 @@ async fn replica_create(
         size: size.get_bytes() as u64,
         allowed_hosts,
     };
-    //let response = ctx.client.create_replica(rq).await.context(GrpcStatus)?;
+
     let response = ctx
         .v1
         .replica
         .create_replica(request)
         .await
         .context(GrpcStatus)?;
+
     match ctx.output {
         OutputFormat::Json => {
             println!(
@@ -258,18 +211,22 @@ async fn replica_destroy(
         })?
         .to_owned();
 
-    let _ = ctx.v1.replica.destroy_replica(
-        v1_rpc::replica::DestroyReplicaRequest {
+    let _ = ctx
+        .v1
+        .replica
+        .destroy_replica(v1_rpc::replica::DestroyReplicaRequest {
             uuid: uuid.clone(),
-        },
-    );
+        })
+        .await
+        .context(GrpcStatus)?;
 
     match ctx.output {
         OutputFormat::Json => {}
         OutputFormat::Default => {
             println!("replica: {} is deleted", &uuid);
         }
-    };
+    }
+
     Ok(())
 }
 

--- a/io-engine/src/bin/io-engine-client/v1/replica_cli.rs
+++ b/io-engine/src/bin/io-engine-client/v1/replica_cli.rs
@@ -283,6 +283,7 @@ async fn replica_list(
         .list_replicas(v1_rpc::replica::ListReplicaOptions {
             name: None,
             poolname: None,
+            uuid: None,
         })
         .await
         .context(GrpcStatus)?;

--- a/io-engine/src/grpc/v0/mayastor_grpc.rs
+++ b/io-engine/src/grpc/v0/mayastor_grpc.rs
@@ -202,7 +202,7 @@ impl TryFrom<CreatePoolRequest> for PoolArgs {
     }
 }
 
-impl From<LvsError> for Status {
+impl From<LvsError> for tonic::Status {
     fn from(e: LvsError) -> Self {
         match e {
             LvsError::Import {
@@ -217,6 +217,18 @@ impl From<LvsError> for Status {
                     Status::invalid_argument(e.to_string())
                 }
             }
+            LvsError::RepDestroy {
+                source, ..
+            } => {
+                if source == Errno::ENOENT {
+                    Status::not_found(e.to_string())
+                } else {
+                    Status::internal(e.to_string())
+                }
+            }
+            LvsError::RepExists {
+                ..
+            } => Status::already_exists(e.to_string()),
             LvsError::ReplicaShareProtocol {
                 ..
             } => Status::invalid_argument(e.to_string()),

--- a/io-engine/src/grpc/v1/nexus.rs
+++ b/io-engine/src/grpc/v1/nexus.rs
@@ -25,7 +25,7 @@ use mayastor_api::v1::nexus::*;
 #[derive(Debug)]
 struct UnixStream(tokio::net::UnixStream);
 
-use crate::bdev::{nexus::NexusPtpl, PtplFileOps};
+use crate::bdev::{dev::device_name, nexus::NexusPtpl, PtplFileOps};
 use ::function_name::named;
 use std::panic::AssertUnwindSafe;
 
@@ -310,10 +310,21 @@ impl<'n> nexus::Nexus<'n> {
 /// implementation, however it is not allowed to use '?' in `locally` macro.
 /// So we implement it as a separate function.
 async fn nexus_add_child(
-    args: AddChildNexusRequest,
+    args: &AddChildNexusRequest,
 ) -> Result<Nexus, nexus::Error> {
     let mut n = nexus_lookup(&args.uuid)?;
-    // TODO: do not add child if it already exists (idempotency)
+    if n.contains_child_uri(&args.uri) || {
+        match device_name(&args.uri) {
+            Ok(name) => n.contains_child_name(&name),
+            _ => false,
+        }
+    } {
+        return Err(nexus::Error::ChildAlreadyExists {
+            child: args.uri.to_string(),
+            name: args.uuid.to_string(),
+        });
+    }
+    debug!("Adding child {} to nexus {} ...", args.uri, args.uuid);
     // For that we need api to check existence of child by name (not uri that
     // contain parameters that may change).
     n.as_mut().add_child(&args.uri, args.norebuild).await?;
@@ -486,10 +497,8 @@ impl NexusRpc for NexusService {
         self.serialized(ctx, args.uuid.clone(), false, async move {
             let rx = rpc_submit::<_, _, nexus::Error>(async move {
                 trace!("{:?}", args);
-                let uuid = args.uuid.clone();
-                debug!("Adding child {} to nexus {} ...", args.uri, uuid);
-                let nexus = nexus_add_child(args).await?;
-                info!("Added child to nexus {}", uuid);
+                let nexus = nexus_add_child(&args).await?;
+                info!("Added child to nexus {}", args.uuid);
                 Ok(nexus)
             })?;
 
@@ -516,10 +525,17 @@ impl NexusRpc for NexusService {
         self.serialized(ctx, args.uuid.clone(), false, async move {
             let rx = rpc_submit::<_, _, nexus::Error>(async move {
                 trace!("{:?}", args);
-                let uuid = args.uuid.clone();
-                debug!("Removing child {} from nexus {} ...", args.uri, uuid);
-                nexus_lookup(&args.uuid)?.remove_child(&args.uri).await?;
-                info!("Removed child {} from nexus {}", args.uri, uuid);
+                if nexus_lookup(&args.uuid)?.contains_child_uri(&args.uri) {
+                    debug!(
+                        "Removing child {} from nexus {} ...",
+                        args.uri, args.uuid
+                    );
+                    nexus_lookup(&args.uuid)?.remove_child(&args.uri).await?;
+                    info!(
+                        "Removed child {} from nexus {}",
+                        args.uri, args.uuid
+                    );
+                }
                 Ok(nexus_lookup(&args.uuid)?.into_grpc().await)
             })?;
 
@@ -546,13 +562,11 @@ impl NexusRpc for NexusService {
         self.serialized(ctx, args.uuid.clone(), false, async move {
             let rx = rpc_submit::<_, _, nexus::Error>(async move {
                 trace!("{:?}", args);
-                let uuid = args.uuid.clone();
-                let uri = args.uri.clone();
-                debug!("Faulting child {} on nexus {}", uri, uuid);
+                debug!("Faulting child {} on nexus {}", args.uri, args.uuid);
                 nexus_lookup(&args.uuid)?
                     .fault_child(&args.uri, nexus::Reason::ByClient)
                     .await?;
-                info!("Faulted child {} on nexus {}", uri, uuid);
+                info!("Faulted child {} on nexus {}", args.uri, args.uuid);
                 Ok(FaultNexusChildResponse {
                     nexus: Some(nexus_lookup(&args.uuid)?.into_grpc().await),
                 })
@@ -577,13 +591,18 @@ impl NexusRpc for NexusService {
         self.serialized(ctx, args.uuid.clone(), false, async move {
             let rx = rpc_submit::<_, _, nexus::Error>(async move {
                 trace!("{:?}", args);
-                let uuid = args.uuid.clone();
-                let uri = args.uri.clone();
-                debug!("Injecting fault to nexus '{}': '{}'", uuid, uri);
+
+                debug!(
+                    "Injecting fault to child {} of nexus {}",
+                    args.uri, args.uuid
+                );
                 nexus_lookup(&args.uuid)?
                     .inject_add_fault(&args.uri)
                     .await?;
-                info!("Injectinged fault to nexus '{}': '{}'", uuid, uri);
+                info!(
+                    "Injected fault to child {} of nexus {}",
+                    args.uri, args.uuid
+                );
                 Ok(())
             })?;
 
@@ -606,16 +625,18 @@ impl NexusRpc for NexusService {
         self.serialized(ctx, args.uuid.clone(), false, async move {
             let rx = rpc_submit::<_, _, nexus::Error>(async move {
                 trace!("{:?}", args);
-                let uuid = args.uuid.clone();
-                let uri = args.uri.clone();
+
                 debug!(
-                    "Removing injected fault to nexus '{}': '{}'",
-                    uuid, uri
+                    "Removing injected fault from child {} of nexus {}",
+                    args.uri, args.uuid
                 );
                 nexus_lookup(&args.uuid)?
                     .inject_remove_fault(&args.uri)
                     .await?;
-                info!("Removed injected fault to nexus '{}': '{}'", uuid, uri);
+                info!(
+                    "Removed injected fault from child {} of nexus {}",
+                    args.uri, args.uuid
+                );
                 Ok(())
             })?;
 
@@ -672,8 +693,7 @@ impl NexusRpc for NexusService {
         self.serialized(ctx, args.uuid.clone(), false, async move {
             let rx = rpc_submit::<_, _, nexus::Error>(async move {
                 trace!("{:?}", args);
-                let uuid = args.uuid.clone();
-                debug!("Publishing nexus {} ...", uuid);
+                debug!("Publishing nexus {} ...", args.uuid);
 
                 if !args.key.is_empty() && args.key.len() != 16 {
                     return Err(nexus::Error::InvalidKey {});
@@ -707,7 +727,7 @@ impl NexusRpc for NexusService {
 
                 info!(
                     "Published nexus {} under {} for {:?}",
-                    uuid, device_uri, args.allowed_hosts
+                    args.uuid, device_uri, args.allowed_hosts
                 );
 
                 let nexus = nexus_lookup(&args.uuid)?.into_grpc().await;

--- a/io-engine/src/grpc/v1/replica.rs
+++ b/io-engine/src/grpc/v1/replica.rs
@@ -257,6 +257,11 @@ impl ReplicaRpc for ReplicaService {
                         .into_iter()
                         .filter(|r| r.name == name)
                         .collect();
+                } else if let Some(uuid) = args.uuid {
+                    replicas = replicas
+                        .into_iter()
+                        .filter(|r| r.uuid == uuid)
+                        .collect();
                 }
 
                 Ok(ListReplicasResponse {

--- a/jsonrpc/src/error.rs
+++ b/jsonrpc/src/error.rs
@@ -37,7 +37,7 @@ impl From<RpcCode> for Code {
     }
 }
 
-impl From<Error> for Status {
+impl From<Error> for tonic::Status {
     fn from(error: Error) -> Status {
         match error {
             Error::RpcError {

--- a/test/python/cross-grpc-version/replica/test_bdd_replica.py
+++ b/test/python/cross-grpc-version/replica/test_bdd_replica.py
@@ -253,7 +253,7 @@ def create_v1_replica_with_existing_name(
     replica = current_replicas[replica_uuid]
     with pytest.raises(grpc.RpcError) as error:
         create_v1_replica(replica.name, replica.uuid, replica.size, share=replica.share)
-    assert error.value.code() == grpc.StatusCode.INTERNAL
+    assert error.value.code() == grpc.StatusCode.ALREADY_EXISTS
 
 
 @when(
@@ -265,7 +265,7 @@ def create_v1_replica_with_existing_uuid(create_v1_replica, replica_uuid, replic
         create_v1_replica(
             "replica-2", replica_uuid, replica_size, share=share_protocol("none")
         )
-    assert error.value.code() == grpc.StatusCode.INTERNAL
+    assert error.value.code() == grpc.StatusCode.ALREADY_EXISTS
 
 
 @when(

--- a/test/python/v1/replica/test_bdd_replica.py
+++ b/test/python/v1/replica/test_bdd_replica.py
@@ -253,7 +253,7 @@ def create_replica_with_existing_name(create_lvs_replica, replica_name, replica_
             replica_size,
             share=share_protocol("none"),
         )
-    assert error.value.code() == grpc.StatusCode.INTERNAL
+    assert error.value.code() == grpc.StatusCode.ALREADY_EXISTS
 
 
 @when(
@@ -265,7 +265,7 @@ def create_replica_with_existing_uuid(create_lvs_replica, replica_uuid, replica_
         create_lvs_replica(
             "replica-2", replica_uuid, replica_size, share=share_protocol("none")
         )
-    assert error.value.code() == grpc.StatusCode.INTERNAL
+    assert error.value.code() == grpc.StatusCode.ALREADY_EXISTS
 
 
 @when("the user creates an unshared replica")
@@ -314,7 +314,7 @@ def the_user_destroys_a_replica_that_does_not_exist(
         mayastor_instance.replica_rpc.DestroyReplica(
             replica_pb.DestroyReplicaRequest(uuid=replica_uuid)
         )
-    assert error.value.code() == grpc.StatusCode.INTERNAL
+    assert error.value.code() == grpc.StatusCode.NOT_FOUND
 
 
 @when("the user destroys the replica")


### PR DESCRIPTION
fix(rpc/api): update to latest api

Fixes missing nexus objects from shutdown and fault operation.
Add support for listing by uuid.
Fixes missing pool type check.

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

fix(api/idempotency): fix returned status codes

When a child is not part of the nexus we should return either Ok or NotFound.
When adding a child, check if it already exists so we can map a good status code.

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

fix(client/v1): added missing response status check

Also future was not being polled..

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>