### PR TITLE
fix(nexus/persistence): use new RemoveChild op in remove_child path

### DIFF
--- a/io-engine/src/bdev/nexus/nexus_bdev_children.rs
+++ b/io-engine/src/bdev/nexus/nexus_bdev_children.rs
@@ -284,15 +284,11 @@ impl<'n> Nexus<'n> {
         };
 
         if res.is_ok() {
-            let healthy = self.child_at(idx).is_healthy();
-
             unsafe {
                 self.as_mut().child_remove_at_unsafe(idx);
             }
-
-            self.persist(PersistOp::Update {
+            self.persist(PersistOp::RemoveChild {
                 child_uri: uri.to_string(),
-                healthy,
             })
             .await;
         }

--- a/io-engine/src/bdev/nexus/nexus_persistence.rs
+++ b/io-engine/src/bdev/nexus/nexus_persistence.rs
@@ -53,6 +53,8 @@ pub(crate) enum PersistOp<'a> {
     Create,
     /// Add a child to an existing persistent entry.
     AddChild { child_uri: String, healthy: bool },
+    /// Remove a child from an existing persistent entry.
+    RemoveChild { child_uri: String },
     /// Update a persistent entry.
     Update { child_uri: String, healthy: bool },
     /// Update a persistent entry only when a precondition on this NexusInfo
@@ -118,6 +120,14 @@ impl<'n> Nexus<'n> {
                     Some(idx) => nexus_info.children[idx] = child_info,
                     None => nexus_info.children.push(child_info),
                 }
+            }
+            PersistOp::RemoveChild {
+                child_uri,
+            } => {
+                let uuid = NexusChild::uuid(&child_uri)
+                    .expect("Failed to get child UUID.");
+
+                nexus_info.children.retain(|child| child.uuid != uuid);
             }
             PersistOp::Update {
                 child_uri,

--- a/io-engine/tests/persistence.rs
+++ b/io-engine/tests/persistence.rs
@@ -300,8 +300,8 @@ async fn persist_io_failure() {
     let response = etcd.get(nexus_uuid, None).await.expect("No entry found");
     let value = response.kvs().first().unwrap().value();
     let nexus_info: NexusInfo = serde_json::from_slice(value).unwrap();
-    let child = child_info(&nexus_info, &uuid(&child3));
-    assert!(!child.healthy);
+    // Since child3 is removed, it shouldn't be in the persisted entry as well.
+    no_child_info(&nexus_info, &uuid(&child3));
 }
 
 /// This test checks the behaviour when a connection to the persistent store is
@@ -527,6 +527,15 @@ fn child_info(nexus: &NexusInfo, uuid: &str) -> ChildInfo {
         }
     }
     panic!("Child info not found for {}", uuid);
+}
+/// Verifies that the child info for the child with given UUID
+/// shouldn't be present in the persisted nexus info.
+fn no_child_info(nexus: &NexusInfo, uuid: &str) {
+    for child in &nexus.children {
+        if child.uuid == uuid {
+            panic!("Child info not expected for {}", uuid);
+        }
+    }
 }
 /// Extract UUID from uri.
 pub(crate) fn uuid(uri: &str) -> String {


### PR DESCRIPTION
### Testing Done

**Before this change -** 
```
Removed faulted child:   
 2023-04-17T05:39:38.417869Z  INFO core::controller::reconciler::nexus: Successfully removed faulted child, child.uri: nvmf://10.1.0.7:8420/nqn.2019-05.io.openebs:7d3da479-108d-499c-b927-a4c458179bcb?uuid=7d3da479-108d-499c-b927-a4c458179bcb, child.state: Faulted, child.state_reason: AdminCommandFailed

Created new replica and attached to nexus: 
  2023-04-17T05:39:39.185977Z  INFO core::controller::resources::operations_helper: complete_update, val: Child { uri: ChildUri("nvmf://10.1.0.8:8420/nqn.2019-05.io.openebs:90866e7f-1f1b-4ff1-b8b6-e6ce53b7edd2?uuid=90866e7f-1f1b-4ff1-b8b6-e6ce53b7edd2"), state: Degraded, rebuild_progress: Some(0), state_reason: OutOfSync, faulted_at: None }

  2023-04-17T05:39:39.188039Z  INFO core::volume::operations_helper: Successfully attached replica to nexus, replica.uuid: 90866e7f-1f1b-4ff1-b8b6-e6ce53b7edd2, replica.pool: 4d471e62-ca17-44d1-a6d3-8820f6156c1a, replica.node: io-engine-3

Removed child stays in Etcd

{"children":[{"healthy":true,"uuid":"2c7bbd5f-6171-46eb-8ef6-0266c89200fe"},{"healthy":false,"uuid":"7d3da479-108d-499c-b927-a4c458179bcb"},{"healthy":true,"uuid":"90866e7f-1f1b-4ff1-b8b6-e6ce53b7edd2"}],"clean_shutdown":false}
```

**With this change -**
```
Removed faulted child :

  2023-04-17T06:23:15.368973Z  INFO core::controller::reconciler::nexus: Successfully removed faulted child, child.uri: nvmf://10.1.0.7:8420/nqn.2019-05.io.openebs:7b988341-1a89-4875-9dd2-f8b307cc7af7?uuid=7b988341-1a89-4875-9dd2-f8b307cc7af7, child.state: Faulted, child.state_reason: AdminCommandFailed

 Faulted child marked in Etcd:
 {"children":[{"healthy":true,"uuid":"fda60965-2e9e-4bcf-8bcf-a7f57661e728"},{"healthy":false,"uuid":"7b988341-1a89-4875-9dd2-f8b307cc7af7"}],"clean_shutdown":false}

New replica attached to nexus: 
  2023-04-17T06:23:15.400546Z  INFO core::controller::resources::operations_helper: complete_update, val: "nvmf://10.1.0.8:8420/nqn.2019-05.io.openebs:ca54baf4-86de-465e-bb64-79e756433326?uuid=ca54baf4-86de-465e-bb64-79e756433326"

Faulted child removed from Etcd. New child added in Etcd: 

{"children":[{"healthy":true,"uuid":"fda60965-2e9e-4bcf-8bcf-a7f57661e728"},{"healthy":true,"uuid":"ca54baf4-86de-465e-bb64-79e756433326"}],"clean_shutdown":false}
```
