### PR TITLE
feat(pool): blobstore cluster size to be set during pool creation through grpc parameter value

### DIFF
--- a/io-engine-tests/src/pool.rs
+++ b/io-engine-tests/src/pool.rs
@@ -78,6 +78,7 @@ impl PoolBuilder {
                 uuid: Some(self.uuid()),
                 pooltype: 0,
                 disks: vec![self.bdev.as_ref().unwrap().clone()],
+                cluster_size: None,
             })
             .await
             .map(|r| r.into_inner())

--- a/io-engine/src/bdev/lvs.rs
+++ b/io-engine/src/bdev/lvs.rs
@@ -214,6 +214,7 @@ impl Lvs {
             name: self.name.to_owned(),
             disks: vec![self.disk.to_owned()],
             uuid: None,
+            cluster_size: None,
         };
         match &self.mode {
             LvsMode::Create => {

--- a/io-engine/src/grpc/v0/mayastor_grpc.rs
+++ b/io-engine/src/grpc/v0/mayastor_grpc.rs
@@ -209,6 +209,7 @@ impl TryFrom<CreatePoolRequest> for PoolArgs {
                 name: args.name,
                 disks: args.disks,
                 uuid: None,
+                cluster_size: None,
             }),
         }
     }

--- a/io-engine/src/grpc/v1/pool.rs
+++ b/io-engine/src/grpc/v1/pool.rs
@@ -89,6 +89,7 @@ impl TryFrom<CreatePoolRequest> for PoolArgs {
             name: args.name,
             disks: args.disks,
             uuid: args.uuid,
+            cluster_size: args.cluster_size,
         })
     }
 }
@@ -116,6 +117,7 @@ impl TryFrom<ImportPoolRequest> for PoolArgs {
             name: args.name,
             disks: args.disks,
             uuid: args.uuid,
+            cluster_size: None,
         })
     }
 }
@@ -149,6 +151,7 @@ impl From<Lvs> for Pool {
             used: l.used(),
             committed: l.committed(),
             pooltype: PoolType::Lvs as i32,
+            cluster_size: l.blob_cluster_size() as u32,
         }
     }
 }

--- a/io-engine/src/lvs/lvol_snapshot.rs
+++ b/io-engine/src/lvs/lvol_snapshot.rs
@@ -500,7 +500,6 @@ impl SnapshotOps for Lvol {
             }
             s.send((errno, lvol_ptr)).ok();
         }
-
         let (s, r) = oneshot::channel::<(i32, *mut spdk_lvol)>();
 
         self.do_create_snapshot(

--- a/io-engine/src/lvs/lvs_error.rs
+++ b/io-engine/src/lvs/lvs_error.rs
@@ -59,6 +59,17 @@ pub enum Error {
         source: Errno,
         msg: String,
     },
+    #[snafu(display(
+        "errno {}: Invalid cluster-size {}, for pool {}",
+        source,
+        msg,
+        name
+    ))]
+    InvalidClusterSize {
+        source: Errno,
+        name: String,
+        msg: String,
+    },
     #[snafu(display("lvol exists {}", name))]
     RepExists {
         source: Errno,
@@ -193,6 +204,9 @@ impl ToErrno for Error {
                 ..
             } => Errno::ENXIO,
             Self::Invalid {
+                source, ..
+            } => source,
+            Self::InvalidClusterSize {
                 source, ..
             } => source,
             Self::RepExists {

--- a/io-engine/src/pool_backend.rs
+++ b/io-engine/src/pool_backend.rs
@@ -8,6 +8,7 @@ pub struct PoolArgs {
     pub name: String,
     pub disks: Vec<String>,
     pub uuid: Option<String>,
+    pub cluster_size: Option<u32>,
 }
 
 /// PoolBackend is the type of pool underneath Lvs, Lvm, etc

--- a/io-engine/src/subsys/config/pool.rs
+++ b/io-engine/src/subsys/config/pool.rs
@@ -174,6 +174,7 @@ impl From<&Pool> for PoolArgs {
             name: pool.name.clone(),
             disks: pool.disks.clone(),
             uuid: None,
+            cluster_size: None,
         }
     }
 }

--- a/io-engine/tests/lvs_pool.rs
+++ b/io-engine/tests/lvs_pool.rs
@@ -42,6 +42,7 @@ async fn lvs_pool_test() {
             name: "tpool".into(),
             disks: vec!["aio:///tmp/disk1.img".into()],
             uuid: None,
+            cluster_size: None,
         })
         .await
         .unwrap();
