### PR TITLE
fix(subsys): getting back posix socket options

### DIFF
--- a/io-engine/src/subsys/config/mod.rs
+++ b/io-engine/src/subsys/config/mod.rs
@@ -29,6 +29,7 @@ use crate::{
         NexusOpts,
         NvmeBdevOpts,
         NvmfTgtConfig,
+        PosixSocketOpts,
     },
 };
 
@@ -128,6 +129,8 @@ pub struct Config {
     pub bdev_opts: BdevOpts,
     /// nexus specific options
     pub nexus_opts: NexusOpts,
+    /// socket specific options
+    pub socket_opts: PosixSocketOpts,
     /// iobuf specific options
     pub iobuf_opts: IoBufOpts,
 }
@@ -191,6 +194,7 @@ impl Config {
             nvme_bdev_opts: self.nvme_bdev_opts.get(),
             bdev_opts: self.bdev_opts.get(),
             nexus_opts: self.nexus_opts.get(),
+            socket_opts: self.socket_opts.get(),
             iobuf_opts: self.iobuf_opts.get(),
         }
     }
@@ -220,6 +224,7 @@ impl Config {
         info!("Applying Mayastor configuration settings");
         assert!(self.nvme_bdev_opts.set());
         assert!(self.bdev_opts.set());
+        assert!(self.socket_opts.set());
         assert!(self.iobuf_opts.set());
 
         debug!("{:#?}", self);


### PR DESCRIPTION
Settings POSIX socket options was accidentally removed. This commit brings it back.