### PR TITLE
feat(clone): support createsnapshotclone implementation from dataplane to spdk

### DIFF
--- a/io-engine/src/core/mod.rs
+++ b/io-engine/src/core/mod.rs
@@ -66,6 +66,8 @@ pub use thread::Mthread;
 
 use crate::subsys::NvmfError;
 pub use snapshot::{
+    CloneParams,
+    CloneXattrs,
     SnapshotDescriptor,
     SnapshotOps,
     SnapshotParams,

--- a/io-engine/src/core/snapshot.rs
+++ b/io-engine/src/core/snapshot.rs
@@ -33,8 +33,66 @@ impl SnapshotParams {
         }
     }
 }
-
-/// Snapshot Descriptor to respond back as part of listsnapshot
+/// Parameters details for the Snapshot Clone.
+#[derive(Clone, Debug)]
+pub struct CloneParams {
+    // Clone replica name
+    pub clone_name: Option<String>,
+    // Clone replica uuid
+    pub clone_uuid: Option<String>,
+    // Source uuid from which the clone to be created
+    pub source_uuid: Option<String>,
+    // Timestamp when the clone is created
+    pub clone_create_time: Option<String>,
+}
+impl CloneParams {
+    pub fn new(
+        clone_name: Option<String>,
+        clone_uuid: Option<String>,
+        source_uuid: Option<String>,
+        clone_create_time: Option<String>,
+    ) -> Self {
+        CloneParams {
+            clone_name,
+            clone_uuid,
+            source_uuid,
+            clone_create_time,
+        }
+    }
+    // Get clone name
+    pub fn clone_name(&self) -> Option<String> {
+        self.clone_name.clone()
+    }
+    // Set clone name
+    pub fn set_clone_name(&mut self, clone_name: String) {
+        self.clone_name = Some(clone_name);
+    }
+    // Get clone uuid
+    pub fn clone_uuid(&self) -> Option<String> {
+        self.clone_uuid.clone()
+    }
+    // Set clone uuid
+    pub fn set_clone_uuid(&mut self, clone_uuid: String) {
+        self.clone_uuid = Some(clone_uuid);
+    }
+    // Get source uuid from which clone is created
+    pub fn source_uuid(&self) -> Option<String> {
+        self.source_uuid.clone()
+    }
+    // Set source uuid
+    pub fn set_source_uuid(&mut self, uuid: String) {
+        self.source_uuid = Some(uuid);
+    }
+    // Get clone creation time
+    pub fn clone_create_time(&self) -> Option<String> {
+        self.clone_create_time.clone()
+    }
+    // Set clone create time
+    pub fn set_clone_create_time(&mut self, time: String) {
+        self.clone_create_time = Some(time);
+    }
+}
+/// Snapshot Descriptor to respond back as part of listsnapshot.
 #[derive(Clone, Debug)]
 pub struct VolumeSnapshotDescriptor {
     pub snapshot_lvol: Lvol,
@@ -115,7 +173,22 @@ impl SnapshotXattrs {
         }
     }
 }
-
+/// Clone attributes used to store its properties.
+#[derive(Debug, EnumCountMacro, EnumIter)]
+pub enum CloneXattrs {
+    CloneUuid,
+    SourceUuid,
+    CloneCreateTime,
+}
+impl CloneXattrs {
+    pub fn name(&self) -> &'static str {
+        match *self {
+            Self::CloneUuid => "uuid",
+            Self::SourceUuid => "io-engine.source_uuid",
+            Self::CloneCreateTime => "io-engine.clone_create_time",
+        }
+    }
+}
 ///  Traits gives the common snapshot/clone interface for Local/Remote Lvol.
 #[async_trait(?Send)]
 pub trait SnapshotOps {
@@ -145,6 +218,11 @@ pub trait SnapshotOps {
 
     /// List Single snapshot details based on snapshot UUID.
     fn list_snapshot_by_snapshot_uuid(&self) -> Vec<VolumeSnapshotDescriptor>;
+
+    async fn create_clone(
+        &self,
+        clone_param: CloneParams,
+    ) -> Result<Lvol, Self::Error>;
 }
 
 /// Traits gives the Snapshots Related Parameters.

--- a/io-engine/src/lvs/lvs_error.rs
+++ b/io-engine/src/lvs/lvs_error.rs
@@ -114,7 +114,15 @@ pub enum Error {
         source: Errno,
         msg: String,
     },
-
+    #[snafu(display(
+        "SnapshotClone {} created with Resultcode {}",
+        msg,
+        source
+    ))]
+    SnapshotCloneCreate {
+        source: Errno,
+        msg: String,
+    },
     #[snafu(display("Flush Failed for replica {}", name))]
     FlushFailed {
         name: String,
@@ -125,6 +133,15 @@ pub enum Error {
         msg
     ))]
     SnapshotConfigFailed {
+        name: String,
+        msg: String,
+    },
+    #[snafu(display(
+        "Clone parameters for replica {} is not correct: {}",
+        name,
+        msg
+    ))]
+    CloneConfigFailed {
         name: String,
         msg: String,
     },

