### PR TITLE
feat(casperf/lvol): add lvol uri type

### DIFF
--- a/io-engine/src/bdev/dev.rs
+++ b/io-engine/src/bdev/dev.rs
@@ -40,6 +40,7 @@ pub(crate) mod uri {
         bdev::{
             aio,
             loopback,
+            lvs,
             malloc,
             null_bdev,
             nvme,
@@ -69,6 +70,7 @@ pub(crate) mod uri {
             "pcie" => Ok(Box::new(nvme::NVMe::try_from(&url)?)),
             "uring" => Ok(Box::new(uring::Uring::try_from(&url)?)),
             "nexus" => Ok(Box::new(nx::Nexus::try_from(&url)?)),
+            "lvol" => Ok(Box::new(lvs::Lvol::try_from(&url)?)),
 
             scheme => Err(BdevError::UriSchemeUnsupported {
                 scheme: scheme.to_string(),

--- a/io-engine/src/bdev/lvs.rs
+++ b/io-engine/src/bdev/lvs.rs
@@ -1,0 +1,279 @@
+//! Allows creation of an lvs lvol through a URI specification rather than gRPC
+//! or direct function call. This is not intended for the usual product
+//! operation but for testing and benchmarking.
+//!
+//! # Uri
+//! lvol:///$name?size=$size&lvs=$lvs
+//!
+//! # Parameters
+//! name: A name for the lvol, example: "lvol-1"
+//! size: A size specified using units, example: 100GiB
+//! lvs: lvs:///$name?mode=$mode&disk=$disk
+//!      name: A name for the lvs, example: "lvs-1"
+//!      mode:
+//!         create: create new lvs pool
+//!         import: import existing lvs pool
+//!         create_import: import existing or create new lvs pool
+//!         purge: destroy and create new lvs pool
+//!      disk: The disk uri for the lvs, example: "aio:///dev/sda"
+
+use std::{
+    collections::HashMap,
+    convert::TryFrom,
+    fmt::{Debug, Formatter},
+};
+
+use async_trait::async_trait;
+use url::Url;
+
+use crate::{
+    bdev::{dev::reject_unknown_parameters, util::uri, CreateDestroy, GetName},
+    bdev_api::BdevError,
+    core::LogicalVolume,
+    lvs::LvsLvol,
+    pool_backend::PoolArgs,
+};
+
+/// An lvol specified via URI.
+pub(super) struct Lvol {
+    /// Name of the lvol.
+    name: String,
+    /// The size of the lvol in bytes.
+    size: u64,
+    /// The lvs specification.
+    lvs: Lvs,
+}
+struct Lvs {
+    /// Name of the lvs.
+    name: String,
+    /// The backing bdev disk uri.
+    disk: String,
+    /// The lvs creation mode.
+    mode: LvsMode,
+}
+
+impl Debug for Lvol {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Lvol '{}' {} B <== {:?}", self.name, self.size, self.lvs)
+    }
+}
+impl Debug for Lvs {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Lvs '{}' <== {}", self.name, self.disk)
+    }
+}
+
+impl TryFrom<&Url> for Lvol {
+    type Error = BdevError;
+
+    fn try_from(uri: &Url) -> Result<Self, Self::Error> {
+        let segments = uri::segments(uri);
+        if segments.is_empty() {
+            return Err(BdevError::InvalidUri {
+                uri: uri.to_string(),
+                message: "empty path".to_string(),
+            });
+        }
+
+        let mut parameters: HashMap<String, String> =
+            uri.query_pairs().into_owned().collect();
+
+        let size = parameters
+            .remove("size")
+            .ok_or(BdevError::InvalidUri {
+                uri: uri.to_string(),
+                message: "'size' is not specified".to_string(),
+            })
+            .and_then(|size| {
+                byte_unit::Byte::from_str(size).map_err(|error| {
+                    BdevError::InvalidUri {
+                        uri: uri.to_string(),
+                        message: format!("'size' is invalid: {error}"),
+                    }
+                })
+            })?
+            .get_bytes() as u64;
+
+        let lvs = parameters
+            .remove("lvs")
+            .ok_or(BdevError::InvalidUri {
+                uri: uri.to_string(),
+                message: "'lvs' must be specified".to_string(),
+            })
+            .and_then(|lvs| {
+                let disk = parameters.remove("disk").unwrap_or_default();
+                Lvs::try_from(format!("{lvs}&disk={disk}"))
+            })?;
+
+        reject_unknown_parameters(uri, parameters)?;
+
+        Ok(Self {
+            name: uri.path()[1 ..].into(),
+            size,
+            lvs,
+        })
+    }
+}
+
+impl TryFrom<String> for Lvs {
+    type Error = BdevError;
+
+    fn try_from(uri: String) -> Result<Self, Self::Error> {
+        let uri =
+            Url::parse(&uri).map_err(|source| BdevError::UriParseFailed {
+                uri,
+                source,
+            })?;
+        let segments = uri::segments(&uri);
+        if segments.is_empty() {
+            return Err(BdevError::InvalidUri {
+                uri: uri.to_string(),
+                message: "empty path".to_string(),
+            });
+        }
+
+        let mut parameters: HashMap<String, String> =
+            uri.query_pairs().into_owned().collect();
+
+        let disk = parameters.remove("disk").ok_or(BdevError::InvalidUri {
+            uri: uri.to_string(),
+            message: "'disk' must be specified".to_string(),
+        })?;
+
+        let mode = parameters
+            .remove("mode")
+            .ok_or(BdevError::InvalidUri {
+                uri: uri.to_string(),
+                message: "'mode' must be specified".to_string(),
+            })
+            .map(LvsMode::from)?;
+
+        Ok(Lvs {
+            name: uri.path()[1 ..].into(),
+            disk,
+            mode,
+        })
+    }
+}
+
+/// Lvs Creation Mode.
+enum LvsMode {
+    /// Create fresh pool on blank bdev.
+    Create,
+    /// Import pool from existing bdev.
+    Import,
+    /// Create or Import.
+    CreateOrImport,
+    /// Destroy any existing pool from bdev and Create new.
+    Purge,
+}
+impl From<String> for LvsMode {
+    fn from(value: String) -> Self {
+        match value.as_str() {
+            "create" => Self::Create,
+            "import" => Self::Import,
+            "create_import" => Self::CreateOrImport,
+            "purge" => Self::Purge,
+            _ => Self::Import,
+        }
+    }
+}
+
+impl GetName for Lvol {
+    fn get_name(&self) -> String {
+        self.name.clone()
+    }
+}
+
+#[async_trait(?Send)]
+impl CreateDestroy for Lvol {
+    type Error = BdevError;
+
+    async fn create(&self) -> Result<String, Self::Error> {
+        let lvs = self.lvs.create().await?;
+        self.lvs.destroy_lvol(&self.name).await.ok();
+        lvs.create_lvol(&self.name, self.size, None, false)
+            .await
+            .map_err(|error| BdevError::CreateBdevFailedStr {
+                error: error.to_string(),
+                name: self.name.to_owned(),
+            })?;
+        Ok(self.name.to_owned())
+    }
+
+    async fn destroy(self: Box<Self>) -> Result<(), Self::Error> {
+        debug!("{:?}: deleting", self);
+        self.lvs.destroy_lvol(&self.name).await?;
+        self.lvs.destroy().await
+    }
+}
+
+impl Lvs {
+    async fn create(&self) -> Result<crate::lvs::Lvs, BdevError> {
+        let args = PoolArgs {
+            name: self.name.to_owned(),
+            disks: vec![self.disk.to_owned()],
+            uuid: None,
+        };
+        match &self.mode {
+            LvsMode::Create => {
+                match crate::lvs::Lvs::import_from_args(args.clone()).await {
+                    Err(crate::lvs::Error::Import {
+                        ..
+                    }) => crate::lvs::Lvs::create_or_import(args).await,
+                    _ => {
+                        return Err(BdevError::BdevExists {
+                            name: self.name.to_owned(),
+                        })
+                    }
+                }
+            }
+            LvsMode::Import => crate::lvs::Lvs::import_from_args(args).await,
+            LvsMode::CreateOrImport => {
+                crate::lvs::Lvs::create_or_import(args).await
+            }
+            LvsMode::Purge => match self.destroy().await {
+                Ok(_)
+                | Err(BdevError::BdevNotFound {
+                    ..
+                }) => crate::lvs::Lvs::create_or_import(args).await,
+                Err(error) => return Err(error),
+            },
+        }
+        .map_err(|error| BdevError::CreateBdevFailedStr {
+            error: error.to_string(),
+            name: self.name.to_owned(),
+        })
+    }
+
+    async fn destroy(&self) -> Result<(), BdevError> {
+        debug!("{self:?}: deleting");
+        let Some(lvs) = crate::lvs::Lvs::lookup(&self.name) else {
+            return Err(BdevError::BdevNotFound { name: self.name.to_owned() });
+        };
+        lvs.destroy()
+            .await
+            .map_err(|error| BdevError::DestroyBdevFailedStr {
+                error: error.to_string(),
+                name: self.name.to_owned(),
+            })
+    }
+
+    async fn destroy_lvol(&self, name: &str) -> Result<(), BdevError> {
+        let Some(lvs) = crate::lvs::Lvs::lookup(&self.name) else {
+            return Err(BdevError::BdevNotFound { name: self.name.to_owned() });
+        };
+        let Some(lvols) = lvs.lvols() else {
+            return Ok(());
+        };
+        let Some(lvol) = lvols.into_iter().find(|l| l.name() == name) else {
+            return Ok(());
+        };
+        lvol.destroy().await.map(|_| ()).map_err(|error| {
+            BdevError::DestroyBdevFailedStr {
+                error: error.to_string(),
+                name: self.name.to_owned(),
+            }
+        })
+    }
+}

--- a/io-engine/src/bdev/mod.rs
+++ b/io-engine/src/bdev/mod.rs
@@ -17,6 +17,7 @@ pub(crate) use dev::uri;
 
 pub(crate) mod device;
 mod loopback;
+mod lvs;
 mod malloc;
 pub mod nexus;
 mod null_bdev;

--- a/io-engine/src/bdev/nexus/nexus_bdev_error.rs
+++ b/io-engine/src/bdev/nexus/nexus_bdev_error.rs
@@ -294,6 +294,9 @@ impl From<Error> for tonic::Status {
             Error::NameExists {
                 ..
             } => Status::already_exists(e.to_string()),
+            Error::InvalidArguments {
+                ..
+            } => Status::invalid_argument(e.to_string()),
             e => Status::new(Code::Internal, e.verbose()),
         }
     }

--- a/io-engine/src/bdev/nx.rs
+++ b/io-engine/src/bdev/nx.rs
@@ -31,7 +31,7 @@ use crate::{
 };
 
 /// A nexus specified via URI.
-pub struct Nexus {
+pub(super) struct Nexus {
     /// Name of the nexus we created, this is equal to the URI path minus
     /// the leading '/'.
     name: String,

--- a/io-engine/src/core/bdev.rs
+++ b/io-engine/src/core/bdev.rs
@@ -295,6 +295,7 @@ where
 
     /// return the URI that was used to construct the bdev, without uuid
     fn bdev_uri_original(&self) -> Option<url::Url> {
+        println!("self: {self:?}");
         for alias in self.aliases().iter() {
             if let Ok(uri) = url::Url::parse(alias) {
                 if bdev_uri_eq(self, &uri) {

--- a/io-engine/src/core/bdev.rs
+++ b/io-engine/src/core/bdev.rs
@@ -295,7 +295,6 @@ where
 
     /// return the URI that was used to construct the bdev, without uuid
     fn bdev_uri_original(&self) -> Option<url::Url> {
-        println!("self: {self:?}");
         for alias in self.aliases().iter() {
             if let Ok(uri) = url::Url::parse(alias) {
                 if bdev_uri_eq(self, &uri) {

--- a/io-engine/src/grpc/v0/mayastor_grpc.rs
+++ b/io-engine/src/grpc/v0/mayastor_grpc.rs
@@ -218,8 +218,12 @@ impl From<LvsError> for tonic::Status {
     fn from(e: LvsError) -> Self {
         match e {
             LvsError::Import {
-                ..
-            } => Status::invalid_argument(e.to_string()),
+                source, ..
+            } => match source {
+                Errno::EINVAL => Status::invalid_argument(e.to_string()),
+                Errno::EEXIST => Status::already_exists(e.to_string()),
+                _ => Status::invalid_argument(e.to_string()),
+            },
             LvsError::RepCreate {
                 source, ..
             } => {

--- a/io-engine/src/lvs/lvs_error.rs
+++ b/io-engine/src/lvs/lvs_error.rs
@@ -10,11 +10,25 @@ use crate::{
 
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub(crate)), context(suffix(false)))]
+pub enum ImportErrorReason {
+    #[snafu(display(""))]
+    None,
+    #[snafu(display(": existing pool disk has different name: {name}"))]
+    NameMismatch { name: String },
+    #[snafu(display(": another pool already exists with this name: {name}"))]
+    NameClash { name: String },
+    #[snafu(display(": existing pool has different uuid: {uuid}"))]
+    UuidMismatch { uuid: String },
+}
+
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)), context(suffix(false)))]
 pub enum Error {
-    #[snafu(display("{source}, failed to import pool {name}"))]
+    #[snafu(display("{source}, failed to import pool {name}{reason}"))]
     Import {
         source: Errno,
         name: String,
+        reason: ImportErrorReason,
     },
     #[snafu(display("{source}, failed to create pool {name}"))]
     PoolCreate {
@@ -55,7 +69,7 @@ pub enum Error {
         source: Errno,
         name: String,
     },
-    #[snafu(display("failed to destroy lvol {}{}", name, if msg.is_empty() { "" } else { msg.as_str() }))]
+    #[snafu(display("failed to destroy lvol {} {}", name, if msg.is_empty() { "" } else { msg.as_str() }))]
     RepDestroy {
         source: Errno,
         name: String,

--- a/io-engine/src/lvs/lvs_error.rs
+++ b/io-engine/src/lvs/lvs_error.rs
@@ -11,22 +11,22 @@ use crate::{
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub(crate)), context(suffix(false)))]
 pub enum Error {
-    #[snafu(display("failed to import pool {}", name))]
+    #[snafu(display("{source}, failed to import pool {name}"))]
     Import {
         source: Errno,
         name: String,
     },
-    #[snafu(display("errno: {} failed to create pool {}", source, name))]
+    #[snafu(display("{source}, failed to create pool {name}"))]
     PoolCreate {
         source: Errno,
         name: String,
     },
-    #[snafu(display("failed to export pool {}", name))]
+    #[snafu(display("{source}, failed to export pool {name}"))]
     Export {
         source: Errno,
         name: String,
     },
-    #[snafu(display("failed to destroy pool {}", name))]
+    #[snafu(display("{source}, failed to destroy pool {name}"))]
     Destroy {
         source: BdevError,
         name: String,

--- a/io-engine/src/lvs/lvs_store.rs
+++ b/io-engine/src/lvs/lvs_store.rs
@@ -290,7 +290,7 @@ impl Lvs {
                 lvs.name()
             );
             let pool_name = lvs.name().to_string();
-            lvs.export().await.unwrap();
+            lvs.export().await?;
             Err(Error::Import {
                 source: Errno::EINVAL,
                 name: pool_name,
@@ -553,7 +553,7 @@ impl Lvs {
 
         info!("{}: lvs exported successfully", self_str);
 
-        bdev_destroy(&base_bdev.bdev_uri_original_str().unwrap())
+        bdev_destroy(&base_bdev.bdev_uri_original_str().unwrap_or_default())
             .await
             .map_err(|e| Error::Destroy {
                 source: e,
@@ -647,7 +647,7 @@ impl Lvs {
 
         info!("{}: lvs destroyed successfully", self_str);
 
-        bdev_destroy(&base_bdev.bdev_uri_original_str().unwrap())
+        bdev_destroy(&base_bdev.bdev_uri_original_str().unwrap_or_default())
             .await
             .map_err(|e| Error::Destroy {
                 source: e,

--- a/io-engine/src/lvs/lvs_store.rs
+++ b/io-engine/src/lvs/lvs_store.rs
@@ -333,10 +333,16 @@ impl Lvs {
                 BdevError::BdevExists {
                     ..
                 } => Ok(parsed.get_name()),
-                _ => Err(Error::InvalidBdev {
-                    source: e,
-                    name: args.disks[0].clone(),
-                }),
+                BdevError::CreateBdevInvalidParams {
+                    source, ..
+                } if source == Errno::EEXIST => Ok(parsed.get_name()),
+                _ => {
+                    tracing::error!("Failed to create pool bdev: {e:?}");
+                    Err(Error::InvalidBdev {
+                        source: e,
+                        name: args.disks[0].clone(),
+                    })
+                }
             },
             Ok(name) => Ok(name),
         }?;
@@ -468,10 +474,16 @@ impl Lvs {
                 BdevError::BdevExists {
                     ..
                 } => Ok(parsed.get_name()),
-                _ => Err(Error::InvalidBdev {
-                    source: e,
-                    name: args.disks[0].clone(),
-                }),
+                BdevError::CreateBdevInvalidParams {
+                    source, ..
+                } if source == Errno::EEXIST => Ok(parsed.get_name()),
+                _ => {
+                    tracing::error!("Failed to create pool bdev: {e:?}");
+                    Err(Error::InvalidBdev {
+                        source: e,
+                        name: args.disks[0].clone(),
+                    })
+                }
             },
             Ok(name) => Ok(name),
         }?;

--- a/io-engine/src/lvs/mod.rs
+++ b/io-engine/src/lvs/mod.rs
@@ -1,6 +1,6 @@
 pub use lvol_snapshot::LvolSnapshotIter;
 pub use lvs_bdev::LvsBdev;
-pub use lvs_error::Error;
+pub use lvs_error::{Error, ImportErrorReason};
 pub use lvs_iter::{LvsBdevIter, LvsIter};
 pub use lvs_lvol::{Lvol, LvolSpaceUsage, LvsLvol, PropName, PropValue};
 pub use lvs_store::Lvs;

--- a/test/grpc/test_nexus.js
+++ b/test/grpc/test_nexus.js
@@ -779,7 +779,7 @@ describe('nexus', function () {
       };
       client.createNexusV2(args, (err) => {
         if (!err) return done(new Error('Expected error'));
-        assert.equal(err.code, grpc.status.INTERNAL);
+        assert.equal(err.code, grpc.status.INVALID_ARGUMENT);
         done();
       });
     });
@@ -799,7 +799,7 @@ describe('nexus', function () {
       };
       client.createNexusV2(args, (err) => {
         if (!err) return done(new Error('Expected error'));
-        assert.equal(err.code, grpc.status.INTERNAL);
+        assert.equal(err.code, grpc.status.INVALID_ARGUMENT);
         done();
       });
     });


### PR DESCRIPTION
This allows us to run casperf against an lvol, example: sudo casperf
"lvol:///lvol-1?size=220GiB&lvs=lvs:///pool-1?mode=purge&disk=aio:///dev/sda" -b 128ki -q 1