### PR TITLE
fix(nexus/io): set nvmf subsystem as frozen

### DIFF
--- a/deploy/csi-daemonset.yaml
+++ b/deploy/csi-daemonset.yaml
@@ -30,7 +30,7 @@ spec:
       # the same.
       containers:
       - name: mayastor-csi
-        image: mayadata/mayastor:v1.0.7
+        image: mayadata/mayastor:v1.0.8
         imagePullPolicy: IfNotPresent
         # we need privileged because we mount filesystems and use mknod
         securityContext:

--- a/deploy/mayastor-daemonset.yaml
+++ b/deploy/mayastor-daemonset.yaml
@@ -33,7 +33,7 @@ spec:
         command: ['sh', '-c', 'until nc -vz nats 4222; do echo "Waiting for message bus..."; sleep 1; done;']
       containers:
       - name: mayastor
-        image: mayadata/mayastor:v1.0.7
+        image: mayadata/mayastor:v1.0.8
         imagePullPolicy: IfNotPresent
         env:
         - name: RUST_LOG

--- a/mayastor/src/bdev/nexus/mod.rs
+++ b/mayastor/src/bdev/nexus/mod.rs
@@ -23,6 +23,7 @@ pub use nexus_bdev::{
     Error,
     Nexus,
     NexusNvmeParams,
+    NexusPauseState,
     NexusState,
     NexusStatus,
     NexusTarget,

--- a/mayastor/src/bdev/nexus/nexus_bdev.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev.rs
@@ -906,7 +906,19 @@ impl<'n> Nexus<'n> {
     /// Note: in order to handle concurrent resumes properly, this function must
     /// be called only from the master core.
     pub async fn resume(self: Pin<&mut Self>) -> Result<(), Error> {
-        self.io_subsystem_mut().resume().await
+        // If we are faulted then rather than failing all IO back to the
+        // initiator we can instead leave the subsystem frozen, and wait
+        // for the control-plane to do something about this.
+        // Meanwhile the initiator will begin its reconnect loop and won't see
+        // a swarm of IO failures which could cause a fs to shutdown.
+        let freeze = match self.status() {
+            NexusStatus::Faulted => {
+                tracing::warn!(?self, "Nexus Faulted: will not resume I/Os");
+                true
+            }
+            _ => false,
+        };
+        self.io_subsystem_mut().resume(freeze).await
     }
 
     /// Suspend any incoming IO to the bdev pausing the controller allows us to
@@ -1029,15 +1041,6 @@ impl<'n> Nexus<'n> {
                     }
                 })))
                 .await;
-        }
-        // If we are faulted then rather than failing all IO back to the
-        // initiator we can instead leave the subsystem paused, and wait
-        // for the control-plane to do something about this.
-        // Meanwhile the initiator will begin it's reconnect loop and won't see
-        // a swarm of IO failures which could cause a fs to shutdown.
-        if self.status() == NexusStatus::Faulted {
-            tracing::warn!(?self, "Nexus Faulted: not resuming subsystem");
-            return Ok(());
         }
         debug!(?self, "RESUMING");
         self.resume().await

--- a/mayastor/src/bdev/nexus/nexus_bdev.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev.rs
@@ -367,7 +367,25 @@ pub enum NexusPauseState {
     Unpaused,
     Pausing,
     Paused,
+    Frozen,
     Unpausing,
+}
+impl From<super::nexus_io_subsystem::NexusPauseState> for NexusPauseState {
+    fn from(value: super::nexus_io_subsystem::NexusPauseState) -> Self {
+        match value {
+            super::nexus_io_subsystem::NexusPauseState::Unpaused => {
+                Self::Unpaused
+            }
+            super::nexus_io_subsystem::NexusPauseState::Pausing => {
+                Self::Pausing
+            }
+            super::nexus_io_subsystem::NexusPauseState::Paused => Self::Paused,
+            super::nexus_io_subsystem::NexusPauseState::Frozen => Self::Frozen,
+            super::nexus_io_subsystem::NexusPauseState::Unpausing => {
+                Self::Unpausing
+            }
+        }
+    }
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -900,6 +918,11 @@ impl<'n> Nexus<'n> {
     /// Returns a mutable reference to Nexus I/O.
     fn io_subsystem_mut(self: Pin<&mut Self>) -> &mut NexusIoSubsystem<'n> {
         unsafe { self.get_unchecked_mut().io_subsystem.as_mut().unwrap() }
+    }
+
+    /// Get the subsystem pause state.
+    pub fn io_subsystem_state(&self) -> Option<NexusPauseState> {
+        self.io_subsystem.as_ref().map(|io| io.pause_state().into())
     }
 
     /// Resumes I/O to the Bdev.

--- a/mayastor/src/bdev/nexus/nexus_io_subsystem.rs
+++ b/mayastor/src/bdev/nexus/nexus_io_subsystem.rs
@@ -52,6 +52,11 @@ impl<'n> NexusIoSubsystem<'n> {
         }
     }
 
+    /// Get the subsystem pause state.
+    pub(super) fn pause_state(&self) -> NexusPauseState {
+        self.pause_state.load()
+    }
+
     /// Suspend any incoming IO to the bdev pausing the controller allows us to
     /// handle internal events and which is a protocol feature.
     /// In case concurrent pause requests take place, the other callers

--- a/scripts/check-deploy-yamls.sh
+++ b/scripts/check-deploy-yamls.sh
@@ -8,7 +8,7 @@ DEPLOYDIR="$ROOTDIR"/deploy
 
 CORES=2
 PROFILE=release
-TAG=v1.0.7
+TAG=v1.0.8
 
 "$SCRIPTDIR"/generate-deploy-yamls.sh -c "$CORES" -t "$TAG" "$PROFILE"
 


### PR DESCRIPTION
Multiple children may be retired at "the same time". In case the first retires "wins" and pauses the subsystem, if we simply leave it paused at the end, the other retires will remain stuck in the pause.
Instead, introduce a new state of Frozen, which allows other pauses to execute their paused code and at the end the subsystem remains frozen.