### PR TITLE
chore(snapshots): cherry-pick 2 commits from develop

### DIFF
--- a/io-engine-tests/src/nvme.rs
+++ b/io-engine-tests/src/nvme.rs
@@ -113,6 +113,17 @@ pub fn nvme_connect(
     status
 }
 
+pub fn nvme_disconnect_all() {
+    let output_dis = Command::new("nvme")
+        .args(["disconnect-all"])
+        .output()
+        .unwrap();
+    assert!(
+        output_dis.status.success(),
+        "failed to disconnect all existing nvme target ",
+    );
+}
+
 pub fn nvme_disconnect_nqn(nqn: &str) {
     let output_dis = Command::new("nvme")
         .args(["disconnect"])

--- a/io-engine/src/grpc/v1/replica.rs
+++ b/io-engine/src/grpc/v1/replica.rs
@@ -76,6 +76,9 @@ impl From<LvolSpaceUsage> for ReplicaSpaceUsage {
             cluster_size: u.cluster_size,
             num_clusters: u.num_clusters,
             num_allocated_clusters: u.num_allocated_clusters,
+            allocated_bytes_snapshots: u.allocated_bytes_snapshots,
+            num_allocated_clusters_snapshots: u
+                .num_allocated_clusters_snapshots,
         }
     }
 }

--- a/io-engine/src/lvs/lvs_lvol.rs
+++ b/io-engine/src/lvs/lvs_lvol.rs
@@ -22,6 +22,7 @@ use spdk_rs::libspdk::{
     spdk_blob_is_clone,
     spdk_blob_is_read_only,
     spdk_blob_is_snapshot,
+    spdk_blob_is_thin_provisioned,
     spdk_blob_set_xattr,
     spdk_blob_sync_md,
     spdk_bs_get_cluster_size,
@@ -899,7 +900,7 @@ impl LogicalVolume for Lvol {
 
     /// Returns a boolean indicating if the Logical Volume is thin provisioned.
     fn is_thin(&self) -> bool {
-        self.as_inner_ref().thin_provision
+        unsafe { spdk_blob_is_thin_provisioned(self.blob_checked()) }
     }
 
     /// Returns a boolean indicating if the Logical Volume is read-only.

--- a/nix/pkgs/libspdk/default.nix
+++ b/nix/pkgs/libspdk/default.nix
@@ -61,8 +61,8 @@ let
     src = fetchFromGitHub {
       owner = "openebs";
       repo = "spdk";
-      rev = "19b04a85f5a1f3676b1a36acad564f0e1d4d8eb8";
-      sha256 = "sha256-vevW4RC63PkVbFfPi8FC7BUZ27oQGTefnQlubibpOX8=";
+      rev = "45c4b74576f9f45b380ff474ed46635f7596991c";
+      sha256 = "sha256-JyuP2poHfbUVJ61YT0pDZKGk+QjT5aDpg/rgxyuYPc4=";
       fetchSubmodules = true;
     };
 


### PR DESCRIPTION
The following 2 commits need to be cherry-picked to release/2.3 from develop:

feat(replica): snapshot space information for replicas
fix(lvol): properly report provisioning mod for volume with snapshots