### PR TITLE
chore(lvs/lvol): add trace message before zeroing super

### DIFF
--- a/io-engine/src/lvs/lvs_lvol.rs
+++ b/io-engine/src/lvs/lvs_lvol.rs
@@ -31,7 +31,6 @@ use spdk_rs::libspdk::{
     vbdev_lvol_destroy,
     vbdev_lvol_get_from_bdev,
     LVS_CLEAR_WITH_UNMAP,
-    SPDK_BDEV_LARGE_BUF_MAX_SIZE,
 };
 
 use super::{Error, Lvs};
@@ -294,34 +293,18 @@ impl Lvol {
                     }
                 })?;
 
-            // Set the buffer size to the maximum allowed by SPDK.
-            let buf_size = SPDK_BDEV_LARGE_BUF_MAX_SIZE as u64;
-            let buf = hdl.dma_malloc(buf_size).map_err(|e| {
-                error!(
-                    ?self,
-                    ?e,
-                    "no memory available to allocate zero buffer"
-                );
-                Error::RepDestroy {
-                    source: Errno::ENOMEM,
-                    name: self.name(),
-                    msg: "no memory available to allocate zero buffer".into(),
-                }
-            })?;
             // write zero to the first 8MB which wipes the metadata and the
             // first 4MB of the data partition
-            let range =
+            let wipe_size =
                 std::cmp::min(self.as_bdev().size_in_bytes(), WIPE_SUPER_LEN);
-            for offset in 0 .. (range / buf_size) {
-                hdl.write_at(offset * buf.len(), &buf).await.map_err(|e| {
-                    error!(?self, ?e);
-                    Error::RepDestroy {
-                        source: Errno::EIO,
-                        name: self.name(),
-                        msg: "failed to write to lvol".into(),
-                    }
-                })?;
-            }
+            hdl.write_zeroes_at(0, wipe_size).await.map_err(|e| {
+                error!(?self, ?e);
+                Error::RepDestroy {
+                    source: Errno::EIO,
+                    name: self.name(),
+                    msg: "failed to write to lvol".into(),
+                }
+            })?;
         }
         Ok(())
     }

--- a/io-engine/src/lvs/lvs_store.rs
+++ b/io-engine/src/lvs/lvs_store.rs
@@ -756,6 +756,8 @@ impl Lvs {
             })
             .map(Lvol::from_inner_ptr)?;
 
+        info!("{:?}: wiping super", lvol);
+
         if let Err(error) = lvol.wipe_super().await {
             // If we fail to destroy it hopefully the control-plane will clean
             // it up, though it's possible it may attempt to use it...

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -156,9 +156,10 @@ if [ -n "$TAG" ] && [ "$TAG" != "$(get_tag)" ]; then
   # Set the TAG which basically allows building the binaries as if it were a git tag
   NIX_TAG_ARGS="--argstr tag $TAG"
   NIX_BUILD="$NIX_BUILD $NIX_TAG_ARGS"
+  alias_tag=
 fi
 TAG=${TAG:-$HASH}
-if [ -n "$OVERRIDE_COMMIT_HASH" ]; then
+if [ -n "$OVERRIDE_COMMIT_HASH" ] && [ -n "$alias_tag" ]; then
   # Set the TAG to the alias and remove the alias
   NIX_TAG_ARGS="--argstr img_tag $alias_tag"
   NIX_BUILD="$NIX_BUILD $NIX_TAG_ARGS"
@@ -169,8 +170,12 @@ fi
 for name in $IMAGES; do
   image_basename="openebs/${name}"
   image=$image_basename
-  if [ -n "$REGISTRY" ]; then
-    image="${REGISTRY}/${image}"
+    if [ -n "$REGISTRY" ]; then
+    if [[ "${REGISTRY}" =~ '/' ]]; then
+      image="${REGISTRY}/$(echo ${image} | cut -d'/' -f2)"
+    else
+      image="${REGISTRY}/${image}"
+    fi
   fi
   # If we're skipping the build, then we just want to upload
   # the images we already have locally.


### PR DESCRIPTION
This is useful to trace how long zeroing takes.
Also use write_zeroes variant that is now available which is much simpler.