### PR TITLE
fix(rebuild): fixing child retirement during rebuild running

### DIFF
--- a/io-engine/src/bdev/nexus/nexus_bdev_rebuild.rs
+++ b/io-engine/src/bdev/nexus/nexus_bdev_rebuild.rs
@@ -199,7 +199,7 @@ impl<'n> Nexus<'n> {
         // If a rebuild job is not found that's ok
         // as we were just going to remove it anyway.
         if let Ok(rj) = self.rebuild_job_mut(child_uri) {
-            let ch = rj.terminate();
+            let ch = rj.force_stop();
             if let Err(e) = ch.await {
                 error!(
                     "Failed to wait on rebuild job for child {child_uri} \
@@ -300,7 +300,7 @@ impl<'n> Nexus<'n> {
 
         // terminate all jobs with the child as a source
         src_jobs.into_iter().for_each(|j| {
-            terminated_jobs.push(j.terminate());
+            terminated_jobs.push(j.force_stop());
             rebuilding_children.push(j.dst_uri.clone());
         });
 

--- a/io-engine/src/bdev/nexus/nexus_io_subsystem.rs
+++ b/io-engine/src/bdev/nexus/nexus_io_subsystem.rs
@@ -172,9 +172,14 @@ impl<'n> NexusIoSubsystem<'n> {
                         self
                     );
 
+                    let nex = format!("{self:?}");
+
                     let (s, r) = oneshot::channel::<i32>();
                     self.pause_waiters.push_back(s);
-                    r.await.unwrap();
+                    if r.await.is_err() {
+                        error!("{nex}: I/O subsystem is gone while waiting");
+                        return Ok(());
+                    }
 
                     trace!(
                         "{:?}: nexus completed state transition, \
@@ -226,9 +231,14 @@ impl<'n> NexusIoSubsystem<'n> {
                         self
                     );
 
+                    let nex = format!("{self:?}");
+
                     let (s, r) = oneshot::channel::<i32>();
                     self.pause_waiters.push_back(s);
-                    r.await.unwrap();
+                    if r.await.is_err() {
+                        error!("{nex}: I/O subsystem is gone while waiting");
+                        return Ok(());
+                    }
 
                     trace!(
                         "{:?}: completed state transition, \

--- a/io-engine/src/rebuild/rebuild_job.rs
+++ b/io-engine/src/rebuild/rebuild_job.rs
@@ -204,10 +204,26 @@ impl RebuildJob {
         self.exec_client_op(RebuildOperation::Resume)
     }
 
-    /// Forcefully terminates the job, overriding any pending client operation
-    /// returns an async channel which can be used to await for termination/
-    pub fn terminate(&self) -> oneshot::Receiver<RebuildState> {
-        self.exec_internal_op(RebuildOperation::Stop).ok();
+    /// Forcefully stops the job, overriding any pending client operation
+    /// returns an async channel which can be used to await for termination.
+    pub(crate) fn force_stop(&self) -> oneshot::Receiver<RebuildState> {
+        self.force_terminate(RebuildOperation::Stop)
+    }
+
+    /// Forcefully fails the job, overriding any pending client operation
+    /// returns an async channel which can be used to await for termination.
+    pub(crate) fn force_fail(&self) -> oneshot::Receiver<RebuildState> {
+        self.force_terminate(RebuildOperation::Fail)
+    }
+
+    /// Forcefully terminates the job with the given operation, overriding any
+    /// pending client operation returns an async channel which can be used
+    /// to await for termination.
+    fn force_terminate(
+        &self,
+        op: RebuildOperation,
+    ) -> oneshot::Receiver<RebuildState> {
+        self.exec_internal_op(op).ok();
         self.add_completion_listener()
             .unwrap_or_else(|_| oneshot::channel().1)
     }

--- a/io-engine/tests/nexus_rebuild_partial.rs
+++ b/io-engine/tests/nexus_rebuild_partial.rs
@@ -203,7 +203,7 @@ async fn nexus_partial_rebuild_io_fault() {
 
     let children = nex_0.get_nexus().await.unwrap().children;
     assert_eq!(children.len(), 2);
-    assert_eq!(children[1].state, ChildState::Online as i32);
+    assert_eq!(children[1].state(), ChildState::Online);
 
     // Chunk A.
     test_write_to_nexus(
@@ -587,19 +587,19 @@ async fn nexus_partial_rebuild_double_fault() {
     let hist = nex_0.get_rebuild_history().await.unwrap();
     assert_eq!(hist.len(), 3);
 
-    // First rebuild must have been stopped, because I/O failed while the job
+    // First rebuild must have been failed, because I/O failed while the job
     // was running.
-    assert_eq!(hist[0].state, RebuildJobState::Stopped as i32);
+    assert_eq!(hist[0].state(), RebuildJobState::Failed);
     assert_eq!(hist[0].is_partial, true);
     assert!(hist[0].blocks_transferred < hist[0].blocks_total);
 
     // 3rd rebuid job must have been a successfully full rebuild.
-    assert_eq!(hist[1].state, RebuildJobState::Completed as i32);
+    assert_eq!(hist[1].state(), RebuildJobState::Completed);
     assert_eq!(hist[1].is_partial, false);
     assert_eq!(hist[1].blocks_transferred, hist[1].blocks_total);
 
     // 3rd rebuid job must have been a successfully partial rebuild.
-    assert_eq!(hist[2].state, RebuildJobState::Completed as i32);
+    assert_eq!(hist[2].state(), RebuildJobState::Completed);
     assert_eq!(hist[2].is_partial, true);
     assert!(hist[2].blocks_transferred < hist[2].blocks_total);
 

--- a/test/python/tests/nexus/test_nexus_rebuild.py
+++ b/test/python/tests/nexus/test_nexus_rebuild.py
@@ -1,0 +1,123 @@
+from common.hdl import MayastorHandle
+from common.command import run_cmd, run_cmd_async
+from common.nvme import nvme_connect, nvme_disconnect
+from common.fio import Fio
+from common.fio_spdk import FioSpdk
+from common.mayastor import containers, mayastors, create_temp_files, check_size
+import pytest
+import asyncio
+import uuid as guid
+import time
+import subprocess
+import mayastor_pb2 as pb
+
+NEXUS_COUNT = 10
+NEXUS_SIZE = 500 * 1024 * 1024
+REPL_SIZE = NEXUS_SIZE
+POOL_SIZE = REPL_SIZE * NEXUS_COUNT + 100 * 1024 * 1024
+
+
+@pytest.fixture
+def local_files(mayastors):
+    files = []
+    for name, ms in mayastors.items():
+        path = f"/tmp/disk-{name}.img"
+        pool_size_mb = int(POOL_SIZE / 1024 / 1024)
+        subprocess.run(
+            ["sudo", "sh", "-c", f"rm -f '{path}'; truncate -s {pool_size_mb}M '{path}'"],
+            check=True,
+        )
+        files.append(path)
+
+    yield
+    for path in files:
+        subprocess.run(["sudo", "rm", "-f", path], check=True)
+
+
+@pytest.fixture
+def create_replicas_on_all_nodes(local_files, mayastors, create_temp_files):
+    uuids = []
+
+    for name, ms in mayastors.items():
+        ms.pool_create(name, f"aio:///tmp/disk-{name}.img")
+        # verify we have zero replicas
+        assert len(ms.replica_list().replicas) == 0
+
+    for i in range(NEXUS_COUNT):
+        uuid = guid.uuid4()
+        for name, ms in mayastors.items():
+            before = ms.pool_list()
+            ms.replica_create(name, uuid, REPL_SIZE)
+            after = ms.pool_list()
+        uuids.append(uuid)
+
+    yield uuids
+
+
+@pytest.fixture
+def create_nexuses(mayastors, create_replicas_on_all_nodes):
+    nexuses = []
+    nexuses_uris = []
+
+    uris = [
+        [replica.uri for replica in mayastors.get(node).replica_list().replicas]
+        for node in ["ms1", "ms2", "ms3"]
+    ]
+    
+    ms = mayastors.get("ms0")
+    for children in zip(*uris):
+        uuid = guid.uuid4()
+        nexus = ms.nexus_create(uuid, NEXUS_SIZE, list(children))
+        nexuses.append(nexus)
+        nexuses_uris.append(ms.nexus_publish(uuid))
+
+    yield nexuses
+
+
+@pytest.mark.parametrize("times", range(10))
+def test_rebuild_failure(containers, mayastors, times, create_nexuses):
+    ms0 = mayastors.get("ms0")
+    ms3 = mayastors.get("ms3")
+
+    # Restart container with replica #3 (ms3).
+    node3 = containers.get("ms3")
+    node3.stop()
+    time.sleep(5)
+    node3.start()
+
+    # Reconnect ms3, and import the existing pool.
+    ms3.reconnect()
+    ms3.pool_create("ms1", "aio:///tmp/disk-ms1.img")
+    time.sleep(1)
+
+    # Add the replicas to the nexuses for rebuild.
+    for (idx, nexus) in enumerate(ms0.nexus_list()):
+        child = list(filter(lambda child: child.state == pb.CHILD_FAULTED, list(nexus.children)))[0]
+        if nexus.state != pb.NEXUS_FAULTED:
+            try:
+                ms0.nexus_remove_replica(nexus.uuid, child.uri)
+                ms0.nexus_add_replica(nexus.uuid, child.uri, False)
+            except:
+                print(f"Failed to remove child {child.uri} from {nexus}")
+
+    time.sleep(5)
+
+    rebuilds = 0
+    for nexus in ms0.nexus_list():
+        for child in nexus.children:
+            if child.rebuild_progress > -1:
+                rebuilds += 1
+                print("nexus", nexus.uuid, "rebuilding", child.uri, f"{child.rebuild_progress}")
+
+    assert rebuilds > 0
+
+    # Stop ms3 again. Rebuild jobs in progress must terminate.
+    node3.stop()
+
+    time.sleep(10)
+
+    # All rebuild jobs must finish.
+    for nexus in ms0.nexus_list():
+        for child in nexus.children:
+            assert child.rebuild_progress == -1
+        ms0.nexus_destroy(nexus.uuid)


### PR DESCRIPTION
* Rebuild state is now always Failed when a child is being retired during rebuild
* Fixed rebuild job stucking
* Fixed several panic conditions