### PR TITLE
fix(nexus): fixing child remove logic

### DIFF
--- a/io-engine-tests/src/fio.rs
+++ b/io-engine-tests/src/fio.rs
@@ -73,6 +73,7 @@ impl FioJob {
             format!("--norandommap=1"),
             format!("--rw={}", self.rw),
             format!("--numjobs={}", self.numjobs),
+            format!("--random_generator=tausworthe64"),
         ];
 
         if let Some(v) = self.blocksize {
@@ -98,46 +99,57 @@ impl FioJob {
         r
     }
 
+    /// I/O engine to use. Default: spdk.
     pub fn with_ioengine(mut self, v: &str) -> Self {
         self.ioengine = v.to_string();
         self
     }
 
+    /// Filename.
     pub fn with_filename(mut self, v: &str) -> Self {
         self.filename = v.to_string();
         self
     }
 
+    /// If true, use non-buffered I/O (usually O_DIRECT). Default: true.
     pub fn with_direct(mut self, v: bool) -> Self {
         self.direct = v;
         self
     }
 
+    /// Block size for I/O units. Default: 4k.
     pub fn with_bs(mut self, v: u32) -> Self {
         self.blocksize = Some(v);
         self
     }
 
+    /// Offset in the file to start I/O. Data before the offset will not be
+    /// touched.
     pub fn with_offset(mut self, v: DataSize) -> Self {
         self.offset = Some(v);
         self
     }
 
+    /// Number of I/O units to keep in flight against the file.
     pub fn with_iodepth(mut self, v: u32) -> Self {
         self.iodepth = Some(v);
         self
     }
 
+    /// Number of clones (processes/threads performing the same workload) of
+    /// this job. Default: 1.
     pub fn with_numjobs(mut self, v: u32) -> Self {
         self.numjobs = v;
         self
     }
 
+    /// Terminate processing after the specified number of seconds.
     pub fn with_runtime(mut self, v: u32) -> Self {
         self.runtime = Some(v);
         self
     }
 
+    /// Total size of I/O for this job.
     pub fn with_size(mut self, v: DataSize) -> Self {
         self.size = Some(v);
         self

--- a/io-engine-tests/src/nexus.rs
+++ b/io-engine-tests/src/nexus.rs
@@ -16,6 +16,7 @@ use super::{
             PublishNexusRequest,
             RebuildHistoryRecord,
             RebuildHistoryRequest,
+            RemoveChildNexusRequest,
             RemoveInjectedNexusFaultRequest,
         },
         SharedRpcHandle,
@@ -216,6 +217,26 @@ impl NexusBuilder {
         norebuild: bool,
     ) -> Result<Nexus, Status> {
         self.add_child(&self.replica_uri(r), norebuild).await
+    }
+
+    pub async fn remove_child_bdev(&self, bdev: &str) -> Result<Nexus, Status> {
+        self.rpc()
+            .lock()
+            .await
+            .nexus
+            .remove_child_nexus(RemoveChildNexusRequest {
+                uuid: self.uuid(),
+                uri: bdev.to_owned(),
+            })
+            .await
+            .map(|r| r.into_inner().nexus.unwrap())
+    }
+
+    pub async fn remove_child_replica(
+        &self,
+        r: &ReplicaBuilder,
+    ) -> Result<Nexus, Status> {
+        self.remove_child_bdev(&self.replica_uri(r)).await
     }
 
     pub async fn online_child_bdev(&self, bdev: &str) -> Result<Nexus, Status> {

--- a/io-engine/src/bdev/nexus/nexus_bdev.rs
+++ b/io-engine/src/bdev/nexus/nexus_bdev.rs
@@ -239,7 +239,7 @@ pub struct Nexus<'n> {
     /// capabilities of the underlying child devices.
     req_size: u64,
     /// Vector of nexus children.
-    children: Vec<NexusChild<'n>>,
+    pub(super) children: Vec<NexusChild<'n>>,
     /// NVMe parameters
     pub(crate) nvme_params: NexusNvmeParams,
     /// uuid of the nexus (might not be the same as the nexus bdev!)
@@ -527,20 +527,6 @@ impl<'n> Nexus<'n> {
         child: NexusChild<'n>,
     ) {
         self.unpin_mut().children.push(child)
-    }
-
-    /// TODO
-    pub(super) unsafe fn child_remove_at_unsafe(
-        self: Pin<&mut Self>,
-        idx: usize,
-    ) {
-        debug!(
-            "{:?}: removing child at index: {}: '{}'",
-            self,
-            idx,
-            self.children[idx].uri()
-        );
-        self.unpin_mut().children.remove(idx);
     }
 
     /// TODO
@@ -1066,7 +1052,7 @@ impl<'n> Nexus<'n> {
     /// Returns a mutable reference to the Nexus with the lifetime as the Nexus
     /// itself.
     #[inline(always)]
-    unsafe fn unpin_mut(self: Pin<&mut Self>) -> &'n mut Nexus<'n> {
+    pub(super) unsafe fn unpin_mut(self: Pin<&mut Self>) -> &'n mut Nexus<'n> {
         &mut *(self.get_unchecked_mut() as *mut _)
     }
 

--- a/io-engine/src/bdev/nexus/nexus_io.rs
+++ b/io-engine/src/bdev/nexus/nexus_io.rs
@@ -676,15 +676,7 @@ impl<'n> NexusBio<'n> {
 
                     // 1: Close I/O channels for all children.
                     for d in nexus.child_devices() {
-                        if let Err(e) = nexus
-                            .disconnect_device_from_channels(d.clone())
-                            .await
-                        {
-                            error!(
-                                "{}: failed to disconnect I/O channels: {:?}",
-                                d, e
-                            );
-                        }
+                        nexus.disconnect_device_from_channels(d.clone()).await;
 
                         device_cmd_queue().enqueue(
                             DeviceCommand::RetireDevice {

--- a/io-engine/src/bdev/nexus/nexus_io_log.rs
+++ b/io-engine/src/bdev/nexus/nexus_io_log.rs
@@ -160,6 +160,8 @@ impl IOLog {
         num_blocks: u64,
         block_len: u64,
     ) -> Self {
+        assert!(!device_name.is_empty() && num_blocks > 0 && block_len > 0);
+
         let mut channels = HashMap::new();
 
         for i in Cores::list_cores() {


### PR DESCRIPTION
* I/O is properly paused when a child is removed.
* ETCD is updated before removing a child.
* A test for child remove is added.