### PR TITLE
Fix rebuild channel hang

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ ansible-hosts
 /test/python/venv/*
 /package.json
 /rust-toolchain.toml
+/test/python/registration_pb2.py
+/test/python/registration_pb2_grpc.py

--- a/io-engine/src/bdev/nexus/nexus_bdev_rebuild.rs
+++ b/io-engine/src/bdev/nexus/nexus_bdev_rebuild.rs
@@ -377,7 +377,11 @@ impl<'n> Nexus<'n> {
         let job = self.rebuild_job(child_uri)?;
         let job_state = job.state();
         if !job_state.done() {
-            tracing::info!("Rebuild update but not done: {:?}", job_state);
+            tracing::info!(
+                rebuild.target = child_uri,
+                rebuild.state = ?job_state,
+                "Rebuild update notification"
+            );
             // Leave all states as they are
             return Ok(());
         }

--- a/io-engine/src/rebuild/rebuild_job_backend.rs
+++ b/io-engine/src/rebuild/rebuild_job_backend.rs
@@ -517,7 +517,11 @@ impl RebuildJobBackend {
 
 impl Drop for RebuildJobBackend {
     fn drop(&mut self) {
-        tracing::warn!(
+        let stats = self.stats();
+        self.states.write().set_final_stats(stats);
+
+        tracing::info!(
+            rebuild.target = self.dst_uri,
             "RebuildJobBackend being dropped with done({})",
             self.state().done()
         );

--- a/io-engine/src/rebuild/rebuild_job_backend.rs
+++ b/io-engine/src/rebuild/rebuild_job_backend.rs
@@ -50,31 +50,24 @@ impl RebuildFBendChan {
             receiver,
         }
     }
-    /// Forward the given request to the backend job.
-    pub(super) async fn send(
-        &self,
-        req: RebuildJobRequest,
-    ) -> Result<(), RebuildError> {
-        self.sender
-            .send(req)
-            .await
-            .map_err(|_| RebuildError::BackendGone)
-    }
-    /// Get a clone of the sender channel.
-    pub(super) fn send_clone(
-        &self,
-    ) -> async_channel::Sender<RebuildJobRequest> {
-        self.sender.clone()
-    }
     async fn recv(&mut self) -> Result<RebuildJobRequest, RebuildError> {
         self.receiver
             .recv()
             .await
             .map_err(|_| RebuildError::FrontendGone {})
     }
+
     /// Get a clone of the receive channel.
-    fn recv_clone(&self) -> async_channel::Receiver<RebuildJobRequest> {
+    pub(super) fn recv_clone(
+        &self,
+    ) -> async_channel::Receiver<RebuildJobRequest> {
         self.receiver.clone()
+    }
+    /// Get a clone of the send channel.
+    pub(super) fn sender_clone(
+        &self,
+    ) -> async_channel::Sender<RebuildJobRequest> {
+        self.sender.clone()
     }
 }
 

--- a/io-engine/src/rebuild/rebuild_state.rs
+++ b/io-engine/src/rebuild/rebuild_state.rs
@@ -1,4 +1,5 @@
 use super::{RebuildError, RebuildOperation};
+use crate::rebuild::RebuildStats;
 
 /// Allowed states for a rebuild job.
 #[derive(Debug, PartialEq, Copy, Clone)]
@@ -55,6 +56,7 @@ pub(super) struct RebuildStates {
     pub(super) pending: Option<RebuildState>,
     /// Last rebuild error, if any.
     pub(super) error: Option<RebuildError>,
+    final_stats: Option<RebuildStats>,
 }
 
 impl std::fmt::Display for RebuildStates {
@@ -70,6 +72,15 @@ impl Default for RebuildState {
 }
 
 impl RebuildStates {
+    /// Get the final rebuild statistics.
+    pub(super) fn final_stats(&self) -> &Option<RebuildStats> {
+        &self.final_stats
+    }
+    /// Set the final rebuild statistics.
+    pub(super) fn set_final_stats(&mut self, stats: RebuildStats) {
+        self.final_stats = Some(stats);
+    }
+
     /// Set's the next pending state
     /// if one is already set then override only if flag is set
     pub(super) fn set_pending(


### PR DESCRIPTION
fix(rebuild): don't clone receiver channel

When creating a rebuild job we were reusing the same comms type which is used to do bi-dir
communication between the rebuild frontend and backend.
In some situations this could lead into blocking stats because the receiver channel was kept
alive by the frontend even after the frontend terminates.

Force closing the channel should in theory help but it seems the queue is not drained on close.
See: async-channel/issues/23

Instead, let's split the channels into two types meaning only the backend has the receiver side.

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

fix(rebuild): set final rebuild stats

When rebuild completes, right before the nexus completes the rebuild callback it's possible
that we get a stats request and in such case we have no stats to give.
To address this, then the rebuild backend completes it now sets the final rebuild stats in
the states, which will allow the stats to be retrieved.

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>