### PR TITLE
fix(snapshot): proper error propagation from remote replicas

### DIFF
--- a/io-engine/src/bdev/nexus/nexus_bdev_snapshot.rs
+++ b/io-engine/src/bdev/nexus/nexus_bdev_snapshot.rs
@@ -16,7 +16,7 @@ use crate::{
 use chrono::{DateTime, Utc};
 use std::pin::Pin;
 /// Per-replica descriptor for nexus snapshot operation.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct NexusReplicaSnapshotDescriptor {
     pub replica_uuid: String,
     pub snapshot_uuid: Option<String>,

--- a/io-engine/src/core/handle.rs
+++ b/io-engine/src/core/handle.rs
@@ -359,6 +359,7 @@ impl<T: BdevOps> BdevHandle<T> {
         } else {
             Err(CoreError::NvmeAdminFailed {
                 opcode: (*nvme_cmd).opc(),
+                source: Errno::EIO,
             })
         }
     }

--- a/io-engine/src/core/mod.rs
+++ b/io-engine/src/core/mod.rs
@@ -250,8 +250,9 @@ pub enum CoreError {
         offset: u64,
         len: u64,
     },
-    #[snafu(display("NVMe Admin command {:x}h failed", opcode))]
+    #[snafu(display("NVMe Admin command {:x}h failed: {}", opcode, source))]
     NvmeAdminFailed {
+        source: Errno,
         opcode: u16,
     },
     #[snafu(display("NVMe IO Passthru command {:x}h failed", opcode))]
@@ -371,9 +372,6 @@ impl ToErrno for CoreError {
             | Self::WriteZeroesFailed {
                 ..
             }
-            | Self::NvmeAdminFailed {
-                ..
-            }
             | Self::NvmeIoPassthruFailed {
                 ..
             }
@@ -383,6 +381,9 @@ impl ToErrno for CoreError {
             | Self::UnshareNvmf {
                 ..
             } => Errno::EIO,
+            Self::NvmeAdminFailed {
+                source, ..
+            } => source,
             Self::NotSupported {
                 source, ..
             } => source,

--- a/io-engine/src/lvs/lvs_lvol.rs
+++ b/io-engine/src/lvs/lvs_lvol.rs
@@ -1152,14 +1152,13 @@ impl LvsLvol for Lvol {
         ) {
             let nvmf_req = NvmfReq::from(nvmf_req_ptr);
 
-            let sc = match errno {
-                0 => 0,
+            match errno {
+                0 => nvmf_req.complete(),
                 _ => {
                     error!("vbdev_lvol_create_snapshot_ext errno {}", errno);
-                    0x06 // SPDK_NVME_SC_INTERNAL_DEVICE_ERROR
+                    nvmf_req.complete_error(errno);
                 }
             };
-            nvmf_req.complete(sc);
         }
 
         info!(


### PR DESCRIPTION
Errno codes are now peoperly propagated to nexus node from replica nodes when creating snapshots on remote replicas.