### PR TITLE
feat(nexus): adding support for disabling nexus reset logic

### DIFF
--- a/io-engine/src/bdev/nexus/mod.rs
+++ b/io-engine/src/bdev/nexus/mod.rs
@@ -169,3 +169,6 @@ pub async fn shutdown_nexuses() {
 
 /// Enables/disables partial rebuild.
 pub static ENABLE_PARTIAL_REBUILD: AtomicBool = AtomicBool::new(true);
+
+/// Enables/disables nexus reset logic.
+pub static ENABLE_NEXUS_RESET: AtomicBool = AtomicBool::new(false);

--- a/io-engine/src/bdev/nexus/nexus_bdev.rs
+++ b/io-engine/src/bdev/nexus/nexus_bdev.rs
@@ -269,7 +269,7 @@ pub struct Nexus<'n> {
     pub(crate) shutdown_requested: AtomicCell<bool>,
     /// Prevent auto-Unpin.
     _pin: PhantomPinned,
-    /// Initiators
+    /// Initiators.
     initiators: parking_lot::Mutex<HashSet<String>>,
 }
 
@@ -457,16 +457,15 @@ impl<'n> Nexus<'n> {
     }
 
     /// Add new initiator to the Nexus
-    pub(crate) unsafe fn add_initiator(self: Pin<&mut Self>, initiator: &str) {
-        self.unpin_mut()
-            .initiators
-            .lock()
-            .insert(initiator.to_string());
+    pub(crate) fn add_initiator(&self, initiator: &str) {
+        debug!("{self:?}: adding initiator '{initiator}'");
+        self.initiators.lock().insert(initiator.to_string());
     }
 
     /// Remove initiator from the Nexus
-    pub(crate) unsafe fn rm_initiator(self: Pin<&mut Self>, initiator: &str) {
-        self.unpin_mut().initiators.lock().remove(initiator);
+    pub(crate) fn rm_initiator(&self, initiator: &str) {
+        debug!("{self:?}: removing initiator '{initiator}'");
+        self.initiators.lock().remove(initiator);
     }
 
     /// initiator count from the Nexus
@@ -834,7 +833,7 @@ impl<'n> Nexus<'n> {
     }
 
     /// Set the Nexus state to 'reset'
-    pub fn set_reset_state(self: Pin<&mut Self>) -> bool {
+    pub fn set_reset_state(&self) -> bool {
         let mut state = self.state.lock();
         match *state {
             // Reset operation is allowed only when the Nexus is Open state
@@ -842,19 +841,12 @@ impl<'n> Nexus<'n> {
                 *state = NexusState::Reconfiguring;
                 true
             }
-            _ => {
-                info!(
-                    nexus=%self.name,
-                    "Transition from {:?} is not permitted to NexusState::Reconfiguring",
-                    state
-                );
-                false
-            }
+            _ => false,
         }
     }
 
     /// Set the Nexus state to 'open'
-    pub fn set_open_state(self: Pin<&mut Self>) -> bool {
+    pub fn set_open_state(&self) -> bool {
         let mut state = self.state.lock();
         match *state {
             // Open operation is allowed only when the Nexus is
@@ -863,14 +855,7 @@ impl<'n> Nexus<'n> {
                 *state = NexusState::Open;
                 true
             }
-            _ => {
-                info!(
-                    nexus=%self.name,
-                    "Transition from {:?} is not permitted to NexusState::Open",
-                    state
-                );
-                false
-            }
+            _ => false,
         }
     }
 

--- a/io-engine/src/bin/io-engine.rs
+++ b/io-engine/src/bin/io-engine.rs
@@ -7,7 +7,10 @@ use futures::future::FutureExt;
 use structopt::StructOpt;
 
 use io_engine::{
-    bdev::{nexus::ENABLE_PARTIAL_REBUILD, util::uring},
+    bdev::{
+        nexus::{ENABLE_NEXUS_RESET, ENABLE_PARTIAL_REBUILD},
+        util::uring,
+    },
     core::{
         device_monitor_loop,
         diagnostics::process_diagnostics_cli,
@@ -53,6 +56,15 @@ fn start_tokio_runtime(args: &MayastorCliArgs) {
 
     if !ENABLE_PARTIAL_REBUILD.load(Ordering::SeqCst) {
         warn!("Partial rebuild is disabled");
+    }
+
+    // Enable nexus reset.
+    if let Ok(v) = std::env::var("NEXUS_RESET") {
+        ENABLE_NEXUS_RESET.store(v == "1", Ordering::SeqCst);
+    }
+
+    if !ENABLE_NEXUS_RESET.load(Ordering::SeqCst) {
+        warn!("Nexus reset is disabled");
     }
 
     // Initialize Lock manager.


### PR DESCRIPTION
In response to initiator timeout, nexus could be reset. This seemed to cause issues, so nexus reset logic is now temporarily disabled by default.
Reset logic can be re-enabled by setting env var `ENABLE_NEXUS_RESET=1`.