### PR TITLE
feat(metrics): adding stats service and pool io stats rpc

### DIFF
--- a/io-engine/src/bin/io-engine-client/context.rs
+++ b/io-engine/src/bin/io-engine-client/context.rs
@@ -67,6 +67,7 @@ mod v1 {
     pub type NexusRpcClient = nexus::NexusRpcClient<Channel>;
     pub type SnapshotRpcClient = snapshot::SnapshotRpcClient<Channel>;
     pub type TestRpcClient = test::TestRpcClient<Channel>;
+    pub type StatsRpcClient = stats::StatsRpcClient<Channel>;
 
     pub struct Context {
         pub bdev: BdevRpcClient,
@@ -77,6 +78,7 @@ mod v1 {
         pub nexus: NexusRpcClient,
         pub snapshot: SnapshotRpcClient,
         pub test: TestRpcClient,
+        pub stats: StatsRpcClient,
     }
 
     impl Context {
@@ -89,6 +91,7 @@ mod v1 {
             let nexus = NexusRpcClient::connect(h.clone()).await.unwrap();
             let snapshot = SnapshotRpcClient::connect(h.clone()).await.unwrap();
             let test = TestRpcClient::connect(h.clone()).await.unwrap();
+            let stats = StatsRpcClient::connect(h).await.unwrap();
 
             Ok(Self {
                 bdev,
@@ -99,6 +102,7 @@ mod v1 {
                 nexus,
                 snapshot,
                 test,
+                stats,
             })
         }
     }

--- a/io-engine/src/bin/io-engine-client/v1/mod.rs
+++ b/io-engine/src/bin/io-engine-client/v1/mod.rs
@@ -9,6 +9,7 @@ pub mod pool_cli;
 pub mod rebuild_cli;
 pub mod replica_cli;
 pub mod snapshot_cli;
+pub mod stats_cli;
 mod test_cli;
 
 pub(crate) use super::context;
@@ -76,6 +77,7 @@ pub(super) async fn main_() -> crate::Result<()> {
         .subcommand(jsonrpc_cli::subcommands())
         .subcommand(controller_cli::subcommands())
         .subcommand(test_cli::subcommands())
+        .subcommand(stats_cli::subcommands())
         .subcommand_required(true)
         .arg_required_else_help(true)
         .get_matches();
@@ -93,6 +95,7 @@ pub(super) async fn main_() -> crate::Result<()> {
         ("replica", args) => replica_cli::handler(ctx, args).await,
         ("rebuild", args) => rebuild_cli::handler(ctx, args).await,
         ("snapshot", args) => snapshot_cli::handler(ctx, args).await,
+        ("stats", args) => stats_cli::handler(ctx, args).await,
         ("controller", args) => controller_cli::handler(ctx, args).await,
         ("jsonrpc", args) => jsonrpc_cli::json_rpc_call(ctx, args).await,
         ("test", args) => test_cli::handler(ctx, args).await,

--- a/io-engine/src/bin/io-engine-client/v1/pool_cli.rs
+++ b/io-engine/src/bin/io-engine-client/v1/pool_cli.rs
@@ -79,13 +79,6 @@ pub fn subcommands() -> Command {
                 .help("Storage pool name"),
         );
 
-    let metrics = Command::new("metrics").about("Get Pool IO Stats").arg(
-        Arg::new("pool")
-            .required(false)
-            .index(1)
-            .help("Storage pool name"),
-    );
-
     Command::new("pool")
         .subcommand_required(true)
         .arg_required_else_help(true)
@@ -95,7 +88,6 @@ pub fn subcommands() -> Command {
         .subcommand(destroy)
         .subcommand(export)
         .subcommand(Command::new("list").about("List storage pools"))
-        .subcommand(metrics)
 }
 
 pub async fn handler(ctx: Context, matches: &ArgMatches) -> crate::Result<()> {
@@ -105,7 +97,6 @@ pub async fn handler(ctx: Context, matches: &ArgMatches) -> crate::Result<()> {
         ("destroy", args) => destroy(ctx, args).await,
         ("export", args) => export(ctx, args).await,
         ("list", args) => list(ctx, args).await,
-        ("metrics", args) => metrics(ctx, args).await,
         (cmd, _) => {
             Err(Status::not_found(format!("command {cmd} does not exist")))
                 .context(GrpcStatus)
@@ -334,92 +325,6 @@ async fn list(mut ctx: Context, _matches: &ArgMatches) -> crate::Result<()> {
     Ok(())
 }
 
-async fn metrics(mut ctx: Context, _matches: &ArgMatches) -> crate::Result<()> {
-    ctx.v2("Requesting Pool metrics");
-    let response = ctx
-        .v1
-        .stats
-        .get_pool_io_stats(v1rpc::stats::ListStatsOption {
-            name: None,
-        })
-        .await
-        .context(GrpcStatus)?;
-    match ctx.output {
-        OutputFormat::Json => {
-            println!(
-                "{}",
-                serde_json::to_string_pretty(response.get_ref())
-                    .unwrap()
-                    .to_colored_json_auto()
-                    .unwrap()
-            );
-        }
-        OutputFormat::Default => {
-            let stats: &Vec<v1rpc::stats::IoStats> = &response.get_ref().stats;
-            if stats.is_empty() {
-                ctx.v1("No Pool IoStats found");
-                return Ok(());
-            }
-
-            let table = stats
-                .iter()
-                .map(|p| {
-                    let read_latency =
-                        ticks_to_time(p.read_latency_ticks, p.tick_rate);
-                    let write_latency =
-                        ticks_to_time(p.write_latency_ticks, p.tick_rate);
-                    let unmap_latency =
-                        ticks_to_time(p.unmap_latency_ticks, p.tick_rate);
-                    let max_read_latency =
-                        ticks_to_time(p.max_read_latency_ticks, p.tick_rate);
-                    let min_read_latency =
-                        ticks_to_time(p.min_read_latency_ticks, p.tick_rate);
-                    let max_write_latency =
-                        ticks_to_time(p.max_write_latency_ticks, p.tick_rate);
-                    let min_write_latency =
-                        ticks_to_time(p.min_write_latency_ticks, p.tick_rate);
-                    vec![
-                        p.name.clone(),
-                        p.num_read_ops.to_string(),
-                        p.bytes_read.to_string(),
-                        p.num_write_ops.to_string(),
-                        p.bytes_written.to_string(),
-                        p.num_unmap_ops.to_string(),
-                        p.bytes_unmapped.to_string(),
-                        read_latency.to_string(),
-                        write_latency.to_string(),
-                        unmap_latency.to_string(),
-                        max_read_latency.to_string(),
-                        min_read_latency.to_string(),
-                        max_write_latency.to_string(),
-                        min_write_latency.to_string(),
-                    ]
-                })
-                .collect();
-            ctx.print_list(
-                vec![
-                    "NAME",
-                    "NUM_READ",
-                    "BYTES_READ",
-                    "NUM_WRITE",
-                    "BYTES_WRITTEN",
-                    "NUM_UNMAP",
-                    "BYTES_UNMAPPED",
-                    "READ_LAT",
-                    "WRITE_LAT",
-                    "UNMAP_LATENCY",
-                    "MAX_READ_LAT",
-                    "MIN_READ_LAT",
-                    "MAX_WRITE_LAT",
-                    "MIN_WRITE_LAT",
-                ],
-                table,
-            );
-        }
-    };
-    Ok(())
-}
-
 fn pool_state_to_str(idx: i32) -> &'static str {
     match v1rpc::pool::PoolState::try_from(idx).unwrap() {
         v1rpc::pool::PoolState::PoolUnknown => "unknown",
@@ -427,8 +332,4 @@ fn pool_state_to_str(idx: i32) -> &'static str {
         v1rpc::pool::PoolState::PoolDegraded => "degraded",
         v1rpc::pool::PoolState::PoolFaulted => "faulted",
     }
-}
-
-fn ticks_to_time(tick: u64, tick_rate: u64) -> u64 {
-    (tick * 1000000) / tick_rate
 }

--- a/io-engine/src/bin/io-engine-client/v1/stats_cli.rs
+++ b/io-engine/src/bin/io-engine-client/v1/stats_cli.rs
@@ -1,0 +1,142 @@
+use crate::{
+    context::{Context, OutputFormat},
+    GrpcStatus,
+};
+use byte_unit::Byte;
+use clap::{Arg, ArgMatches, Command};
+use colored_json::ToColoredJson;
+use io_engine_api::v1 as v1rpc;
+use snafu::ResultExt;
+use tonic::Status;
+
+pub fn subcommands() -> Command {
+    let pool = Command::new("pool").about("Get Pool IO Stats").arg(
+        Arg::new("name")
+            .required(false)
+            .index(1)
+            .help("Storage pool name"),
+    );
+
+    let reset = Command::new("reset").about("Reset all resource IO Stats");
+
+    Command::new("stats")
+        .subcommand_required(true)
+        .arg_required_else_help(true)
+        .about("Resource IOStats")
+        .subcommand(pool)
+        .subcommand(reset)
+}
+
+pub async fn handler(ctx: Context, matches: &ArgMatches) -> crate::Result<()> {
+    match matches.subcommand().unwrap() {
+        ("pool", args) => pool(ctx, args).await,
+        ("reset", _) => reset(ctx).await,
+        (cmd, _) => {
+            Err(Status::not_found(format!("command {cmd} does not exist")))
+                .context(GrpcStatus)
+        }
+    }
+}
+
+async fn pool(mut ctx: Context, _matches: &ArgMatches) -> crate::Result<()> {
+    ctx.v2("Requesting Pool metrics");
+    let response = ctx
+        .v1
+        .stats
+        .get_pool_io_stats(v1rpc::stats::ListStatsOption {
+            name: None,
+        })
+        .await
+        .context(GrpcStatus)?;
+    match ctx.output {
+        OutputFormat::Json => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(response.get_ref())
+                    .unwrap()
+                    .to_colored_json_auto()
+                    .unwrap()
+            );
+        }
+        OutputFormat::Default => {
+            let stats: &Vec<v1rpc::stats::IoStats> = &response.get_ref().stats;
+            if stats.is_empty() {
+                ctx.v1("No Pool IoStats found");
+                return Ok(());
+            }
+
+            let table = stats
+                .iter()
+                .map(|p| {
+                    let read_latency =
+                        ticks_to_time(p.read_latency_ticks, p.tick_rate);
+                    let write_latency =
+                        ticks_to_time(p.write_latency_ticks, p.tick_rate);
+                    let unmap_latency =
+                        ticks_to_time(p.unmap_latency_ticks, p.tick_rate);
+                    let max_read_latency =
+                        ticks_to_time(p.max_read_latency_ticks, p.tick_rate);
+                    let min_read_latency =
+                        ticks_to_time(p.min_read_latency_ticks, p.tick_rate);
+                    let max_write_latency =
+                        ticks_to_time(p.max_write_latency_ticks, p.tick_rate);
+                    let min_write_latency =
+                        ticks_to_time(p.min_write_latency_ticks, p.tick_rate);
+                    vec![
+                        p.name.clone(),
+                        p.num_read_ops.to_string(),
+                        adjust_bytes(p.bytes_read),
+                        p.num_write_ops.to_string(),
+                        adjust_bytes(p.bytes_written),
+                        p.num_unmap_ops.to_string(),
+                        adjust_bytes(p.bytes_unmapped),
+                        read_latency.to_string(),
+                        write_latency.to_string(),
+                        unmap_latency.to_string(),
+                        max_read_latency.to_string(),
+                        min_read_latency.to_string(),
+                        max_write_latency.to_string(),
+                        min_write_latency.to_string(),
+                    ]
+                })
+                .collect();
+            ctx.print_list(
+                vec![
+                    "NAME",
+                    "NUM_RD_OPS",
+                    "TOTAL_RD",
+                    "NUM_WR_OPS",
+                    "TOTAL_WR",
+                    "NUM_UNMAP_OPS",
+                    "TOTAL_UNMAPPED",
+                    "RD_LAT",
+                    "WR_LAT",
+                    "UNMAP_LATENCY",
+                    "MAX_RD_LAT",
+                    "MIN_RD_LAT",
+                    "MAX_WR_LAT",
+                    "MIN_WR_LAT",
+                ],
+                table,
+            );
+        }
+    };
+    Ok(())
+}
+
+async fn reset(mut ctx: Context) -> crate::Result<()> {
+    ctx.v2("Resetting all metrics");
+    let _ = ctx.v1.stats.reset_io_stats(()).await.context(GrpcStatus)?;
+    println!("Stats Reset Completed");
+    Ok(())
+}
+
+fn adjust_bytes(bytes: u64) -> String {
+    let byte = Byte::from_bytes(bytes as u128);
+    let adjusted_byte = byte.get_appropriate_unit(true);
+    adjusted_byte.to_string()
+}
+
+fn ticks_to_time(tick: u64, tick_rate: u64) -> u64 {
+    ((tick as u128 * 1000000) / tick_rate as u128) as u64
+}

--- a/io-engine/src/core/bdev.rs
+++ b/io-engine/src/core/bdev.rs
@@ -190,6 +190,15 @@ where
             }),
         }
     }
+
+    /// Resets io stats for a given Bdev.
+    pub async fn reset_bdev_io_stats(&self) -> Result<(), CoreError> {
+        self.inner.stats_reset_async().await.map_err(|err| {
+            CoreError::DeviceStatisticsFailed {
+                source: err,
+            }
+        })
+    }
 }
 
 #[async_trait(? Send)]