@@ -53,7 +54,7 @@ async fn lvs_pool_test() {
     // have an idempotent snafu, we dont crash and
     // burn
     ms.spawn(async {
-        assert!(Lvs::create("tpool", "aio:///tmp/disk1.img", None)
+        assert!(Lvs::create("tpool", "aio:///tmp/disk1.img", None, None)
             .await
             .is_err())
     })
@@ -109,7 +110,7 @@ async fn lvs_pool_test() {
         assert!(Lvs::import("tpool", "aio:///tmp/disk1.img").await.is_err());
 
         assert_eq!(Lvs::iter().count(), 0);
-        assert!(Lvs::create("tpool", "aio:///tmp/disk1.img", None)
+        assert!(Lvs::create("tpool", "aio:///tmp/disk1.img", None, None)
             .await
             .is_ok());
 
@@ -138,6 +139,7 @@ async fn lvs_pool_test() {
             name: "tpool2".to_string(),
             disks: vec!["malloc:///malloc0?size_mb=64".to_string()],
             uuid: None,
+            cluster_size: None,
         })
         .await
         .unwrap();
@@ -172,6 +174,7 @@ async fn lvs_pool_test() {
             name: "tpool".to_string(),
             disks: vec!["aio:///tmp/disk1.img".to_string()],
             uuid: None,
+            cluster_size: None,
         })
         .await
         .unwrap();
@@ -304,6 +307,7 @@ async fn lvs_pool_test() {
             name: "tpool".into(),
             disks: vec!["aio:///tmp/disk1.img".into()],
             uuid: None,
+            cluster_size: None,
         })
         .await
         .unwrap();
@@ -333,6 +337,7 @@ async fn lvs_pool_test() {
             name: "jpool".into(),
             disks: vec!["aio:///tmp/disk1.img".into()],
             uuid: None,
+            cluster_size: None,
         })
         .await
         .err()
@@ -348,6 +353,7 @@ async fn lvs_pool_test() {
             name: "tpool2".into(),
             disks: vec!["/tmp/disk2.img".into()],
             uuid: None,
+            cluster_size: None,
         })
         .await
         .unwrap();

--- a/io-engine/tests/nexus_child_retire.rs
+++ b/io-engine/tests/nexus_child_retire.rs
@@ -558,6 +558,7 @@ async fn init_ms_etcd_test() -> ComposeTest {
                 name: POOL_NAME_0.to_string(),
                 disks: vec![BDEV_NAME_0.to_string()],
                 uuid: None,
+                cluster_size: None,
             })
             .await
             .unwrap();
@@ -572,6 +573,7 @@ async fn init_ms_etcd_test() -> ComposeTest {
                 name: POOL_NAME_1.to_string(),
                 disks: vec![DISK_NAME_1.to_string()],
                 uuid: None,
+                cluster_size: None,
             })
             .await
             .unwrap();

--- a/io-engine/tests/nexus_io.rs
+++ b/io-engine/tests/nexus_io.rs
@@ -1072,6 +1072,7 @@ async fn nexus_io_write_zeroes() {
                 name: POOL_NAME.to_string(),
                 disks: vec![BDEVNAME1.to_string()],
                 uuid: None,
+                cluster_size: None,
             })
             .await
             .unwrap();

--- a/io-engine/tests/nexus_with_local.rs
+++ b/io-engine/tests/nexus_with_local.rs
@@ -48,6 +48,7 @@ async fn create_replicas(h: &mut RpcHandle) {
             uuid: Some(pool_uuid()),
             pooltype: 0,
             disks: vec!["malloc:///disk0?size_mb=64".into()],
+            cluster_size: None,
         })
         .await
         .unwrap();

--- a/io-engine/tests/nvmf_connect.rs
+++ b/io-engine/tests/nvmf_connect.rs
@@ -96,6 +96,7 @@ async fn init_nvmf_share() -> String {
                 name: POOL_NAME.to_string(),
                 disks: vec![BDEV_NAME.to_string()],
                 uuid: None,
+                cluster_size: None,
             })
             .await
             .unwrap();

--- a/io-engine/tests/replica_snapshot.rs
+++ b/io-engine/tests/replica_snapshot.rs
@@ -96,6 +96,7 @@ async fn replica_snapshot() {
                 name: POOL1_NAME.to_string(),
                 disks: vec![format!("aio://{DISKNAME1}")],
                 uuid: None,
+                cluster_size: None,
             })
             .await
             .unwrap();

--- a/io-engine/tests/snapshot_nexus.rs
+++ b/io-engine/tests/snapshot_nexus.rs
@@ -135,6 +135,7 @@ async fn launch_instance(create_replicas: bool) -> (ComposeTest, Vec<String>) {
             uuid: Some(pool_uuid()),
             pooltype: 0,
             disks: vec!["malloc:///disk0?size_mb=128".into()],
+            cluster_size: None,
         })
         .await
         .unwrap();


### PR DESCRIPTION
- The default cluster size considered by SPDK is 4MiB.
- During pool creation, cluster_size can be taken from the gRPC and consider that value.
- The cluster_size can be consider with multiple of 1MiB.
- If the cluster_size passed not multiple of 1MiB, then default 4MiB cluster size will be considered for the pool creation.