### PR TITLE
fix(snapshot/pool): get committed bytes from lvol committed

### DIFF
--- a/io-engine/src/core/logical_volume.rs
+++ b/io-engine/src/core/logical_volume.rs
@@ -28,6 +28,9 @@ pub trait LogicalVolume {
     /// Return the size of the Logical Volume in bytes
     fn size(&self) -> u64;
 
+    /// Return the committed size of the Logical Volume in bytes.
+    fn committed(&self) -> u64;
+
     /// Returns Lvol disk space usage
     fn usage(&self) -> LvolSpaceUsage;
 }

--- a/io-engine/src/lvs/lvs_lvol.rs
+++ b/io-engine/src/lvs/lvs_lvol.rs
@@ -637,9 +637,17 @@ impl LogicalVolume for Lvol {
         unsafe { spdk_blob_is_read_only(self.blob_checked()) }
     }
 
-    /// Return the size of the Snapshot in bytes.
+    /// Return the size of the Logical Volume in bytes.
     fn size(&self) -> u64 {
         self.as_bdev().size_in_bytes()
+    }
+
+    /// Return the committed size of the Logical Volume in bytes.
+    fn committed(&self) -> u64 {
+        match self.is_snapshot() {
+            true => self.usage().allocated_bytes,
+            false => self.size(),
+        }
     }
 
     /// Returns Lvol disk space usage.

--- a/io-engine/src/lvs/lvs_store.rs
+++ b/io-engine/src/lvs/lvs_store.rs
@@ -191,7 +191,7 @@ impl Lvs {
     /// returns committed size
     pub fn committed(&self) -> u64 {
         self.lvols()
-            .map_or(0, |vols| vols.fold(0, |acc, r| acc + r.size()))
+            .map_or(0, |vols| vols.fold(0, |acc, r| acc + r.committed()))
     }
 
     /// returns the base bdev of this lvs


### PR DESCRIPTION
If we simply get committed from size then we don't take into account that snapshot lvol's will not grow to their capacity.
Instead, add a specific committed fn to accrue the committed bytes.