### PR TITLE
fix(fs/shutdown): freeze nexus when faulted

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1789,15 +1789,6 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
-name = "memoffset"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
@@ -1879,8 +1870,6 @@ dependencies = [
  "bitflags",
  "cfg-if",
  "libc",
- "memoffset 0.7.1",
- "pin-utils",
  "static_assertions",
 ]
 

--- a/io-engine/src/bdev/nexus/mod.rs
+++ b/io-engine/src/bdev/nexus/mod.rs
@@ -49,7 +49,8 @@ pub use nexus_child::{
 };
 use nexus_io::{NexusBio, NioCtx};
 use nexus_io_log::{IOLog, IOLogChannel};
-use nexus_io_subsystem::{NexusIoSubsystem, NexusPauseState};
+use nexus_io_subsystem::NexusIoSubsystem;
+pub use nexus_io_subsystem::NexusPauseState;
 pub use nexus_iter::{
     nexus_iter,
     nexus_iter_mut,

--- a/io-engine/src/bdev/nexus/nexus_bdev.rs
+++ b/io-engine/src/bdev/nexus/nexus_bdev.rs
@@ -37,7 +37,11 @@ use super::{
 use crate::{
     bdev::{
         device_destroy,
-        nexus::{nexus_persistence::PersistentNexusInfo, NexusIoSubsystem},
+        nexus::{
+            nexus_io_subsystem::NexusPauseState,
+            nexus_persistence::PersistentNexusInfo,
+            NexusIoSubsystem,
+        },
     },
     core::{
         partition,
@@ -825,6 +829,11 @@ impl<'n> Nexus<'n> {
     /// Returns a mutable reference to Nexus I/O.
     fn io_subsystem_mut(self: Pin<&mut Self>) -> &mut NexusIoSubsystem<'n> {
         unsafe { self.get_unchecked_mut().io_subsystem.as_mut().unwrap() }
+    }
+
+    /// Get the subsystem pause state.
+    pub fn io_subsystem_state(&self) -> Option<NexusPauseState> {
+        self.io_subsystem.as_ref().map(|io| io.pause_state())
     }
 
     /// Resumes I/O to the Bdev.

--- a/io-engine/src/bdev/nexus/nexus_bdev_children.rs
+++ b/io-engine/src/bdev/nexus/nexus_bdev_children.rs
@@ -1023,16 +1023,6 @@ impl<'n> Nexus<'n> {
             );
         }
 
-        // If we are faulted then rather than failing all IO back to the
-        // initiator we can instead leave the subsystem paused, and wait
-        // for the control-plane to do something about this.
-        // Meanwhile the initiator will begin its reconnect loop and won't see
-        // a swarm of IO failures which could cause a fs to shutdown.
-        if self.status() == NexusStatus::Faulted {
-            tracing::warn!("{self:?}: Nexus Faulted: not resuming subsystem");
-            return Ok(());
-        }
-
         debug!("{self:?}: resuming...");
         self.as_mut().resume().await?;
         debug!("{self:?}: resuming ok");

--- a/io-engine/src/bdev/nexus/nexus_bdev_children.rs
+++ b/io-engine/src/bdev/nexus/nexus_bdev_children.rs
@@ -1023,6 +1023,16 @@ impl<'n> Nexus<'n> {
             );
         }
 
+        // If we are faulted then rather than failing all IO back to the
+        // initiator we can instead leave the subsystem paused, and wait
+        // for the control-plane to do something about this.
+        // Meanwhile the initiator will begin its reconnect loop and won't see
+        // a swarm of IO failures which could cause a fs to shutdown.
+        if self.status() == NexusStatus::Faulted {
+            tracing::warn!("{self:?}: Nexus Faulted: not resuming subsystem");
+            return Ok(());
+        }
+
         debug!("{self:?}: resuming...");
         self.as_mut().resume().await?;
         debug!("{self:?}: resuming ok");

--- a/io-engine/src/bdev/nexus/nexus_io_subsystem.rs
+++ b/io-engine/src/bdev/nexus/nexus_io_subsystem.rs
@@ -80,6 +80,11 @@ impl<'n> NexusIoSubsystem<'n> {
         }
     }
 
+    /// Get the subsystem pause state.
+    pub(super) fn pause_state(&self) -> NexusPauseState {
+        self.pause_state.load()
+    }
+
     /// Suspend any incoming IO to the bdev pausing the controller allows us to
     /// handle internal events and which is a protocol feature.
     /// In case concurrent pause requests take place, the other callers

--- a/io-engine/tests/nexus_io.rs
+++ b/io-engine/tests/nexus_io.rs
@@ -4,8 +4,10 @@ use io_engine::{
     bdev::nexus::{
         nexus_create,
         nexus_create_v2,
+        nexus_lookup,
         nexus_lookup_mut,
         NexusNvmeParams,
+        NexusPauseState,
         NvmeAnaState,
     },
     constants::NVME_NQN_PREFIX,
@@ -35,6 +37,7 @@ use common::{
         },
         Binary,
         Builder,
+        ComposeTest,
     },
     nvme::{
         get_nvme_resv_report,
@@ -62,6 +65,7 @@ static POOL_NAME: &str = "tpool";
 static NXNAME: &str = "nexus0";
 static NEXUS_UUID: &str = "cdc2a7db-3ac3-403a-af80-7fadc1581c47";
 static REPL_UUID: &str = "65acdaac-14c4-41d8-a55e-d03bfd7185a4";
+static REPL2_UUID: &str = "65acdaac-14c4-41d8-a55e-d03bfd7185a5";
 static HOSTNQN: &str = NVME_NQN_PREFIX;
 static HOSTID0: &str = "53b35ce9-8e71-49a9-ab9b-cba7c5670fad";
 static HOSTID1: &str = "c1affd2d-ef79-4ba4-b5cf-8eb48f9c07d0";
@@ -1094,4 +1098,188 @@ async fn nexus_io_write_zeroes() {
                 .expect("read should return block of 0");
         })
         .await;
+}
+
+#[tokio::test]
+async fn nexus_io_freeze() {
+    common::composer_init();
+
+    std::env::set_var("NEXUS_NVMF_ANA_ENABLE", "1");
+    std::env::set_var("NEXUS_NVMF_RESV_ENABLE", "1");
+    // create a new composeTest
+    let test = Builder::new()
+        .name("nexus_io_freeze")
+        .network("10.1.0.0/16")
+        .unwrap()
+        .add_container_bin(
+            "ms1",
+            Binary::from_dbg("io-engine").with_bind("/tmp", "/host/tmp"),
+        )
+        .with_clean(true)
+        .build()
+        .await
+        .unwrap();
+    create_pool_replicas(&test, 0).await;
+
+    let mayastor = get_ms();
+    let ip0 = test.container_ip("ms1");
+    let nexus_name = format!("nexus-{NEXUS_UUID}");
+    let nexus_children = [
+        format!("nvmf://{ip0}:8420/{HOSTNQN}:{REPL_UUID}"),
+        format!("nvmf://{ip0}:8420/{HOSTNQN}:{REPL2_UUID}"),
+    ];
+
+    let name = nexus_name.clone();
+    let children = nexus_children.clone();
+    mayastor
+        .spawn(async move {
+            // create nexus on local node with remote replica as child
+            nexus_create(&name, 32 * 1024 * 1024, Some(NEXUS_UUID), &children)
+                .await
+                .unwrap();
+            // publish nexus on local node over nvmf
+            nexus_lookup_mut(&name)
+                .unwrap()
+                .share(Protocol::Nvmf, None)
+                .await
+                .unwrap();
+            assert_eq!(
+                nexus_pause_state(&name),
+                Some(NexusPauseState::Unpaused)
+            );
+        })
+        .await;
+
+    // This will lead into a child retire, which means the nexus will be faulted
+    // and subsystem frozen!
+    test.restart("ms1").await.unwrap();
+    wait_nexus_faulted(&nexus_name, std::time::Duration::from_secs(2))
+        .await
+        .unwrap();
+
+    let name = nexus_name.clone();
+    mayastor
+        .spawn(async move {
+            assert_eq!(nexus_pause_state(&name), Some(NexusPauseState::Frozen));
+
+            nexus_lookup_mut(&name).unwrap().pause().await.unwrap();
+            assert_eq!(nexus_pause_state(&name), Some(NexusPauseState::Frozen));
+
+            nexus_lookup_mut(&name).unwrap().resume().await.unwrap();
+            assert_eq!(nexus_pause_state(&name), Some(NexusPauseState::Frozen));
+
+            nexus_lookup_mut(&name).unwrap().destroy().await.unwrap();
+        })
+        .await;
+
+    create_pool_replicas(&test, 0).await;
+
+    let name = nexus_name.clone();
+    let children = nexus_children.clone();
+    mayastor
+        .spawn(async move {
+            nexus_create(&name, 32 * 1024 * 1024, Some(NEXUS_UUID), &children)
+                .await
+                .unwrap();
+            nexus_lookup_mut(&name)
+                .unwrap()
+                .share(Protocol::Nvmf, None)
+                .await
+                .unwrap();
+
+            // Pause, so now WE must be the ones which resume to frozen!
+            nexus_lookup_mut(&name).unwrap().pause().await.unwrap();
+            assert_eq!(nexus_pause_state(&name), Some(NexusPauseState::Paused));
+        })
+        .await;
+
+    test.restart("ms1").await.unwrap();
+    wait_nexus_faulted(&nexus_name, std::time::Duration::from_secs(2))
+        .await
+        .unwrap();
+
+    let name = nexus_name.clone();
+    mayastor
+        .spawn(async move {
+            nexus_lookup_mut(&name).unwrap().pause().await.unwrap();
+            assert_eq!(nexus_pause_state(&name), Some(NexusPauseState::Paused));
+
+            nexus_lookup_mut(&name).unwrap().resume().await.unwrap();
+            assert_eq!(nexus_pause_state(&name), Some(NexusPauseState::Paused));
+
+            // Final resume, transition to Frozen!
+            nexus_lookup_mut(&name).unwrap().resume().await.unwrap();
+            assert_eq!(nexus_pause_state(&name), Some(NexusPauseState::Frozen));
+
+            nexus_lookup_mut(&name).unwrap().destroy().await.unwrap();
+        })
+        .await;
+}
+
+fn nexus_pause_state(name: &str) -> Option<NexusPauseState> {
+    nexus_lookup(name).unwrap().io_subsystem_state()
+}
+
+async fn create_pool_replicas(test: &ComposeTest, index: usize) {
+    let grpc = GrpcConnect::new(test);
+    let mut hdls = grpc.grpc_handles().await.unwrap();
+    let hdl = &mut hdls[index];
+
+    // create a pool on remote node
+    hdl.mayastor
+        .create_pool(CreatePoolRequest {
+            name: POOL_NAME.to_string(),
+            disks: vec!["malloc:///disk0?size_mb=128".into()],
+        })
+        .await
+        .unwrap();
+
+    // create replica, shared over nvmf
+    hdl.mayastor
+        .create_replica(CreateReplicaRequest {
+            uuid: REPL_UUID.to_string(),
+            pool: POOL_NAME.to_string(),
+            size: 32 * 1024 * 1024,
+            thin: false,
+            share: 1,
+            allowed_hosts: vec![],
+        })
+        .await
+        .unwrap();
+
+    // create replica, shared over nvmf
+    hdl.mayastor
+        .create_replica(CreateReplicaRequest {
+            uuid: REPL2_UUID.to_string(),
+            pool: POOL_NAME.to_string(),
+            size: 32 * 1024 * 1024,
+            thin: false,
+            share: 1,
+            allowed_hosts: vec![],
+        })
+        .await
+        .unwrap();
+}
+
+async fn wait_nexus_faulted(
+    name: &str,
+    timeout: std::time::Duration,
+) -> Result<(), std::time::Duration> {
+    let mayastor = get_ms();
+    let start = std::time::Instant::now();
+
+    while start.elapsed() <= timeout {
+        let name = name.to_string();
+        let faulted = mayastor
+            .spawn(async move {
+                nexus_lookup(&name).unwrap().status() == NexusStatus::Faulted
+            })
+            .await;
+        if faulted {
+            return Ok(());
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+
+    Err(start.elapsed())
 }

--- a/scripts/pytest-tests.sh
+++ b/scripts/pytest-tests.sh
@@ -21,6 +21,14 @@ function run_tests()
       python -m pytest --tc-file='test_config.ini' --docker-compose="$name" "$name"
     )
     fi
+    if [ -f "$name" ]
+    then
+    (
+      set -x
+      base=$(dirname "$name")
+      python -m pytest --tc-file='test_config.ini' --docker-compose="$base" "$name"
+    )
+    fi
   done
 }
 
