### PR TITLE
fix(nexus): fixing handling of nexus child I/O failure

### DIFF
--- a/io-engine/Cargo.toml
+++ b/io-engine/Cargo.toml
@@ -10,6 +10,7 @@ build = "build.rs"
 [features]
 io-engine-testing = ["nexus-fault-injection"]
 nexus-fault-injection = [] # Enables nexus-level fault injection code.
+nexus-io-tracing = [] # Enables nexus I/O tracing code.
 
 [[bin]]
 name = "io-engine"

--- a/io-engine/src/bdev/nexus/nexus_bdev_children.rs
+++ b/io-engine/src/bdev/nexus/nexus_bdev_children.rs
@@ -994,6 +994,11 @@ impl<'n> Nexus<'n> {
                     }
                 }
             }).await;
+
+            debug!(
+                "{self:?}: retire device '{device_name}': \
+                persistent store updated"
+            );
         } else {
             error!(
                 "{:?}: child device to retire is not found: '{}'",

--- a/io-engine/src/bdev/nexus/nexus_channel.rs
+++ b/io-engine/src/bdev/nexus/nexus_channel.rs
@@ -25,13 +25,13 @@ impl<'n> Debug for NexusChannel<'n> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "Channel '{} @ {}({})' [r:{}/w:{}/c:{}]",
-            self.nexus.nexus_name(),
-            self.core,
-            Cores::current(),
-            self.readers.len(),
-            self.writers.len(),
-            self.nexus.child_count(),
+            "I/O chan '{nex}' core:{core}({cur}) [r:{r}/w:{w}/c:{c}]",
+            nex = self.nexus.nexus_name(),
+            core = self.core,
+            cur = Cores::current(),
+            r = self.readers.len(),
+            w = self.writers.len(),
+            c = self.nexus.child_count(),
         )
     }
 }
@@ -65,7 +65,7 @@ impl Display for DrEvent {
 impl<'n> NexusChannel<'n> {
     /// TODO
     pub(crate) fn new(mut nexus: Pin<&mut Nexus<'n>>) -> Self {
-        debug!("{:?}: new channel on core {}", nexus, Cores::current());
+        debug!("{nexus:?}: new channel on core {c}", c = Cores::current());
 
         let mut writers = Vec::new();
         let mut readers = Vec::new();
@@ -83,9 +83,9 @@ impl<'n> NexusChannel<'n> {
                     _ => {
                         c.set_faulted_state(FaultReason::CantOpen);
                         error!(
-                            "Failed to get I/O handle for {}, \
-                                skipping block device",
-                            c.uri()
+                            "Failed to get I/O handle for {c}, \
+                            skipping block device",
+                            c = c.uri()
                         )
                     }
                 });
@@ -104,8 +104,9 @@ impl<'n> NexusChannel<'n> {
     /// TODO
     pub(crate) fn destroy(mut self) {
         debug!(
-            "{:?}: destroying IO channel on core {}",
-            self.nexus, self.core
+            "{nex:?}: destroying I/O channel on core {core}",
+            nex = self.nexus,
+            core = self.core
         );
         self.writers.clear();
         self.readers.clear();
@@ -169,7 +170,7 @@ impl<'n> NexusChannel<'n> {
         self.writers
             .retain(|c| c.get_device().device_name() != device_name);
 
-        debug!("{:?}: device '{}' disconnected", self, device_name);
+        debug!("{self:?}: device '{device_name}' disconnected");
     }
 
     /// Refreshing our channels simply means that we either have a child going
@@ -177,7 +178,7 @@ impl<'n> NexusChannel<'n> {
     /// we simply put back all the channels, and reopen the bdevs that are in
     /// the online state.
     pub(crate) fn reconnect_all(&mut self) {
-        debug!("{:?}: reconnecting all children", self);
+        debug!("{self:?}: reconnecting all children");
 
         // clear the vector of channels and reset other internal values,
         // clearing the values will drop any existing handles in the
@@ -232,7 +233,7 @@ impl<'n> NexusChannel<'n> {
         self.writers = writers;
         self.readers = readers;
 
-        trace!("{:?}: new number of readers/writes", self);
+        trace!("{self:?}: new number of readers/writers");
     }
 
     /// Faults the child by its device, with the given fault reason.

--- a/io-engine/tests/nexus_fio.rs
+++ b/io-engine/tests/nexus_fio.rs
@@ -44,7 +44,7 @@ async fn nexus_fio_single_remote() {
             "ms_nex",
             Binary::from_dbg("io-engine").with_args(vec![
                 "-l",
-                "5,6",
+                "3,4",
                 "-F",
                 "compact,color",
             ]),
@@ -131,7 +131,6 @@ async fn nexus_fio_single_remote() {
 /// Create a nexus on two replicas: okay one and overcomitted one, and run FIO.
 /// FIO must succeed as one replica is not overcommited.
 #[tokio::test]
-#[ignore]
 async fn nexus_fio_mixed() {
     common::composer_init();
 
@@ -141,17 +140,17 @@ async fn nexus_fio_mixed() {
         .unwrap()
         .add_container_bin(
             "ms_0",
-            Binary::from_dbg("io-engine").with_args(vec!["-l", "1,2"]),
+            Binary::from_dbg("io-engine").with_args(vec!["-l", "1"]),
         )
         .add_container_bin(
             "ms_1",
-            Binary::from_dbg("io-engine").with_args(vec!["-l", "3,4"]),
+            Binary::from_dbg("io-engine").with_args(vec!["-l", "2"]),
         )
         .add_container_bin(
             "ms_nex",
             Binary::from_dbg("io-engine").with_args(vec![
                 "-l",
-                "5,6",
+                "3,4",
                 "-F",
                 "compact,color",
             ]),


### PR DESCRIPTION
Fixes an issue where the ordering of child IO failure impacts the error handling by the nexus.
When a child IO fails, and the other children have already completed their own IO then the nexus fails this IO back to the initiator. If a child IO fails, but another child’s IO succeeds later, then we retry the IO to all children again, and there is no failure.