### PR TITLE
fix(nexus): improper replica snapshot status in nexus snapshot operation

### DIFF
--- a/test/python/v1/nexus/features/snapshot.feature
+++ b/test/python/v1/nexus/features/snapshot.feature
@@ -4,5 +4,6 @@ Scenario: creating a snapshot for published healthy one replica nexus with activ
   Given a published one replica nexus
   Given fio client is performing I/O on the published nexus
   When a nexus snapshot is created
-  Then snapshot should be created on all nexus replicas
+  Then successful status for replicas should be returned to the caller
+  And snapshot should be created on all nexus replicas
   And fio should complete without I/O errors

--- a/test/python/v1/nexus/test_nexus_snapshot.py
+++ b/test/python/v1/nexus/test_nexus_snapshot.py
@@ -63,7 +63,7 @@ def start_fio_client(connect_nexus_1):
     f.communicate()
 
 
-@when("a nexus snapshot is created")
+@when("a nexus snapshot is created", target_fixture="create_nexus_snapshot")
 def create_nexus_snapshot(
     connect_nexus_1, mayastor_mod, nexus_cfg, replica_cfg, snapshot1_cfg
 ):
@@ -77,6 +77,17 @@ def create_nexus_snapshot(
         replicas,
         [],
     )
+
+
+@then("successful status for replicas should be returned to the caller")
+def check_nexus_snapshot_creation_status(create_nexus_snapshot, replica_cfg):
+    res = create_nexus_snapshot
+    assert len(res.replicas_done) == 1, "No status for replicas provided"
+    assert len(res.replicas_skipped) == 0, "Skipped replicas reported"
+    assert (
+        res.replicas_done[0].replica_uuid == replica_cfg[0]
+    ), "UUID for replica mismatches"
+    assert res.replicas_done[0].status_code == 0, "Status code mismatches"
 
 
 @then("snapshot should be created on all nexus replicas")


### PR DESCRIPTION
Fixed replicas_done member in V1 nexus::create_snapshot() gRPC method.