--- a/io-engine/src/core/bdev.rs
+++ b/io-engine/src/core/bdev.rs
@@ -8,7 +8,7 @@ use async_trait::async_trait;
 use nix::errno::Errno;
 use snafu::ResultExt;
 
-use spdk_rs::libspdk::spdk_bdev;
+use spdk_rs::libspdk::{spdk_bdev, spdk_get_ticks_hz};
 
 use crate::{
     bdev::bdev_event_callback,
@@ -157,7 +157,14 @@ where
         BdevIter::<T>::new().next()
     }
 
-    /// TODO
+    /// Gets tick rate of the current io engine instance.
+    /// NOTE: tick_rate returned in SPDK struct is not accurate. Hence we get it
+    /// via this method.
+    pub fn get_tick_rate(&self) -> u64 {
+        unsafe { spdk_get_ticks_hz() }
+    }
+
+    /// Returns IoStats for a particular bdev.
     pub async fn stats_async(&self) -> Result<BlockDeviceIoStats, CoreError> {
         match self.inner.stats_async().await {
             Ok(stat) => Ok(BlockDeviceIoStats {
@@ -167,6 +174,16 @@ where
                 bytes_written: stat.bytes_written,
                 num_unmap_ops: stat.num_unmap_ops,
                 bytes_unmapped: stat.bytes_unmapped,
+                read_latency_ticks: stat.read_latency_ticks,
+                max_read_latency_ticks: stat.max_read_latency_ticks,
+                min_read_latency_ticks: stat.min_read_latency_ticks,
+                write_latency_ticks: stat.write_latency_ticks,
+                max_write_latency_ticks: stat.max_write_latency_ticks,
+                min_write_latency_ticks: stat.min_write_latency_ticks,
+                max_unmap_latency_ticks: stat.max_unmap_latency_ticks,
+                min_unmap_latency_ticks: stat.min_unmap_latency_ticks,
+                unmap_latency_ticks: stat.unmap_latency_ticks,
+                tick_rate: self.get_tick_rate(),
             }),
             Err(err) => Err(CoreError::DeviceStatisticsFailed {
                 source: err,

--- a/io-engine/src/core/block_device.rs
+++ b/io-engine/src/core/block_device.rs
@@ -16,7 +16,7 @@ use spdk_rs::ffihelper::{cb_arg, done_cb};
 use std::os::raw::c_void;
 use uuid::Uuid;
 
-/// TODO
+/// Structure representing Bdev Io Stats.
 #[derive(Debug, Default, Clone, Copy, Merge)]
 pub struct BlockDeviceIoStats {
     #[merge(strategy = merge::num::saturating_add)]
@@ -31,6 +31,26 @@ pub struct BlockDeviceIoStats {
     pub num_unmap_ops: u64,
     #[merge(strategy = merge::num::saturating_add)]
     pub bytes_unmapped: u64,
+    #[merge(strategy = merge::num::saturating_add)]
+    pub read_latency_ticks: u64,
+    #[merge(strategy = merge::num::saturating_add)]
+    pub write_latency_ticks: u64,
+    #[merge(strategy = merge::num::saturating_add)]
+    pub unmap_latency_ticks: u64,
+    #[merge(strategy = merge::num::saturating_add)]
+    pub max_read_latency_ticks: u64,
+    #[merge(strategy = merge::num::saturating_add)]
+    pub min_read_latency_ticks: u64,
+    #[merge(strategy = merge::num::saturating_add)]
+    pub max_write_latency_ticks: u64,
+    #[merge(strategy = merge::num::saturating_add)]
+    pub min_write_latency_ticks: u64,
+    #[merge(strategy = merge::num::saturating_add)]
+    pub max_unmap_latency_ticks: u64,
+    #[merge(strategy = merge::num::saturating_add)]
+    pub min_unmap_latency_ticks: u64,
+    #[merge(strategy = merge::num::saturating_add)]
+    pub tick_rate: u64,
 }
 
 /// Core trait that represents a block device.

--- a/io-engine/src/grpc/mod.rs
+++ b/io-engine/src/grpc/mod.rs
@@ -8,6 +8,7 @@ use std::{
 use futures::channel::oneshot::Receiver;
 use nix::errno::Errno;
 pub use server::MayastorGrpcServer;
+use tokio::sync::RwLock;
 use tonic::{Request, Response, Status};
 
 use crate::{
@@ -115,16 +116,25 @@ impl GrpcClientContext {
     }
 }
 
-/// trait to lock serialize gRPC request outstanding
+/// Trait to lock serialize gRPC request outstanding.
 #[async_trait::async_trait]
 pub(crate) trait Serializer<F, T> {
     async fn locked(&self, ctx: GrpcClientContext, f: F) -> Result<T, Status>;
 }
 
+/// Trait allows Service implementing it to be locked by other Services along
+/// with usual serializing.
 #[async_trait::async_trait]
 pub(crate) trait RWSerializer<F, T> {
     async fn locked(&self, ctx: GrpcClientContext, f: F) -> Result<T, Status>;
     async fn shared(&self, ctx: GrpcClientContext, f: F) -> Result<T, Status>;
+}
+
+/// Trait allows service implementing to return RWLock of itself to the
+/// caller.
+#[async_trait::async_trait]
+pub(crate) trait RWLock {
+    async fn rw_lock(&self) -> &RwLock<Option<GrpcClientContext>>;
 }
 
 pub type GrpcResult<T> = std::result::Result<Response<T>, Status>;

--- a/io-engine/src/grpc/mod.rs
+++ b/io-engine/src/grpc/mod.rs
@@ -81,6 +81,7 @@ pub mod v1 {
     pub mod pool;
     pub mod replica;
     pub mod snapshot;
+    pub mod stats;
     pub mod test;
 }
 

--- a/io-engine/src/grpc/server.rs
+++ b/io-engine/src/grpc/server.rs
@@ -12,6 +12,7 @@ use super::{
         pool::PoolService,
         replica::ReplicaService,
         snapshot::SnapshotService,
+        stats::StatsService,
         test::TestService,
     },
 };
@@ -115,6 +116,9 @@ impl MayastorGrpcServer {
                     v1::nexus::NexusRpcServer::new(NexusService::new())
                 }),
             )
+            .add_optional_service(enable_v1.map(|_| {
+                v1::stats::StatsRpcServer::new(StatsService::default())
+            }))
             .add_optional_service(enable_v0.map(|_| {
                 MayastorRpcServer::new(MayastorSvc::new(Duration::from_millis(
                     4,

--- a/io-engine/src/grpc/v1/pool.rs
+++ b/io-engine/src/grpc/v1/pool.rs
@@ -5,11 +5,10 @@ use crate::{
     pool_backend::{PoolArgs, PoolBackend},
 };
 use futures::FutureExt;
+use io_engine_api::v1::pool::*;
 use nix::errno::Errno;
 use std::{convert::TryFrom, fmt::Debug};
 use tonic::{Request, Response, Status};
-
-use io_engine_api::v1::pool::*;
 
 #[derive(Debug)]
 struct UnixStream(tokio::net::UnixStream);

--- a/io-engine/src/grpc/v1/replica.rs
+++ b/io-engine/src/grpc/v1/replica.rs
@@ -11,7 +11,7 @@ use crate::{
         UntypedBdev,
         UpdateProps,
     },
-    grpc::{rpc_submit, GrpcClientContext, GrpcResult, RWSerializer},
+    grpc::{rpc_submit, GrpcClientContext, GrpcResult, RWLock, RWSerializer},
     lvs::{Error as LvsError, Lvol, LvolSpaceUsage, Lvs, LvsLvol},
 };
 use ::function_name::named;
@@ -88,6 +88,13 @@ where
                 )))
             }
         }
+    }
+}
+
+#[async_trait::async_trait]
+impl RWLock for ReplicaService {
+    async fn rw_lock(&self) -> &tokio::sync::RwLock<Option<GrpcClientContext>> {
+        self.client_context.as_ref()
     }
 }
 

--- a/io-engine/src/grpc/v1/stats.rs
+++ b/io-engine/src/grpc/v1/stats.rs
@@ -1,0 +1,158 @@
+use crate::{
+    grpc::{rpc_submit, GrpcClientContext, GrpcResult, Serializer},
+    lvs::Lvs,
+};
+use futures::FutureExt;
+use io_engine_api::v1::stats::*;
+use std::fmt::Debug;
+use tonic::{Request, Response, Status};
+
+use crate::core::{BlockDeviceIoStats, CoreError, UntypedBdev};
+use ::function_name::named;
+use std::panic::AssertUnwindSafe;
+
+/// RPC service for Resource IoStats.
+#[derive(Debug)]
+#[allow(dead_code)]
+pub struct StatsService {
+    name: String,
+    client_context: tokio::sync::Mutex<Option<GrpcClientContext>>,
+}
+
+#[async_trait::async_trait]
+impl<F, T> Serializer<F, T> for StatsService
+where
+    T: Send + 'static,
+    F: core::future::Future<Output = Result<T, Status>> + Send + 'static,
+{
+    async fn locked(&self, ctx: GrpcClientContext, f: F) -> Result<T, Status> {
+        let mut context_guard = self.client_context.lock().await;
+
+        // Store context as a marker of to detect abnormal termination of the
+        // request. Even though AssertUnwindSafe() allows us to
+        // intercept asserts in underlying method strategies, such a
+        // situation can still happen when the high-level future that
+        // represents gRPC call at the highest level (i.e. the one created
+        // by gRPC server) gets cancelled (due to timeout or somehow else).
+        // This can't be properly intercepted by 'locked' function itself in the
+        // first place, so the state needs to be cleaned up properly
+        // upon subsequent gRPC calls.
+        if let Some(c) = context_guard.replace(ctx) {
+            warn!("{}: gRPC method timed out, args: {}", c.id, c.args);
+        }
+
+        let fut = AssertUnwindSafe(f).catch_unwind();
+        let r = fut.await;
+
+        // Request completed, remove the marker.
+        let ctx = context_guard.take().expect("gRPC context disappeared");
+
+        match r {
+            Ok(r) => r,
+            Err(_e) => {
+                warn!("{}: gRPC method panicked, args: {}", ctx.id, ctx.args);
+                Err(Status::cancelled(format!(
+                    "{}: gRPC method panicked",
+                    ctx.id
+                )))
+            }
+        }
+    }
+}
+
+impl Default for StatsService {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl StatsService {
+    /// Constructor for Stats Service.
+    pub fn new() -> Self {
+        Self {
+            name: String::from("StatsSvc"),
+            client_context: tokio::sync::Mutex::new(None),
+        }
+    }
+}
+
+#[tonic::async_trait]
+impl StatsRpc for StatsService {
+    #[named]
+    async fn get_pool_io_stats(
+        &self,
+        request: Request<ListStatsOption>,
+    ) -> GrpcResult<PoolIoStatsResponse> {
+        self.locked(
+            GrpcClientContext::new(&request, function_name!()),
+            async move {
+                let args = request.into_inner();
+                let rx = rpc_submit::<_, _, CoreError>(async move {
+                    let mut pool_stats: Vec<IoStats> = Vec::new();
+                    if let Some(name) = args.name {
+                        if let Some(l) = Lvs::lookup(&name) {
+                            let stats = l.base_bdev().stats_async().await?;
+                            let io_stat = IoStats::from(ExternalType((
+                                name.clone(),
+                                stats,
+                            )));
+                            pool_stats.push(io_stat);
+                        }
+                    } else {
+                        let bdev_list: Vec<(String, UntypedBdev)> = Lvs::iter()
+                            .map(|lvs| {
+                                (lvs.name().to_string(), lvs.base_bdev())
+                            })
+                            .collect();
+                        for (name, bdev) in bdev_list.iter() {
+                            let bdev_stat = bdev.stats_async().await?;
+                            let io_stat = IoStats::from(ExternalType((
+                                name.clone(),
+                                bdev_stat,
+                            )));
+                            pool_stats.push(io_stat);
+                        }
+                    }
+                    Ok(PoolIoStatsResponse {
+                        stats: pool_stats,
+                    })
+                })?;
+                rx.await
+                    .map_err(|_| Status::cancelled("cancelled"))?
+                    .map_err(Status::from)
+                    .map(Response::new)
+            },
+        )
+        .await
+    }
+    async fn reset_io_stats(&self, _request: Request<()>) -> GrpcResult<()> {
+        unimplemented!()
+    }
+}
+
+struct ExternalType<T>(T);
+
+/// Conversion fn to get gRPC type IOStat from BlockDeviceIoStats.
+impl From<ExternalType<(String, BlockDeviceIoStats)>> for IoStats {
+    fn from(value: ExternalType<(String, BlockDeviceIoStats)>) -> Self {
+        Self {
+            name: value.0 .0,
+            num_read_ops: value.0 .1.num_read_ops,
+            bytes_read: value.0 .1.bytes_read,
+            num_write_ops: value.0 .1.num_write_ops,
+            bytes_written: value.0 .1.bytes_written,
+            num_unmap_ops: value.0 .1.num_unmap_ops,
+            bytes_unmapped: value.0 .1.bytes_unmapped,
+            read_latency_ticks: value.0 .1.read_latency_ticks,
+            write_latency_ticks: value.0 .1.write_latency_ticks,
+            unmap_latency_ticks: value.0 .1.unmap_latency_ticks,
+            max_read_latency_ticks: value.0 .1.max_read_latency_ticks,
+            min_read_latency_ticks: value.0 .1.min_read_latency_ticks,
+            max_write_latency_ticks: value.0 .1.max_write_latency_ticks,
+            min_write_latency_ticks: value.0 .1.min_write_latency_ticks,
+            max_unmap_latency_ticks: value.0 .1.max_unmap_latency_ticks,
+            min_unmap_latency_ticks: value.0 .1.min_unmap_latency_ticks,
+            tick_rate: value.0 .1.tick_rate,
+        }
+    }
+}


### PR DESCRIPTION
This PR adds new gRPC service (StatsService). It also has implementation for Pool Io Stats. Subsequent PRs will cover similar RPC for Replica and Nexus also.

io-engine-client cmd for the Pool Stats is also added. Here is the example output.
```

[nix-shell:~/dataplane/mayastor]# ./target/debug/io-engine-client -b 10.1.0.5 stats pool
NAME   NUM_RD_OPS TOTAL_RD  NUM_WR_OPS TOTAL_WR  NUM_UNMAP_OPS TOTAL_UNMAPPED RD_LAT WR_LAT UNMAP_LATENCY MAX_RD_LAT MIN_RD_LAT MAX_WR_LAT MIN_WR_LAT
pool-1 3          12.00 KiB 4          16.00 KiB 0             0 B            67     16     0             64         0          9          1      
```   

After Reset stats call:

```
[nix-shell:~/dataplane/mayastor]# ./target/debug/io-engine-client -b 10.1.0.5 stats pool
NAME   NUM_RD_OPS TOTAL_RD NUM_WR_OPS TOTAL_WR NUM_UNMAP_OPS TOTAL_UNMAPPED RD_LAT WR_LAT UNMAP_LATENCY MAX_RD_LAT MIN_RD_LAT       MAX_WR_LAT MIN_WR_LAT      
pool-1 0          0 B      0          0 B      0             0 B            0      0      0             0          6611736227136040 0          6611736227136040
```



