### PR TITLE
Wipe replicas for system testing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1457,6 +1457,7 @@ dependencies = [
  "strum_macros",
  "sysfs",
  "tokio",
+ "tokio-stream",
  "tonic 0.8.3",
  "tower",
  "tracing",

--- a/io-engine-tests/src/compose/rpc/v1.rs
+++ b/io-engine-tests/src/compose/rpc/v1.rs
@@ -51,6 +51,7 @@ pub struct RpcHandle {
     pub host: host::HostRpcClient<Channel>,
     pub nexus: nexus::NexusRpcClient<Channel>,
     pub snapshot: snapshot::SnapshotRpcClient<Channel>,
+    pub test: test::TestRpcClient<Channel>,
 }
 
 impl RpcHandle {
@@ -104,6 +105,10 @@ impl RpcHandle {
                 .await
                 .unwrap();
 
+        let test = test::TestRpcClient::connect(format!("http://{endpoint}"))
+            .await
+            .unwrap();
+
         Ok(Self {
             name,
             endpoint,
@@ -114,6 +119,7 @@ impl RpcHandle {
             host,
             nexus,
             snapshot,
+            test,
         })
     }
 }

--- a/io-engine-tests/src/lib.rs
+++ b/io-engine-tests/src/lib.rs
@@ -406,10 +406,10 @@ pub fn compare_devices(
     second_device: &str,
     size: u64,
     expected_pass: bool,
-) -> String {
+) {
     let (exit, stdout, stderr) = run_script::run(
         r#"
-        cmp -b $1 $2 5M 5M -n $3
+        cmp -b $1 $2 -n $3
         test $? -eq $4
     "#,
         &vec![
@@ -422,7 +422,6 @@ pub fn compare_devices(
     )
     .unwrap();
     assert_eq!(exit, 0, "stdout: {stdout}\nstderr: {stderr}");
-    stdout
 }
 
 pub fn device_path_from_uri(device_uri: &str) -> String {

--- a/io-engine-tests/src/replica.rs
+++ b/io-engine-tests/src/replica.rs
@@ -82,6 +82,11 @@ impl ReplicaBuilder {
         self
     }
 
+    pub fn with_nvmf(mut self) -> Self {
+        self.share = mayastor_api::v1::common::ShareProtocol::Nvmf as i32;
+        self
+    }
+
     pub fn rpc(&self) -> SharedRpcHandle {
         self.rpc.clone()
     }

--- a/io-engine/Cargo.toml
+++ b/io-engine/Cargo.toml
@@ -104,6 +104,7 @@ url = "2.2.2"
 gettid = "0.1.2"
 async-process = { version = "1.5.0" }
 rstack = { version = "0.3.2" }
+tokio-stream = "0.1.14"
 
 jsonrpc = { path = "../jsonrpc"}
 mayastor-api = { path = "../rpc/mayastor-api" }

--- a/io-engine/src/bdev/loopback.rs
+++ b/io-engine/src/bdev/loopback.rs
@@ -104,10 +104,11 @@ impl CreateDestroy for Loopback {
     async fn destroy(self: Box<Self>) -> Result<(), Self::Error> {
         debug!("{:?}: deleting", self);
 
-        dispatch_loopback_removed(&self.name);
-
         if let Some(mut bdev) = UntypedBdev::lookup_by_name(&self.name) {
             bdev.remove_alias(&self.alias);
+            dispatch_loopback_removed(bdev.name());
+        } else {
+            tracing::warn!("{:?}: bdev not found", self);
         }
 
         Ok(())

--- a/io-engine/src/bdev/nexus/nexus_bdev_children.rs
+++ b/io-engine/src/bdev/nexus/nexus_bdev_children.rs
@@ -517,7 +517,7 @@ impl<'n> Nexus<'n> {
         // even if some of the children failed to open. This is work is not
         // completed yet so we fail the registration all together for now.
         if let Some(error) = error {
-            // Close any children that WERE succesfully opened.
+            // Close any children that WERE successfully opened.
             for child in self.children_iter() {
                 if child.is_opened() {
                     child.close().await.ok();

--- a/io-engine/src/bin/io-engine-client/v1/mod.rs
+++ b/io-engine/src/bin/io-engine-client/v1/mod.rs
@@ -9,6 +9,7 @@ pub mod pool_cli;
 pub mod rebuild_cli;
 pub mod replica_cli;
 pub mod snapshot_cli;
+mod test_cli;
 
 pub(crate) use super::context;
 use crate::ContextCreate;
@@ -75,6 +76,7 @@ pub(super) async fn main_() -> crate::Result<()> {
         .subcommand(snapshot_cli::subcommands())
         .subcommand(jsonrpc_cli::subcommands())
         .subcommand(controller_cli::subcommands())
+        .subcommand(test_cli::subcommands())
         .get_matches();
 
     let ctx = context::Context::new(&matches)
@@ -92,6 +94,7 @@ pub(super) async fn main_() -> crate::Result<()> {
         ("snapshot", Some(args)) => snapshot_cli::handler(ctx, args).await,
         ("controller", Some(args)) => controller_cli::handler(ctx, args).await,
         ("jsonrpc", Some(args)) => jsonrpc_cli::json_rpc_call(ctx, args).await,
+        ("test", Some(args)) => test_cli::handler(ctx, args).await,
         _ => panic!("Command not found"),
     };
     status

--- a/io-engine/src/bin/io-engine-client/v1/test_cli.rs
+++ b/io-engine/src/bin/io-engine-client/v1/test_cli.rs
@@ -1,0 +1,273 @@
+use crate::{
+    context::{Context, OutputFormat},
+    parse_size,
+    ClientError,
+    GrpcStatus,
+};
+use byte_unit::Byte;
+use clap::{App, AppSettings, Arg, ArgMatches, SubCommand};
+use colored_json::ToColoredJson;
+use futures::StreamExt;
+use mayastor_api::v1 as v1_rpc;
+use snafu::ResultExt;
+use std::{convert::TryInto, str::FromStr};
+use strum::VariantNames;
+use strum_macros::{AsRefStr, EnumString, EnumVariantNames};
+use tonic::Status;
+
+pub fn subcommands<'a, 'b>() -> App<'a, 'b> {
+    let wipe = SubCommand::with_name("wipe")
+        .about("Wipe Resource")
+        .arg(
+            Arg::with_name("resource")
+                .required(true)
+                .index(1)
+                .possible_values(Resource::resources())
+                .help("Resource to Wipe"),
+        )
+        .arg(
+            Arg::with_name("uuid")
+                .required(true)
+                .index(2)
+                .help("Resource uuid"),
+        )
+        .arg(
+            Arg::with_name("pool-uuid")
+                .long("pool-uuid")
+                .required(false)
+                .takes_value(true)
+                .requires_if("resource", Resource::Replica.as_ref())
+                .conflicts_with("pool-name")
+                .help("Uuid of the pool where the replica resides"),
+        )
+        .arg(
+            Arg::with_name("pool-name")
+                .long("pool-name")
+                .required(false)
+                .takes_value(true)
+                .requires_if("resource", Resource::Replica.as_ref())
+                .conflicts_with("pool-uuid")
+                .help("Name of the pool where the replica resides"),
+        )
+        .arg(
+            Arg::with_name("method")
+                .short("m")
+                .long("method")
+                .takes_value(true)
+                .value_name("METHOD")
+                .default_value("WriteZeroes")
+                .possible_values(WipeMethod::methods())
+                .help("Method used to wipe the replica"),
+        )
+        .arg(
+            Arg::with_name("chunk-size")
+                .short("c")
+                .long("chunk-size")
+                .takes_value(true)
+                .value_name("CHUNK-SIZE")
+                .help("Reporting back stats after each chunk is wiped"),
+        );
+
+    SubCommand::with_name("test")
+        .settings(&[
+            AppSettings::SubcommandRequiredElseHelp,
+            AppSettings::ColoredHelp,
+            AppSettings::ColorAlways,
+        ])
+        .about("Test management")
+        .subcommand(wipe)
+}
+
+#[derive(EnumString, EnumVariantNames, AsRefStr)]
+#[strum(serialize_all = "camelCase")]
+enum Resource {
+    Replica,
+}
+impl Resource {
+    fn resources() -> &'static [&'static str] {
+        Self::VARIANTS
+    }
+}
+
+#[derive(EnumString, EnumVariantNames)]
+#[strum(serialize_all = "PascalCase")]
+enum WipeMethod {
+    None,
+    WriteZeroes,
+    Unmap,
+    WritePattern,
+}
+impl WipeMethod {
+    fn methods() -> &'static [&'static str] {
+        Self::VARIANTS
+    }
+}
+impl From<WipeMethod> for v1_rpc::test::wipe_options::WipeMethod {
+    fn from(value: WipeMethod) -> Self {
+        match value {
+            WipeMethod::None => Self::None,
+            WipeMethod::WriteZeroes => Self::WriteZeroes,
+            WipeMethod::Unmap => Self::Unmap,
+            WipeMethod::WritePattern => Self::WritePattern,
+        }
+    }
+}
+
+pub async fn handler(
+    ctx: Context,
+    matches: &ArgMatches<'_>,
+) -> crate::Result<()> {
+    match matches.subcommand() {
+        ("wipe", Some(args)) => wipe(ctx, args).await,
+        (cmd, _) => {
+            Err(Status::not_found(format!("command {cmd} does not exist")))
+                .context(GrpcStatus)
+        }
+    }
+}
+
+async fn wipe(ctx: Context, matches: &ArgMatches<'_>) -> crate::Result<()> {
+    let resource = matches
+        .value_of("resource")
+        .map(Resource::from_str)
+        .ok_or_else(|| ClientError::MissingValue {
+            field: "resource".to_string(),
+        })?
+        .map_err(|e| Status::invalid_argument(e.to_string()))
+        .context(GrpcStatus)?;
+
+    match resource {
+        Resource::Replica => replica_wipe(ctx, matches).await,
+    }
+}
+
+async fn replica_wipe(
+    mut ctx: Context,
+    matches: &ArgMatches<'_>,
+) -> crate::Result<()> {
+    let uuid = matches
+        .value_of("uuid")
+        .ok_or_else(|| ClientError::MissingValue {
+            field: "uuid".to_string(),
+        })?
+        .to_owned();
+
+    let pool = match matches.value_of("pool-uuid") {
+        Some(uuid) => Some(v1_rpc::test::wipe_replica_request::Pool::PoolUuid(
+            uuid.to_string(),
+        )),
+        None => matches.value_of("pool-name").map(|name| {
+            v1_rpc::test::wipe_replica_request::Pool::PoolName(name.to_string())
+        }),
+    };
+
+    let method_str = matches.value_of("method").ok_or_else(|| {
+        ClientError::MissingValue {
+            field: "method".to_string(),
+        }
+    })?;
+    let method = WipeMethod::from_str(method_str)
+        .map_err(|e| Status::invalid_argument(e.to_string()))
+        .context(GrpcStatus)?;
+
+    let chunk_size = parse_size(matches.value_of("chunk-size").unwrap_or("0"))
+        .map_err(|s| Status::invalid_argument(format!("Bad size '{s}'")))
+        .context(GrpcStatus)?;
+    let response = ctx
+        .v1
+        .test
+        .wipe_replica(v1_rpc::test::WipeReplicaRequest {
+            uuid,
+            pool,
+            wipe_options: Some(v1_rpc::test::StreamWipeOptions {
+                options: Some(v1_rpc::test::WipeOptions {
+                    wipe_method: v1_rpc::test::wipe_options::WipeMethod::from(
+                        method,
+                    ) as i32,
+                    write_pattern: None,
+                }),
+                chunk_size: chunk_size.get_bytes() as u64,
+            }),
+        })
+        .await
+        .context(GrpcStatus)?;
+
+    let mut resp = response.into_inner();
+
+    fn bandwidth(response: &v1_rpc::test::WipeReplicaResponse) -> String {
+        let unknown = "??".to_string();
+        let Some(Ok(elapsed)) = response.since.clone().map(TryInto::<std::time::Duration>::try_into) else {
+            return unknown;
+        };
+        let elapsed_f = elapsed.as_secs_f64();
+        if !elapsed_f.is_normal() {
+            return unknown;
+        }
+
+        let bandwidth = (response.wiped_bytes as f64 / elapsed_f) as u128;
+        format!(
+            "{}/s",
+            byte_unit::Byte::from_bytes(bandwidth).get_appropriate_unit(true)
+        )
+    }
+
+    match ctx.output {
+        OutputFormat::Json => {
+            while let Some(response) = resp.next().await {
+                let response = response.context(GrpcStatus)?;
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&response)
+                        .unwrap()
+                        .to_colored_json_auto()
+                        .unwrap()
+                );
+            }
+        }
+        OutputFormat::Default => {
+            let header = vec![
+                "UUID",
+                "TOTAL_BYTES",
+                "CHUNK_SIZE",
+                "LAST_CHUNK_SIZE",
+                "TOTAL_CHUNKS",
+                "WIPED_BYTES",
+                "WIPED_CHUNKS",
+                "REMAINING_BYTES",
+                "BANDWIDTH",
+            ];
+
+            let (s, r) = tokio::sync::mpsc::channel(10);
+            tokio::spawn(async move {
+                while let Some(response) = resp.next().await {
+                    let response = response.map(|response| {
+                        let bandwidth = bandwidth(&response);
+                        vec![
+                            response.uuid,
+                            adjust_bytes(response.total_bytes),
+                            adjust_bytes(response.chunk_size),
+                            adjust_bytes(response.last_chunk_size),
+                            response.total_chunks.to_string(),
+                            adjust_bytes(response.wiped_bytes),
+                            response.wiped_chunks.to_string(),
+                            adjust_bytes(response.remaining_bytes),
+                            bandwidth,
+                        ]
+                    });
+                    s.send(response).await.unwrap();
+                }
+            });
+            ctx.print_streamed_list(header, r)
+                .await
+                .context(GrpcStatus)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn adjust_bytes(bytes: u64) -> String {
+    let byte = Byte::from_bytes(bytes as u128);
+    let adjusted_byte = byte.get_appropriate_unit(true);
+    adjusted_byte.to_string()
+}

--- a/io-engine/src/core/mod.rs
+++ b/io-engine/src/core/mod.rs
@@ -96,6 +96,7 @@ pub(crate) mod segment_map;
 mod share;
 pub mod snapshot;
 pub(crate) mod thread;
+pub(crate) mod wiper;
 mod work_queue;
 
 /// Obtain the full error chain
@@ -307,6 +308,10 @@ pub enum CoreError {
         reason: String,
         source: Errno,
     },
+    #[snafu(display("Failed to wipe the device"))]
+    WipeFailed {
+        source: wiper::Error,
+    },
 }
 
 /// Represent error as Errno value.
@@ -411,6 +416,9 @@ impl ToErrno for CoreError {
             Self::SnapshotCreate {
                 source, ..
             } => source,
+            Self::WipeFailed {
+                ..
+            } => Errno::EIO,
         }
     }
 }

--- a/io-engine/src/core/wiper.rs
+++ b/io-engine/src/core/wiper.rs
@@ -1,0 +1,398 @@
+use crate::core::{CoreError, UntypedBdevHandle};
+use snafu::Snafu;
+use std::{fmt::Debug, ops::Deref};
+
+/// The Error for the Wiper.
+#[derive(Clone, Debug, Snafu)]
+#[snafu(visibility(pub(crate)), context(suffix(false)))]
+pub enum Error {
+    #[snafu(display("Too many notifications, try increasing the chunk_size"))]
+    TooManyChunks {},
+    #[snafu(display("The chunk_size is larger than the bdev"))]
+    ChunkTooLarge {},
+    #[snafu(display(
+        "The chunk_size is not a multiple of the bdev block size"
+    ))]
+    ChunkBlockSizeInvalid {},
+    #[snafu(display("The bdev seems to have no size!"))]
+    ZeroBdev {},
+    #[snafu(display("The wipe has been aborted"))]
+    WipeAborted {},
+    #[snafu(display("Error while wiping the bdev (IO Error)"))]
+    WipeIoFailed { source: Box<CoreError> },
+    #[snafu(display("Wipe Method {method:?} not implemented"))]
+    MethodUnimplemented { method: WipeMethod },
+    #[snafu(display("Failed to post client notification: {error}"))]
+    ChunkNotifyFailed { error: String },
+}
+
+impl From<Error> for CoreError {
+    fn from(source: Error) -> Self {
+        Self::WipeFailed {
+            source,
+        }
+    }
+}
+impl From<CoreError> for Error {
+    fn from(source: CoreError) -> Self {
+        Self::WipeIoFailed {
+            source: Box::new(source),
+        }
+    }
+}
+
+/// A wiper which can wipe a bdev using a specified wipe method.
+pub(crate) struct Wiper {
+    /// The bdev which is to be wiped.
+    bdev: UntypedBdevHandle,
+    /// The method used to wipe the bdev.
+    wipe_method: WipeMethod,
+}
+
+/// Options for the streamed wiper.
+pub(crate) struct StreamWipeOptions {
+    /// Wipe in chunks and notify client when every chunk is complete.
+    /// We might be able to add a range here if we wanted to..
+    pub(crate) chunk_size: u64,
+    /// Method used to wipe the bdev.
+    pub(crate) wipe_method: WipeMethod,
+}
+
+/// A streamed version of `Wiper` which can notify a client as it progresses and
+/// can track if the client has disconnected for faster error handling.
+/// todo: abstract `N` and `A` into a Stream like trait.
+pub(crate) struct StreamedWiper<S: NotifyStream> {
+    wiper: Wiper,
+    stats: WipeStats,
+    stream: S,
+}
+
+/// A notification stream which can be used to notify a client everytime a
+/// certain size is wiped.
+pub(crate) trait NotifyStream {
+    /// Notify the client with the given stats.
+    fn notify(&self, stats: &WipeStats) -> Result<(), String>;
+    /// Check if the stream is closed.
+    fn is_closed(&self) -> bool;
+}
+
+/// Wipe method, allowing for some flexibility.
+#[derive(Default, Debug, Clone, Copy)]
+pub enum WipeMethod {
+    /// Don't actually wipe, just pretend.
+    #[default]
+    None,
+    /// Wipe by writing zeroes.
+    WriteZeroes,
+    /// Wipe by sending unmap/trim.
+    Unmap,
+    /// When using WRITE_PATTERN, wipe using this 32bit write pattern, example:
+    /// 0xDEADBEEF.
+    WritePattern(u32),
+}
+
+/// Final Wipe stats.
+#[derive(Debug)]
+pub(crate) struct FinalWipeStats {
+    start: std::time::Instant,
+    end: std::time::Instant,
+    stats: WipeStats,
+}
+impl FinalWipeStats {
+    /// Log the stats.
+    pub(crate) fn log(&self) {
+        let stats = &self.stats;
+        let elapsed = self.end - self.start;
+        let elapsed_f = elapsed.as_secs_f64();
+        let bandwidth = if elapsed_f.is_normal() {
+            let bandwidth = (stats.total_bytes as f64 / elapsed_f) as u128;
+            byte_unit::Byte::from_bytes(bandwidth)
+                .get_appropriate_unit(true)
+                .to_string()
+        } else {
+            "??".to_string()
+        };
+
+        tracing::warn!(
+            "Wiped {} => {:.3?} => {bandwidth}/s",
+            self.stats.uuid,
+            elapsed
+        );
+    }
+}
+
+/// Wipe stats which help track the progress.
+#[derive(Default, Debug)]
+pub(crate) struct WipeStats {
+    /// Uuid of the bdev to be wiped.
+    pub(crate) uuid: uuid::Uuid,
+    /// The stats iterator for the wipe operation.
+    pub(crate) stats: WipeIterator,
+    /// Track how long it's been since the first wipe IO.
+    pub(crate) since: Option<std::time::Duration>,
+}
+impl Deref for WipeStats {
+    type Target = WipeIterator;
+
+    fn deref(&self) -> &Self::Target {
+        &self.stats
+    }
+}
+impl WipeStats {
+    /// Complete the current chunk.
+    fn complete_chunk(&mut self, start: std::time::Instant, size: u64) {
+        self.stats.complete_chunk(size);
+        self.since = Some(start.elapsed());
+    }
+}
+
+impl Wiper {
+    /// Return a new `Self` which can wipe the given bdev using the provided
+    /// wipe method.
+    pub fn new(
+        bdev: UntypedBdevHandle,
+        wipe_method: WipeMethod,
+    ) -> Result<Self, Error> {
+        Ok(Self {
+            bdev,
+            wipe_method: Self::supported(wipe_method)?,
+        })
+    }
+    /// Wipe the bdev at the given byte offset and byte size.
+    async fn wipe(&self, offset: u64, size: u64) -> Result<(), Error> {
+        match self.wipe_method {
+            WipeMethod::None => Ok(()),
+            WipeMethod::WriteZeroes => {
+                self.bdev.write_zeroes_at(offset, size).await.map_err(
+                    |source| Error::WipeIoFailed {
+                        source: Box::new(source),
+                    },
+                )
+            }
+            WipeMethod::Unmap | WipeMethod::WritePattern(_) => {
+                Err(Error::MethodUnimplemented {
+                    method: self.wipe_method,
+                })
+            }
+        }?;
+        Ok(())
+    }
+    /// Check if the given method is supported.
+    pub(crate) fn supported(
+        wipe_method: WipeMethod,
+    ) -> Result<WipeMethod, Error> {
+        match wipe_method {
+            WipeMethod::None | WipeMethod::WriteZeroes => Ok(wipe_method),
+            WipeMethod::Unmap | WipeMethod::WritePattern(_) => {
+                Err(Error::MethodUnimplemented {
+                    method: wipe_method,
+                })
+            }
+        }
+    }
+}
+
+impl<S: NotifyStream> StreamedWiper<S> {
+    /// Create a new `Self` which wipes a bdev using the given `Wiper` by wiping
+    /// in chunk sizes and notifying with stats after every chunk.
+    pub fn new(
+        wiper: Wiper,
+        chunk_size_bytes: u64,
+        max_chunks: usize,
+        stream: S,
+    ) -> Result<Self, Error> {
+        let size = wiper.bdev.get_bdev().size_in_bytes();
+        let block_len = wiper.bdev.get_bdev().block_len() as u64;
+        snafu::ensure!(chunk_size_bytes <= size, ChunkTooLarge {});
+        let iterator = WipeIterator::new(0, size, chunk_size_bytes, block_len)?;
+
+        snafu::ensure!(
+            iterator.total_chunks < max_chunks as u64,
+            TooManyChunks {}
+        );
+
+        let stats = WipeStats {
+            uuid: wiper.bdev.get_bdev().uuid(),
+            stats: iterator,
+            since: None,
+        };
+        Ok(Self {
+            wiper,
+            stats,
+            stream,
+        })
+    }
+
+    /// Wipe the bdev while notifying after every chunk_size is complete. This
+    /// is to allow the client to notice wipe is in progress and not stuck.
+    pub async fn wipe(mut self) -> Result<FinalWipeStats, Error> {
+        self.notify()?;
+        let start = std::time::Instant::now();
+        while let Some((offset, size)) = self.stats.next() {
+            self.wipe_chunk(start, offset, size).await?;
+        }
+        Ok(FinalWipeStats {
+            start,
+            end: std::time::Instant::now(),
+            stats: self.stats,
+        })
+    }
+
+    /// Wipe a "chunk" using a byte offset and byte length.
+    async fn wipe_chunk(
+        &mut self,
+        start: std::time::Instant,
+        offset: u64,
+        size: u64,
+    ) -> Result<(), Error> {
+        self.wipe_with_abort(offset, size).await?;
+
+        self.stats.complete_chunk(start, size);
+
+        self.notify()
+    }
+
+    /// Wipe the bdev at the given byte offset and byte size.
+    /// Uses the abort checker allowing us to stop early if a client disconnects
+    /// or if the process is being shutdown.
+    async fn wipe_with_abort(
+        &self,
+        offset: u64,
+        size: u64,
+    ) -> Result<(), Error> {
+        // todo: configurable?
+        let max_io_size = 8 * 1024 * 1024;
+        if size > max_io_size {
+            let block_len = self.wiper.bdev.get_bdev().block_len() as u64;
+            let mut iterator =
+                WipeIterator::new(offset, size, max_io_size, block_len)?;
+            while let Some((offset, size)) = iterator.next() {
+                self.wiper.wipe(offset, size).await?;
+                iterator.complete_chunk(size);
+                self.check_abort()?;
+            }
+        } else {
+            self.wiper.wipe(offset, size).await?;
+        }
+        Ok(())
+    }
+
+    fn check_abort(&self) -> Result<(), Error> {
+        if self.stream.is_closed() {
+            return Err(Error::WipeAborted {});
+        }
+        Ok(())
+    }
+
+    /// Notify with the latest stats.
+    fn notify(&self) -> Result<(), Error> {
+        if let Err(error) = self.stream.notify(&self.stats) {
+            self.check_abort()?;
+            return Err(Error::ChunkNotifyFailed {
+                error,
+            });
+        }
+        Ok(())
+    }
+}
+
+impl Iterator for WipeStats {
+    type Item = (u64, u64);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.stats.next()
+    }
+}
+
+/// Iterator to keep track of a wipe.
+#[derive(Default, Debug)]
+pub(crate) struct WipeIterator {
+    /// The starting offset to wipe.
+    start_offset: u64,
+    /// Total bytes to be wiped.
+    pub(crate) total_bytes: u64,
+    /// Size of a chunk.
+    /// # Note: The last chunk may be of a smaller size if the chunk size is not a multiple of the total size.
+    pub(crate) chunk_size_bytes: u64,
+    pub(crate) extra_chunk_size_bytes: Option<u64>,
+
+    /// How many chunks we've wiped so far.
+    pub(crate) wiped_chunks: u64,
+    /// How many byes we've wiped so far.
+    pub(crate) wiped_bytes: u64,
+    /// Remaining chunks to be wiped.
+    pub(crate) remaining_chunks: u64,
+    /// Number of chunks to wipe.
+    pub(crate) total_chunks: u64,
+}
+impl WipeIterator {
+    fn new(
+        start_offset: u64,
+        total_bytes: u64,
+        chunk_size_bytes: u64,
+        block_len: u64,
+    ) -> Result<Self, Error> {
+        snafu::ensure!(total_bytes > 0, ZeroBdev {});
+
+        let chunk_size_bytes = if chunk_size_bytes == 0 {
+            total_bytes
+        } else {
+            chunk_size_bytes
+        };
+
+        snafu::ensure!(chunk_size_bytes <= total_bytes, ChunkTooLarge {});
+        snafu::ensure!(
+            chunk_size_bytes % block_len == 0,
+            ChunkBlockSizeInvalid {}
+        );
+
+        let mut chunks = total_bytes / chunk_size_bytes;
+        let remainder = total_bytes % chunk_size_bytes;
+        // must be aligned to block device
+        snafu::ensure!(remainder % block_len == 0, ChunkBlockSizeInvalid {});
+        let extra_chunk_size_bytes = if remainder == 0 {
+            None
+        } else {
+            chunks += 1;
+            Some(remainder)
+        };
+
+        Ok(Self {
+            start_offset,
+            total_bytes,
+            chunk_size_bytes,
+            extra_chunk_size_bytes,
+            wiped_chunks: 0,
+            wiped_bytes: 0,
+            remaining_chunks: chunks,
+            total_chunks: chunks,
+        })
+    }
+    fn complete_chunk(&mut self, size: u64) {
+        self.wiped_chunks += 1;
+        self.wiped_bytes += size;
+        self.remaining_chunks -= 1;
+    }
+}
+impl Iterator for WipeIterator {
+    type Item = (u64, u64);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // we've wiped, let caller bail out.
+        if self.wiped_chunks >= self.total_chunks {
+            None
+        } else {
+            let offset =
+                self.start_offset + (self.wiped_chunks * self.chunk_size_bytes);
+            match self.extra_chunk_size_bytes {
+                // the very last chunk might have a different size is the bdev
+                // size is not an exact multiple of the chunk
+                // size.
+                Some(size) if self.remaining_chunks == 1 => {
+                    Some((offset, size))
+                }
+                None | Some(_) => Some((offset, self.chunk_size_bytes)),
+            }
+        }
+    }
+}

--- a/io-engine/src/grpc/mod.rs
+++ b/io-engine/src/grpc/mod.rs
@@ -53,6 +53,7 @@ pub mod v1 {
     pub mod pool;
     pub mod replica;
     pub mod snapshot;
+    pub mod test;
 }
 
 /// Default timeout for gRPC calls, in seconds. Should be enforced in case

--- a/io-engine/src/grpc/v0/mayastor_grpc.rs
+++ b/io-engine/src/grpc/v0/mayastor_grpc.rs
@@ -279,6 +279,9 @@ impl From<LvsError> for tonic::Status {
             LvsError::InvalidBdev {
                 source, ..
             } => source.into(),
+            LvsError::WipeFailed {
+                source,
+            } => source.into(),
             _ => Status::internal(e.verbose()),
         }
     }

--- a/io-engine/src/grpc/v1/replica.rs
+++ b/io-engine/src/grpc/v1/replica.rs
@@ -21,11 +21,12 @@ use nix::errno::Errno;
 use std::{convert::TryFrom, panic::AssertUnwindSafe, pin::Pin};
 use tonic::{Request, Response, Status};
 
-#[derive(Debug)]
-#[allow(dead_code)]
+#[derive(Debug, Clone)]
 pub struct ReplicaService {
+    #[allow(unused)]
     name: String,
-    client_context: tokio::sync::Mutex<Option<GrpcClientContext>>,
+    client_context:
+        std::sync::Arc<tokio::sync::Mutex<Option<GrpcClientContext>>>,
 }
 
 #[async_trait::async_trait]
@@ -117,7 +118,7 @@ impl ReplicaService {
     pub fn new() -> Self {
         Self {
             name: String::from("ReplicaSvc"),
-            client_context: tokio::sync::Mutex::new(None),
+            client_context: std::sync::Arc::new(tokio::sync::Mutex::new(None)),
         }
     }
 }
@@ -398,7 +399,7 @@ impl ReplicaRpc for ReplicaService {
                     .map(Response::new)
             },
         )
-        .await
+            .await
     }
 
     #[named]

