### PR TITLE
fix(channel_reconfig): don't reconfigure the non-IO nexus channel

### DIFF
--- a/io-engine/src/bdev/nexus/mod.rs
+++ b/io-engine/src/bdev/nexus/mod.rs
@@ -188,3 +188,7 @@ pub static ENABLE_PARTIAL_REBUILD: AtomicBool = AtomicBool::new(true);
 
 /// Enables/disables nexus reset logic.
 pub static ENABLE_NEXUS_RESET: AtomicBool = AtomicBool::new(false);
+
+/// Whether the nexus channel should have readers/writers configured.
+/// This must be set true ONLY from tests.
+pub static ENABLE_IO_ALL_THRD_NX_CHAN: AtomicBool = AtomicBool::new(false);

--- a/io-engine/src/bdev/nexus/nexus_bdev.rs
+++ b/io-engine/src/bdev/nexus/nexus_bdev.rs
@@ -608,7 +608,9 @@ impl<'n> Nexus<'n> {
         self.traverse_io_channels(
             sender,
             |chan, _sender| -> ChannelTraverseStatus {
-                chan.reconnect_all();
+                if chan.is_io_channel() {
+                    chan.reconnect_all();
+                }
                 ChannelTraverseStatus::Ok
             },
             |status, sender| {

--- a/io-engine/src/bdev/nexus/nexus_channel.rs
+++ b/io-engine/src/bdev/nexus/nexus_channel.rs
@@ -4,11 +4,13 @@ use std::{
     cell::UnsafeCell,
     fmt::{Debug, Display, Formatter},
     pin::Pin,
+    sync::atomic::Ordering,
 };
 
 use super::{FaultReason, IOLogChannel, Nexus, NexusBio};
 
 use crate::core::{BlockDeviceHandle, CoreError, Cores};
+use spdk_rs::Thread;
 
 /// I/O channel, per core.
 #[repr(C)]
@@ -22,6 +24,7 @@ pub struct NexusChannel<'n> {
     frozen_ios: Vec<NexusBio<'n>>,
     nexus: Pin<&'n mut Nexus<'n>>,
     core: u32,
+    is_io_chan: bool,
 }
 
 impl<'n> Debug for NexusChannel<'n> {
@@ -77,26 +80,45 @@ impl<'n> NexusChannel<'n> {
     pub(crate) fn new(nexus: Pin<&mut Nexus<'n>>) -> Self {
         debug!("{nexus:?}: new channel on core {c}", c = Cores::current());
 
+        let b_init_thrd_hdls =
+            super::ENABLE_IO_ALL_THRD_NX_CHAN.load(Ordering::SeqCst);
+        let is_io_chan =
+            Thread::current().unwrap() != Thread::primary() || b_init_thrd_hdls;
+
         let mut writers = Vec::new();
         let mut readers = Vec::new();
 
-        nexus
-            .children_iter()
-            .filter(|c| c.is_healthy())
-            .for_each(|c| match (c.get_io_handle(), c.get_io_handle()) {
-                (Ok(w), Ok(r)) => {
-                    writers.push(w);
-                    readers.push(r);
-                }
-                _ => {
-                    c.set_faulted_state(FaultReason::CantOpen);
-                    error!(
-                        "Failed to get I/O handle for {c}, \
-                        skipping block device",
-                        c = c.uri()
-                    )
-                }
-            });
+        if is_io_chan {
+            nexus.children_iter().filter(|c| c.is_healthy()).for_each(
+                |c| match (c.get_io_handle(), c.get_io_handle()) {
+                    (Ok(w), Ok(r)) => {
+                        writers.push(w);
+                        readers.push(r);
+                    }
+                    _ => {
+                        c.set_faulted_state(FaultReason::CantOpen);
+                        error!(
+                            "Failed to get I/O handle for {c}, \
+                            skipping block device",
+                            c = c.uri()
+                        )
+                    }
+                },
+            );
+        } else {
+            // If we are here, this means the nexus channel being created is not
+            // the one to be used for normal IOs. Such a channel is
+            // created in rebuild path today, and it's on the init
+            // thread. The channels that we use for normal nexus IO
+            // are not on init thread however, those are on spdk threads
+            // created for nvmf target during poll group init. Those are the
+            // spdk threads named mayastor_nvmf_tcp_pg_core_*. The
+            // channel on init thread is only used for rebuild IOs.
+            // And the rebuild IOs are dispatched by
+            // directly calling write API without going via writers abstraction.
+            // Refer GTM-1075 for the race condition details.
+            debug!("{nexus:?}: skip nexus channel setup({t:?}). is_io_channel: {is_io_chan}", t = Thread::current().unwrap());
+        }
 
         Self {
             writers,
@@ -108,6 +130,7 @@ impl<'n> NexusChannel<'n> {
             io_mode: IoMode::Normal,
             frozen_ios: Vec::new(),
             core: Cores::current(),
+            is_io_chan,
         }
     }
 
@@ -139,6 +162,11 @@ impl<'n> NexusChannel<'n> {
     /// Returns the total number of available readers in this channel.
     pub(crate) fn num_readers(&self) -> usize {
         self.readers.len()
+    }
+
+    // Returns a bool indicating whether this channel is setup for normal IOs.
+    pub(crate) fn is_io_channel(&self) -> bool {
+        self.is_io_chan
     }
 
     /// Calls the given callback for each active writer.

--- a/io-engine/src/bin/casperf.rs
+++ b/io-engine/src/bin/casperf.rs
@@ -396,6 +396,7 @@ fn main() {
     let args = MayastorCliArgs {
         reactor_mask: "0x2".to_string(),
         skip_sig_handler: true,
+        enable_io_all_thrd_nexus_channels: true,
         no_pci: false,
         ..Default::default()
     };

--- a/io-engine/tests/io.rs
+++ b/io-engine/tests/io.rs
@@ -9,7 +9,10 @@ pub mod common;
 
 #[tokio::test]
 async fn io_test() {
-    let ms = common::MayastorTest::new(MayastorCliArgs::default());
+    let ms = common::MayastorTest::new(MayastorCliArgs {
+        enable_io_all_thrd_nexus_channels: true,
+        ..Default::default()
+    });
 
     let output = Command::new("truncate")
         .args(["-s", "64m", DISKNAME])

--- a/io-engine/tests/nexus_child_retire.rs
+++ b/io-engine/tests/nexus_child_retire.rs
@@ -61,7 +61,12 @@ use io_engine::{
 static MAYASTOR: OnceCell<MayastorTest> = OnceCell::new();
 
 fn get_ms() -> &'static MayastorTest<'static> {
-    MAYASTOR.get_or_init(|| MayastorTest::new(MayastorCliArgs::default()))
+    MAYASTOR.get_or_init(|| {
+        MayastorTest::new(MayastorCliArgs {
+            enable_io_all_thrd_nexus_channels: true,
+            ..Default::default()
+        })
+    })
 }
 
 /// Test cluster.

--- a/io-engine/tests/nexus_io.rs
+++ b/io-engine/tests/nexus_io.rs
@@ -91,7 +91,12 @@ static PTPL_CONTAINER_DIR: &str = "/host/tmp/ptpl";
 static MAYASTOR: OnceCell<MayastorTest> = OnceCell::new();
 
 fn get_ms() -> &'static MayastorTest<'static> {
-    MAYASTOR.get_or_init(|| MayastorTest::new(MayastorCliArgs::default()))
+    MAYASTOR.get_or_init(|| {
+        MayastorTest::new(MayastorCliArgs {
+            enable_io_all_thrd_nexus_channels: true,
+            ..Default::default()
+        })
+    })
 }
 
 fn get_mayastor_nvme_device() -> String {

--- a/io-engine/tests/nexus_rebuild.rs
+++ b/io-engine/tests/nexus_rebuild.rs
@@ -30,7 +30,12 @@ const META_SIZE: u64 = 128 * 1024 * 1024; // 128MiB
 const MAX_CHILDREN: u64 = 16;
 
 fn get_ms() -> &'static MayastorTest<'static> {
-    MAYASTOR.get_or_init(|| MayastorTest::new(MayastorCliArgs::default()))
+    MAYASTOR.get_or_init(|| {
+        MayastorTest::new(MayastorCliArgs {
+            enable_io_all_thrd_nexus_channels: true,
+            ..Default::default()
+        })
+    })
 }
 
 fn test_ini(name: &'static str) {

--- a/io-engine/tests/replica_snapshot.rs
+++ b/io-engine/tests/replica_snapshot.rs
@@ -84,7 +84,10 @@ async fn replica_snapshot() {
         .await
         .unwrap();
 
-    let mayastor = MayastorTest::new(MayastorCliArgs::default());
+    let mayastor = MayastorTest::new(MayastorCliArgs {
+        enable_io_all_thrd_nexus_channels: true,
+        ..Default::default()
+    });
     let ip0 = hdls[0].endpoint.ip();
 
     let t = mayastor

--- a/io-engine/tests/snapshot_lvol.rs
+++ b/io-engine/tests/snapshot_lvol.rs
@@ -48,7 +48,12 @@ static POOL_DEVICE_NAME: &str = "aio:///tmp/disk1.img";
 static LVOL_SIZE: u64 = 24 * 1024 * 1024;
 /// Get the global Mayastor test suite instance.
 fn get_ms() -> &'static MayastorTest<'static> {
-    MAYASTOR.get_or_init(|| MayastorTest::new(MayastorCliArgs::default()))
+    MAYASTOR.get_or_init(|| {
+        MayastorTest::new(MayastorCliArgs {
+            enable_io_all_thrd_nexus_channels: true,
+            ..Default::default()
+        })
+    })
 }
 
 /// Must be called only in Mayastor context !s


### PR DESCRIPTION
This PR changes the way we handle nexus channel on init_thread spdk thread. Since the nexus channel on init_thread is not used for normal I/O, we now don’t attempt to reconfigure it as part of dynamic reconfiguration event. This avoids the race between some ongoing async qpair connect on init thread racing with a sync connect attempt from channel reconfigure path