### PR TITLE
build(images): add tag argument

### DIFF
--- a/.github/workflows/pr-submodule-branch.yml
+++ b/.github/workflows/pr-submodule-branch.yml
@@ -1,0 +1,24 @@
+name: Submodule Branch Check
+on:
+  pull_request:
+    types: ['opened', 'edited', 'reopened', 'synchronize']
+  push:
+    branches:
+      - develop
+      - 'release/**'
+jobs:
+  submodule-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Check root submodules branch
+        run: |
+          pr_branch="${{ github.event.pull_request.base.ref }}"
+          if [ -n "$pr_branch" ]; then
+            check_branch="$pr_branch"
+          else
+            check_branch="${{ github.ref_name }}"
+          fi
+          ./scripts/set-submodule-branches.sh --branch "$check_branch"
+          cat .gitmodules
+          git diff --exit-code ".gitmodules"

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,12 @@
 [submodule "rpc/mayastor-api"]
 	path = rpc/mayastor-api
 	url = https://github.com/openebs/mayastor-api
+	branch = develop
 [submodule "spdk-rs"]
 	path = spdk-rs
 	url = https://github.com/openebs/spdk-rs
+	branch = develop
 [submodule "utils/io-engine-dependencies"]
 	path = utils/io-engine-dependencies
 	url = https://github.com/openebs/mayastor-dependencies.git
+	branch = develop

--- a/default.nix
+++ b/default.nix
@@ -1,5 +1,6 @@
 { crossSystem ? null
 , img_tag ? ""
+, tag ? ""
 }:
 
 let
@@ -7,7 +8,7 @@ let
   pkgs = import sources.nixpkgs {
     overlays = [
       (_: _: { inherit sources; })
-      (import ./nix/overlay.nix { inherit img_tag; })
+      (import ./nix/overlay.nix { inherit img_tag tag; })
     ];
     inherit crossSystem;
   };

--- a/nix/lib/version.nix
+++ b/nix/lib/version.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, git }:
+{ lib, stdenv, git, tag ? "" }:
 let
   whitelistSource = src: allowedPrefixes:
     builtins.filterSource
