### PR TITLE
Various fixes for idempotency, error messages and concurrency

### DIFF
--- a/io-engine/src/bdev/nexus/nexus_bdev_error.rs
+++ b/io-engine/src/bdev/nexus/nexus_bdev_error.rs
@@ -131,11 +131,7 @@ pub enum Error {
         name
     ))]
     RemoveLastHealthyChild { child: String, name: String },
-    #[snafu(display(
-        "Cannot remove or offline the last healthy child {} of nexus {}",
-        child,
-        name
-    ))]
+    #[snafu(display("Child {} of nexus {} not found", child, name))]
     ChildNotFound { child: String, name: String },
     #[snafu(display("Child {} of nexus {} is not open", child, name))]
     ChildDeviceNotOpen { child: String, name: String },

--- a/io-engine/src/bdev/nexus/nexus_share.rs
+++ b/io-engine/src/bdev/nexus/nexus_share.rs
@@ -255,7 +255,9 @@ impl<'n> From<&Nexus<'n>> for NexusPtpl {
 impl PtplFileOps for NexusPtpl {
     fn destroy(&self) -> Result<(), std::io::Error> {
         if let Some(path) = self.path() {
-            std::fs::remove_file(path)?;
+            if path.exists() {
+                std::fs::remove_file(path)?;
+            }
         }
         Ok(())
     }

--- a/io-engine/src/bdev_api.rs
+++ b/io-engine/src/bdev_api.rs
@@ -80,10 +80,7 @@ pub enum BdevError {
     #[snafu(display("BDEV '{}' could not be found", name))]
     BdevNotFound { name: String },
     // Invalid creation parameters.
-    #[snafu(display(
-        "Failed to create a BDEV '{}': invalid parameters",
-        name
-    ))]
+    #[snafu(display("Failed to create a BDEV '{}'", name))]
     CreateBdevInvalidParams { source: Errno, name: String },
     // Generic creation failure.
     #[snafu(display("Failed to create a BDEV '{}'", name))]

