### PR TITLE
fix(snapshot): properly display snapshot allocated space

### DIFF
--- a/io-engine-tests/src/bdev_io.rs
+++ b/io-engine-tests/src/bdev_io.rs
@@ -3,10 +3,11 @@ use io_engine::core::{CoreError, UntypedBdevHandle};
 pub async fn write_some(
     nexus_name: &str,
     offset: u64,
+    num_blocks: u32,
     fill: u8,
 ) -> Result<(), CoreError> {
     let h = UntypedBdevHandle::open(nexus_name, true, false)?;
-    let buflen = u64::from(h.get_bdev().block_len() * 2);
+    let buflen = u64::from(h.get_bdev().block_len() * num_blocks);
     let mut buf = h.dma_malloc(buflen).expect("failed to allocate buffer");
     buf.fill(fill);
 
@@ -20,11 +21,12 @@ pub async fn write_some(
 pub async fn read_some(
     nexus_name: &str,
     offset: u64,
+    num_blocks: u32,
     fill: u8,
 ) -> Result<(), CoreError> {
     let h = UntypedBdevHandle::open(nexus_name, true, false)?;
 
-    let buflen = u64::from(h.get_bdev().block_len() * 2);
+    let buflen = u64::from(h.get_bdev().block_len() * num_blocks);
     let mut buf = h.dma_malloc(buflen).expect("failed to allocate buffer");
     let slice = buf.as_mut_slice();
 

--- a/io-engine/src/core/snapshot.rs
+++ b/io-engine/src/core/snapshot.rs
@@ -39,7 +39,7 @@ impl SnapshotParams {
 pub struct VolumeSnapshotDescriptor {
     pub snapshot_lvol: Lvol,
     pub source_uuid: String,
-    pub source_size: u64,
+    pub snapshot_size: u64,
     pub snap_param: SnapshotParams,
     pub num_clones: u64, /* TODO: Need to move to SnapshotParams part of
                           * clone feature. */
@@ -50,7 +50,7 @@ impl VolumeSnapshotDescriptor {
     pub fn new(
         snapshot_lvol: Lvol,
         source_uuid: String,
-        source_size: u64,
+        snapshot_size: u64,
         snap_param: SnapshotParams,
         num_clones: u64,
         valid_snapshot: bool,
@@ -58,7 +58,7 @@ impl VolumeSnapshotDescriptor {
         Self {
             snapshot_lvol,
             source_uuid,
-            source_size,
+            snapshot_size,
             snap_param,
             num_clones,
             valid_snapshot,
@@ -73,9 +73,9 @@ impl VolumeSnapshotDescriptor {
         self.source_uuid.clone()
     }
 
-    /// Give snapshot size.
-    pub fn source_size(&self) -> u64 {
-        self.source_size
+    /// Give amount of bytes owned by snapshot.
+    pub fn snapshot_size(&self) -> u64 {
+        self.snapshot_size
     }
 
     /// Get SnapshotParameters.

--- a/io-engine/src/grpc/v1/snapshot.rs
+++ b/io-engine/src/grpc/v1/snapshot.rs
@@ -135,7 +135,7 @@ impl From<ReplicaSnapshotDescriptor> for SnapshotInfo {
         Self {
             snapshot_uuid: snap_lvol.uuid(),
             snapshot_name: snap_lvol.name(),
-            snapshot_size: snap_lvol.size(),
+            snapshot_size: snap_lvol.usage().allocated_bytes,
             num_clones: 0, //TODO: Need to implement along with clone
             timestamp: snapshot_param
                 .create_time()
@@ -157,14 +157,14 @@ impl From<VolumeSnapshotDescriptor> for SnapshotInfo {
         Self {
             snapshot_uuid: s.snapshot_lvol().uuid(),
             snapshot_name: s.snapshot_params().name().unwrap_or_default(),
-            snapshot_size: s.snapshot_lvol().size(),
+            snapshot_size: s.snapshot_lvol().usage().allocated_bytes,
             num_clones: s.num_clones(),
             timestamp: s
                 .snapshot_params()
                 .create_time()
                 .map(|s| s.parse::<DateTime<Utc>>().unwrap_or_default().into()),
             source_uuid: s.source_uuid(),
-            source_size: s.source_size(),
+            source_size: s.snapshot_lvol().size(),
             pool_uuid: s.snapshot_lvol().pool_uuid(),
             pool_name: s.snapshot_lvol().pool_name(),
             entity_id: s.snapshot_params().entity_id().unwrap_or_default(),

--- a/io-engine/src/lvs/lvs_lvol.rs
+++ b/io-engine/src/lvs/lvs_lvol.rs
@@ -589,22 +589,23 @@ impl Lvol {
         // set remaining snapshot parameters for snapshot list
         snapshot_param.set_name(self.name());
         // set parent replica uuid and size of the snapshot
-        let (parent_uuid, parent_size) = if let Some(parent_lvol) = parent {
-            (parent_lvol.uuid(), parent_lvol.size())
+        let parent_uuid = if let Some(parent_lvol) = parent {
+            parent_lvol.uuid()
         } else {
             match Bdev::lookup_by_uuid_str(
                 snapshot_param.parent_id().unwrap_or_default().as_str(),
             )
             .and_then(|b| Lvol::try_from(b).ok())
             {
-                Some(parent) => (parent.uuid(), parent.size()),
-                None => (String::default(), 0),
+                Some(parent) => parent.uuid(),
+                None => String::default(),
             }
         };
+
         let snapshot_descriptor = VolumeSnapshotDescriptor::new(
             self.to_owned(),
             parent_uuid,
-            parent_size,
+            self.usage().allocated_bytes,
             snapshot_param,
             0, /* TODO: It will updated as part of snapshot clone
                 * implementation */

--- a/io-engine/src/lvs/lvs_store.rs
+++ b/io-engine/src/lvs/lvs_store.rs
@@ -201,6 +201,12 @@ impl Lvs {
         Bdev::checked_from_ptr(p).unwrap()
     }
 
+    /// Returns blobstore cluster size.
+    pub fn blob_cluster_size(&self) -> u64 {
+        let blobs = self.blob_store();
+        unsafe { spdk_bs_get_cluster_size(blobs) }
+    }
+
     /// returns the UUID of the lvs
     pub fn uuid(&self) -> String {
         let t = unsafe { self.as_inner_ref().uuid.u.raw };

--- a/io-engine/tests/io.rs
+++ b/io-engine/tests/io.rs
@@ -31,6 +31,6 @@ async fn io_test() {
 // only execute one future per reactor loop.
 async fn start() {
     bdev_create(BDEVNAME).await.expect("failed to create bdev");
-    bdev_io::write_some(BDEVNAME, 0, 0xff).await.unwrap();
-    bdev_io::read_some(BDEVNAME, 0, 0xff).await.unwrap();
+    bdev_io::write_some(BDEVNAME, 0, 2, 0xff).await.unwrap();
+    bdev_io::read_some(BDEVNAME, 0, 2, 0xff).await.unwrap();
 }

--- a/io-engine/tests/nexus_io.rs
+++ b/io-engine/tests/nexus_io.rs
@@ -380,8 +380,8 @@ async fn nexus_io_resv_acquire() {
             )
             .await
             .unwrap();
-            bdev_io::write_some(NXNAME, 0, 0xff).await.unwrap();
-            bdev_io::read_some(NXNAME, 0, 0xff).await.unwrap();
+            bdev_io::write_some(NXNAME, 0, 2, 0xff).await.unwrap();
+            bdev_io::read_some(NXNAME, 0, 2, 0xff).await.unwrap();
         })
         .await;
 
@@ -472,10 +472,10 @@ async fn nexus_io_resv_acquire() {
 
     mayastor
         .spawn(async move {
-            bdev_io::write_some(NXNAME, 0, 0xff)
+            bdev_io::write_some(NXNAME, 0, 2, 0xff)
                 .await
                 .expect("writes should still succeed");
-            bdev_io::read_some(NXNAME, 0, 0xff)
+            bdev_io::read_some(NXNAME, 0, 2, 0xff)
                 .await
                 .expect("reads should succeed");
 
@@ -576,8 +576,8 @@ async fn nexus_io_resv_preempt() {
             )
             .await
             .unwrap();
-            bdev_io::write_some(NXNAME, 0, 0xff).await.unwrap();
-            bdev_io::read_some(NXNAME, 0, 0xff).await.unwrap();
+            bdev_io::write_some(NXNAME, 0, 2, 0xff).await.unwrap();
+            bdev_io::read_some(NXNAME, 0, 2, 0xff).await.unwrap();
         })
         .await;
 
@@ -665,10 +665,10 @@ async fn nexus_io_resv_preempt() {
     // shutdown.
     mayastor
         .spawn(async move {
-            bdev_io::write_some(NXNAME, 0, 0xff)
+            bdev_io::write_some(NXNAME, 0, 2, 0xff)
                 .await
                 .expect_err("writes should fail");
-            bdev_io::read_some(NXNAME, 0, 0xff)
+            bdev_io::read_some(NXNAME, 0, 2, 0xff)
                 .await
                 .expect_err("reads should fail");
         })
@@ -852,8 +852,8 @@ async fn nexus_io_resv_preempt_tabled() {
                     )
                     .await
                     .unwrap();
-                    bdev_io::write_some(NXNAME, 0, 0xff).await.unwrap();
-                    bdev_io::read_some(NXNAME, 0, 0xff).await.unwrap();
+                    bdev_io::write_some(NXNAME, 0, 2, 0xff).await.unwrap();
+                    bdev_io::read_some(NXNAME, 0, 2, 0xff).await.unwrap();
                 })
                 .await;
         } else {
@@ -1077,19 +1077,19 @@ async fn nexus_io_write_zeroes() {
             .await
             .unwrap();
 
-            bdev_io::write_some(&name, 0, 0xff).await.unwrap();
+            bdev_io::write_some(&name, 0, 2, 0xff).await.unwrap();
             // Read twice to ensure round-robin read from both replicas
-            bdev_io::read_some(&name, 0, 0xff)
+            bdev_io::read_some(&name, 0, 2, 0xff)
                 .await
                 .expect("read should return block of 0xff");
-            bdev_io::read_some(&name, 0, 0xff)
+            bdev_io::read_some(&name, 0, 2, 0xff)
                 .await
                 .expect("read should return block of 0xff");
             bdev_io::write_zeroes_some(&name, 0, 512).await.unwrap();
-            bdev_io::read_some(&name, 0, 0)
+            bdev_io::read_some(&name, 0, 2, 0)
                 .await
                 .expect("read should return block of 0");
-            bdev_io::read_some(&name, 0, 0)
+            bdev_io::read_some(&name, 0, 2, 0)
                 .await
                 .expect("read should return block of 0");
         })

--- a/io-engine/tests/replica_snapshot.rs
+++ b/io-engine/tests/replica_snapshot.rs
@@ -101,23 +101,23 @@ async fn replica_snapshot() {
                 .await
                 .unwrap();
             create_nexus(0, &ip0).await;
-            bdev_io::write_some(NXNAME, 0, 0xff).await.unwrap();
+            bdev_io::write_some(NXNAME, 0, 2, 0xff).await.unwrap();
             // Issue an unimplemented vendor command
             // This checks that the target is correctly rejecting such commands
             // In practice the nexus will not send such commands
             custom_nvme_admin(0xc1).await.expect_err(
                 "unexpectedly succeeded invalid nvme admin command",
             );
-            bdev_io::read_some(NXNAME, 0, 0xff).await.unwrap();
+            bdev_io::read_some(NXNAME, 0, 2, 0xff).await.unwrap();
             let ts = create_snapshot().await.unwrap();
             // Check that IO to the replica still works after creating a
             // snapshot
             info!("testing IO to nexus");
-            bdev_io::read_some(NXNAME, 0, 0xff).await.unwrap();
-            bdev_io::write_some(NXNAME, 0, 0xff).await.unwrap();
-            bdev_io::read_some(NXNAME, 0, 0xff).await.unwrap();
-            bdev_io::write_some(NXNAME, 1024, 0xaa).await.unwrap();
-            bdev_io::read_some(NXNAME, 1024, 0xaa).await.unwrap();
+            bdev_io::read_some(NXNAME, 0, 2, 0xff).await.unwrap();
+            bdev_io::write_some(NXNAME, 0, 2, 0xff).await.unwrap();
+            bdev_io::read_some(NXNAME, 0, 2, 0xff).await.unwrap();
+            bdev_io::write_some(NXNAME, 1024, 2, 0xaa).await.unwrap();
+            bdev_io::read_some(NXNAME, 1024, 2, 0xaa).await.unwrap();
             ts
         })
         .await;
@@ -144,10 +144,10 @@ async fn replica_snapshot() {
             //    .expect_err("writing to snapshot should fail");
             // Verify that data read from snapshot remains unchanged
             info!("testing IO to nexus for snapshot");
-            bdev_io::write_some(NXNAME, 0, 0x55).await.unwrap();
-            bdev_io::read_some(NXNAME, 0, 0x55).await.unwrap();
-            bdev_io::read_some(NXNAME_SNAP, 0, 0xff).await.unwrap();
-            bdev_io::read_some(NXNAME_SNAP, 1024, 0).await.unwrap();
+            bdev_io::write_some(NXNAME, 0, 2, 0x55).await.unwrap();
+            bdev_io::read_some(NXNAME, 0, 2, 0x55).await.unwrap();
+            bdev_io::read_some(NXNAME_SNAP, 0, 2, 0xff).await.unwrap();
+            bdev_io::read_some(NXNAME_SNAP, 1024, 2, 0).await.unwrap();
         })
         .await;
 


### PR DESCRIPTION
Currently snapshot descriptor provides total replica size rather than amount of storage allocated for snapshot data. This fix uses Lvol usage statistics to return allocated_bytes for snapshots to denote storage space used by snapshots.