### PR TITLE
feat(nvmf): adding support for configuring target CRD

### DIFF
--- a/io-engine-tests/src/nexus.rs
+++ b/io-engine-tests/src/nexus.rs
@@ -15,6 +15,7 @@ use super::{
             RebuildHistoryRecord,
             RebuildHistoryRequest,
             RemoveChildNexusRequest,
+            ShutdownNexusRequest,
         },
         SharedRpcHandle,
         Status,
@@ -177,6 +178,18 @@ impl NexusBuilder {
             })
             .await
             .map(|r| r.into_inner().nexus.unwrap())
+    }
+
+    pub async fn shutdown(&mut self) -> Result<(), Status> {
+        self.rpc()
+            .lock()
+            .await
+            .nexus
+            .shutdown_nexus(ShutdownNexusRequest {
+                uuid: self.uuid(),
+            })
+            .await
+            .map(|_| ())
     }
 
     pub async fn destroy(&mut self) -> Result<(), Status> {

--- a/io-engine-tests/src/nvmf.rs
+++ b/io-engine-tests/src/nvmf.rs
@@ -77,7 +77,7 @@ pub async fn test_fio_to_nvmf(
     nvmf: &NvmfLocation,
     mut fio: Fio,
 ) -> std::io::Result<()> {
-    let tgt = nvmf.as_args().join(" ");
+    let tgt = format!("'{}'", nvmf.as_args().join(" "));
 
     fio.jobs = fio
         .jobs

--- a/io-engine/src/core/bdev.rs
+++ b/io-engine/src/core/bdev.rs
@@ -240,7 +240,9 @@ where
             Some(Protocol::Nvmf) => {
                 if let Some(ss) = NvmfSubsystem::nqn_lookup(self.name()) {
                     ss.stop().await.context(UnshareNvmf {})?;
-                    ss.destroy();
+                    unsafe {
+                        ss.shutdown_unsafe();
+                    }
                 }
             }
             Some(Protocol::Off) | None => {}

--- a/io-engine/src/core/env.rs
+++ b/io-engine/src/core/env.rs
@@ -164,6 +164,13 @@ pub struct MayastorCliArgs {
     #[structopt(short = "T", long = "tgt-iface", env = "NVMF_TGT_IFACE")]
     /// NVMF target interface (ip, mac, name or subnet).
     pub nvmf_tgt_interface: Option<String>,
+    /// NVMF target Command Retry Delay.
+    #[structopt(
+        long = "tgt-crdt",
+        env = "NVMF_TGT_CRDT",
+        default_value = "30"
+    )]
+    pub nvmf_tgt_crdt: u16,
     /// api Version
     #[structopt(
         long,
@@ -230,6 +237,7 @@ impl Default for MayastorCliArgs {
             nvme_ctl_io_ctx_pool_size: 65535,
             registration_endpoint: None,
             nvmf_tgt_interface: None,
+            nvmf_tgt_crdt: 30,
             api_versions: vec![ApiVersion::V0, ApiVersion::V1],
             diagnose_stack: None,
             reactor_freeze_detection: false,
@@ -328,6 +336,7 @@ pub struct MayastorEnvironment {
     bdev_io_ctx_pool_size: u64,
     nvme_ctl_io_ctx_pool_size: u64,
     nvmf_tgt_interface: Option<String>,
+    pub nvmf_tgt_crdt: u16,
     api_versions: Vec<ApiVersion>,
 }
 
@@ -372,6 +381,7 @@ impl Default for MayastorEnvironment {
             bdev_io_ctx_pool_size: 65535,
             nvme_ctl_io_ctx_pool_size: 65535,
             nvmf_tgt_interface: None,
+            nvmf_tgt_crdt: 30,
             api_versions: vec![ApiVersion::V0, ApiVersion::V1],
         }
     }
@@ -489,6 +499,7 @@ impl MayastorEnvironment {
             bdev_io_ctx_pool_size: args.bdev_io_ctx_pool_size,
             nvme_ctl_io_ctx_pool_size: args.nvme_ctl_io_ctx_pool_size,
             nvmf_tgt_interface: args.nvmf_tgt_interface,
+            nvmf_tgt_crdt: args.nvmf_tgt_crdt,
             api_versions: args.api_versions,
             ..Default::default()
         }

--- a/io-engine/src/subsys/config/opts.rs
+++ b/io-engine/src/subsys/config/opts.rs
@@ -27,6 +27,8 @@ use std::{
     str::FromStr,
 };
 
+use crate::core::MayastorEnvironment;
+
 pub trait GetOpts {
     fn get(&self) -> Self;
     fn set(&self) -> bool {
@@ -78,6 +80,8 @@ pub struct NvmfTgtConfig {
     pub name: String,
     /// the max number of namespaces this target should allow for
     pub max_namespaces: u32,
+    /// Command Retry Delay.
+    pub crdt: u16,
     /// TCP transport options
     pub opts: NvmfTcpTransportOpts,
 }
@@ -87,15 +91,18 @@ impl From<NvmfTgtConfig> for Box<spdk_nvmf_target_opts> {
         let mut out = Self::default();
         copy_str_with_null(&o.name, &mut out.name);
         out.max_subsystems = o.max_namespaces;
+        out.crdt[0] = o.crdt;
         out
     }
 }
 
 impl Default for NvmfTgtConfig {
     fn default() -> Self {
+        let args = MayastorEnvironment::global_or_default();
         Self {
             name: "mayastor_target".to_string(),
             max_namespaces: 2048,
+            crdt: args.nvmf_tgt_crdt,
             opts: NvmfTcpTransportOpts::default(),
         }
     }

--- a/io-engine/src/target/nvmf.rs
+++ b/io-engine/src/target/nvmf.rs
@@ -26,7 +26,9 @@ where
 pub async fn unshare(uuid: &str) -> Result<(), NvmfError> {
     if let Some(ss) = NvmfSubsystem::nqn_lookup(uuid) {
         ss.stop().await?;
-        ss.destroy();
+        unsafe {
+            ss.shutdown_unsafe();
+        }
     }
     Ok(())
 }

--- a/io-engine/tests/nexus_fail_crd.rs
+++ b/io-engine/tests/nexus_fail_crd.rs
@@ -1,0 +1,229 @@
+pub mod common;
+
+use std::{sync::Arc, time::Duration};
+use tokio::sync::{
+    oneshot,
+    oneshot::{Receiver, Sender},
+};
+
+use common::{
+    compose::{
+        rpc::v1::{GrpcConnect, SharedRpcHandle},
+        Binary,
+        Builder,
+    },
+    fio::{Fio, FioJob},
+    nexus::NexusBuilder,
+    nvme::{find_mayastor_nvme_device_path, NmveConnectGuard},
+    pool::PoolBuilder,
+    replica::ReplicaBuilder,
+    test::{add_fault_injection, remove_fault_injection},
+};
+
+const POOL_SIZE: u64 = 500;
+const REPL_SIZE: u64 = 450;
+const NEXUS_NAME: &str = "nexus_0";
+const NEXUS_SIZE: u64 = REPL_SIZE;
+const NEXUS_UUID: &str = "bbe6cbb6-c508-443a-877a-af5fa690c760";
+
+/// Tests that without CRD enabled, initiator would eventually fail I/Os.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn nexus_fail_no_crd() {
+    test_nexus_fail("0")
+        .await
+        .expect_err("I/O expected to fail");
+}
+
+/// Tests that CRD properly delays I/O retries on initiator, while the target
+/// has a chance to replace a failed nexus.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn nexus_fail_crd() {
+    test_nexus_fail("20")
+        .await
+        .expect("I/O expected to succeed");
+}
+
+async fn test_nexus_fail(crdt: &str) -> std::io::Result<()> {
+    common::composer_init();
+
+    let test = Builder::new()
+        .name("cargo-test")
+        .network("10.1.0.0/16")
+        .unwrap()
+        .add_container_bin(
+            "ms_0",
+            Binary::from_dbg("io-engine").with_args(vec!["-l", "5"]),
+        )
+        .add_container_bin(
+            "ms_nex",
+            Binary::from_dbg("io-engine").with_args(vec![
+                "-l",
+                "1,2,3,4",
+                "--tgt-crdt",
+                crdt,
+            ]),
+        )
+        .with_clean(true)
+        .build()
+        .await
+        .unwrap();
+
+    let test = Arc::new(test);
+
+    let conn = GrpcConnect::new(&test);
+
+    let ms_0 = conn.grpc_handle_shared("ms_0").await.unwrap();
+    let ms_nex = conn.grpc_handle_shared("ms_nex").await.unwrap();
+
+    let mut pool_0 = PoolBuilder::new(ms_0.clone())
+        .with_name("pool0")
+        .with_new_uuid()
+        .with_malloc("mem0", POOL_SIZE);
+
+    let mut repl_0 = ReplicaBuilder::new(ms_0.clone())
+        .with_pool(&pool_0)
+        .with_name("r0")
+        .with_new_uuid()
+        .with_size_mb(REPL_SIZE)
+        .with_thin(false);
+
+    pool_0.create().await.unwrap();
+    repl_0.create().await.unwrap();
+    repl_0.share().await.unwrap();
+
+    let mut nex_0 = NexusBuilder::new(ms_nex.clone())
+        .with_name(NEXUS_NAME)
+        .with_uuid(NEXUS_UUID)
+        .with_size_mb(NEXUS_SIZE)
+        .with_replica(&repl_0);
+
+    nex_0.create().await.unwrap();
+    nex_0.publish().await.unwrap();
+
+    let children = nex_0.get_nexus().await.unwrap().children;
+    let dev_name = children[0].device_name.as_ref().unwrap();
+
+    let inj = "domain=nexus&op=write&offset=0";
+    let inj_w = format!("inject://{dev_name}?{inj}");
+
+    let inj = "domain=nexus&op=read&offset=0";
+    let inj_r = format!("inject://{dev_name}?{inj}");
+
+    let cfg = JobCfg {
+        ms_nex: ms_nex.clone(),
+        nex_0: nex_0.clone(),
+        repl_0: repl_0.clone(),
+        inj_w: inj_w.clone(),
+        inj_r: inj_r.clone(),
+    };
+
+    // Run two tasks in parallel, I/O and nexus management.
+    let (s, r) = oneshot::channel();
+
+    let j0 = tokio::spawn({
+        let cfg = cfg.clone();
+        async move { run_io_task(s, cfg).await }
+    });
+    tokio::pin!(j0);
+
+    let j1 = tokio::spawn({
+        let cfg = cfg.clone();
+        async move {
+            run_manage_task(r, cfg).await;
+        }
+    });
+    tokio::pin!(j1);
+
+    let (io_res, _) = tokio::join!(j0, j1);
+    io_res.unwrap()
+}
+
+#[derive(Clone)]
+struct JobCfg {
+    ms_nex: SharedRpcHandle,
+    nex_0: NexusBuilder,
+    repl_0: ReplicaBuilder,
+    inj_w: String,
+    inj_r: String,
+}
+
+/// Runs multiple FIO I/O jobs.
+async fn run_io_task(s: Sender<()>, cfg: JobCfg) -> std::io::Result<()> {
+    let nvmf = cfg.nex_0.nvmf_location();
+    let _cg = NmveConnectGuard::connect_addr(&nvmf.addr, &nvmf.nqn);
+    let path = find_mayastor_nvme_device_path(&nvmf.serial)
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .to_string();
+
+    let jobs = (0 .. 10).map(|_| {
+        FioJob::new()
+            .with_direct(true)
+            .with_ioengine("libaio")
+            .with_iodepth(128)
+            .with_filename(&path)
+            .with_runtime(20)
+            .with_rw("randwrite")
+    });
+
+    let fio = Fio::new().with_jobs(jobs);
+
+    // Notify the nexus management task that connection is complete and I/O
+    // starts.
+    s.send(()).unwrap();
+
+    // Start FIO.
+    tokio::spawn(async move { fio.run() }).await.unwrap()
+}
+
+/// Manages the nexus in parallel to I/O task.
+/// [1] Nexus is failed by injecting a fault.
+/// [2] I/O running in parallel should freeze or fail, depending on how target's
+/// configured.
+/// [3] Nexus is recreated.
+async fn run_manage_task(r: Receiver<()>, cfg: JobCfg) {
+    let JobCfg {
+        ms_nex,
+        inj_w,
+        inj_r,
+        mut nex_0,
+        repl_0,
+        ..
+    } = cfg;
+
+    // Wait until I/O task connects and signals it is ready.
+    r.await.unwrap();
+
+    // Allow I/O to run for some time.
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    // Inject fault, so the nexus would fail.
+    add_fault_injection(ms_nex.clone(), &inj_w).await.unwrap();
+    add_fault_injection(ms_nex.clone(), &inj_r).await.unwrap();
+
+    // When nexus fails, I/O should be freezing due to CRD (if enabled).
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    // Destroy the nexus, remove injectios and re-create and re-publish the
+    // nexus with the same ID.
+    // I/O would eventually retry and the new nexus would run I/O.
+    nex_0.shutdown().await.unwrap();
+    nex_0.destroy().await.unwrap();
+
+    remove_fault_injection(ms_nex.clone(), &inj_w)
+        .await
+        .unwrap();
+    remove_fault_injection(ms_nex.clone(), &inj_r)
+        .await
+        .unwrap();
+
+    let mut nex_0 = NexusBuilder::new(ms_nex.clone())
+        .with_name(NEXUS_NAME)
+        .with_uuid(NEXUS_UUID)
+        .with_size_mb(NEXUS_SIZE)
+        .with_replica(&repl_0);
+
+    nex_0.create().await.unwrap();
+    nex_0.publish().await.unwrap();
+}

--- a/io-engine/tests/nvmf.rs
+++ b/io-engine/tests/nvmf.rs
@@ -79,7 +79,9 @@ fn nvmf_target() {
                     assert!(bdev.is_claimed());
                     assert_eq!(bdev.claimed_by().unwrap(), "NVMe-oF Target");
 
-                    s.destroy();
+                    unsafe {
+                        s.shutdown_unsafe();
+                    }
                     assert!(!bdev.is_claimed());
                     assert_eq!(bdev.claimed_by(), None);
                 }


### PR DESCRIPTION
This PR adds support to allow to specify target CRDT (Command Retry Delay) via CLI/env, to prevent immediate initiator failure when a nexus fails when the last nexus child fails. This provides a period to allow control plane to recreate the nexus.  The default is set to 30 sec.