### PR TITLE
fix(subsys): getting back posix socket options

### DIFF
--- a/mayastor/src/subsys/config/mod.rs
+++ b/mayastor/src/subsys/config/mod.rs
@@ -28,6 +28,7 @@ use crate::{
         NexusOpts,
         NvmeBdevOpts,
         NvmfTgtConfig,
+        PosixSocketOpts,
     },
 };
 
@@ -127,6 +128,8 @@ pub struct Config {
     pub bdev_opts: BdevOpts,
     /// nexus specific options
     pub nexus_opts: NexusOpts,
+    /// socket specific options
+    pub socket_opts: PosixSocketOpts,
 }
 
 impl Config {
@@ -188,6 +191,7 @@ impl Config {
             nvme_bdev_opts: self.nvme_bdev_opts.get(),
             bdev_opts: self.bdev_opts.get(),
             nexus_opts: self.nexus_opts.get(),
+            socket_opts: self.socket_opts.get(),
         }
     }
 
@@ -217,5 +221,6 @@ impl Config {
 
         assert!(self.nvme_bdev_opts.set());
         assert!(self.bdev_opts.set());
+        assert!(self.socket_opts.set());
     }
 }

--- a/mayastor/src/subsys/config/opts.rs
+++ b/mayastor/src/subsys/config/opts.rs
@@ -482,14 +482,20 @@ impl GetOpts for PosixSocketOpts {
         };
 
         let size = std::mem::size_of::<spdk_sock_impl_opts>() as u64;
-        unsafe {
-            let name = std::ffi::CString::new("posix").unwrap();
-            let rc = spdk_sock_impl_set_opts(
+        let name = std::ffi::CString::new("posix").unwrap();
+
+        if unsafe {
+            spdk_sock_impl_set_opts(
                 name.as_ptr(),
                 &opts as *const _ as *mut spdk_sock_impl_opts,
                 size,
-            );
-            rc == 0
+            )
+        } != 0
+        {
+            warn!("Failed to apply socket options");
+            return false;
         }
+        info!("Socket options successfully applied");
+        true
     }
 }


### PR DESCRIPTION
Settings POSIX socket options was accidentally removed. This commit brings it back.