### PR TITLE
CI: Image build fixes

### DIFF
--- a/nix/lib/sourcer.nix
+++ b/nix/lib/sourcer.nix
@@ -1,13 +1,17 @@
 { lib, stdenv, git, tag ? "" }:
 let
   whitelistSource = src: allowedPrefixes:
-    builtins.filterSource
-      (path: type:
+    builtins.path {
+      filter = (path: type:
         lib.any
           (allowedPrefix:
-            lib.hasPrefix (toString (src + "/${allowedPrefix}")) path)
-          allowedPrefixes)
-      src;
+            (lib.hasPrefix (toString (src + "/${allowedPrefix}")) path) ||
+            (type == "directory" && lib.hasPrefix path (toString (src + "/${allowedPrefix}")))
+          )
+          allowedPrefixes);
+      path = src;
+      name = "io-engine";
+    };
 in
 {
   git-src = whitelistSource ../../. [ ".git" ];

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -23,6 +23,13 @@ get_hash() {
   vers=`git rev-parse --short=12 HEAD`
   echo -n $vers
 }
+nix_experimental() {
+  if (nix eval 2>&1 || true) | grep "extra-experimental-features" 1>/dev/null; then
+      echo -n " --extra-experimental-features nix-command "
+  else
+      echo -n " "
+  fi
+}
 
 help() {
   cat <<EOF
@@ -47,6 +54,7 @@ EOF
 
 DOCKER="docker"
 NIX_BUILD="nix-build"
+NIX_EVAL="nix eval$(nix_experimental)"
 RM="rm"
 SCRIPTDIR=$(dirname "$0")
 TAG=`get_tag`
@@ -169,7 +177,7 @@ if [ -n "$OVERRIDE_COMMIT_HASH" ] && [ -n "$alias_tag" ]; then
 fi
 
 for name in $IMAGES; do
-  image_basename="openebs/${name}"
+  image_basename=$($NIX_EVAL -f . images.$name.imageName | xargs)
   image=$image_basename
     if [ -n "$REGISTRY" ]; then
     if [[ "${REGISTRY}" =~ '/' ]]; then


### PR DESCRIPTION
    refactor(nix/build): replace builtins.filterSource and builtins.path
    
    Not only is filterSource deprecated but also path is compatible with
    nix-illegal characters in their names, like @.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    ci: fix missing docker org change
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>