@@ -12,6 +12,7 @@ in
 stdenv.mkDerivation {
   name = "io-engine-version";
   src = whitelistSource ../../. [ ".git" ];
+  outputs = [ "out" "long" "tag_or_long" ];
 
   # Newer git versions check directory ownership when executing commands.
   # Nix builds in directories with user/group different from the login user,
@@ -25,10 +26,27 @@ stdenv.mkDerivation {
 
   buildCommand = ''
     cd $src
-    vers=$(${git}/bin/git -c safe.directory=$src describe --exact-match 2>/dev/null || echo "")
+    vers=${tag}
+    if [ -z "$vers" ]; then
+      vers=$(${git}/bin/git -c safe.directory=$src describe --exact-match 2>/dev/null || echo "")
+    fi
     if [ -z "$vers" ]; then
       vers=`${git}/bin/git -c safe.directory=$src rev-parse --short=12 HEAD`
     fi
     echo -n $vers >$out
+
+    if [ "${tag}" != "" ]; then
+      vers="${tag}-0-g$(${git}/bin/git -c safe.directory=$src rev-parse --short=12 HEAD)"
+    else
+      vers=$(${git}/bin/git -c safe.directory=$src describe --abbrev=12 --always --long)
+    fi
+    echo -n $vers >$long
+
+    # when we point to a tag, it's just the tag
+    vers=${tag}
+    if [ -z "$vers" ]; then
+        vers=$(${git}/bin/git -c safe.directory=$src describe --abbrev=12 --always)
+    fi
+    echo -n $vers >$tag_or_long
   '';
 }

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -1,4 +1,4 @@
-{ img_tag ? "" }:
+{ img_tag ? "", tag ? "" }:
 self: super: {
   fio = super.callPackage ./pkgs/fio { };
   images = super.callPackage ./pkgs/images { inherit img_tag; };
@@ -6,9 +6,9 @@ self: super: {
   libspdk = (super.callPackage ./pkgs/libspdk { with-fio = false; }).release;
   libspdk-fio = (super.callPackage ./pkgs/libspdk { with-fio = true; multi-outputs = true; }).release;
   libspdk-dev = (super.callPackage ./pkgs/libspdk { with-fio = true; }).debug;
-  io-engine = (super.callPackage ./pkgs/io-engine { }).release;
-  io-engine-adhoc = (super.callPackage ./pkgs/io-engine { }).adhoc;
-  io-engine-dev = (super.callPackage ./pkgs/io-engine { }).debug;
+  io-engine = (super.callPackage ./pkgs/io-engine { inherit tag; }).release;
+  io-engine-adhoc = (super.callPackage ./pkgs/io-engine { inherit tag; }).adhoc;
+  io-engine-dev = (super.callPackage ./pkgs/io-engine { inherit tag; }).debug;
   mkContainerEnv = super.callPackage ./lib/mkContainerEnv.nix { };
   ms-buildenv = super.callPackage ./pkgs/ms-buildenv { };
   nvme-cli = super.callPackage ./pkgs/nvme-cli { };

--- a/nix/pkgs/images/default.nix
+++ b/nix/pkgs/images/default.nix
@@ -24,8 +24,7 @@
 , img_tag ? ""
 }:
 let
-  versionDrv = import ../../lib/version.nix { inherit lib stdenv git; };
-  version = if pkgs.lib.stringLength img_tag == 0 then builtins.readFile "${versionDrv}" else img_tag;
+  version = if img_tag != "" then img_tag else io-engine.version;
   path = lib.makeBinPath [ "/" busybox utillinux ];
 
   # common props for all io-engine images

--- a/nix/pkgs/io-engine/cargo-package.nix
+++ b/nix/pkgs/io-engine/cargo-package.nix
@@ -24,10 +24,11 @@
 , targetPackages
 , buildPackages
 , targetPlatform
-, version
+, versions
 , cargoBuildFlags ? [ ]
 }:
 let
+  version = versions.version;
   channel = import ../../lib/rust.nix { inherit sources; };
   rustPlatform = makeRustPlatform {
     rustc = channel.stable;
@@ -41,7 +42,6 @@ let
           allowedPrefixes)
       src;
   src_list = [
-    ".git"
     "Cargo.lock"
     "Cargo.toml"
     "cli"
@@ -61,6 +61,9 @@ let
     LIBCLANG_PATH = "${llvmPackages_11.libclang.lib}/lib";
     PROTOC = "${protobuf}/bin/protoc";
     PROTOC_INCLUDE = "${protobuf}/include";
+
+    GIT_VERSION_LONG = "${versions.long}";
+    GIT_VERSION = "${versions.tag_or_long}";
 
     nativeBuildInputs = [ pkg-config protobuf llvmPackages_11.clang ];
     buildInputs = [

--- a/nix/pkgs/io-engine/default.nix
+++ b/nix/pkgs/io-engine/default.nix
@@ -23,10 +23,17 @@
 , buildPackages
 , targetPlatform
 , pkgs
+, git
+, tag
 }:
 let
-  version = (builtins.fromTOML (builtins.readFile ../../../io-engine/Cargo.toml)).package.version;
-  project-builder = pkgs.callPackage ./cargo-package.nix { inherit version; };
+  versionDrv = import ../../lib/version.nix { inherit lib stdenv git tag; };
+  versions = {
+    "version" = builtins.readFile "${versionDrv}";
+    "long" = builtins.readFile "${versionDrv.long}";
+    "tag_or_long" = builtins.readFile "${versionDrv.tag_or_long}";
+  };
+  project-builder = pkgs.callPackage ./cargo-package.nix { inherit versions; };
 in
 {
   release = project-builder.release;

--- a/nix/pkgs/io-engine/units.nix
+++ b/nix/pkgs/io-engine/units.nix
@@ -23,8 +23,13 @@
 , pkgs
 }:
 let
-  version = (builtins.fromTOML (builtins.readFile ../../../io-engine/Cargo.toml)).package.version;
-  project-builder = { cargoBuildFlags }: pkgs.callPackage ./cargo-package.nix { inherit version cargoBuildFlags; };
+  versionDrv = import ../../lib/version.nix { inherit lib stdenv git tag; };
+  versions = {
+    "version" = version;
+    "long" = builtins.readFile "${versionDrv.long}";
+    "tag_or_long" = builtins.readFile "${versionDrv.tag_or_long}";
+  };
+  project-builder = { cargoBuildFlags }: pkgs.callPackage ./cargo-package.nix { inherit versions cargoBuildFlags; };
   components = { build }: {
     io-engine = (project-builder { cargoBuildFlags = [ "--bin io-engine" ]; }).${build};
     io-engine-cli = (project-builder { cargoBuildFlags = [ "--bin io-engine-cli" ]; }).${build};

--- a/scripts/set-submodule-branches.sh
+++ b/scripts/set-submodule-branches.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+submodule_set_branch_all() {
+  branch=${1:-}
+  if [ -n "$branch" ]; then
+    branch="--branch $branch"
+  else
+    branch="--default"
+  fi
+  for mod in `git config --file .gitmodules --get-regexp path | awk '{ print $2 }'`; do
+    git submodule set-branch $branch $mod
+  done
+}
+
+BRANCH=`git rev-parse --abbrev-ref HEAD`
+SET_BRANCH=
+CLEAR_BRANCH=
+while [ "$#" -gt 0 ]; do
+  case $1 in
+    -b|--branch)
+      shift
+      BRANCH=$1
+      shift
+      ;;
+    -c|--clear)
+      CLEAR_BRANCH=="y"
+      shift
+      ;;
+    *)
+      echo "Unknown option: $1"
+      exit 1
+      ;;
+  esac
+done
+
+
+
+if [ "$BRANCH" == "develop" ] || [ "${BRANCH#release/}" != "${BRANCH}" ]; then
+  SET_BRANCH="${BRANCH}"
+fi
+
+if [ -n "$CLEAR_BRANCH" ]; then
+  submodule_set_branch_all ""
+elif [ -n "$SET_BRANCH" ]; then
+  submodule_set_branch_all "$SET_BRANCH"
+else
+  echo "Not modifying branch"
+fi


### PR DESCRIPTION
Allows one to explicitly build the binaries with a given tag, as opposed to the alias-tag which simply adds a docker image tag alias.