### PR TITLE
feat(replica/resize): add support for resizing a replica

### DIFF
--- a/io-engine/src/grpc/v0/mayastor_grpc.rs
+++ b/io-engine/src/grpc/v0/mayastor_grpc.rs
@@ -249,6 +249,18 @@ impl From<LvsError> for tonic::Status {
                 Errno::EMEDIUMTYPE => Status::aborted(e.to_string()),
                 _ => Status::internal(e.to_string()),
             },
+            LvsError::RepResize {
+                source, ..
+            } => match source {
+                Errno::ENOSPC | Errno::ENOMEM => {
+                    Status::resource_exhausted(e.to_string())
+                }
+                Errno::EPERM => Status::permission_denied(e.to_string()),
+                Errno::EINVAL | Errno::ENOENT => {
+                    Status::invalid_argument(e.to_string())
+                }
+                _ => Status::internal(e.to_string()),
+            },
             LvsError::RepExists {
                 ..
             } => Status::already_exists(e.to_string()),

--- a/io-engine/src/lvs/lvs_error.rs
+++ b/io-engine/src/lvs/lvs_error.rs
@@ -86,6 +86,11 @@ pub enum Error {
         name: String,
         msg: String,
     },
+    #[snafu(display("failed to resize lvol {}", name))]
+    RepResize {
+        source: Errno,
+        name: String,
+    },
     #[snafu(display("bdev {} is not a lvol", name))]
     NotALvol {
         source: Errno,
@@ -216,6 +221,9 @@ impl ToErrno for Error {
                 source, ..
             } => source,
             Self::RepDestroy {
+                source, ..
+            } => source,
+            Self::RepResize {
                 source, ..
             } => source,
             Self::NotALvol {


### PR DESCRIPTION
Added the support for resizing a replica. The replicas need to be expanded as part of the volume expand workflow.