### PR TITLE
Various CI and CLI improvements

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -276,6 +276,7 @@ pipeline {
                 // They could be lingering if there were previous test failures.
                 sh 'docker system prune -f'
                 sh 'nix-shell --run "./scripts/pytest-tests.sh" ci.nix'
+                sh 'nix-shell --run "./scripts/pytest-tests.sh --clean-all-exit" ci.nix'
                 sh 'docker system prune -f'
               }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -276,8 +276,12 @@ pipeline {
                 // They could be lingering if there were previous test failures.
                 sh 'docker system prune -f'
                 sh 'nix-shell --run "./scripts/pytest-tests.sh" ci.nix'
-                sh 'nix-shell --run "./scripts/pytest-tests.sh --clean-all-exit" ci.nix'
-                sh 'docker system prune -f'
+              }
+              post {
+                always {
+                  junit '*-xunit-report.xml'
+                  sh 'sudo ./scripts/check-coredumps.sh --since "${START_DATE}"'
+                }
               }
             }
           }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -279,6 +279,7 @@ pipeline {
               }
               post {
                 always {
+                  sh 'nix-shell --run "./scripts/pytest-tests.sh --clean-all-exit" ci.nix'
                   junit '*-xunit-report.xml'
                   sh 'sudo ./scripts/check-coredumps.sh --since "${START_DATE}"'
                 }

--- a/io-engine/src/bin/io-engine-client/v1/controller_cli.rs
+++ b/io-engine/src/bin/io-engine-client/v1/controller_cli.rs
@@ -114,7 +114,9 @@ async fn controller_stats(
                 "READS",
                 "WRITES",
                 "READ/B",
-                "WRITTEN/B, NUM_UNMAPS, BYTES_UNMAPPED",
+                "WRITTEN/B",
+                "NUM_UNMAPS",
+                "BYTES_UNMAPPED",
             ];
             ctx.print_list(hdr, vec![row]);
         }

--- a/scripts/pytest-tests.sh
+++ b/scripts/pytest-tests.sh
@@ -5,6 +5,18 @@ set -eu -o pipefail
 SCRIPTDIR="$(realpath "$(dirname "$0")")"
 ROOTDIR=$(readlink -f "$SCRIPTDIR/..")
 
+function cleanup_handler()
+{
+  ERROR=$?
+  trap - INT QUIT TERM HUP
+  clean_all
+  if [ $ERROR != 0 ]; then exit $ERROR; fi
+}
+function trap_setup()
+{
+  trap cleanup_handler INT QUIT TERM HUP
+}
+
 function clean_all()
 {
   echo "Cleaning up all docker-compose clusters..."
@@ -74,6 +86,9 @@ while [ "$#" -gt 0 ]; do
   esac
   shift
 done
+
+# Ensure we cleanup when terminated
+trap_setup
 
 if [ -n "$TEST_LIST" ]; then
   echo -e "$TEST_LIST" | run_tests


### PR DESCRIPTION
    test(python/bdd): cleanup when terminated
    
    Sometimes when testing we want to ^C and run something else, but this leaves
    cruft behind.
    In such case, we should cleanup to ensure environment is clean.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    ci(python): add junit reports
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    chore: update dependencies repo
    
    Fixes missing test output on CI failures.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    test(python): enhance python bdd testing script
    
    Allows specification of a test list
    Allows specification of a specific scenario
    Adds cleanup args:
    --clean-all: cleans all docker-compose clusters
    --clean-all-exit: clean all and exit
    Adds cleanup on a per-test basis
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    fix(io-engine/cli): fix controller stats
    
    Human output parameters were setup incorrectly..
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>
