### PR TITLE
fix(nexus): making admin command failed state recoverable

### DIFF
--- a/io-engine/src/bdev/nexus/nexus_child.rs
+++ b/io-engine/src/bdev/nexus/nexus_child.rs
@@ -161,7 +161,11 @@ impl FaultReason {
     pub fn is_recoverable(&self) -> bool {
         matches!(
             self,
-            Self::NoSpace | Self::TimedOut | Self::IoError | Self::Offline
+            Self::NoSpace
+                | Self::TimedOut
+                | Self::IoError
+                | Self::Offline
+                | Self::AdminCommandFailed
         )
     }
 }

--- a/io-engine/src/grpc/v0/nexus_grpc.rs
+++ b/io-engine/src/grpc/v0/nexus_grpc.rs
@@ -56,6 +56,7 @@ fn map_child_state(child: &NexusChild) -> (ChildState, ChildStateReason) {
         ChildStateClient::Closed => (Degraded, Closed),
         ChildStateClient::Faulted(r) => (
             match r {
+                FaultReason::AdminCommandFailed => Faulted,
                 FaultReason::IoError => Faulted,
                 s if s.is_recoverable() => Degraded,
                 _ => Faulted,

--- a/io-engine/src/grpc/v1/nexus.rs
+++ b/io-engine/src/grpc/v1/nexus.rs
@@ -158,6 +158,7 @@ fn map_child_state(child: &NexusChild) -> (ChildState, ChildStateReason) {
         ChildStateClient::Closed => (Degraded, Closed),
         ChildStateClient::Faulted(r) => (
             match r {
+                FaultReason::AdminCommandFailed => Faulted,
                 FaultReason::IoError => Faulted,
                 s if s.is_recoverable() => Degraded,
                 _ => Faulted,


### PR DESCRIPTION
AdminCommandFailed is made recoverable (can be onlined), but still Faulted externaly (as visible via GRPC).