@@ -47,6 +55,7 @@ tests/replica_uuid
 #tests/rpc
 
 tests/nexus_multipath
+tests/nexus_fault
 tests/nexus
 
 v1/pool

--- a/shell.nix
+++ b/shell.nix
@@ -46,6 +46,7 @@ mkShell {
     python3
     utillinux
     gnuplot
+    xfsprogs
     libunwind
     autoconf
     automake
@@ -58,6 +59,7 @@ mkShell {
   SPDK_PATH = if nospdk then null else "${libspdk-dev}";
   FIO_SPDK = if nospdk then null else "${libspdk-dev}/fio/spdk_nvme";
   ETCD_BIN = "${etcd}/bin/etcd";
+  ETCDCTL_API = "3";
 
   shellHook = ''
     ${pkgs.lib.optionalString (nospdk) "cowsay ${nospdk_moth}"}

--- a/test/python/common/fio.py
+++ b/test/python/common/fio.py
@@ -2,7 +2,7 @@ import shutil
 
 
 class Fio(object):
-    def __init__(self, name, rw, device, runtime=15, optstr=""):
+    def __init__(self, name, rw, device, size=None, runtime=15, optstr=""):
         self.name = name
         self.rw = rw
         self.device = device
@@ -11,17 +11,26 @@ class Fio(object):
         self.success = {}
         self.runtime = runtime
         self.optstr = optstr
+        self.size = size
 
     def build(self):
         devs = [self.device] if isinstance(self.device, str) else self.device
+        size = ""
+        if self.size is not None:
+            size = "--size={}".format(self.size)
 
         command = (
             "sudo fio --ioengine=linuxaio --direct=1 --bs=4k "
             "--time_based=1 {} --rw={} "
             "--group_reporting=1 --norandommap=1 --iodepth=64 "
-            "--runtime={} --name={} --filename={}"
+            "--runtime={} --name={} --filename={} {}"
         ).format(
-            self.optstr, self.rw, self.runtime, self.name, ":".join(map(str, devs))
+            self.optstr,
+            self.rw,
+            self.runtime,
+            self.name,
+            ":".join(map(str, devs)),
+            size,
         )
 
         return command

--- a/test/python/common/hdl.py
+++ b/test/python/common/hdl.py
@@ -97,11 +97,11 @@ class MayastorHandle(object):
         return self.ms.CreatePool(pb.CreatePoolRequest(name=name, disks=disks))
 
     def pool_destroy(self, name):
-        """Destroy  the pool."""
+        """Destroy the pool."""
         return self.ms.DestroyPool(pb.DestroyPoolRequest(name=name))
 
     def replica_create(self, pool, uuid, size, share=1):
-        """Create  a replica on the pool with the specified UUID and size."""
+        """Create a replica on the pool with the specified UUID and size."""
         return self.ms.CreateReplica(
             pb.CreateReplicaRequest(
                 pool=pool, uuid=str(uuid), size=size, thin=False, share=share
@@ -120,6 +120,10 @@ class MayastorHandle(object):
         """Destroy the replica by the UUID, the pool is resolved within
         mayastor."""
         return self.ms.DestroyReplica(pb.DestroyReplicaRequest(uuid=uuid))
+
+    def replica_share(self, uuid, share=1):
+        """Share a replica with the specified share protocol."""
+        return self.ms.ShareReplica(pb.ShareReplicaRequest(uuid=str(uuid), share=share))
 
     def replica_list(self):
         """List existing replicas"""

--- a/test/python/tests/nexus_fault/docker-compose.yml
+++ b/test/python/tests/nexus_fault/docker-compose.yml
@@ -1,0 +1,66 @@
+#
+# {SRCDIR} should point to your working tree which should be your current pwd
+#
+
+version: '3'
+services:
+  ms0:
+    container_name: "ms0"
+    image: rust:latest
+    environment:
+        - MY_POD_IP=10.0.0.2
+        - NEXUS_NVMF_ANA_ENABLE=1
+        - NEXUS_NVMF_RESV_ENABLE=1
+    command: ${SRCDIR}/target/debug/io-engine -g 0.0.0.0 -l 1 -r /tmp/ms0.sock
+    networks:
+      mayastor_net:
+        ipv4_address: 10.0.0.2
+    cap_add:
+      # NUMA related
+      - SYS_ADMIN
+      - SYS_NICE
+      # uring needs mmap
+      - IPC_LOCK
+    security_opt:
+      # we can set this to a JSON file to allow per syscall access
+      - seccomp=unconfined
+    volumes:
+      - ${SRCDIR}:${SRCDIR}
+      - /nix:/nix
+      - /dev/hugepages:/dev/hugepages
+      - /tmp:/tmp
+      - /var/tmp:/var/tmp
+  ms1:
+    container_name: "ms1"
+    image: rust:latest
+    environment:
+        - MY_POD_IP=10.0.0.3
+        - NEXUS_NVMF_ANA_ENABLE=1
+        - NEXUS_NVMF_RESV_ENABLE=1
+    command: ${SRCDIR}/target/debug/io-engine -g 0.0.0.0 -l 2 -r /tmp/ms1.sock
+    networks:
+      mayastor_net:
+        ipv4_address: 10.0.0.3
+    cap_add:
+      # NUMA related
+      - SYS_ADMIN
+      - SYS_NICE
+      # uring needs mmap
+      - IPC_LOCK
+    security_opt:
+      # we can set this to a JSON file to allow per syscall access
+      - seccomp=unconfined
+    volumes:
+      - ${SRCDIR}:${SRCDIR}
+      - /nix:/nix
+      - /dev/hugepages:/dev/hugepages
+      - /tmp:/tmp
+      - /var/tmp:/var/tmp
+
+networks:
+  mayastor_net:
+    name: mayastor_net
+    ipam:
+      driver: default
+      config:
+        - subnet: "10.0.0.0/16"

--- a/test/python/tests/nexus_fault/docker-compose.yml
+++ b/test/python/tests/nexus_fault/docker-compose.yml
@@ -8,9 +8,9 @@ services:
     container_name: "ms0"
     image: rust:latest
     environment:
-        - MY_POD_IP=10.0.0.2
-        - NEXUS_NVMF_ANA_ENABLE=1
-        - NEXUS_NVMF_RESV_ENABLE=1
+      - MY_POD_IP=10.0.0.2
+      - NEXUS_NVMF_ANA_ENABLE=1
+      - NEXUS_NVMF_RESV_ENABLE=1
     command: ${SRCDIR}/target/debug/io-engine -g 0.0.0.0 -l 1 -r /tmp/ms0.sock
     networks:
       mayastor_net:
@@ -34,9 +34,9 @@ services:
     container_name: "ms1"
     image: rust:latest
     environment:
-        - MY_POD_IP=10.0.0.3
-        - NEXUS_NVMF_ANA_ENABLE=1
-        - NEXUS_NVMF_RESV_ENABLE=1
+      - MY_POD_IP=10.0.0.3
+      - NEXUS_NVMF_ANA_ENABLE=1
+      - NEXUS_NVMF_RESV_ENABLE=1
     command: ${SRCDIR}/target/debug/io-engine -g 0.0.0.0 -l 2 -r /tmp/ms1.sock
     networks:
       mayastor_net:

--- a/test/python/tests/nexus_fault/features/nexus_fault.feature
+++ b/test/python/tests/nexus_fault/features/nexus_fault.feature
@@ -14,3 +14,15 @@ Feature: Faulted nexus I/O management
     And the faulted nexus is recreated
     Then the fio workload should complete gracefully
     And the initiator filesystem should not be shutdown
+
+  Scenario: replacing a temporarily faulted nexus should not cause initiator filesystem to shutdown
+    Given a single replica (remote) nexus is published via nvmf
+    And the nexus is connected to a kernel initiator
+    And a filesystem is placed on top of the connected device
+    And the filesystem is mounted
+    And a fio workload is started on top of the mounted filesystem
+    When the remote mayastor instance is restarted
+    And the faulted nexus is recreated on another node
+    And the initiator swaps the nexuses
+    Then the fio workload should complete gracefully
+    And the initiator filesystem should not be shutdown

--- a/test/python/tests/nexus_fault/features/nexus_fault.feature
+++ b/test/python/tests/nexus_fault/features/nexus_fault.feature
@@ -1,0 +1,16 @@
+Feature: Faulted nexus I/O management
+
+  Background:
+    Given a local mayastor instance
+    And a remote mayastor instance
+
+  Scenario: a temporarily faulted nexus should not cause initiator filesystem to shutdown
+    Given a single replica (remote) nexus is published via nvmf
+    And the nexus is connected to a kernel initiator
+    And a filesystem is placed on top of the connected device
+    And the filesystem is mounted
+    And a fio workload is started on top of the mounted filesystem
+    When the remote mayastor instance is restarted
+    And the faulted nexus is recreated
+    Then the fio workload should complete gracefully
+    And the initiator filesystem should not be shutdown

--- a/test/python/tests/nexus_fault/test_nexus_fault.py
+++ b/test/python/tests/nexus_fault/test_nexus_fault.py
@@ -1,0 +1,255 @@
+"""Faulted nexus I/O management feature tests."""
+
+import pytest
+from pytest_bdd import (
+    given,
+    scenario,
+    then,
+    when,
+)
+
+import os
+import subprocess
+import time
+
+from retrying import retry
+
+from common.command import run_cmd
+from common.fio import Fio
+from common.mayastor import container_mod, mayastor_mod
+from common.nvme import nvme_connect, nvme_disconnect
+
+import grpc
+import nexus_pb2 as pb
+
+
+def megabytes(n):
+    return n * 1024 * 1024
+
+
+@scenario(
+    "features/nexus_fault.feature",
+    "a temporarily faulted nexus should not cause initiator filesystem to shutdown",
+)
+def test_a_temporarily_faulted_nexus_should_not_cause_initiator_filesystem_to_shutdown():
+    """a temporarily faulted nexus should not cause initiator filesystem to shutdown."""
+
+
+@given("a filesystem is placed on top of the connected device")
+def _(connect_nexus_1):
+    """a filesystem is placed on top of the connected device."""
+    device = connect_nexus_1
+    print(device)
+    run_cmd(f"sudo mkfs.xfs {device}")
+
+
+@given(
+    "a fio workload is started on top of the mounted filesystem", target_fixture="fio"
+)
+def _(mounted_nexus):
+    """a fio workload is started on top of the mounted filesystem."""
+    fio_cmd = Fio(
+        f"job-raw", "randwrite", f"{mounted_nexus}/fio.io", size="200M"
+    ).build()
+    print(fio_cmd)
+    yield subprocess.Popen(fio_cmd, shell=True)
+
+
+@given("a local mayastor instance")
+def _(remote_instance):
+    """a local mayastor instance."""
+
+
+@given("a remote mayastor instance")
+def _(local_instance):
+    """a remote mayastor instance."""
+
+
+@given("a single replica (remote) nexus is published via nvmf")
+def _(create_nexus):
+    """a single replica (remote) nexus is published via nvmf."""
+    nexus = create_nexus
+    print(nexus)
+
+
+@given("the filesystem is mounted", target_fixture="mounted_nexus")
+def _(connect_nexus_1):
+    """the filesystem is mounted."""
+    dev = connect_nexus_1
+    path = f"/mnt{dev}"
+    run_cmd(f"sudo mkdir -p {path}")
+    run_cmd(f"sudo mount {dev} {path}")
+    yield path
+    run_cmd(f"sudo umount {path}")
+
+
+@given("the nexus is connected to a kernel initiator", target_fixture="connect_nexus_1")
+def _(publish_nexus):
+    """the nexus is connected to a kernel initiator."""
+    yield nvme_connect(publish_nexus)
+    nvme_disconnect(publish_nexus)
+
+
+@when("the remote mayastor instance is restarted")
+def _(container_mod, mayastor_mod, remote_instance, nexus_uuid, find_nexus):
+    """the remote mayastor instance is restarted."""
+    container_mod.get(remote_instance).restart()
+    nexus = find_nexus(nexus_uuid)
+    while nexus.state != pb.NexusState.NEXUS_FAULTED:
+        nexus = find_nexus(nexus_uuid)
+        print(nexus)
+
+    remote_ready(mayastor_mod, remote_instance)
+
+
+@when("the faulted nexus is recreated")
+def _(recreate_pool, republish_nexus):
+    """the faulted nexus is recreated."""
+
+
+@then("the fio workload should complete gracefully")
+def _(fio):
+    """the fio workload should complete gracefully."""
+    try:
+        code = fio.wait(timeout=60)
+    except subprocess.TimeoutExpired:
+        assert False, "FIO timed out"
+    assert code == 0, "FIO failed, exit code: %d" % code
+
+
+@then("the initiator filesystem should not be shutdown")
+def _(mounted_nexus):
+    """the initiator filesystem should not be shutdown."""
+    try:
+        # xfs_info should still be working as the fs is not shutdown
+        run_cmd(f"xfs_info {mounted_nexus}")
+    except:
+        pytest.fail(f"Filesystem on {mounted_nexus} should not be shutdown")
+
+
+@pytest.fixture(scope="module")
+def remote_instance():
+    yield "ms0"
+
+
+@pytest.fixture(scope="module")
+def local_instance():
+    yield "ms1"
+
+
+@pytest.fixture
+def create_nexus(mayastor_mod, nexus_uuid, create_replica, local_instance):
+    nexus = mayastor_mod[local_instance].nexus_create(
+        uuid=nexus_uuid,
+        size=megabytes(303),
+        children=list([create_replica.uri]),
+    )
+    yield nexus
+
+
+@pytest.fixture
+def publish_nexus(mayastor_mod, nexus_uuid, create_nexus, local_instance):
+    yield mayastor_mod[local_instance].nexus_publish(nexus_uuid)
+
+
+@pytest.fixture
+def republish_nexus(mayastor_mod, nexus_uuid, local_instance, recreate_replica):
+    mayastor_mod[local_instance].nexus_destroy(nexus_uuid)
+    mayastor_mod[local_instance].nexus_create(
+        uuid=nexus_uuid,
+        size=megabytes(303),
+        children=list([recreate_replica.uri]),
+    )
+    yield mayastor_mod[local_instance].nexus_publish(nexus_uuid)
+
+
+@pytest.fixture(scope="module")
+def local_files():
+    files = [f"/tmp/disk-{base}.img" for base in ["remote"]]
+    for path in files:
+        subprocess.run(
+            ["sudo", "sh", "-c", f"rm -f '{path}' && truncate -s 400M '{path}'"],
+            check=True,
+        )
+    yield files
+    for path in files:
+        subprocess.run(["sudo", "rm", "-f", path], check=True)
+
+
+@pytest.fixture
+def create_pool(mayastor_mod, pool_remote, remote_instance, local_files):
+    pool = mayastor_mod[remote_instance].pool_create(pool_remote, local_files[0])
+    print(pool)
+    yield pool
+
+
+@pytest.fixture
+def recreate_pool(mayastor_mod, pool_remote, remote_instance, local_files):
+    pool = mayastor_mod[remote_instance].pool_create(pool_remote, local_files[0])
+    print(pool)
+    yield pool
+
+
+@pytest.fixture
+def create_replica(mayastor_mod, pool_remote, remote_instance, create_pool):
+    replica = mayastor_mod[remote_instance].replica_create(
+        pool_remote, "c64f5e67-e979-4933-8952-741600d3792a", megabytes(333)
+    )
+    print(replica)
+    yield replica
+
+
+@pytest.fixture
+def recreate_replica(mayastor_mod, pool_remote, remote_instance, recreate_pool):
+    replica = mayastor_mod[remote_instance].replica_create(
+        pool_remote, "c64f5e67-e979-4933-8952-741600d3792a", megabytes(333)
+    )
+    print(replica)
+    yield replica
+
+
+@pytest.fixture(scope="module")
+def pool_remote():
+    yield "pool-remote"
+
+
+@pytest.fixture(scope="module")
+def nexus_uuid():
+    yield "2c58c9f0-da89-4cb9-8097-dc67fa132493"
+
+
+@pytest.fixture(scope="module")
+def mayastor_instance(mayastor_mod):
+    yield mayastor_mod["ms0"]
+
+
+@pytest.fixture(scope="module")
+def find_nexus(mayastor_mod, local_instance):
+    def find(uuid):
+        for nexus in mayastor_mod[local_instance].nexus_list():
+            if nexus.uuid == uuid:
+                return nexus
+        return None
+
+    yield find
+
+
+@retry(wait_fixed=200, stop_max_attempt_number=30)
+def remote_ready(mayastor_mod, remote_instance):
+    mayastor_mod[remote_instance].pool_list()
+
+
+@retry(wait_fixed=200, stop_max_attempt_number=10)
+def xfs_not_shutdown(mounted_nexus):
+    try:
+        run_cmd(f"ls {mounted_nexus}")
+        pytest.fail(f"Filesystem on {mounted_nexus} should not be available")
+    except:
+        pass
+
+    try:
+        # xfs_info should still be working as the fs is not shutdown
+        run_cmd(f"xfs_info {mounted_nexus}")
+    except:
+        pytest.fail(f"Filesystem on {mounted_nexus} should not be shutdown")
+        pass


### PR DESCRIPTION
When the last healthy child of a nexus is faulted, errors are propagated up the stack causing the filesystem to shutdown itself down.

Instead I propose that we simply leave the nexus in a paused state, allowing the initiator to start the re-connection cycle, giving us some “time” to recreate the nexus again when the replica is available again.

todo: we might want to add a time-limit after which we resort to failing IOs?