### PR TITLE
feat(clone): special handling to delete snapshot when active clones are linked to it

### DIFF
--- a/io-engine-tests/src/pool.rs
+++ b/io-engine-tests/src/pool.rs
@@ -2,7 +2,7 @@ pub use super::compose::rpc::v1::pool::Pool;
 use super::{
     compose::rpc::v1::{
         pool::{CreatePoolRequest, ListPoolOptions},
-        replica::{ListReplicaOptions, Replica},
+        replica::{ListReplicaOptions, Replica, ReplicaType},
         SharedRpcHandle,
         Status,
     },
@@ -104,6 +104,7 @@ impl PoolBuilder {
                 poolname: None,
                 uuid: None,
                 pooluuid: self.uuid.clone(),
+                replicatype: ReplicaType::AllReplicas as i32,
             })
             .await
             .map(|r| r.into_inner().replicas)

--- a/io-engine-tests/src/replica.rs
+++ b/io-engine-tests/src/replica.rs
@@ -11,6 +11,7 @@ use mayastor_api::v1::replica::{
     DestroyReplicaRequest,
     ListReplicaOptions,
     Replica,
+    ReplicaType,
     ShareReplicaRequest,
 };
 use tonic::{Code, Status};
@@ -204,6 +205,7 @@ pub async fn list_replicas(
             poolname: None,
             uuid: None,
             pooluuid: None,
+            replicatype: ReplicaType::AllReplicas as i32,
         })
         .await
         .map(|r| r.into_inner().replicas)
@@ -221,6 +223,7 @@ pub async fn find_replica_by_uuid(
             poolname: None,
             uuid: Some(uuid.to_owned()),
             pooluuid: None,
+            replicatype: ReplicaType::AllReplicas as i32,
         })
         .await
         .map(|r| r.into_inner().replicas)?

--- a/io-engine/src/bdev/nexus/nexus_bdev_snapshot.rs
+++ b/io-engine/src/bdev/nexus/nexus_bdev_snapshot.rs
@@ -179,6 +179,7 @@ impl ReplicaSnapshotExecutor {
                     snapshot.name(),
                     Some(ctx.snapshot_uuid.clone()),
                     snapshot.create_time(),
+                    false,
                 );
 
                 let replica_uuid = ctx.replica_uuid.clone();

--- a/io-engine/src/bin/initiator.rs
+++ b/io-engine/src/bin/initiator.rs
@@ -149,6 +149,7 @@ async fn create_snapshot(uri: &str) -> Result<()> {
         Some(Uuid::new_v4().to_string()), // unique snapshot name
         Some(Uuid::new_v4().to_string()), // unique snapshot uuid
         Some(Utc::now().to_string()),
+        false,
     );
 
     let t = h.create_snapshot(snapshot).await?;

--- a/io-engine/src/bin/io-engine-client/v1/replica_cli.rs
+++ b/io-engine/src/bin/io-engine-client/v1/replica_cli.rs
@@ -271,6 +271,7 @@ async fn replica_list(
             poolname: None,
             uuid: None,
             pooluuid: None,
+            replicatype: v1_rpc::replica::ReplicaType::AllReplicas as i32,
         })
         .await
         .context(GrpcStatus)?;

--- a/io-engine/src/bin/io-engine-client/v1/snapshot_cli.rs
+++ b/io-engine/src/bin/io-engine-client/v1/snapshot_cli.rs
@@ -11,6 +11,7 @@ use colored_json::ToColoredJson;
 use mayastor_api::v1 as v1_rpc;
 use snafu::ResultExt;
 use tonic::Status;
+use v1_rpc::snapshot::*;
 
 pub async fn handler(
     ctx: Context,
@@ -378,6 +379,7 @@ async fn create_for_replica(
                         r.entity_id.clone(),
                         r.txn_id.clone(),
                         r.valid_snapshot.to_string(),
+                        r.discarded_snapshot.to_string(),
                     ]
                 })
                 .collect();
@@ -394,6 +396,7 @@ async fn create_for_replica(
                     "ENTITY_ID",
                     "TXN_ID",
                     "VALID_SNAPSHOT",
+                    "discarded_snapshot",
                 ],
                 table,
             );
