### PR TITLE
fix(snapshot): reset usage cache for the parent lvol when snapshot is destroyed

### DIFF
--- a/io-engine/src/core/snapshot.rs
+++ b/io-engine/src/core/snapshot.rs
@@ -349,6 +349,14 @@ pub trait SnapshotOps {
         &self,
         total_ancestor_snap_size: u64,
     ) -> Option<u64>;
+
+    /// When snapshot is destroyed, reset the parent lvol usage cache and its
+    /// successor snapshot and clone usage cache.
+    fn reset_snapshot_parent_successor_usage_cache(&self);
+
+    /// When snapshot is destroyed, reset cache of successor snapshots and
+    /// clones based on snapshot parent uuid.
+    fn reset_successor_lvol_usage_cache(&self, snapshot_parent_uuid: String);
 }
 
 /// Traits gives the Snapshots Related Parameters.

--- a/io-engine/src/lvs/lvs_lvol.rs
+++ b/io-engine/src/lvs/lvs_lvol.rs
@@ -1016,6 +1016,7 @@ impl LvsLvol for Lvol {
             if snapshot_lvol.list_clones_by_snapshot_uuid().is_empty()
                 && snapshot_lvol.is_discarded_snapshot()
             {
+                snapshot_lvol.reset_snapshot_parent_successor_usage_cache();
                 snapshot_lvol.destroy().await?;
             }
         }

--- a/nix/pkgs/libspdk/default.nix
+++ b/nix/pkgs/libspdk/default.nix
@@ -56,13 +56,13 @@ let
   # 7. Copy SHA256 from 'got' of the error message to 'sha256' field.
   # 8. 'nix-shell' build must now succeed.
   drvAttrs = rec {
-    version = "23.01-716b1ed";
+    version = "23.01-6c81b80";
 
     src = fetchFromGitHub {
       owner = "openebs";
       repo = "spdk";
-      rev = "716b1ed489f1bc17698f7c4e5be347b0b7dc56ca";
-      sha256 = "sha256-Q9fwW8x4kPNslYjnlG08aZQ7aX8En92BAP6cXG81JaI=";
+      rev = "6c81b80f1f202160de57924549655813b28f7120";
+      sha256 = "sha256-Nwxpw25jffQ1srQh+rBNbX6z24YVAdvWg+r7nh2Ku4c=";
       fetchSubmodules = true;
     };
 


### PR DESCRIPTION
**Change Details:**
1. When snapshot is destroyed, reset the usage cache for parent lvol.

2. When snapshot is destroyed, reset the usage cache of successor snapshots (same parent) and clones.
 
3. When the last clone is destroyed and there are any discarded snapshots leftout, as part of destroying snapshot, reset the parent Lvol usage details from cache.
 
4. If discarded Snapshot destroy happens as part of pool import, also reset the parent Lvol usage details from cache.

**Why Changes Required**

Volume usage information should show properly when chain of snapshots and clones are deleted. Thin provisioned lvol cache information to be cleared to show the actual allocated size when any linked lvol (snapshot/clone) is destroyed.