### PR TITLE
feat(nexus): flush io operation for nexus

### DIFF
--- a/io-engine/src/bdev/nvmx/channel.rs
+++ b/io-engine/src/bdev/nvmx/channel.rs
@@ -646,7 +646,7 @@ impl IoStatsController {
                 self.io_stats.num_unmap_ops += num_ops;
                 self.io_stats.bytes_unmapped += num_blocks;
             }
-            IoType::WriteZeros => {}
+            IoType::WriteZeros | IoType::Flush => {}
             _ => {
                 warn!("Unsupported I/O type for I/O statistics: {:?}", op);
             }

--- a/io-engine/src/core/block_device.rs
+++ b/io-engine/src/core/block_device.rs
@@ -301,11 +301,11 @@ pub trait BlockDeviceHandle {
         })
     }
     /// Flush the io in buffer to disk, for the Local Block Device.
-    async fn flush_io(&self) -> Result<u64, CoreError> {
-        Err(CoreError::NotSupported {
-            source: Errno::EOPNOTSUPP,
-        })
-    }
+    fn flush_io(
+        &self,
+        cb: IoCompletionCallback,
+        cb_arg: IoCompletionCallbackArg,
+    ) -> Result<(), CoreError>;
 }
 
 /// TODO

--- a/io-engine/src/core/mod.rs
+++ b/io-engine/src/core/mod.rs
@@ -163,6 +163,10 @@ pub enum CoreError {
     ResetDispatch {
         source: Errno,
     },
+    #[snafu(display("Failed to dispatch flush: {}", source))]
+    FlushDispatch {
+        source: Errno,
+    },
     #[snafu(display(
         "Failed to dispatch NVMe Admin command {:x}h: {}",
         opcode,


### PR DESCRIPTION
Added support for IoType::Flush for nexus (was a no-op before), which allows flushing buffered data for both SPDK-backed local replicas and NVMx-backed replicas as well.