### PR TITLE
test(python): pin docker version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -279,9 +279,8 @@ pipeline {
               }
               post {
                 always {
-                  sh 'nix-shell --run "./scripts/pytest-tests.sh --clean-all-exit" ci.nix'
                   junit '*-xunit-report.xml'
-                  sh 'sudo ./scripts/check-coredumps.sh --since "${START_DATE}"'
+                  sh 'nix-shell --run "./scripts/pytest-tests.sh --clean-all-exit" ci.nix'
                 }
               }
             }

--- a/test/python/requirements.txt
+++ b/test/python/requirements.txt
@@ -11,3 +11,4 @@ pytest-timeout==2.1.0
 pytest-variables==3.0.0
 retrying==1.3.4
 requests==2.31.0
+docker==6.1.3


### PR DESCRIPTION
Python package docker 7 no longer uses ssl_version parameter.