### PR TITLE
fix(casperf): invalid next offset calculation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ test-yamls/*
 /node_modules
 artifacts/
 .idea
+.vscode
 **/.pytest_cache
 **/__pycache__
 /chart/charts/

--- a/io-engine/src/bdev/nexus/mod.rs
+++ b/io-engine/src/bdev/nexus/mod.rs
@@ -149,6 +149,11 @@ pub fn register_module() {
 /// so that a possible remove event from SPDK also results in bdev removal
 #[allow(clippy::needless_collect)]
 pub async fn shutdown_nexuses() {
+    if NexusModule::current_opt().is_none() {
+        info!("Skipping nexus shutdown - Nexus Module not registered...");
+        return;
+    }
+
     info!("Shutting down nexuses...");
 
     // TODO: We need to collect list of Nexuses before destroying them,

--- a/io-engine/src/bdev/nexus/nexus_module.rs
+++ b/io-engine/src/bdev/nexus/nexus_module.rs
@@ -21,12 +21,17 @@ pub(crate) struct NexusModule {}
 
 impl NexusModule {
     /// Returns Nexus Bdev module instance.
+    /// # Warning
     /// Panics if the Nexus module was not registered.
     pub fn current() -> BdevModule {
         match BdevModule::find_by_name(NEXUS_MODULE_NAME) {
             Ok(m) => m,
             Err(err) => panic!("{}", err),
         }
+    }
+    /// Returns Nexus Bdev module instance, if registered.
+    pub fn current_opt() -> Option<BdevModule> {
+        BdevModule::find_by_name(NEXUS_MODULE_NAME).ok()
     }
 }
 


### PR DESCRIPTION
Also add easy block size specification, eg: allows "1MiB". Disable cleanup of nexuses when they're not configured. Prevent double cleanup with duplicate handlers.