### PR TITLE
feat(build): updating to rust compiler 1.72.0 and latest tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,7 +128,7 @@ dependencies = [
  "serde_nanos",
  "serde_repr",
  "thiserror",
- "time 0.3.21",
+ "time",
  "tokio",
  "tokio-retry",
  "tokio-rustls",
@@ -489,18 +489,17 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.26"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
+checksum = "defd4e7873dbddba6c7c91e199c7fcb946abc4a6a4ac3195400bcfb01b5de877"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
  "serde",
- "time 0.1.45",
  "wasm-bindgen",
- "winapi",
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
@@ -767,9 +766,9 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.0.0"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f711ade317dd348950a9910f81c5947e3d8907ebd2b83f76203ff1807e6a2bc2"
+checksum = "622178105f911d937a42cdb140730ba4a3ed2becd8ae6ce39c7d28b5d75d4588"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1118,9 +1117,9 @@ dependencies = [
 
 [[package]]
 name = "fiat-crypto"
-version = "0.1.20"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e825f6987101665dea6ec934c09ec6d721de7bc1bf92248e1d5810c8cd636b77"
+checksum = "d0870c84016d4b481be5c9f323c24f65e31e901ae618f0e80f4308fb00de1d2d"
 
 [[package]]
 name = "fixedbitset"
@@ -1323,7 +1322,7 @@ checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
@@ -1739,6 +1738,7 @@ dependencies = [
  "hex",
  "http",
  "io-engine",
+ "io-engine-tests-macros",
  "io-uring",
  "ioctl-gen",
  "jsonrpc",
@@ -1782,6 +1782,15 @@ dependencies = [
  "url",
  "uuid 0.8.2",
  "version-info",
+]
+
+[[package]]
+name = "io-engine-tests-macros"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -2071,7 +2080,7 @@ checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys 0.45.0",
 ]
 
@@ -2190,9 +2199,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.32.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ac5bbd07aea88c60a577a1ce218075ffd59208b2d7ca97adf9bfc5aeb21ebe"
+checksum = "9cf5f9dd3933bd50a9e1f149ec995f39ae2c496d31fd772c1fd45ebc27e902b0"
 dependencies = [
  "memchr",
 ]
@@ -2375,9 +2384,9 @@ checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
 name = "platforms"
-version = "3.0.2"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3d7ddaed09e0eb771a79ab0fd64609ba0afb0a8366421957936ad14cbd13630"
+checksum = "4503fa043bf02cee09a9582e9554b4c6403b2ef55e4612e96561d294419429f8"
 
 [[package]]
 name = "plotters"
@@ -2817,9 +2826,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.6"
+version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1feddffcfcc0b33f5c6ce9a29e341e4cd59c3f78e7ee45f4a40c038b1d6cbb"
+checksum = "cd8d6c9f025a446bc4d18ad9632e69aec8f287aa84499ee335599fabd20c3fd8"
 dependencies = [
  "log",
  "ring",
@@ -2850,9 +2859,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.3"
+version = "0.101.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "261e9e0888cba427c3316e6322805653c9425240b6fd96cee7cb671ab70ab8d0"
+checksum = "7d93931baf2d282fff8d3a532bbfd7653f734643161b87e3e01e59a04439bf0d"
 dependencies = [
  "ring",
  "untrusted",
@@ -2941,9 +2950,9 @@ checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
 
 [[package]]
 name = "serde"
-version = "1.0.187"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a7fe14252655bd1e578af19f5fa00fe02fd0013b100ca6b49fde31c41bae4c"
+checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
 dependencies = [
  "serde_derive",
 ]
@@ -2960,9 +2969,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.187"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e46b2a6ca578b3f1d4501b12f78ed4692006d79d82a1a7c561c12dbc3d625eb8"
+checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3024,7 +3033,7 @@ dependencies = [
  "indexmap",
  "serde",
  "serde_json",
- "time 0.3.21",
+ "time",
 ]
 
 [[package]]
@@ -3366,17 +3375,6 @@ checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
 dependencies = [
  "cfg-if",
  "once_cell",
-]
-
-[[package]]
-name = "time"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
-dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
 ]
 
 [[package]]
@@ -3883,9 +3881,9 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50bff7831e19200a85b17131d085c25d7811bc4e186efdaf54bbd132994a88cb"
+checksum = "143b538f18257fac9cad154828a57c6bf5157e1aa604d4816b5995bf6de87ae5"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -3977,12 +3975,6 @@ dependencies = [
  "log",
  "try-lock",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 panic = "abort"
 
 [workspace]
+resolver="1"
 members = [
 	"jsonrpc",
 	"libnvme-rs",

--- a/io-engine-tests/Cargo.toml
+++ b/io-engine-tests/Cargo.toml
@@ -68,6 +68,7 @@ libnvme-rs = { path = "../libnvme-rs" }
 mayastor-api = { path = "../rpc/mayastor-api" }
 version-info = { path = "../utils/io-engine-dependencies/version-info" }
 io-engine = { path = "../io-engine" }
+io-engine-tests-macros = { path = "./io-engine-tests-macros" }
 
 [dependencies.serde]
 features = ["derive"]

--- a/io-engine-tests/io-engine-tests-macros/Cargo.toml
+++ b/io-engine-tests/io-engine-tests-macros/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "io-engine-tests-macros"
+version = "0.1.0"
+edition = "2018"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1.0.66"
+quote = "1.0.33"
+syn = { version = "2.0.29", features = ["extra-traits"] }

--- a/io-engine-tests/io-engine-tests-macros/src/lib.rs
+++ b/io-engine-tests/io-engine-tests-macros/src/lib.rs
@@ -1,0 +1,27 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, ItemFn};
+
+/// All tests marked with this attribute will run in the same single, specially
+/// designated thread. This allows one test to initialize SPDK and other tests
+/// to use SPDK, regardless of which system thread `cargo test` will assign
+/// to them.
+/// The test marked with thid attribute expands as a tokio async test.
+#[proc_macro_attribute]
+pub fn spdk_test(_args: TokenStream, item: TokenStream) -> TokenStream {
+    let item = parse_macro_input!(item as ItemFn);
+    let orig = item.clone();
+    let fn_ident = item.sig.ident;
+
+    quote! {
+        #[tokio::test]
+        async fn #fn_ident () {
+            #orig
+
+            io_engine_tests::test_task::run_single_thread_test_task(|| {
+                #fn_ident();
+            }).await;
+        }
+    }
+    .into()
+}

--- a/io-engine-tests/src/file_io.rs
+++ b/io-engine-tests/src/file_io.rs
@@ -92,8 +92,7 @@ pub async fn test_write_to_file(
 ) -> std::io::Result<()> {
     let src_buf = create_test_buf(buf_size);
 
-    let mut dst_buf: Vec<u8> = vec![];
-    dst_buf.resize(src_buf.len(), 0);
+    let mut dst_buf: Vec<u8> = vec![0; src_buf.len()];
 
     let mut f = OpenOptions::new()
         .write(true)

--- a/io-engine-tests/src/lib.rs
+++ b/io-engine-tests/src/lib.rs
@@ -34,6 +34,7 @@ pub mod pool;
 pub mod replica;
 pub mod snapshot;
 pub mod test;
+pub mod test_task;
 
 pub use compose::MayastorTest;
 
@@ -565,3 +566,5 @@ macro_rules! test_diag {
         println!($($arg)*);
     }}
 }
+
+pub use io_engine_tests_macros::spdk_test;

--- a/io-engine-tests/src/lib.rs
+++ b/io-engine-tests/src/lib.rs
@@ -312,11 +312,11 @@ pub fn mount_and_get_md5(device: &str) -> Result<String, String> {
 
 pub fn fio_run_verify(device: &str) -> Result<String, String> {
     let (exit, stdout, stderr) = run_script::run(
-        r#"
+        r"
         fio --name=randrw --rw=randrw --ioengine=libaio --direct=1 --time_based=1 \
         --runtime=5 --bs=4k --verify=crc32 --group_reporting=1 --output-format=terse \
         --verify_fatal=1 --verify_async=2 --filename=$1
-    "#,
+    ",
     &vec![device.into()],
     &run_script::ScriptOptions::new(),
     )
@@ -498,7 +498,7 @@ pub async fn wait_for_rebuild(
 
 pub fn fio_verify_size(device: &str, size: u64) -> i32 {
     let (exit, stdout, stderr) = run_script::run(
-        r#"
+        r"
         fio --thread=1 --numjobs=1 --iodepth=16 --bs=512 \
         --direct=1 --ioengine=libaio --rw=randwrite --verify=crc32 \
         --verify_fatal=1 --name=write_verify --filename=$1 --size=$2
@@ -506,7 +506,7 @@ pub fn fio_verify_size(device: &str, size: u64) -> i32 {
         fio --thread=1 --numjobs=1 --iodepth=16 --bs=512 \
         --direct=1 --ioengine=libaio --verify=crc32 --verify_only \
         --verify_fatal=1 --name=verify --filename=$1
-    "#,
+    ",
         &vec![device.into(), size.to_string()],
         &run_script::ScriptOptions::new(),
     )

--- a/io-engine-tests/src/test_task.rs
+++ b/io-engine-tests/src/test_task.rs
@@ -1,0 +1,44 @@
+use crossbeam::channel::{bounded, Receiver, Sender};
+use once_cell::sync::OnceCell;
+use tokio::sync::oneshot;
+
+pub use io_engine_tests_macros::spdk_test;
+
+struct TestTask {
+    sx: oneshot::Sender<()>,
+    f: Box<dyn FnOnce() + Send + 'static>,
+}
+
+fn main_loop(receiver: Receiver<TestTask>) {
+    loop {
+        let task = receiver.recv().unwrap();
+        (task.f)();
+        task.sx.send(()).unwrap();
+    }
+}
+
+static MAIN_THREAD: OnceCell<Sender<TestTask>> = OnceCell::new();
+
+/// Executes a test task in a special designated thread.
+pub async fn run_single_thread_test_task<F>(f: F)
+where
+    F: FnOnce() + Send + 'static,
+{
+    let (sx, rx) = oneshot::channel();
+
+    let sc = MAIN_THREAD.get_or_init(|| {
+        let (sc, rc) = bounded(1);
+        std::thread::spawn(move || {
+            main_loop(rc);
+        });
+        sc
+    });
+
+    let task = TestTask {
+        sx,
+        f: Box::new(f),
+    };
+    sc.send(task).unwrap();
+
+    rx.await.unwrap();
+}

--- a/io-engine/src/bdev/lvs.rs
+++ b/io-engine/src/bdev/lvs.rs
@@ -271,7 +271,9 @@ impl Lvs {
     async fn destroy(&self) -> Result<(), BdevError> {
         debug!("{self:?}: deleting");
         let Some(lvs) = crate::lvs::Lvs::lookup(&self.name) else {
-            return Err(BdevError::BdevNotFound { name: self.name.to_owned() });
+            return Err(BdevError::BdevNotFound {
+                name: self.name.to_owned(),
+            });
         };
         lvs.destroy()
             .await
@@ -283,7 +285,9 @@ impl Lvs {
 
     async fn destroy_lvol(&self, name: &str) -> Result<(), BdevError> {
         let Some(lvs) = crate::lvs::Lvs::lookup(&self.name) else {
-            return Err(BdevError::BdevNotFound { name: self.name.to_owned() });
+            return Err(BdevError::BdevNotFound {
+                name: self.name.to_owned(),
+            });
         };
         let Some(lvols) = lvs.lvols() else {
             return Ok(());

--- a/io-engine/src/bdev/nexus/nexus_persistence.rs
+++ b/io-engine/src/bdev/nexus/nexus_persistence.rs
@@ -86,7 +86,7 @@ impl<'n> Nexus<'n> {
         // the persistent store is slow to response, or has failed.
         self.set_nexus_io_mode(IoMode::Freeze).await;
 
-        let mut nexus_info = persistent_nexus_info.inner_mut();
+        let nexus_info = persistent_nexus_info.inner_mut();
 
         match &op {
             PersistOp::Create => {

--- a/io-engine/src/bdev/nvmx/controller.rs
+++ b/io-engine/src/bdev/nvmx/controller.rs
@@ -258,7 +258,7 @@ impl<'a> NvmeController<'a> {
     /// populate name spaces, current we only populate the first namespace
     fn populate_namespaces(&mut self) -> bool {
         let ctrlr = self.ctrlr_as_ptr();
-        let mut ctrlr_inner = self.inner.as_mut().unwrap();
+        let ctrlr_inner = self.inner.as_mut().unwrap();
         let ns = unsafe { spdk_nvme_ctrlr_get_ns(ctrlr, 1) };
         let ns_active = unsafe { spdk_nvme_ctrlr_is_active_ns(ctrlr, 1) };
         let mut notify_listeners = false;

--- a/io-engine/src/bdev/nvmx/controller_inner.rs
+++ b/io-engine/src/bdev/nvmx/controller_inner.rs
@@ -248,7 +248,7 @@ impl TimeoutConfig {
     }
 
     pub fn from_ptr(ptr: *mut TimeoutConfig) -> &'static mut TimeoutConfig {
-        unsafe { &mut *(ptr as *mut TimeoutConfig) }
+        unsafe { &mut *ptr }
     }
 }
 

--- a/io-engine/src/bdev/nvmx/handle.rs
+++ b/io-engine/src/bdev/nvmx/handle.rs
@@ -1040,7 +1040,7 @@ impl BlockDeviceHandle for NvmeDeviceHandle {
             NvmeIoCtx {
                 cb,
                 cb_arg,
-                iov: std::ptr::null_mut() as *mut iovec, // No I/O vec involved.
+                iov: std::ptr::null_mut(), // No I/O vec involved.
                 iovcnt: 0,
                 iovpos: 0,
                 iov_offset: 0,
@@ -1103,7 +1103,7 @@ impl BlockDeviceHandle for NvmeDeviceHandle {
             NvmeIoCtx {
                 cb,
                 cb_arg,
-                iov: std::ptr::null_mut() as *mut iovec, // No I/O vec involved.
+                iov: std::ptr::null_mut(), // No I/O vec involved.
                 iovcnt: 0,
                 iovpos: 0,
                 iov_offset: 0,
@@ -1202,7 +1202,7 @@ impl BlockDeviceHandle for NvmeDeviceHandle {
             NvmeIoCtx {
                 cb,
                 cb_arg,
-                iov: std::ptr::null_mut() as *mut iovec, // No I/O vec involved.
+                iov: std::ptr::null_mut(), // No I/O vec involved.
                 iovcnt: 0,
                 iovpos: 0,
                 iov_offset: 0,

--- a/io-engine/src/bdev/nvmx/qpair.rs
+++ b/io-engine/src/bdev/nvmx/qpair.rs
@@ -250,16 +250,14 @@ impl QPair {
         };
 
         let qpair = self.as_ptr();
-        let res = recv.await.map_err(|_| {
+        recv.await.map_err(|_| {
             // Receiver failure may be caused by qpair having been dropped,
             // so we cannot use `self` here.
             error!(?qpair, "I/O qpair connection canceled");
             CoreError::OpenBdev {
                 source: Errno::ECANCELED,
             }
-        })?;
-
-        res
+        })?
     }
 
     /// Starts a new async connection and returns a receiver for it.

--- a/io-engine/src/bdev/nx.rs
+++ b/io-engine/src/bdev/nx.rs
@@ -128,8 +128,11 @@ impl CreateDestroy for Nexus {
 
     async fn destroy(self: Box<Self>) -> Result<(), Self::Error> {
         debug!("{:?}: deleting", self);
-        let Some(nexus) = crate::bdev::nexus::nexus_lookup_mut(&self.name) else {
-            return Err(BdevError::BdevNotFound { name: self.name.to_owned() });
+        let Some(nexus) = crate::bdev::nexus::nexus_lookup_mut(&self.name)
+        else {
+            return Err(BdevError::BdevNotFound {
+                name: self.name.to_owned(),
+            });
         };
         nexus
             .destroy()

--- a/io-engine/src/bin/io-engine-client/v0/rebuild_cli.rs
+++ b/io-engine/src/bin/io-engine-client/v0/rebuild_cli.rs
@@ -424,7 +424,7 @@ async fn stats(
                     "tasks_total",
                     "tasks_active",
                 ],
-                vec![vec![
+                vec![[
                     response.blocks_total,
                     response.blocks_recovered,
                     response.progress,

--- a/io-engine/src/bin/io-engine-client/v1/test_cli.rs
+++ b/io-engine/src/bin/io-engine-client/v1/test_cli.rs
@@ -221,7 +221,11 @@ async fn replica_wipe(
 
     fn bandwidth(response: &v1_rpc::test::WipeReplicaResponse) -> String {
         let unknown = "??".to_string();
-        let Some(Ok(elapsed)) = response.since.clone().map(TryInto::<std::time::Duration>::try_into) else {
+        let Some(Ok(elapsed)) = response
+            .since
+            .clone()
+            .map(TryInto::<std::time::Duration>::try_into)
+        else {
             return unknown;
         };
         let elapsed_f = elapsed.as_secs_f64();

--- a/io-engine/src/grpc/v1/replica.rs
+++ b/io-engine/src/grpc/v1/replica.rs
@@ -137,7 +137,7 @@ fn filter_replicas_by_replica_type(
         .filter(|replica| {
             let query = &query;
 
-            let query_fields = vec![
+            let query_fields = [
                 (query.replica, (!replica.is_snapshot && !replica.is_clone)),
                 (query.snapshot, replica.is_snapshot),
                 (query.clone, replica.is_clone),

--- a/io-engine/src/grpc/v1/snapshot.rs
+++ b/io-engine/src/grpc/v1/snapshot.rs
@@ -329,7 +329,7 @@ fn filter_snapshots_by_snapshot_query_type(
         .filter(|snapshot| {
             let query = &query;
 
-            let query_fields = vec![
+            let query_fields = [
                 (query.invalid, snapshot.valid_snapshot),
                 (query.discarded, snapshot.discarded_snapshot),
                 // ... add other fields here as needed

--- a/io-engine/src/grpc/v1/test.rs
+++ b/io-engine/src/grpc/v1/test.rs
@@ -222,7 +222,9 @@ impl TryFrom<&Option<StreamWipeOptions>>
         value: &Option<StreamWipeOptions>,
     ) -> Result<Self, Self::Error> {
         let Some(wipe) = value else {
-            return Err(tonic::Status::invalid_argument("Missing StreamWipeOptions"));
+            return Err(tonic::Status::invalid_argument(
+                "Missing StreamWipeOptions",
+            ));
         };
         let Some(options) = &wipe.options else {
             return Err(tonic::Status::invalid_argument("Missing WipeOptions"));

--- a/io-engine/src/lvs/lvol_snapshot.rs
+++ b/io-engine/src/lvs/lvol_snapshot.rs
@@ -503,15 +503,13 @@ impl SnapshotOps for Lvol {
 
         let (s, r) = oneshot::channel::<(i32, *mut spdk_lvol)>();
 
-        let create_snapshot = self
-            .do_create_snapshot(
-                snap_param,
-                snapshot_create_done_cb,
-                cb_arg(s),
-                r,
-            )
-            .await;
-        create_snapshot
+        self.do_create_snapshot(
+            snap_param,
+            snapshot_create_done_cb,
+            cb_arg(s),
+            r,
+        )
+        .await
     }
     /// Create a snapshot in Remote.
     async fn create_snapshot_remote(
@@ -676,10 +674,8 @@ impl SnapshotOps for Lvol {
 
         let (s, r) = oneshot::channel::<(i32, *mut spdk_lvol)>();
 
-        let create_clone = self
-            .do_create_clone(clone_param, clone_done_cb, cb_arg(s), r)
-            .await;
-        create_clone
+        self.do_create_clone(clone_param, clone_done_cb, cb_arg(s), r)
+            .await
     }
 
     /// List clones based on snapshot_uuid.

--- a/io-engine/src/rebuild/rebuild_job_backend.rs
+++ b/io-engine/src/rebuild/rebuild_job_backend.rs
@@ -1,5 +1,6 @@
 use std::{
     fmt::Display,
+    rc::Rc,
     sync::{
         atomic::{AtomicU64, Ordering},
         Arc,
@@ -109,7 +110,7 @@ pub(super) struct RebuildJobBackend {
     /// Channel to share information between frontend and backend.
     pub(super) info_chan: RebuildFBendChan,
     /// All the rebuild related descriptors.
-    pub(super) descriptor: Arc<RebuildDescriptor>,
+    pub(super) descriptor: Rc<RebuildDescriptor>,
     /// Job serial number.
     serial: u64,
 }
@@ -232,7 +233,7 @@ impl RebuildJobBackend {
             states: Default::default(),
             complete_chan: Default::default(),
             info_chan: RebuildFBendChan::new(),
-            descriptor: Arc::new(RebuildDescriptor {
+            descriptor: Rc::new(RebuildDescriptor {
                 src_uri: src_uri.to_string(),
                 dst_uri: dst_uri.to_string(),
                 range,

--- a/io-engine/src/rebuild/rebuild_state.rs
+++ b/io-engine/src/rebuild/rebuild_state.rs
@@ -2,9 +2,10 @@ use super::{RebuildError, RebuildOperation};
 use crate::rebuild::RebuildStats;
 
 /// Allowed states for a rebuild job.
-#[derive(Debug, PartialEq, Copy, Clone)]
+#[derive(Default, Debug, PartialEq, Copy, Clone)]
 pub enum RebuildState {
     /// Init when the job is newly created
+    #[default]
     Init,
     /// Running when the job is rebuilding
     Running,
@@ -62,12 +63,6 @@ pub(super) struct RebuildStates {
 impl std::fmt::Display for RebuildStates {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "{self:?}")
-    }
-}
-
-impl Default for RebuildState {
-    fn default() -> Self {
-        RebuildState::Init
     }
 }
 

--- a/io-engine/src/rebuild/rebuild_task.rs
+++ b/io-engine/src/rebuild/rebuild_task.rs
@@ -2,7 +2,7 @@ use futures::{channel::mpsc, stream::FusedStream, SinkExt, StreamExt};
 use parking_lot::Mutex;
 use snafu::ResultExt;
 use spdk_rs::{DmaBuf, LbaRange};
-use std::sync::Arc;
+use std::{rc::Rc, sync::Arc};
 
 use crate::core::{Reactors, VerboseError};
 
@@ -198,7 +198,7 @@ impl RebuildTasks {
         &mut self,
         id: usize,
         blk: u64,
-        descriptor: Arc<RebuildDescriptor>,
+        descriptor: Rc<RebuildDescriptor>,
     ) {
         let task = self.tasks[id].clone();
 

--- a/io-engine/tests/core.rs
+++ b/io-engine/tests/core.rs
@@ -140,7 +140,7 @@ async fn core_4() {
 
     // nexus size is always "nexus_size"
     // (size of child1, create success, size of child2, add child2 success)
-    let test_cases = vec![
+    let test_cases = [
         (nexus_size, true, nexus_size * 2, true),
         (nexus_size, true, nexus_size / 2, false),
         (nexus_size * 2, true, nexus_size, false),
@@ -214,8 +214,7 @@ async fn core_5() {
     let nexus_size: u64 = 100 * 1024 * 1024; // 100MiB
     let nexus_name: &str = "nexus_size";
 
-    let test_cases =
-        vec![(nexus_size, nexus_size * 2), (nexus_size, nexus_size)];
+    let test_cases = [(nexus_size, nexus_size * 2), (nexus_size, nexus_size)];
 
     for test_case in test_cases.iter() {
         let nexus_size = test_case.0;

--- a/io-engine/tests/lock_lba_range.rs
+++ b/io-engine/tests/lock_lba_range.rs
@@ -84,7 +84,7 @@ fn recv_from<T>(r: Receiver<T>) -> T {
     }
 }
 
-#[test]
+#[common::spdk_test]
 // Test acquiring and releasing a lock.
 fn lock_unlock() {
     test_ini();
@@ -103,7 +103,7 @@ fn lock_unlock() {
     test_fini();
 }
 
-#[test]
+#[common::spdk_test]
 // Test taking out multiple locks on an overlapping block range.
 // The second lock should only succeeded after the first lock is released.
 fn multiple_locks() {
@@ -152,7 +152,7 @@ fn multiple_locks() {
     test_fini();
 }
 
-#[test]
+#[common::spdk_test]
 // Test locking a block range and then issuing a front-end I/O to an overlapping
 // range.
 // TODO: Add additional test for issuing front-end I/O then taking a lock

--- a/io-engine/tests/nexus_rebuild_partial.rs
+++ b/io-engine/tests/nexus_rebuild_partial.rs
@@ -368,8 +368,8 @@ async fn nexus_partial_rebuild_offline_online() {
 /// 3) Create injection that will fail at offset == FAULT_POS.
 /// 4a) Online r0 so it rebuilds in background.
 /// 4b) Write new data to the nexus: data start < FAULT_POS < data end.
-/// 5) I/O must fail _before_ rebuild finishes. This will prevent creartion of
-///    a rebuild log.
+/// 5) I/O must fail _before_ rebuild finishes. This will prevent creartion of a
+///    rebuild log.
 /// 6) Remove the injection.
 /// 7) Online r0: a full rebuild must now run.
 /// 8) Offline, write and online again to have a successfull partial rebuild.

--- a/io-engine/tests/nexus_thin_no_space.rs
+++ b/io-engine/tests/nexus_thin_no_space.rs
@@ -162,8 +162,8 @@ async fn nexus_thin_nospc_remote_single() {
 /// 2. Create a thick-provisioned replica occupying some space on pool #1.
 /// 3. Create two thin-provisioned replica on these pools.
 /// 4. Create a nexus on these two replicas.
-/// 5. Write amount data less than replica size and pool capacity,
-///    but more than pool #1 free space.
+/// 5. Write amount data less than replica size and pool capacity, but more than
+///    pool #1 free space.
 /// 6. First child must degrade with no space.
 /// 7. Delete the thick-provisioned replica, thus freeing space on pool #1.
 /// 8. Online child #1.

--- a/io-engine/tests/nvmf.rs
+++ b/io-engine/tests/nvmf.rs
@@ -25,7 +25,7 @@ use regex::Regex;
 static DISKNAME1: &str = "/tmp/disk1.img";
 static BDEVNAME1: &str = "aio:///tmp/disk1.img?blk_size=512";
 
-#[test]
+#[common::spdk_test]
 fn nvmf_target() {
     common::mayastor_test_init();
     common::truncate_file(DISKNAME1, 64 * 1024);

--- a/io-engine/tests/nvmf.rs
+++ b/io-engine/tests/nvmf.rs
@@ -99,7 +99,7 @@ async fn nvmf_set_target_interface() {
     async fn start_ms(network: &str, args: Vec<&str>) -> ComposeTest {
         common::composer_init();
 
-        let test = Builder::new()
+        Builder::new()
             .name("cargo-test")
             .network(network)
             .unwrap()
@@ -110,9 +110,7 @@ async fn nvmf_set_target_interface() {
             .with_clean(true)
             .build()
             .await
-            .unwrap();
-
-        test
+            .unwrap()
     }
 
     async fn test_ok(network: &str, args: Vec<&str>, tgt_ip: Option<&str>) {

--- a/io-engine/tests/persistence.rs
+++ b/io-engine/tests/persistence.rs
@@ -352,7 +352,7 @@ async fn start_infrastructure(test_name: &str) -> ComposeTest {
     common::composer_init();
 
     let etcd_endpoint = format!("http://etcd.{test_name}:2379");
-    let test = Builder::new()
+    Builder::new()
         .name(test_name)
         .add_container_spec(
             ContainerSpec::from_binary(
@@ -387,8 +387,7 @@ async fn start_infrastructure(test_name: &str) -> ComposeTest {
         )
         .build()
         .await
-        .unwrap();
-    test
+        .unwrap()
 }
 
 /// Creates and publishes a nexus.

--- a/io-engine/tests/poller.rs
+++ b/io-engine/tests/poller.rs
@@ -19,7 +19,7 @@ fn test_fn(a: u32, b: u32) -> u32 {
     a + b
 }
 
-#[test]
+#[common::spdk_test]
 fn poller() {
     common::mayastor_test_init();
     MayastorEnvironment::new(MayastorCliArgs {

--- a/io-engine/tests/reactor.rs
+++ b/io-engine/tests/reactor.rs
@@ -15,7 +15,7 @@ use pin_utils::core_reexport::time::Duration;
 pub mod common;
 
 // This test requires the system to have at least 2 cpus
-#[test]
+#[common::spdk_test]
 fn reactor_start_stop() {
     let args = MayastorCliArgs {
         reactor_mask: "0x3".into(),

--- a/io-engine/tests/reactor_block_on.rs
+++ b/io-engine/tests/reactor_block_on.rs
@@ -13,7 +13,7 @@ pub mod common;
 
 static COUNT: Lazy<AtomicCell<u32>> = Lazy::new(|| AtomicCell::new(0));
 
-#[test]
+#[common::spdk_test]
 fn reactor_block_on() {
     common::mayastor_test_init();
     MayastorEnvironment::new(MayastorCliArgs::default()).init();

--- a/io-engine/tests/snapshot_lvol.rs
+++ b/io-engine/tests/snapshot_lvol.rs
@@ -1254,7 +1254,6 @@ async fn test_snapshot_attr() {
 #[tokio::test]
 async fn test_delete_snapshot_with_valid_clone() {
     let ms = get_ms();
-    const LVOL_NAME: &str = "lvol13";
 
     ms.spawn(async move {
         // Create a pool and lvol.
@@ -1378,7 +1377,6 @@ async fn test_delete_snapshot_with_valid_clone() {
 #[tokio::test]
 async fn test_delete_snapshot_with_valid_clone_fail_1() {
     let ms = get_ms();
-    const LVOL_NAME: &str = "lvol14";
 
     ms.spawn(async move {
         // Create a pool and lvol.

--- a/nix/lib/rust.nix
+++ b/nix/lib/rust.nix
@@ -4,6 +4,6 @@ let
     import sources.nixpkgs { overlays = [ (import sources.rust-overlay) ]; };
 in
 with pkgs; rec  {
-  nightly = rust-bin.nightly."2023-01-08".default;
-  stable = rust-bin.stable.latest.default;
+  nightly = rust-bin.nightly."2023-08-25".default;
+  stable = rust-bin.stable."1.72.0".default;
 }

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "3488cec01351c2f1086b02a3a61808be7a25103e",
-        "sha256": "1gqswi63qvgvywzxlsbk2h6zlpvfi61hc4azqkk73ynbyhvkig2d",
+        "rev": "673e2d3d2a3951adc6f5e3351c9fce6ad130baed",
+        "sha256": "sha256:1vgjkaikv8lwm3kmb4jbc96kxhdy38nmf1v4s7nmx6j4bd8pmlyd",
         "type": "tarball",
-        "url": "https://github.com/oxalica/rust-overlay/archive/3488cec01351c2f1086b02a3a61808be7a25103e.tar.gz",
+        "url": "https://github.com/oxalica/rust-overlay/archive/673e2d3d2a3951adc6f5e3351c9fce6ad130baed.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/scripts/rust-linter-env.sh
+++ b/scripts/rust-linter-env.sh
@@ -46,10 +46,10 @@ fi
 # rustfmt and clippy "2021-11-29".
 # When upgrading Rust toolchain version, check 'cargo --version',
 # 'cargo fmt --version', 'cargo clippy --version' and put them here.
-RUST_TOOLCHAIN_VER="2023-01-08"
-WANTED_CARGO_VER="cargo 1.68.0-nightly (* 2023-01-04)"
-WANTED_RUSTFMT_VER="rustfmt 1.5.1-nightly (* 2023-01-07)"
-WANTED_CLIPPY_VER="clippy 0.1.68 (* 2023-01-07)"
+RUST_TOOLCHAIN_VER="2023-08-25"
+WANTED_CARGO_VER="cargo 1.74.0-nightly (* 2023-08-22)"
+WANTED_RUSTFMT_VER="rustfmt 1.6.0-nightly (* 2023-08-24)"
+WANTED_CLIPPY_VER="clippy 0.1.73 (* 2023-08-24)"
 CARGO="cargo"
 CARGO_MODE="system"
 

--- a/scripts/rust-linter.sh
+++ b/scripts/rust-linter.sh
@@ -6,3 +6,6 @@ $CARGO clippy --all --all-targets -- -D warnings \
     -A clippy::await-holding-refcell-ref \
     -A clippy::result-large-err \
     -A clippy::type-complexity \
+    -A clippy::option_env_unwrap \
+    -A clippy::redundant-guards \
+    -A clippy::suspicious-doc-comments


### PR DESCRIPTION
Updated the following tool version:
* Rust toolchain Nix overlay: 2023-08-25
* Stable rustc 1.72.0 (5680fa18f 2023-08-23)
* cargo 1.74.0-nightly
* rustfmt 1.6.0-nightly
* clippy 0.1.73

Code fixed to meet new clippy rules.