### PR TITLE
fix: update rpc api to fix wrong param change

### DIFF
--- a/io-engine/src/grpc/v1/replica.rs
+++ b/io-engine/src/grpc/v1/replica.rs
@@ -74,9 +74,13 @@ impl From<LvolSpaceUsage> for ReplicaSpaceUsage {
         Self {
             capacity_bytes: u.capacity_bytes,
             allocated_bytes: u.allocated_bytes,
+            // todo: rpc api submodule was updated, so have to fill these in as
+            // 0 for now..
+            allocated_bytes_snapshots: 0,
             cluster_size: u.cluster_size,
             num_clusters: u.num_clusters,
             num_allocated_clusters: u.num_allocated_clusters,
+            num_allocated_clusters_snapshots: 0,
         }
     }
 }


### PR DESCRIPTION
e2e was using a message where the param index changed, so we have to keep numbering as is..