--- a/io-engine/tests/snapshot_lvol.rs
+++ b/io-engine/tests/snapshot_lvol.rs
@@ -7,6 +7,8 @@ use common::compose::MayastorTest;
 use io_engine::{
     bdev::device_open,
     core::{
+        CloneParams,
+        CloneXattrs,
         LogicalVolume,
         MayastorCliArgs,
         SnapshotParams,
@@ -84,11 +86,28 @@ async fn check_snapshot(params: SnapshotParams) {
         .expect("Can't find target snapshot device");
 
     for (attr_name, attr_value) in attrs {
-        let v = Lvol::get_blob_xattr(&lvol, &attr_name)
+        let v = Lvol::get_blob_xattr(&lvol, attr_name.name())
             .expect("Failed to get snapshot attribute");
         assert_eq!(v, attr_value, "Snapshot attr doesn't match");
     }
 }
+
+async fn check_clone(clone_lvol: Lvol, params: CloneParams) {
+    let attrs = [
+        (CloneXattrs::SourceUuid, params.source_uuid().unwrap()),
+        (
+            CloneXattrs::CloneCreateTime,
+            params.clone_create_time().unwrap(),
+        ),
+        (CloneXattrs::CloneUuid, params.clone_uuid().unwrap()),
+    ];
+    for (attr_name, attr_value) in attrs {
+        let v = Lvol::get_blob_xattr(&clone_lvol, attr_name.name())
+            .expect("Failed to get clone attribute");
+        assert_eq!(v, attr_value, "clone attr doesn't match");
+    }
+}
+
 async fn clean_snapshots(snapshot_list: Vec<VolumeSnapshotDescriptor>) {
     for snapshot in snapshot_list {
         let snap_lvol = UntypedBdev::lookup_by_uuid_str(
@@ -207,6 +226,8 @@ async fn test_lvol_bdev_snapshot() {
             .await
             .expect("Can't find target snapshot device");
         assert_eq!(snap_uuid, lvol.uuid(), "Snapshot UUID doesn't match");
+        let snapshot_list = Lvol::list_all_snapshots();
+        clean_snapshots(snapshot_list).await;
     })
     .await;
 }
@@ -258,6 +279,8 @@ async fn test_lvol_handle_snapshot() {
             .expect("Failed to create snapshot");
 
         check_snapshot(snapshot_params).await;
+        let snapshot_list = Lvol::list_all_snapshots();
+        clean_snapshots(snapshot_list).await;
     })
     .await;
 }
@@ -527,7 +550,7 @@ async fn test_list_pool_snapshots() {
         // Check that snapshots match their initial parameters.
         check_snapshot_descriptor(&snapshot_params1, &snapshots[idxs[0]]);
         check_snapshot_descriptor(&snapshot_params2, &snapshots[idxs[1]]);
-
+        clean_snapshots(snapshots).await;
         pool.export().await.expect("Failed to export the pool");
     })
     .await;
@@ -580,6 +603,79 @@ async fn test_list_all_snapshots_with_replica_destroy() {
         info!("Total number of snapshots: {}", snapshot_list.len());
         assert_eq!(1, snapshot_list.len(), "Snapshot Count not matched!!");
         clean_snapshots(snapshot_list).await;
+    })
+    .await;
+}
+#[tokio::test]
+async fn test_snapshot_clone() {
+    let ms = get_ms();
+
+    ms.spawn(async move {
+        // Create a pool and lvol.
+        let pool = create_test_pool(
+            "pool8",
+            "malloc:///disk5?size_mb=128".to_string(),
+        )
+        .await;
+        let lvol = pool
+            .create_lvol(
+                "lvol8",
+                32 * 1024 * 1024,
+                Some(&Uuid::new_v4().to_string()),
+                false,
+            )
+            .await
+            .expect("Failed to create test lvol");
+
+        // Create a snapshot-1 via lvol object.
+        let entity_id = String::from("lvol8_e1");
+        let parent_id = lvol.uuid();
+        let txn_id = Uuid::new_v4().to_string();
+        let snap_name = String::from("lvol8_snap1");
+        let snapshot_uuid = Uuid::new_v4().to_string();
+
+        let snapshot_params = SnapshotParams::new(
+            Some(entity_id),
+            Some(parent_id),
+            Some(txn_id),
+            Some(snap_name),
+            Some(snapshot_uuid),
+            Some(Utc::now().to_string()),
+        );
+
+        lvol.create_snapshot(snapshot_params.clone())
+            .await
+            .expect("Failed to create a snapshot");
+
+        let snapshot_list = Lvol::list_all_snapshots();
+        assert_eq!(1, snapshot_list.len(), "Snapshot Count not matched!!");
+        let snapshot_lvol = UntypedBdev::lookup_by_uuid_str(
+            snapshot_list
+                .get(0)
+                .unwrap()
+                .snapshot_params()
+                .snapshot_uuid()
+                .unwrap_or_default()
+                .as_str(),
+        )
+        .map(|b| Lvol::try_from(b).expect("Can't create Lvol from device"))
+        .unwrap();
+        let clone_name = String::from("lvol8_snap1_clone_1");
+        let clone_uuid = Uuid::new_v4().to_string();
+        let source_uuid = snapshot_lvol.uuid();
+
+        let clone_param = CloneParams::new(
+            Some(clone_name),
+            Some(clone_uuid),
+            Some(source_uuid),
+            Some(Utc::now().to_string()),
+        );
+        let clone = snapshot_lvol
+            .create_clone(clone_param.clone())
+            .await
+            .expect("Failed to create a clone");
+        info!("Clone creation success with uuid {:?}", clone.uuid());
+        check_clone(clone, clone_param).await;
     })
     .await;
 }


### PR DESCRIPTION
1. Dataplane implementation of CreateSnapshot Clone
2. Initialization of all xAttr for Clone
3. Call the new SPDK API of clone to update clone xattr
4. Basic BDD to check CreateSnapshotClone Operation and its attributes.