### PR TITLE
fix(snapshot): return proper errorcode for createsnapshot

### DIFF
--- a/io-engine/src/core/bdev.rs
+++ b/io-engine/src/core/bdev.rs
@@ -137,7 +137,7 @@ where
             Some(bdev) => {
                 let b: Vec<Self> = bdev
                     .into_iter()
-                    .filter(|b| b.uuid_as_string() == uuid)
+                    .filter(|b| b.uuid_as_string() == uuid.to_lowercase())
                     .collect();
 
                 b.first().map(|b| Self {


### PR DESCRIPTION
1. When snapshot_uuid is duplicate, return proper error code in gRPC response. => EEXIST => Status::already_exists
2. When Snapshot config parameters are not passed with proper value, return proper gRPC error response. ENOMEDIUM => Status => failed_precondition