@@ -409,6 +412,7 @@ async fn list(mut ctx: Context, matches: &ArgMatches<'_>) -> crate::Result<()> {
     let request = v1_rpc::snapshot::ListSnapshotsRequest {
         source_uuid,
         snapshot_uuid,
+        snapshot_query_type: SnapshotQueryType::AllSnapshots as i32,
     };
 
     let response = ctx
@@ -449,6 +453,7 @@ async fn list(mut ctx: Context, matches: &ArgMatches<'_>) -> crate::Result<()> {
                         r.entity_id.clone(),
                         r.txn_id.clone(),
                         r.valid_snapshot.to_string(),
+                        r.discarded_snapshot.to_string(),
                     ]
                 })
                 .collect();
@@ -465,6 +470,7 @@ async fn list(mut ctx: Context, matches: &ArgMatches<'_>) -> crate::Result<()> {
                     "ENTITY_ID",
                     "TXN_ID",
                     "VALID_SNAPSHOT",
+                    "discarded_SNAPSHOT",
                 ],
                 table,
             );

--- a/io-engine/src/grpc/v0/mayastor_grpc.rs
+++ b/io-engine/src/grpc/v0/mayastor_grpc.rs
@@ -1760,6 +1760,7 @@ impl mayastor_server::Mayastor for MayastorSvc {
                     Some(name.clone()),
                     None, // snapshot UUID will be handled on per-replica base.
                     Some(Utc::now().to_string()),
+                    false,
                 );
 
                 let mut replicas = Vec::new();

--- a/io-engine/src/grpc/v1/replica.rs
+++ b/io-engine/src/grpc/v1/replica.rs
@@ -245,7 +245,7 @@ impl ReplicaRpc for ReplicaService {
                     .ok_or(LvsError::RepDestroy {
                         source: Errno::ENOENT,
                         name: args.uuid.to_owned(),
-                        msg: "".into(),
+                        msg: "Replica not found".into(),
                     })?;
 
                 if let Some(lvs) = lvs {
@@ -263,7 +263,7 @@ impl ReplicaRpc for ReplicaService {
                         });
                     }
                 }
-                lvol.destroy().await?;
+                lvol.destroy_replica().await?;
                 Ok(())
             })?;
 

--- a/io-engine/src/lvs/lvs_error.rs
+++ b/io-engine/src/lvs/lvs_error.rs
@@ -144,6 +144,12 @@ pub enum Error {
         name: String,
         msg: String,
     },
+    #[snafu(display("failed to set property {} on {}", attr, name))]
+    SetXAttr {
+        source: Errno,
+        attr: String,
+        name: String,
+    },
 }
 
 /// Map CoreError to errno code.
@@ -222,6 +228,9 @@ impl ToErrno for Error {
             Self::CloneConfigFailed {
                 ..
             } => Errno::EINVAL,
+            Self::SetXAttr {
+                source, ..
+            } => source,
         }
     }
 }

--- a/io-engine/src/lvs/lvs_store.rs
+++ b/io-engine/src/lvs/lvs_store.rs
@@ -342,7 +342,9 @@ impl Lvs {
         }?;
 
         let pool = Self::import(&args.name, &bdev).await?;
