### PR TITLE
feat(casperf/nexus): add simple nexus uri support

### DIFF
--- a/io-engine/src/bdev/dev.rs
+++ b/io-engine/src/bdev/dev.rs
@@ -44,6 +44,7 @@ pub(crate) mod uri {
             null_bdev,
             nvme,
             nvmx,
+            nx,
             uring,
             BdevCreateDestroy,
         },
@@ -59,13 +60,15 @@ pub(crate) mod uri {
 
         match url.scheme() {
             "aio" => Ok(Box::new(aio::Aio::try_from(&url)?)),
-            "bdev" => Ok(Box::new(loopback::Loopback::try_from(&url)?)),
-            "loopback" => Ok(Box::new(loopback::Loopback::try_from(&url)?)),
+            "bdev" | "loopback" => {
+                Ok(Box::new(loopback::Loopback::try_from(&url)?))
+            }
             "malloc" => Ok(Box::new(malloc::Malloc::try_from(&url)?)),
             "null" => Ok(Box::new(null_bdev::Null::try_from(&url)?)),
             "nvmf" => Ok(Box::new(nvmx::NvmfDeviceTemplate::try_from(&url)?)),
             "pcie" => Ok(Box::new(nvme::NVMe::try_from(&url)?)),
             "uring" => Ok(Box::new(uring::Uring::try_from(&url)?)),
+            "nexus" => Ok(Box::new(nx::Nexus::try_from(&url)?)),
 
             scheme => Err(BdevError::UriSchemeUnsupported {
                 scheme: scheme.to_string(),

--- a/io-engine/src/bdev/mod.rs
+++ b/io-engine/src/bdev/mod.rs
@@ -24,6 +24,7 @@ pub mod null_ng;
 mod nvme;
 mod nvmf;
 pub(crate) mod nvmx;
+mod nx;
 mod uring;
 pub mod util;
 

--- a/io-engine/src/bdev/nexus/mod.rs
+++ b/io-engine/src/bdev/nexus/mod.rs
@@ -92,8 +92,12 @@ struct NexusShareReply {
 }
 
 /// public function which simply calls register module
-pub fn register_module() {
+pub fn register_module(register_json: bool) {
     nexus_module::register_module();
+
+    if !register_json {
+        return;
+    }
 
     use crate::{
         core::{Share, ShareProps, UntypedBdev},

--- a/io-engine/src/bdev/nx.rs
+++ b/io-engine/src/bdev/nx.rs
@@ -1,0 +1,142 @@
+//! Allows creation of a nexus through a URI specification rather than gRPC or
+//! direct function call. This is not intended for the usual product operation
+//! but for testing and benchmarking.
+//!
+//! # Uri
+//! nexus:///$name?size=$size&children=$children
+//!
+//! # Parameters
+//! name: A name for the nexus, example: "nexus-1"
+//! size: A size specified using units, example: 100GiB
+//! children: A comma-separated list of children URI's, example: aio:///dev/sda
+//!
+//! # Examples
+//! Single child:
+//! nexus:///nx1?size=240GiB&children=aio:///dev/sda
+//! Multiple children:
+//! nexus:///nx1?size=240GiB&children=aio:///dev/sda,aio:///dev/sdc
+
+use std::{
+    collections::HashMap,
+    convert::TryFrom,
+    fmt::{Debug, Formatter},
+};
+
+use async_trait::async_trait;
+use url::Url;
+
+use crate::{
+    bdev::{dev::reject_unknown_parameters, util::uri, CreateDestroy, GetName},
+    bdev_api::BdevError,
+};
+
+/// A nexus specified via URI.
+pub struct Nexus {
+    /// Name of the nexus we created, this is equal to the URI path minus
+    /// the leading '/'.
+    name: String,
+    /// The size of the nexus in bytes.
+    size: u64,
+    /// The children of the nexus.
+    children: Vec<String>,
+}
+
+impl Debug for Nexus {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Nexus '{}' {} B <= {:?}",
+            self.name, self.size, self.children
+        )
+    }
+}
+
+impl TryFrom<&Url> for Nexus {
+    type Error = BdevError;
+
+    fn try_from(uri: &Url) -> Result<Self, Self::Error> {
+        let segments = uri::segments(uri);
+        if segments.is_empty() {
+            return Err(BdevError::InvalidUri {
+                uri: uri.to_string(),
+                message: "empty path".to_string(),
+            });
+        }
+
+        let mut parameters: HashMap<String, String> =
+            uri.query_pairs().into_owned().collect();
+
+        let size: u64 = if let Some(value) = parameters.remove("size") {
+            byte_unit::Byte::from_str(value)
+                .map_err(|error| BdevError::InvalidUri {
+                    uri: uri.to_string(),
+                    message: format!("'size' is invalid: {error}"),
+                })?
+                .get_bytes() as u64
+        } else {
+            return Err(BdevError::InvalidUri {
+                uri: uri.to_string(),
+                message: "'size' is not specified".to_string(),
+            });
+        };
+
+        let children: Vec<String> =
+            if let Some(value) = parameters.remove("children") {
+                value.split(',').map(|s| s.to_string()).collect::<Vec<_>>()
+            } else {
+                return Err(BdevError::InvalidUri {
+                    uri: uri.to_string(),
+                    message: "'children' must be specified".to_string(),
+                });
+            };
+
+        reject_unknown_parameters(uri, parameters)?;
+
+        Ok(Self {
+            name: uri.path()[1 ..].into(),
+            size,
+            children,
+        })
+    }
+}
+
+impl GetName for Nexus {
+    fn get_name(&self) -> String {
+        self.name.clone()
+    }
+}
+
+#[async_trait(?Send)]
+impl CreateDestroy for Nexus {
+    type Error = BdevError;
+
+    async fn create(&self) -> Result<String, Self::Error> {
+        crate::bdev::nexus::nexus_create(
+            &self.name,
+            self.size,
+            None,
+            &self.children,
+        )
+        .await
+        .map_err(|error| BdevError::CreateBdevFailedStr {
+            error: error.to_string(),
+            name: self.name.to_owned(),
+        })?;
+
+        Ok(self.name.to_owned())
+    }
+
+    async fn destroy(self: Box<Self>) -> Result<(), Self::Error> {
+        debug!("{:?}: deleting", self);
+        let Some(nexus) = crate::bdev::nexus::nexus_lookup_mut(&self.name) else {
+            return Err(BdevError::BdevNotFound { name: self.name.to_owned() });
+        };
+        nexus
+            .destroy()
+            .await
+            .map_err(|error| BdevError::DestroyBdevFailedStr {
+                error: error.to_string(),
+                name: self.name.to_owned(),
+            })
+    }
+}

--- a/io-engine/src/bdev_api.rs
+++ b/io-engine/src/bdev_api.rs
@@ -91,6 +91,10 @@ pub enum BdevError {
     // Generic destruction failure.
     #[snafu(display("Failed to destroy a BDEV '{}'", name))]
     DestroyBdevFailed { source: Errno, name: String },
+    #[snafu(display("Failed to create BDEV '{name}': {error}"))]
+    CreateBdevFailedStr { name: String, error: String },
+    #[snafu(display("Failed to destroy BDEV '{name}': {error}"))]
+    DestroyBdevFailedStr { name: String, error: String },
     // Command canceled.
     #[snafu(display("Command canceled for a BDEV '{}'", name))]
     BdevCommandCanceled { source: Canceled, name: String },

--- a/io-engine/src/bin/casperf.rs
+++ b/io-engine/src/bin/casperf.rs
@@ -396,6 +396,7 @@ fn main() {
     let args = MayastorCliArgs {
         reactor_mask: "0x2".to_string(),
         skip_sig_handler: true,
+        no_pci: false,
         ..Default::default()
     };
 

--- a/io-engine/src/bin/casperf.rs
+++ b/io-engine/src/bin/casperf.rs
@@ -401,6 +401,7 @@ fn main() {
 
     MayastorEnvironment::new(args).init();
     sig_override();
+    io_engine::bdev::nexus::register_module(false);
     Reactors::master().send_future(async move {
         let jobs = uris
             .iter_mut()

--- a/io-engine/src/lib.rs
+++ b/io-engine/src/lib.rs
@@ -42,6 +42,6 @@ macro_rules! CPS_INIT {
 
 pub extern "C" fn cps_init() {
     subsys::register_subsystem();
-    bdev::nexus::register_module();
+    bdev::nexus::register_module(true);
     bdev::null_ng::register();
 }


### PR DESCRIPTION
Allows creating a nexus via a URI which can be used for testing and benchs.

Also enables pci access using `pcie:///` URI.