--- a/io-engine/src/grpc/v1/test.rs
+++ b/io-engine/src/grpc/v1/test.rs
@@ -1,0 +1,255 @@
+use crate::{
+    bdev_api::BdevError,
+    core::{
+        wiper::{Error as WipeError, StreamedWiper, WipeStats, Wiper},
+        Bdev,
+        VerboseError,
+    },
+    grpc::{rpc_submit, GrpcClientContext, Serializer},
+    lvs::{Error as LvsError, Lvol, Lvs, LvsLvol},
+};
+use ::function_name::named;
+use mayastor_api::v1::test::{
+    wipe_options::WipeMethod,
+    wipe_replica_request,
+    StreamWipeOptions,
+    TestRpc,
+    WipeReplicaRequest,
+    WipeReplicaResponse,
+};
+use nix::errno::Errno;
+use std::convert::{TryFrom, TryInto};
+use tokio_stream::wrappers::ReceiverStream;
+use tonic::{Request, Response, Status};
+
+#[derive(Debug, Clone)]
+pub struct TestService {
+    #[allow(unused)]
+    name: String,
+    replica_svc: super::replica::ReplicaService,
+}
+
+impl TestService {
+    pub fn new(replica_svc: super::replica::ReplicaService) -> Self {
+        Self {
+            name: String::from("TestSvc"),
+            replica_svc,
+        }
+    }
+}
+
+#[tonic::async_trait]
+impl TestRpc for TestService {
+    type WipeReplicaStream =
+        ReceiverStream<Result<WipeReplicaResponse, Status>>;
+
+    #[named]
+    async fn wipe_replica(
+        &self,
+        request: Request<WipeReplicaRequest>,
+    ) -> Result<Response<Self::WipeReplicaStream>, Status> {
+        // This is to avoid having to use a trampoline to send channels between
+        // different reactors.
+        let max_chunks = 1024;
+        let (tx, rx) = tokio::sync::mpsc::channel(max_chunks);
+
+        let replica_svc = self.replica_svc.clone();
+        let tx_cln = tx.clone();
+        let options = crate::core::wiper::StreamWipeOptions::try_from(
+            &request.get_ref().wipe_options,
+        )?;
+        let uuid = request.get_ref().uuid.clone();
+
+        crate::core::spawn(async move {
+            let result = replica_svc
+                .locked(
+                    GrpcClientContext::new(&request, function_name!()),
+                    async move {
+                        let args = request.into_inner();
+                        info!("{:?}", args);
+                        let rx = rpc_submit(async move {
+                            let lvol = Bdev::lookup_by_uuid_str(&args.uuid)
+                                .ok_or(LvsError::InvalidBdev {
+                                    source: BdevError::BdevNotFound {
+                                        name: args.uuid.clone(),
+                                    },
+                                    name: args.uuid,
+                                })
+                                .and_then(Lvol::try_from)?;
+                            validate_pool(&lvol, args.pool)?;
+
+                            let wiper = lvol.wiper(options.wipe_method)?;
+
+                            let proto_stream = WiperStream(tx_cln);
+                            let wiper = StreamedWiper::new(
+                                wiper,
+                                options.chunk_size,
+                                max_chunks,
+                                proto_stream,
+                            )?;
+                            let final_stats = wiper.wipe().await?;
+                            final_stats.log();
+                            Result::<(), LvsError>::Ok(())
+                        })?;
+                        rx.await
+                            .map_err(|_| Status::cancelled("cancelled"))?
+                            .map_err(Status::from)
+                    },
+                )
+                .await;
+            if tx.is_closed() {
+                tracing::error!("Wipe of {uuid} aborted: client disconnected");
+            } else if let Err(error) = result {
+                tracing::error!("Wipe of {uuid} failed: {error}");
+                tx.send(Err(error)).await.ok();
+            }
+        });
+
+        Ok(Response::new(ReceiverStream::new(rx)))
+    }
+}
+
+impl TryFrom<&Option<StreamWipeOptions>>
+    for crate::core::wiper::StreamWipeOptions
+{
+    type Error = tonic::Status;
+
+    fn try_from(
+        value: &Option<StreamWipeOptions>,
+    ) -> Result<Self, Self::Error> {
+        let Some(wipe) = value else {
+            return Err(tonic::Status::invalid_argument("Missing StreamWipeOptions"));
+        };
+        let Some(options) = &wipe.options else {
+            return Err(tonic::Status::invalid_argument("Missing WipeOptions"));
+        };
+
+        Ok(crate::core::wiper::StreamWipeOptions {
+            chunk_size: wipe.chunk_size,
+            wipe_method: {
+                let method = WipeMethod::from_i32(options.wipe_method).ok_or(
+                    tonic::Status::invalid_argument("Invalid Wipe Method"),
+                )?;
+                Wiper::supported(match method {
+                    WipeMethod::None => crate::core::wiper::WipeMethod::None,
+                    WipeMethod::WriteZeroes => {
+                        crate::core::wiper::WipeMethod::WriteZeroes
+                    }
+                    WipeMethod::Unmap => crate::core::wiper::WipeMethod::Unmap,
+                    WipeMethod::WritePattern => {
+                        crate::core::wiper::WipeMethod::WritePattern(
+                            options.write_pattern.unwrap_or(0xdeadbeef),
+                        )
+                    }
+                })
+                .map_err(|error| {
+                    tonic::Status::invalid_argument(error.to_string())
+                })?
+            },
+        })
+    }
+}
+
+impl From<&WipeStats> for WipeReplicaResponse {
+    fn from(value: &WipeStats) -> Self {
+        Self {
+            uuid: value.uuid.to_string(),
+            total_bytes: value.total_bytes,
+            chunk_size: value.chunk_size_bytes,
+            last_chunk_size: value
+                .extra_chunk_size_bytes
+                .unwrap_or(value.chunk_size_bytes),
+            total_chunks: value.total_chunks,
+            wiped_bytes: value.wiped_bytes,
+            wiped_chunks: value.wiped_chunks,
+            remaining_bytes: value.total_bytes - value.wiped_bytes,
+            since: value.since.and_then(|d| TryInto::try_into(d).ok()),
+        }
+    }
+}
+
+impl From<WipeError> for tonic::Status {
+    fn from(value: WipeError) -> Self {
+        match value {
+            WipeError::TooManyChunks {
+                ..
+            } => Self::invalid_argument(value.to_string()),
+            WipeError::ChunkTooLarge {
+                ..
+            } => Self::invalid_argument(value.to_string()),
+            WipeError::ZeroBdev {
+                ..
+            } => Self::invalid_argument(value.to_string()),
+            WipeError::ChunkBlockSizeInvalid {
+                ..
+            } => Self::invalid_argument(value.to_string()),
+            WipeError::WipeIoFailed {
+                ..
+            } => Self::data_loss(value.verbose()),
+            WipeError::MethodUnimplemented {
+                ..
+            } => Self::invalid_argument(value.to_string()),
+            WipeError::ChunkNotifyFailed {
+                ..
+            } => Self::internal(value.to_string()),
+            WipeError::WipeAborted {
+                ..
+            } => Self::aborted(value.to_string()),
+        }
+    }
+}
+
+/// Validate that the specified pool contains the specified lvol.
+fn validate_pool(
+    lvol: &Lvol,
+    pool: Option<wipe_replica_request::Pool>,
+) -> Result<(), LvsError> {
+    let Some(pool) = pool else {
+        return Ok(());
+    };
+
+    let lvs = lookup_pool(pool)?;
+    if lvol.lvs().uuid() == lvs.uuid() && lvol.lvs().name() == lvs.name() {
+        return Ok(());
+    }
+
+    let msg = format!("Specified {lvs:?} does match the target {lvol:?}!");
+    tracing::error!("{msg}");
+    Err(LvsError::Invalid {
+        source: Errno::EINVAL,
+        msg,
+    })
+}
+fn lookup_pool(pool: wipe_replica_request::Pool) -> Result<Lvs, LvsError> {
+    match pool {
+        wipe_replica_request::Pool::PoolUuid(uuid) => {
+            Lvs::lookup_by_uuid(&uuid).ok_or(LvsError::PoolNotFound {
+                source: Errno::ENOMEDIUM,
+                msg: format!("Pool uuid={uuid} is not loaded"),
+            })
+        }
+        wipe_replica_request::Pool::PoolName(name) => {
+            Lvs::lookup(&name).ok_or(LvsError::PoolNotFound {
+                source: Errno::ENOMEDIUM,
+                msg: format!("Pool name={name} is not loaded"),
+            })
+        }
+    }
+}
+
+struct WiperStream(
+    tokio::sync::mpsc::Sender<Result<WipeReplicaResponse, tonic::Status>>,
+);
+impl crate::core::wiper::NotifyStream for WiperStream {
+    fn notify(&self, stats: &WipeStats) -> Result<(), String> {
+        let response = WipeReplicaResponse::from(stats);
+        // `send()` may get stuck if we send/receive from different reactors so
+        // for now let's simply use try_send, which will fail if the max
+        // buffers are reached.
+        self.0.try_send(Ok(response)).map_err(|e| e.to_string())
+    }
+
+    fn is_closed(&self) -> bool {
+        self.0.is_closed()
+    }
+}

