### PR TITLE
fix(io-engine/rebuild): read asan options and backtrace at runtime

### DIFF
--- a/io-engine/src/core/env.rs
+++ b/io-engine/src/core/env.rs
@@ -1074,9 +1074,13 @@ fn print_asan_env() {
         let v = v.unwrap_or_default();
         info!("    {s:25} = {v}");
     }
+    fn print_run_var(name: &str) {
+        let v = std::env::var(name).unwrap_or_default();
+        info!("    {name:25} = {v}");
+    }
 
     warn!("Compiled with Address Sanitizer enabled");
-    print_var("ASAN_OPTIONS", option_env!("ASAN_OPTIONS"));
+    print_run_var("ASAN_OPTIONS");
     print_var("ASAN_BUILD_ENV", option_env!("ASAN_BUILD_ENV"));
     print_var("RUSTFLAGS", option_env!("RUSTFLAGS"));
     print_var(
@@ -1088,5 +1092,5 @@ fn print_asan_env() {
         "CARGO_PROFILE_DEV_PANIC",
         option_env!("CARGO_PROFILE_DEV_PANIC"),
     );
-    print_var("RUST_BACKTRACE", option_env!("RUST_BACKTRACE"));
+    print_run_var("RUST_BACKTRACE");
 }

--- a/io-engine/src/core/env.rs
+++ b/io-engine/src/core/env.rs
@@ -1070,27 +1070,23 @@ fn make_hostnqn(node_name: Option<&String>) -> Option<String> {
 }
 
 fn print_asan_env() {
-    fn print_var(s: &str, v: Option<&str>) {
-        let v = v.unwrap_or_default();
-        info!("    {s:25} = {v}");
+    macro_rules! print_compile_var {
+        ($name:literal) => {
+            let value = option_env!($name).unwrap_or_default();
+            info!("    {:25} = {value}", $name);
+        };
     }
     fn print_run_var(name: &str) {
-        let v = std::env::var(name).unwrap_or_default();
-        info!("    {name:25} = {v}");
+        let value = std::env::var(name).unwrap_or_default();
+        info!("    {name:25} = {value}");
     }
 
     warn!("Compiled with Address Sanitizer enabled");
     print_run_var("ASAN_OPTIONS");
-    print_var("ASAN_BUILD_ENV", option_env!("ASAN_BUILD_ENV"));
-    print_var("RUSTFLAGS", option_env!("RUSTFLAGS"));
-    print_var(
-        "CARGO_BUILD_RUSTFLAGS",
-        option_env!("CARGO_BUILD_RUSTFLAGS"),
-    );
-    print_var("CARGO_BUILD_TARGET", option_env!("CARGO_BUILD_TARGET"));
-    print_var(
-        "CARGO_PROFILE_DEV_PANIC",
-        option_env!("CARGO_PROFILE_DEV_PANIC"),
-    );
+    print_compile_var!("ASAN_BUILD_ENV");
+    print_compile_var!("RUSTFLAGS");
+    print_compile_var!("CARGO_BUILD_RUSTFLAGS");
+    print_compile_var!("CARGO_BUILD_TARGET");
+    print_compile_var!("CARGO_PROFILE_DEV_PANIC");
     print_run_var("RUST_BACKTRACE");
 }

--- a/scripts/pytest-tests.sh
+++ b/scripts/pytest-tests.sh
@@ -68,7 +68,7 @@ then
   exit 1
 fi
 
-cd "$SRCDIR/test/python" && source ./venv/bin/activate
+pushd "$SRCDIR/test/python" >/dev/null && source ./venv/bin/activate && popd >/dev/null
 
 TEST_LIST=
 while [ "$#" -gt 0 ]; do
@@ -81,11 +81,20 @@ while [ "$#" -gt 0 ]; do
       exit 0
       ;;
     *)
-      TEST_LIST="$TEST_LIST \n$1"
+      set +e
+      real_1="$(realpath $1 2>/dev/null)"
+      set -e
+      param="$1"
+      if [ -d "$real_1" ] || [ -f "$real_1" ] || [ -f "${real_1%::*}" ]; then
+        param="$real_1"
+      fi
+      TEST_LIST="$TEST_LIST \n$param"
       ;;
   esac
   shift
 done
+
+cd "$SRCDIR/test/python"
 
 # Ensure we cleanup when terminated
 trap_setup


### PR DESCRIPTION
    refactor(io-engine): tidy up print asan vars

    Use macro to avoid repeating var name.

    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    fix(io-engine/rebuild): read asan options and backtrace at runtime

    ASAN_OPTIONS and RUST_BACKTRACE were mistakenly read at compile time.
    Specifically RUST_BACKTRACE was causing rebuilds when read at compile time as
    it seems its value changes.

    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>