### PR TITLE
fix(enospc): allow enospc nexus to fail IOs

### DIFF
--- a/io-engine/src/bdev/nexus/mod.rs
+++ b/io-engine/src/bdev/nexus/mod.rs
@@ -37,7 +37,8 @@ pub use nexus_bdev::{
     NvmeAnaState,
     NvmeReservation,
 };
-pub(crate) use nexus_bdev_error::{nexus_err, Error};
+pub(crate) use nexus_bdev_error::nexus_err;
+pub use nexus_bdev_error::Error;
 pub(crate) use nexus_channel::{DrEvent, IoMode, NexusChannel};
 pub use nexus_child::{
     ChildError,

--- a/io-engine/src/bdev/nexus/nexus_child.rs
+++ b/io-engine/src/bdev/nexus/nexus_child.rs
@@ -240,6 +240,11 @@ impl ChildState {
             _ => false,
         }
     }
+
+    /// Check if the state is fault due to ENOSPC.
+    pub fn is_enospc(&self) -> bool {
+        matches!(self, Self::Faulted(FaultReason::NoSpace))
+    }
 }
 
 /// Synchronization state of a nexus child.


### PR DESCRIPTION
In the case of enospc there's no guarantee we'll be able to recreate nexus with children properly again.
For now let's fail IO back to initiator.