--- a/io-engine/src/lvs/lvs_error.rs
+++ b/io-engine/src/lvs/lvs_error.rs
@@ -150,6 +150,10 @@ pub enum Error {
         attr: String,
         name: String,
     },
+    #[snafu(display("Failed to wipe the replica"))]
+    WipeFailed {
+        source: crate::core::wiper::Error,
+    },
 }
 
 /// Map CoreError to errno code.
@@ -231,6 +235,17 @@ impl ToErrno for Error {
             Self::SetXAttr {
                 source, ..
             } => source,
+            Self::WipeFailed {
+                ..
+            } => Errno::EINVAL,
+        }
+    }
+}
+
+impl From<crate::core::wiper::Error> for Error {
+    fn from(source: crate::core::wiper::Error) -> Self {
+        Self::WipeFailed {
+            source,
         }
     }
 }

--- a/io-engine/tests/wipe.rs
+++ b/io-engine/tests/wipe.rs
@@ -1,0 +1,314 @@
+use futures::StreamExt;
+use io_engine_tests::{
+    compose::{
+        rpc::v1::{GrpcConnect, RpcHandle},
+        Binary,
+        Builder,
+        ComposeTest,
+    },
+    dd_urandom_blkdev,
+    nvme::{list_mayastor_nvme_devices, NmveConnectGuard},
+    pool::PoolBuilder,
+    replica::ReplicaBuilder,
+};
+
+use mayastor_api::{
+    v1 as v1_rpc,
+    v1::{
+        replica::Replica,
+        test::{wipe_options::WipeMethod, WipeReplicaResponse},
+    },
+};
+
+const REPLICA_NAME: &str = "r1";
+const REPLICA_UUID: &str = "e962fb16-acf2-4cde-bf50-3655b0381efa";
+mod common;
+
+#[tokio::test]
+async fn replica_wipe() {
+    common::composer_init();
+
+    std::env::set_var("NEXUS_NVMF_ANA_ENABLE", "1");
+    std::env::set_var("NEXUS_NVMF_RESV_ENABLE", "1");
+    // create a new composeTest
+    let test = Builder::new()
+        .name("replica_wipe")
+        .network("10.1.0.0/16")
+        .unwrap()
+        .add_container_bin(
+            "ms1",
+            Binary::from_dbg("io-engine").with_bind("/tmp", "/host/tmp"),
+        )
+        .with_clean(true)
+        .with_logs(false)
+        .build()
+        .await
+        .unwrap();
+    let mut replica_builder = create_pool_replica(&test).await;
+
+    let grpc = GrpcConnect::new(&test);
+    let mut ms = grpc.grpc_handle("ms1").await.unwrap();
+
+    let replica = replica_builder.create().await.unwrap();
+    let replica_size = 1024 * 1024 * 1024;
+    assert_eq!(replica_size, replica.size);
+    let tests = vec![
+        TestWipeReplica {
+            wipe_method: WipeMethod::None,
+            chunk_size: 0,
+            expected_chunk_size: replica.size,
+            expected_last_chunk_size: replica.size,
+            expected_notifications: 2,
+            expected_successes: 2,
+        },
+        TestWipeReplica {
+            wipe_method: WipeMethod::None,
+            chunk_size: replica.size,
+            expected_chunk_size: replica.size,
+            expected_last_chunk_size: replica.size,
+            expected_notifications: 2,
+            expected_successes: 2,
+        },
+        TestWipeReplica {
+            wipe_method: WipeMethod::None,
+            chunk_size: 512 * 1024 * 1024,
+            expected_chunk_size: 512 * 1024 * 1024,
+            expected_last_chunk_size: 512 * 1024 * 1024,
+            expected_notifications: 3,
+            expected_successes: 3,
+        },
+        TestWipeReplica {
+            wipe_method: WipeMethod::None,
+            chunk_size: 500 * 1024 * 1024,
+            expected_chunk_size: 500 * 1024 * 1024,
+            expected_last_chunk_size: 24 * 1024 * 1024,
+            expected_notifications: 4,
+            expected_successes: 4,
+        },
+        TestWipeReplica {
+            wipe_method: WipeMethod::None,
+            chunk_size: 500 * 1024 * 1024 + 512,
+            expected_chunk_size: 500 * 1024 * 1024 + 512,
+            expected_last_chunk_size: 24 * 1024 * 1024 - 2 * 512,
+            expected_notifications: 4,
+            expected_successes: 4,
+        },
+        TestWipeReplica {
+            wipe_method: WipeMethod::None,
+            chunk_size: 500 * 1024 * 1024 + 500, // 500 % 512 != 0
+            expected_chunk_size: 0,
+            expected_last_chunk_size: 0,
+            expected_notifications: 1,
+            expected_successes: 0,
+        },
+        TestWipeReplica {
+            wipe_method: WipeMethod::None,
+            chunk_size: 1024 * 1024, // too many chunks!
+            expected_chunk_size: 0,
+            expected_last_chunk_size: 0,
+            expected_notifications: 1,
+            expected_successes: 0,
+        },
+    ];
+
+    for test in tests {
+        validate_wipe_replica(&mut ms, &replica, test).await;
+    }
+    replica_builder.destroy().await.unwrap();
+    let nvmf_location = replica_builder.nvmf_location();
+
+    // Create a smaller replica to validate write_zero wiping!
+    let replica = replica_builder
+        .with_size_mb(4)
+        .with_nvmf()
+        .create()
+        .await
+        .unwrap();
+
+    let _nvme_guard =
+        NmveConnectGuard::connect_addr(&nvmf_location.addr, &nvmf_location.nqn);
+    let device = nvme_device();
+
+    let mb = 1024 * 1024;
+    // already zeroed up to 8MiB after creation!
+    io_engine_tests::compare_devices(&device, "/dev/zero", 4 * mb, true);
+
+    assert_eq!(dd_urandom_blkdev(&device), 0);
+    io_engine_tests::compare_devices(&device, "/dev/zero", 4 * mb, false);
+
+    wipe_replica(&mut ms, &replica, WipeMethod::None, mb).await;
+    io_engine_tests::compare_devices(&device, "/dev/zero", mb, false);
+
+    wipe_replica(&mut ms, &replica, WipeMethod::WriteZeroes, mb).await;
+    io_engine_tests::compare_devices(&device, "/dev/zero", mb, true);
+
+    io_engine_tests::compare_devices(&device, "/dev/zero", 4 * mb, true);
+}
+
+fn nvme_device() -> String {
+    let nvme_ms = list_mayastor_nvme_devices();
+    assert_eq!(nvme_ms.len(), 1);
+    format!("/dev/{}", nvme_ms[0].device)
+}
+
+#[derive(Debug)]
+struct TestWipeReplica {
+    wipe_method: WipeMethod,
+    chunk_size: u64,
+    expected_chunk_size: u64,
+    expected_last_chunk_size: u64,
+    expected_notifications: usize,
+    expected_successes: usize,
+}
+
+async fn wipe_replica(
+    ms: &mut RpcHandle,
+    replica: &Replica,
+    wipe_method: WipeMethod,
+    chunk_size: u64,
+) {
+    let response =
+        issue_wipe_replica(ms, replica, wipe_method, chunk_size).await;
+    let stream = response.into_inner();
+    let responses = collect_stream(stream).await;
+    let last = responses.last();
+    assert!(last.is_some());
+    assert!(last.unwrap().is_ok());
+    assert_eq!(last.unwrap().as_ref().unwrap().remaining_bytes, 0);
+}
+
+async fn validate_wipe_replica(
+    ms: &mut RpcHandle,
+    replica: &Replica,
+    wipe: TestWipeReplica,
+) {
+    let response =
+        issue_wipe_replica(ms, replica, wipe.wipe_method, wipe.chunk_size)
+            .await;
+    let stream = response.into_inner();
+    let responses = collect_stream(stream).await;
+    let oks = responses
+        .iter()
+        .filter_map(|r| r.as_ref().ok())
+        .collect::<Vec<_>>();
+    let errs = responses
+        .iter()
+        .filter_map(|r| r.as_ref().err())
+        .collect::<Vec<_>>();
+    assert_eq!(responses.len(), wipe.expected_notifications, "{wipe:#?}");
+    assert_eq!(oks.len(), wipe.expected_successes, "{wipe:#?}");
+    assert_eq!(
+        errs.len(),
+        wipe.expected_notifications - wipe.expected_successes,
+        "{wipe:#?}"
+    );
+
+    if let Some(ok) = oks.last() {
+        assert_eq!(ok.remaining_bytes, 0, "{wipe:#?}");
+    }
+
+    let mut expected_chunks = 0;
+    // validate all up to the last one!
+    if !oks.is_empty() {
+        for ok in oks.iter().take(oks.len() - 1) {
+            assert_eq!(ok.chunk_size, wipe.expected_chunk_size, "{wipe:#?}");
+            assert_eq!(ok.wiped_chunks, expected_chunks, "{wipe:#?}");
+            assert_eq!(
+                ok.remaining_bytes,
+                replica.size - expected_chunks * wipe.expected_chunk_size,
+                "{wipe:#?}"
+            );
+            assert_eq!(
+                ok.wiped_bytes,
+                expected_chunks * wipe.expected_chunk_size,
+                "{wipe:#?}"
+            );
+            assert_eq!(
+                ok.last_chunk_size, wipe.expected_last_chunk_size,
+                "{wipe:#?}"
+            );
+            expected_chunks += 1;
+        }
+        if wipe.expected_chunk_size != wipe.expected_last_chunk_size {
+            assert_eq!(
+                replica.size - (expected_chunks - 1) * wipe.expected_chunk_size,
+                wipe.expected_last_chunk_size,
+                "{wipe:#?}"
+            );
+        }
+    }
+
+    if let Some(ok) = oks.last() {
+        assert_eq!(ok.chunk_size, wipe.expected_chunk_size, "{wipe:#?}");
+        assert_eq!(ok.wiped_chunks, expected_chunks, "{wipe:#?}");
+        assert_eq!(
+            ok.last_chunk_size, wipe.expected_last_chunk_size,
+            "{wipe:#?}"
+        );
+        assert_eq!(ok.remaining_bytes, 0, "{wipe:#?}");
+        assert_eq!(
+            ok.wiped_bytes,
+            (expected_chunks - 1) * wipe.expected_chunk_size
+                + wipe.expected_last_chunk_size,
+            "{wipe:#?}"
+        );
+    }
+}
+
+async fn collect_stream(
+    mut stream: tonic::Streaming<WipeReplicaResponse>,
+) -> Vec<Result<WipeReplicaResponse, tonic::Status>> {
+    let mut responses = vec![];
+    while let Some(response) = stream.next().await {
+        println!("{response:?}");
+        responses.push(response);
+    }
+    responses
+}
+
+async fn issue_wipe_replica(
+    ms: &mut RpcHandle,
+    replica: &Replica,
+    wipe_method: WipeMethod,
+    chunk_size: u64,
+) -> tonic::Response<tonic::Streaming<WipeReplicaResponse>> {
+    let replica = replica.clone();
+    ms.test
+        .wipe_replica(v1_rpc::test::WipeReplicaRequest {
+            uuid: replica.uuid,
+            pool: Some(v1_rpc::test::wipe_replica_request::Pool::PoolUuid(
+                replica.pooluuid,
+            )),
+            wipe_options: Some(v1_rpc::test::StreamWipeOptions {
+                options: Some(v1_rpc::test::WipeOptions {
+                    wipe_method: wipe_method as i32,
+                    write_pattern: None,
+                }),
+                chunk_size,
+            }),
+        })
+        .await
+        .unwrap()
+}
+
+async fn create_pool_replica(test: &ComposeTest) -> ReplicaBuilder {
+    const POOL_SIZE_MB: u64 = 1100;
+    const REPL_SIZE_MB: u64 = 1024;
+
+    let grpc = GrpcConnect::new(test);
+    let ms = grpc.grpc_handle_shared("ms1").await.unwrap();
+
+    let mut pool = PoolBuilder::new(ms.clone())
+        .with_name("pool0")
+        .with_new_uuid()
+        .with_malloc("mem0", POOL_SIZE_MB);
+
+    let repl_0 = ReplicaBuilder::new(ms.clone())
+        .with_pool(&pool)
+        .with_name(REPLICA_NAME)
+        .with_uuid(REPLICA_UUID)
+        .with_size_mb(REPL_SIZE_MB)
+        .with_thin(false);
+    pool.create().await.unwrap();
+    repl_0
+}