-
+        // Try to destroy the pending snapshots without catching
+        // the error.
+        Lvol::destroy_pending_discarded_snapshot().await;
         // if the uuid is provided for the import request check
         // for the pool uuid to make sure it is the correct one
         if let Some(uuid) = args.uuid {

--- a/io-engine/src/subsys/nvmf/admin_cmd.rs
+++ b/io-engine/src/subsys/nvmf/admin_cmd.rs
@@ -246,6 +246,7 @@ pub fn create_snapshot(
         Some(snapshot_name),
         Some(Uuid::generate().to_string()),
         Some(Utc::now().to_string()),
+        false,
     );
     // Blobfs operations must be on md_thread
     Reactors::master().send_future(async move {

--- a/io-engine/tests/replica_snapshot.rs
+++ b/io-engine/tests/replica_snapshot.rs
@@ -182,6 +182,7 @@ async fn create_snapshot() -> Result<u64, CoreError> {
         Some(Uuid::new_v4().to_string()), // unique snapshot name
         Some(Uuid::new_v4().to_string()), // unique snapshot UUID
         Some(Utc::now().to_string()),
+        false,
     );
 
     let h = UntypedBdevHandle::open(NXNAME, true, false).unwrap();

--- a/io-engine/tests/snapshot_lvol.rs
+++ b/io-engine/tests/snapshot_lvol.rs
@@ -32,7 +32,7 @@ static MAYASTOR: OnceCell<MayastorTest> = OnceCell::new();
 
 static POOL_DISK_NAME: &str = "/tmp/disk1.img";
 static POOL_DEVICE_NAME: &str = "aio:///tmp/disk1.img";
-
+static LVOL_SIZE: u64 = 24 * 1024 * 1024;
 /// Get the global Mayastor test suite instance.
 fn get_ms() -> &'static MayastorTest<'static> {
     MAYASTOR.get_or_init(|| MayastorTest::new(MayastorCliArgs::default()))
@@ -130,7 +130,7 @@ async fn clean_snapshots(snapshot_list: Vec<VolumeSnapshotDescriptor>) {
 
 async fn test_lvol_alloc_after_snapshot(index: u32, thin: bool) {
     let ms = get_ms();
-    const LVOL_SIZE: u64 = 24 * 1024 * 1024;
+
     let pool_name = format!("pool_{index}");
     let disk = format!("malloc:///disk{index}?size_mb=64");
     let lvol_name = format!("lvol_{index}");
@@ -163,6 +163,7 @@ async fn test_lvol_alloc_after_snapshot(index: u32, thin: bool) {
             Some(snap_name),
             Some(snapshot_uuid),
             Some(Utc::now().to_string()),
+            false,
         );
         lvol.create_snapshot(snapshot_params.clone())
             .await
@@ -198,6 +199,7 @@ async fn test_lvol_alloc_after_snapshot(index: u32, thin: bool) {
             Some(snap_name),
             Some(snapshot_uuid),
             Some(Utc::now().to_string()),
+            false,
         );
         lvol.create_snapshot(snapshot_params.clone())
             .await
@@ -300,6 +302,7 @@ async fn test_lvol_bdev_snapshot() {
             Some(snap_name.clone()),
             Some(snap_uuid.clone()),
             Some(Utc::now().to_string()),
+            false,
         );
 
         lvol.create_snapshot(snapshot_params.clone())
@@ -359,6 +362,7 @@ async fn test_lvol_handle_snapshot() {
             Some(snap_name),
             Some(snap_uuid),
             Some(Utc::now().to_string()),
+            false,
         );
 
         handle
@@ -406,6 +410,7 @@ async fn test_lvol_list_snapshot() {
             Some(snap_name),
             Some(snapshot_uuid),
             Some(Utc::now().to_string()),
+            false,
         );
 
         lvol.create_snapshot(snapshot_params.clone())
@@ -426,6 +431,7 @@ async fn test_lvol_list_snapshot() {
             Some(snap_name),
             Some(snapshot_uuid),
             Some(Utc::now().to_string()),
+            false,
         );
 
         lvol.create_snapshot(snapshot_params.clone())
@@ -475,6 +481,7 @@ async fn test_list_all_snapshots() {
             Some(snap_name),
             Some(snapshot_uuid),
             Some(Utc::now().to_string()),
+            false,
         );
 
         lvol.create_snapshot(snapshot_params.clone())
@@ -495,6 +502,7 @@ async fn test_list_all_snapshots() {
             Some(snap_name),
             Some(snapshot_uuid),
             Some(Utc::now().to_string()),
+            false,
         );
 
         lvol.create_snapshot(snapshot_params.clone())
@@ -526,6 +534,7 @@ async fn test_list_all_snapshots() {
             Some(snap_name),
             Some(snapshot_uuid),
             Some(Utc::now().to_string()),
+            false,
         );
 
         lvol.create_snapshot(snapshot_params.clone())
@@ -546,6 +555,7 @@ async fn test_list_all_snapshots() {
             Some(snap_name),
             Some(snapshot_uuid),
             Some(Utc::now().to_string()),
+            false,
         );
 
         lvol.create_snapshot(snapshot_params.clone())
@@ -594,6 +604,7 @@ async fn test_list_pool_snapshots() {
             Some(snap_name),
             Some(snapshot_uuid),
             Some(Utc::now().to_string()),
+            false,
         );
 
         lvol.create_snapshot(snapshot_params1.clone())
@@ -614,6 +625,7 @@ async fn test_list_pool_snapshots() {
             Some(snap_name2.clone()),
             Some(snapshot_uuid2.clone()),
             Some(Utc::now().to_string()),
+            false,
         );
 
         lvol.create_snapshot(snapshot_params2.clone())
@@ -679,6 +691,7 @@ async fn test_list_all_snapshots_with_replica_destroy() {
             Some(snap_name),
             Some(snapshot_uuid),
             Some(Utc::now().to_string()),
+            false,
         );
 
         lvol.create_snapshot(snapshot_params.clone())
@@ -698,7 +711,6 @@ async fn test_list_all_snapshots_with_replica_destroy() {
 async fn test_snapshot_referenced_size() {
     let ms = get_ms();
     const LVOL_NAME: &str = "lvol8";
-    const LVOL_SIZE: u64 = 24 * 1024 * 1024;
 
     ms.spawn(async move {
         // Create a pool and lvol.
@@ -741,6 +753,7 @@ async fn test_snapshot_referenced_size() {
             Some(snap1_name.clone()),
             Some(Uuid::new_v4().to_string()),
             Some(Utc::now().to_string()),
+            false,
         );
 
         lvol.create_snapshot(snapshot_params.clone())
@@ -890,6 +903,7 @@ async fn test_snapshot_clone() {
             Some(snap_name),
             Some(snapshot_uuid),
             Some(Utc::now().to_string()),
+            false,
         );
 
         lvol.create_snapshot(snapshot_params.clone())
@@ -966,7 +980,6 @@ async fn test_snapshot_clone() {
 async fn test_snapshot_volume_provisioning_mode() {
     let ms = get_ms();
     const LVOL_NAME: &str = "lvol10";
-    const LVOL_SIZE: u64 = 24 * 1024 * 1024;
 
     ms.spawn(async move {
         // Create a pool and lvol.
@@ -994,6 +1007,7 @@ async fn test_snapshot_volume_provisioning_mode() {
             Some(snap1_name.clone()),
             Some(Uuid::new_v4().to_string()),
             Some(Utc::now().to_string()),
+            false,
         );
 
         // Volume must be reported as thick-provisioned before taking a snapshot.
@@ -1055,6 +1069,7 @@ async fn test_snapshot_attr() {
             Some(snap_name),
             Some(snapshot_uuid),
             Some(Utc::now().to_string()),
+            false,
         );
 
         lvol.create_snapshot(snapshot_params.clone())
@@ -1133,8 +1148,239 @@ async fn test_snapshot_attr() {
         let v = Lvol::get_blob_xattr(&imported_snapshot_lvol, &snap_attr_name)
             .expect("Failed to get snapshot attribute");
         assert_eq!(v, snap_attr_value, "Snapshot attribute doesn't match");
-
+        clean_snapshots(snapshot_list).await;
         pool.destroy().await.expect("Failed to destroy test pool");
+    })
+    .await;
+}
+#[tokio::test]
+async fn test_delete_snapshot_with_valid_clone() {
+    let ms = get_ms();
+    const LVOL_NAME: &str = "lvol13";
+
+    ms.spawn(async move {
+        // Create a pool and lvol.
+        let pool = create_test_pool(
+            "pool13",
+            "malloc:///disk13?size_mb=128".to_string(),
+        )
+        .await;
+        let lvol = pool
+            .create_lvol(
+                "lvol13",
+                32 * 1024 * 1024,
+                Some(&Uuid::new_v4().to_string()),
+                false,
+            )
+            .await
+            .expect("Failed to create test lvol");
+
+        // Create a test snapshot.
+        let entity_id = String::from("lvol13_e1");
+        let parent_id = lvol.uuid();
+        let txn_id = Uuid::new_v4().to_string();
+        let snap_name = String::from("lvol13_snap1");
+        let snapshot_uuid = Uuid::new_v4().to_string();
+
+        let snapshot_params = SnapshotParams::new(
+            Some(entity_id),
+            Some(parent_id),
+            Some(txn_id),
+            Some(snap_name),
+            Some(snapshot_uuid),
+            Some(Utc::now().to_string()),
+            false,
+        );
+
+        lvol.create_snapshot(snapshot_params.clone())
+            .await
+            .expect("Failed to create a snapshot");
+
+        let snapshot_list = Lvol::list_all_snapshots();
+        assert_eq!(1, snapshot_list.len(), "Snapshot Count not matched!!");
+
+        let snapshot_lvol = UntypedBdev::lookup_by_uuid_str(
+            snapshot_list
+                .get(0)
+                .unwrap()
+                .snapshot_params()
+                .snapshot_uuid()
+                .unwrap_or_default()
+                .as_str(),
+        )
+        .map(|b| Lvol::try_from(b).expect("Can't create Lvol from device"))
+        .unwrap();
+
+        let clone_name = String::from("lvol13_snap1_clone_1");
+        let clone_uuid = Uuid::new_v4().to_string();
+        let source_uuid = snapshot_lvol.uuid();
+
+        let clone_param = CloneParams::new(
+            Some(clone_name),
+            Some(clone_uuid),
+            Some(source_uuid),
+            Some(Utc::now().to_string()),
+        );
+        let clone1 = snapshot_lvol
+            .create_clone(clone_param.clone())
+            .await
+            .expect("Failed to create a clone");
+
+        let clone_name = String::from("lvol13_snap1_clone_2");
+        let clone_uuid = Uuid::new_v4().to_string();
+        let source_uuid = snapshot_lvol.uuid();
+
+        let clone_param = CloneParams::new(
+            Some(clone_name),
+            Some(clone_uuid),
+            Some(source_uuid),
+            Some(Utc::now().to_string()),
+        );
+        let clone2 = snapshot_lvol
+            .create_clone(clone_param.clone())
+            .await
+            .expect("Failed to create a clone");
+
+        snapshot_lvol.destroy_snapshot().await.ok();
+        let snapshot_list = Lvol::list_all_snapshots();
+        let snapshot_lvol = UntypedBdev::lookup_by_uuid_str(
+            snapshot_list
+                .get(0)
+                .unwrap()
+                .snapshot_params()
+                .snapshot_uuid()
+                .unwrap_or_default()
+                .as_str(),
+        )
+        .map(|b| Lvol::try_from(b).expect("Can't create Lvol from device"))
+        .unwrap();
+        assert!(
+            snapshot_lvol.is_discarded_snapshot(),
+            "Snapshot discardedSnapshotFlag not set properly"
+        );
+        clone1.destroy_replica().await.expect("Clone1 Destroy Failed");
+        let snapshot_list = Lvol::list_all_snapshots();
+        assert_eq!(
+            1,
+            snapshot_list.len(),
+            "Snapshot should not be deleted as part single clone deletion"
+        );
+        clone2.destroy_replica().await.expect("Clone2 Destroy Failed");
+
+        let snapshot_list = Lvol::list_all_snapshots();
+        assert_eq!(
+            0,
+            snapshot_list.len(),
+            "Snapshot marked as deleted not deleted after last linked clone is destroyed"
+        );
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn test_delete_snapshot_with_valid_clone_fail_1() {
+    let ms = get_ms();
+    const LVOL_NAME: &str = "lvol14";
+
+    ms.spawn(async move {
+        // Create a pool and lvol.
+        let pool = create_test_pool(
+            "pool14",
+            "malloc:///disk14?size_mb=128".to_string(),
+        )
+        .await;
+        let lvol = pool
+            .create_lvol(
+                "lvol14",
+                32 * 1024 * 1024,
+                Some(&Uuid::new_v4().to_string()),
+                false,
+            )
+            .await
+            .expect("Failed to create test lvol");
+
+        // Create a test snapshot.
+        let entity_id = String::from("lvol14_e1");
+        let parent_id = lvol.uuid();
+        let txn_id = Uuid::new_v4().to_string();
+        let snap_name = String::from("lvol14_snap1");
+        let snapshot_uuid = Uuid::new_v4().to_string();
+
+        let snapshot_params = SnapshotParams::new(
+            Some(entity_id),
+            Some(parent_id),
+            Some(txn_id),
+            Some(snap_name),
+            Some(snapshot_uuid),
+            Some(Utc::now().to_string()),
+            false,
+        );
+
+        lvol.create_snapshot(snapshot_params.clone())
+            .await
+            .expect("Failed to create a snapshot");
+
+        let snapshot_list = Lvol::list_all_snapshots();
+        assert_eq!(1, snapshot_list.len(), "Snapshot Count not matched!!");
+
+        let snapshot_lvol = UntypedBdev::lookup_by_uuid_str(
+            snapshot_list
+                .get(0)
+                .unwrap()
+                .snapshot_params()
+                .snapshot_uuid()
+                .unwrap_or_default()
+                .as_str(),
+        )
+        .map(|b| Lvol::try_from(b).expect("Can't create Lvol from device"))
+        .unwrap();
+
+        let clone_name = String::from("lvol14_snap1_clone_1");
+        let clone_uuid = Uuid::new_v4().to_string();
+        let source_uuid = snapshot_lvol.uuid();
+
+        let clone_param = CloneParams::new(
+            Some(clone_name),
+            Some(clone_uuid),
+            Some(source_uuid),
+            Some(Utc::now().to_string()),
+        );
+        let clone1 = snapshot_lvol
+            .create_clone(clone_param.clone())
+            .await
+            .expect("Failed to create a clone");
+
+        snapshot_lvol.destroy_snapshot().await.ok();
+        let snapshot_list = Lvol::list_all_snapshots();
+        let snapshot_lvol = UntypedBdev::lookup_by_uuid_str(
+            snapshot_list
+                .get(0)
+                .unwrap()
+                .snapshot_params()
+                .snapshot_uuid()
+                .unwrap_or_default()
+                .as_str(),
+        )
+        .map(|b| Lvol::try_from(b).expect("Can't create Lvol from device"))
+        .unwrap();
+        assert!(
+            snapshot_lvol.is_discarded_snapshot(),
+            "Snapshot discardedSnapshotFlag not set properly"
+        );
+        clone1.destroy().await.expect("Clone1 Destroy Failed");
+        let snapshot_list = Lvol::list_all_snapshots();
+        assert_eq!(
+            1,
+            snapshot_list.len(),
+            "Snapshot should not be destroyed, if fault happened after clone deletion"
+        );
+        Lvol::destroy_pending_discarded_snapshot().await;
+        let snapshot_list = Lvol::list_all_snapshots();
+        assert_eq!(
+            0,
+            snapshot_list.len(),
+            "After clone destroy failure retry, snapshot is not destroyed"
+        );
     })
     .await;
 }

--- a/io-engine/tests/snapshot_nexus.rs
+++ b/io-engine/tests/snapshot_nexus.rs
@@ -11,7 +11,7 @@ use common::{
             bdev::ListBdevOptions,
             pool::CreatePoolRequest,
             replica::{CreateReplicaRequest, ListReplicaOptions},
-            snapshot::{ListSnapshotsRequest, SnapshotInfo},
+            snapshot::{ListSnapshotsRequest, SnapshotInfo, SnapshotQueryType},
             GrpcConnect,
         },
         Builder,
@@ -250,6 +250,7 @@ async fn test_replica_handle_snapshot() {
         .list_snapshot(ListSnapshotsRequest {
             source_uuid: None,
             snapshot_uuid: None,
+            snapshot_query_type: SnapshotQueryType::AllSnapshots as i32,
         })
         .await
         .expect("Failed to list snapshots on replica node")
@@ -269,6 +270,7 @@ async fn test_replica_handle_snapshot() {
         Some(String::from(SNAP_NAME)),
         Some(Uuid::new_v4().to_string()),
         Some(Utc::now().to_string()),
+        false,
     );
     let mut snapshot_params_clone = snapshot_params.clone();
 
@@ -291,6 +293,7 @@ async fn test_replica_handle_snapshot() {
         .list_snapshot(ListSnapshotsRequest {
             source_uuid: None,
             snapshot_uuid: None,
+            snapshot_query_type: SnapshotQueryType::AllSnapshots as i32,
         })
         .await
         .expect("Failed to list snapshots on replica node")
@@ -320,6 +323,7 @@ async fn test_multireplica_nexus_snapshot() {
             Some(String::from("s1")),
             Some(Uuid::new_v4().to_string()),
             Some(Utc::now().to_string()),
+            false,
         );
 
         let replicas = vec![
@@ -371,6 +375,7 @@ async fn test_list_no_snapshots() {
         .list_snapshot(ListSnapshotsRequest {
             source_uuid: None,
             snapshot_uuid: None,
+            snapshot_query_type: SnapshotQueryType::AllSnapshots as i32,
         })
         .await
         .expect("Failed to list snapshots on replica node")
@@ -443,6 +448,7 @@ async fn test_nexus_snapshot() {
         Some(String::from(SNAP_NAME)),
         Some(snapshot_uuid.clone()),
         Some(Utc::now().to_string()),
+        false,
     );
     let snapshot_params_clone = snapshot_params.clone();
 
@@ -452,6 +458,7 @@ async fn test_nexus_snapshot() {
         .list_snapshot(ListSnapshotsRequest {
             source_uuid: None,
             snapshot_uuid: None,
+            snapshot_query_type: SnapshotQueryType::AllSnapshots as i32,
         })
         .await
         .expect("Failed to list snapshots on replica node")
@@ -494,6 +501,7 @@ async fn test_nexus_snapshot() {
         .list_snapshot(ListSnapshotsRequest {
             source_uuid: None,
             snapshot_uuid: None,
+            snapshot_query_type: SnapshotQueryType::AllSnapshots as i32,
         })
         .await
         .expect("Failed to list snapshots on replica node")
@@ -527,6 +535,7 @@ async fn test_duplicated_snapshot_uuid_name() {
         Some(String::from("snapshot51")),
         Some(snapshot_uuid.clone()),
         Some(Utc::now().to_string()),
+        false,
     );
     let snapshot_params_clone = snapshot_params.clone();
 
@@ -580,6 +589,7 @@ async fn test_duplicated_snapshot_uuid_name() {
         .list_snapshot(ListSnapshotsRequest {
             source_uuid: None,
             snapshot_uuid: None,
+            snapshot_query_type: SnapshotQueryType::AllSnapshots as i32,
         })
         .await
         .expect("Failed to list snapshots on replica node")
@@ -629,6 +639,7 @@ async fn test_snapshot_ancestor_usage() {
             Some(String::from(SNAP1_NAME)),
             Some(snapshot_uuid.clone()),
             Some(Utc::now().to_string()),
+            false,
         );
 
         let r = NexusReplicaSnapshotDescriptor {
@@ -755,6 +766,7 @@ async fn test_snapshot_ancestor_usage() {
             Some(String::from(SNAP2_NAME)),
             Some(Uuid::new_v4().to_string()),
             Some(Utc::now().to_string()),
+            false,
         );
 
         let replicas = vec![NexusReplicaSnapshotDescriptor {
@@ -817,6 +829,7 @@ async fn test_snapshot_ancestor_usage() {
         .list_snapshot(ListSnapshotsRequest {
             source_uuid: None,
             snapshot_uuid: None,
+            snapshot_query_type: SnapshotQueryType::AllSnapshots as i32,
         })
         .await
         .expect("Failed to list snapshots on replica node")
@@ -859,6 +872,7 @@ async fn test_snapshot_ancestor_usage() {
             Some(String::from(SNAP3_NAME)),
             Some(Uuid::new_v4().to_string()),
             Some(Utc::now().to_string()),
+            false,
         );
 
         let replicas = vec![NexusReplicaSnapshotDescriptor {
@@ -883,6 +897,7 @@ async fn test_snapshot_ancestor_usage() {
         .list_snapshot(ListSnapshotsRequest {
             source_uuid: None,
             snapshot_uuid: None,
+            snapshot_query_type: SnapshotQueryType::AllSnapshots as i32,
         })
         .await
         .expect("Failed to list snapshots on replica node")


### PR DESCRIPTION
1. When `DeleteSnapshot` gRPC is triggered where there are valid clones are linked to it, Snapshot will mark "future_delete" flag true. But don't delete the snapshot from SPDK.
2. When `ListSnapshot` gRPC is called, a new parameter is return which will tell the Snapshot is marked as "deleted"
3. If any new clones will be created from this Snapshot using `CreateClone` gRPC , request will be rejected from Dataplane.
4. When `DeleteReplica` gRPC is called, if the replica is identified as last clone linked to snapshot which is already marked as "deleted", delete the snapshot along with clone replica.
5. When `DeleteReplica`gPRC, if clone is deleted but before snapshot delete, there is any fault or io-engine crash, as part `pool_import` request from CP, clean the discarded snapshot which is not done in last request.