--- a/io-engine/src/bin/io-engine-client/v0/nexus_cli.rs
+++ b/io-engine/src/bin/io-engine-client/v0/nexus_cli.rs
@@ -708,17 +708,18 @@ async fn nexus_publish(
         .get_one::<String>("key")
         .cloned()
         .unwrap_or_default();
-    let protocol = match matches.get_one::<&str>("protocol") {
-        None => v0::ShareProtocolNexus::NexusNbd,
-        Some(&"nvmf") => v0::ShareProtocolNexus::NexusNvmf,
-        Some(_) => {
-            return Err(Status::new(
-                Code::Internal,
-                "Invalid value of share protocol".to_owned(),
-            ))
-            .context(GrpcStatus);
-        }
-    };
+    let protocol =
+        match matches.get_one::<String>("protocol").map(|s| s.as_str()) {
+            None => v0::ShareProtocolNexus::NexusNbd,
+            Some("nvmf") => v0::ShareProtocolNexus::NexusNvmf,
+            Some(_) => {
+                return Err(Status::new(
+                    Code::Internal,
+                    "Invalid value of share protocol".to_owned(),
+                ))
+                .context(GrpcStatus);
+            }
+        };
     let allowed_hosts = matches
         .get_many::<String>("allowed-host")
         .unwrap_or_default()

--- a/io-engine/src/bin/io-engine-client/v1/nexus_cli.rs
+++ b/io-engine/src/bin/io-engine-client/v1/nexus_cli.rs
@@ -579,17 +579,18 @@ async fn nexus_publish(
         .cloned()
         .unwrap_or_default();
 
-    let protocol = match matches.get_one::<&str>("protocol") {
-        None => v1::common::ShareProtocol::Nvmf as i32,
-        Some(&"nvmf") => v1::common::ShareProtocol::Nvmf as i32,
-        Some(_) => {
-            return Err(Status::new(
-                Code::Internal,
-                "Invalid value of share protocol".to_owned(),
-            ))
-            .context(GrpcStatus);
-        }
-    };
+    let protocol =
+        match matches.get_one::<String>("protocol").map(|s| s.as_str()) {
+            None => v1::common::ShareProtocol::Nvmf as i32,
+            Some("nvmf") => v1::common::ShareProtocol::Nvmf as i32,
+            Some(_) => {
+                return Err(Status::new(
+                    Code::Internal,
+                    "Invalid value of share protocol".to_owned(),
+                ))
+                .context(GrpcStatus);
+            }
+        };
     let allowed_hosts = matches
         .get_many::<String>("allowed-host")
         .unwrap_or_default()

--- a/io-engine/src/bin/io-engine-client/v1/test_cli.rs
+++ b/io-engine/src/bin/io-engine-client/v1/test_cli.rs
@@ -183,10 +183,14 @@ async fn replica_wipe(
         .map_err(|e| Status::invalid_argument(e.to_string()))
         .context(GrpcStatus)?;
 
-    let chunk_size =
-        parse_size(matches.get_one::<&str>("chunk-size").unwrap_or(&"0"))
-            .map_err(|s| Status::invalid_argument(format!("Bad size '{s}'")))
-            .context(GrpcStatus)?;
+    let chunk_size = parse_size(
+        matches
+            .get_one::<String>("chunk-size")
+            .map(|s| s.as_str())
+            .unwrap_or("0"),
+    )
+    .map_err(|s| Status::invalid_argument(format!("Bad size '{s}'")))
+    .context(GrpcStatus)?;
     let response = ctx
         .v1
         .test

--- a/io-engine/src/grpc/mod.rs
+++ b/io-engine/src/grpc/mod.rs
@@ -120,6 +120,12 @@ pub(crate) trait Serializer<F, T> {
     async fn locked(&self, ctx: GrpcClientContext, f: F) -> Result<T, Status>;
 }
 
+#[async_trait::async_trait]
+pub(crate) trait RWSerializer<F, T> {
+    async fn locked(&self, ctx: GrpcClientContext, f: F) -> Result<T, Status>;
+    async fn shared(&self, ctx: GrpcClientContext, f: F) -> Result<T, Status>;
+}
+
 pub type GrpcResult<T> = std::result::Result<Response<T>, Status>;
 
 /// call the given future within the context of the reactor on the first core

--- a/io-engine/src/grpc/server.rs
+++ b/io-engine/src/grpc/server.rs
@@ -93,10 +93,14 @@ impl MayastorGrpcServer {
                 v1::replica::ReplicaRpcServer::new(replica_v1.clone())
             }))
             .add_optional_service(enable_v1.map(|_| {
-                v1::test::TestRpcServer::new(TestService::new(replica_v1))
+                v1::test::TestRpcServer::new(TestService::new(
+                    replica_v1.clone(),
+                ))
             }))
             .add_optional_service(enable_v1.map(|_| {
-                v1::snapshot::SnapshotRpcServer::new(SnapshotService::new())
+                v1::snapshot::SnapshotRpcServer::new(SnapshotService::new(
+                    replica_v1,
+                ))
             }))
             .add_optional_service(enable_v1.map(|_| {
                 v1::host::HostRpcServer::new(HostService::new(

--- a/io-engine/src/grpc/v1/test.rs
+++ b/io-engine/src/grpc/v1/test.rs
@@ -5,7 +5,7 @@ use crate::{
         Bdev,
         VerboseError,
     },
-    grpc::{rpc_submit, GrpcClientContext, GrpcResult, Serializer},
+    grpc::{rpc_submit, GrpcClientContext, GrpcResult, RWSerializer},
     lvs::{Error as LvsError, Lvol, Lvs, LvsLvol},
 };
 use ::function_name::named;
@@ -74,7 +74,7 @@ impl TestRpc for TestService {
 
         crate::core::spawn(async move {
             let result = replica_svc
-                .locked(
+                .shared(
                     GrpcClientContext::new(&request, function_name!()),
                     async move {
                         let args = request.into_inner();

--- a/io-engine/src/lvs/lvs_store.rs
+++ b/io-engine/src/lvs/lvs_store.rs
@@ -906,7 +906,9 @@ impl From<&Lvs> for LvsPtpl {
 impl PtplFileOps for LvsPtpl {
     fn destroy(&self) -> Result<(), std::io::Error> {
         if let Some(path) = self.path() {
-            std::fs::remove_dir_all(path)?;
+            if path.exists() {
+                std::fs::remove_dir_all(path)?;
+            }
         }
         Ok(())
     }

--- a/io-engine/src/subsys/config/opts.rs
+++ b/io-engine/src/subsys/config/opts.rs
@@ -215,8 +215,8 @@ where
     <T as TryFrom<u128>>::Error: Display,
 {
     match std::env::var(name) {
-        Ok(value) => {
-            let result = match humantime::parse_duration(&value) {
+        Ok(human_value) => {
+            let result = match humantime::parse_duration(&human_value) {
                 Ok(value) => {
                     let in_units = unit.value(value);
                     if in_units == 0 && !value.is_zero() {
@@ -230,11 +230,11 @@ where
             };
             match result {
                 Ok(value) => {
-                    info!("Overriding {} value to '{}'", name, value);
+                    info!("Overriding {} value to '{}'", name, human_value);
                     value
                 }
                 Err(e) => {
-                    error!("Invalid value: {} (error {}) specified for {}. Reverting to default value ({}{})", value, e, name, default, unit.units());
+                    error!("Invalid value: {} (error {}) specified for {}. Reverting to default value ({}{})", human_value, e, name, default, unit.units());
                     default
                 }
             }

--- a/test/grpc/test_replica.js
+++ b/test/grpc/test_replica.js
@@ -166,7 +166,7 @@ describe('replica', function () {
     client.createPool(
       { name: POOL, disks: disks.map((d) => `${d}?blk_size=1238513`) },
       (err) => {
-        assert.equal(err.code, grpc.status.INTERNAL);
+        assert.equal(err.code, grpc.status.INVALID_ARGUMENT);
         done();
       }
     );
@@ -517,7 +517,7 @@ describe('replica', function () {
         [
           (next) => rmBlockFile(next),
           (next) => fs.writeFile(blockFile, buf, next),
-          (next) => client.createPool({ name: POOL, disks: disks }, next)
+          (next) => client.createPool({ name: POOL, disks }, next)
         ],
         done
       );


### PR DESCRIPTION
    fix(grpc/snapshot): snapshot grpc should use replica svc
    
    We should not allow concurrent snapshot and replica operations as they might clash.
    todo: allow per-resource locking
    Furthermore it was observed that holding a bdev ptr whilst it's being deleted might
    cause a crash, we need to determine if this was to do with it being held over an
    async point, or a more general problem.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    ci(test/wipe/replicas): allow list and wipe replicas
    
    System test is using wipe replicas, which can block list calls from the control-plane
    and thus confusing it thinking the node is not responding.
    Let's allow concurrent wipe with lists, since wiping doesn't destroy or modify
    replica metadata anyway.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    fix(io-engine/client): fix cli args
    
    Some args were not setup correctly since clap update.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    fix: bad error message
    
    ChildNotFound error had an invalid error message.
    Don't output NotFound messages for ptpl.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    fix(lvs/status): fixup missing bdev errors
    
    Allows the control-plane to determine what the inner error was.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>