### PR TITLE
fix(retire/rebuild): schedule rebuild termination async

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,12 +1,12 @@
 [submodule "rpc/mayastor-api"]
 	path = rpc/mayastor-api
 	url = https://github.com/openebs/mayastor-api
-	branch = develop
+	branch = release/2.2
 [submodule "spdk-rs"]
 	path = spdk-rs
 	url = https://github.com/openebs/spdk-rs
-	branch = develop
+	branch = release/2.2
 [submodule "utils/io-engine-dependencies"]
 	path = utils/io-engine-dependencies
 	url = https://github.com/openebs/mayastor-dependencies.git
-	branch = develop
+	branch = release/2.2

--- a/io-engine/src/bdev/nexus/nexus_bdev_children.rs
+++ b/io-engine/src/bdev/nexus/nexus_bdev_children.rs
@@ -955,8 +955,10 @@ impl<'n> Nexus<'n> {
             // Cancel rebuild job for this child, if any.
             if let Some(job) = child.rebuild_job() {
                 debug!("{self:?}: retire: stopping rebuild job...");
-                job.terminate().await.ok();
-                debug!("{self:?}: retire: rebuild job stopped");
+                let terminated = job.terminate();
+                Reactors::master().send_future(async move {
+                    terminated.await.ok();
+                });
             }
 
             let uri = child.uri();

--- a/io-engine/src/grpc/v0/nexus_grpc.rs
+++ b/io-engine/src/grpc/v0/nexus_grpc.rs
@@ -56,9 +56,8 @@ fn map_child_state(child: &NexusChild) -> (ChildState, ChildStateReason) {
         ChildStateClient::Closed => (Degraded, Closed),
         ChildStateClient::Faulted(r) => (
             match r {
-                FaultReason::AdminCommandFailed => Faulted,
-                FaultReason::IoError => Faulted,
-                s if s.is_recoverable() => Degraded,
+                FaultReason::NoSpace => Degraded,
+                FaultReason::Offline => Degraded,
                 _ => Faulted,
             },
             map_fault_reason(r),

--- a/io-engine/src/grpc/v1/nexus.rs
+++ b/io-engine/src/grpc/v1/nexus.rs
@@ -158,9 +158,8 @@ fn map_child_state(child: &NexusChild) -> (ChildState, ChildStateReason) {
         ChildStateClient::Closed => (Degraded, Closed),
         ChildStateClient::Faulted(r) => (
             match r {
-                FaultReason::AdminCommandFailed => Faulted,
-                FaultReason::IoError => Faulted,
-                s if s.is_recoverable() => Degraded,
+                FaultReason::NoSpace => Degraded,
+                FaultReason::Offline => Degraded,
                 _ => Faulted,
             },
             map_fault_reason(r),


### PR DESCRIPTION
When retiring don't wait for rebuild to terminate as it may get stuck if the device is not fully retired. It seems that IOs get stuck? For now we simply defer terminate to master reactor.