### PR DESCRIPTION
    feat(wipe/replica): add rpc to a wipe a replica using methods
    
    Adds test rpc to wipe replica using streaming on the server side which allows the client
    to receive updates as the wipe is ongoing. This is mainly useful for large replicas
    which may take a very long time to wipe!
    
    We provide a few wipe methods, none, zero, unmap and pattern but only none and zero
    are implement for now.
    
    The cli was also updated:
    ❯ io-engine-client test wipe replica 1d8c0749-c5fc-45b0-addc-f9f037c2da3f -c 100MiB -m WriteZeroes
    UUID                                  TOTAL_BYTES  CHUNK_SIZE  LAST_CHUNK_SIZE  TOTAL_CHUNKS  WIPED_BYTES  WIPED_CHUNKS  REMAINING_BYTES  BANDWIDTH
    1d8c0749-c5fc-45b0-addc-f9f037c2da3f  1024.00 MiB  100.00 MiB  24.00 MiB        11            0 B          0             1024.00 MiB      ??       
    1d8c0749-c5fc-45b0-addc-f9f037c2da3f  1024.00 MiB  100.00 MiB  24.00 MiB        11            100.00 MiB   1             924.00 MiB       258.36 MiB/s
    1d8c0749-c5fc-45b0-addc-f9f037c2da3f  1024.00 MiB  100.00 MiB  24.00 MiB        11            200.00 MiB   2             824.00 MiB       263.32 MiB/s
    1d8c0749-c5fc-45b0-addc-f9f037c2da3f  1024.00 MiB  100.00 MiB  24.00 MiB        11            300.00 MiB   3             724.00 MiB       260.81 MiB/s
    1d8c0749-c5fc-45b0-addc-f9f037c2da3f  1024.00 MiB  100.00 MiB  24.00 MiB        11            400.00 MiB   4             624.00 MiB       262.16 MiB/s
    1d8c0749-c5fc-45b0-addc-f9f037c2da3f  1024.00 MiB  100.00 MiB  24.00 MiB        11            500.00 MiB   5             524.00 MiB       265.00 MiB/s
    1d8c0749-c5fc-45b0-addc-f9f037c2da3f  1024.00 MiB  100.00 MiB  24.00 MiB        11            600.00 MiB   6             424.00 MiB       261.61 MiB/s
    1d8c0749-c5fc-45b0-addc-f9f037c2da3f  1024.00 MiB  100.00 MiB  24.00 MiB        11            700.00 MiB   7             324.00 MiB       262.06 MiB/s
    1d8c0749-c5fc-45b0-addc-f9f037c2da3f  1024.00 MiB  100.00 MiB  24.00 MiB        11            800.00 MiB   8             224.00 MiB       261.64 MiB/s
    1d8c0749-c5fc-45b0-addc-f9f037c2da3f  1024.00 MiB  100.00 MiB  24.00 MiB        11            900.00 MiB   9             124.00 MiB       261.20 MiB/s
    1d8c0749-c5fc-45b0-addc-f9f037c2da3f  1024.00 MiB  100.00 MiB  24.00 MiB        11            1000.00 MiB  10            24.00 MiB        262.80 MiB/s
    1d8c0749-c5fc-45b0-addc-f9f037c2da3f  1024.00 MiB  100.00 MiB  24.00 MiB        11            1024.00 MiB  11            0 B              263.18 MiB/s

    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    fix(loopback): dispatch bdev removed using bdev name
    
    Send it with the actual bdev name and not the uri name.
    This fixes things when we have a bdev with name and uuid and we create
    it with the uuid instead of the name.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>
