### PR TITLE
CI fixes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -172,6 +172,7 @@ pipeline {
             cleanWs()
             unstash 'source'
             sh 'printenv'
+            sh 'nix-shell --run "cargo build --bins --features=io-engine-testing" ci.nix'
             sh 'nix-shell --run "./scripts/cargo-test.sh" ci.nix'
           }
           post {
@@ -206,6 +207,7 @@ pipeline {
             cleanWs()
             unstash 'source'
             sh 'printenv'
+            sh 'nix-shell --run "cargo build --bins --features=io-engine-testing" ci.nix'
             sh 'nix-shell --run "./scripts/grpc-test.sh" ci.nix'
           }
           post {

--- a/ci.nix
+++ b/ci.nix
@@ -112,11 +112,12 @@ mkShell {
     ${pkgs.lib.optionalString (norust) "echo 'Hint: use rustup tool.'"}
     ${pkgs.lib.optionalString (norust) "echo"}
 
-    echo
-
     # SRCDIR is needed by docker-compose files as it requires absolute paths
     export SRCDIR=`pwd`
-    pre-commit install
-    pre-commit install --hook commit-msg
+    if [ -z "$CI" ]; then
+      echo
+      pre-commit install
+      pre-commit install --hook commit-msg
+    fi
   '';
 }

--- a/io-engine-tests/src/lib.rs
+++ b/io-engine-tests/src/lib.rs
@@ -525,6 +525,7 @@ pub fn reactor_run_millis(milliseconds: u64) {
 }
 
 pub fn composer_init() {
+    std::fs::create_dir_all("/var/run/dpdk").ok();
     let path = std::path::PathBuf::from(std::env!("CARGO_MANIFEST_DIR"));
     let srcdir = path.parent().unwrap();
     composer::initialize(srcdir);

--- a/scripts/clean-cargo-tests.sh
+++ b/scripts/clean-cargo-tests.sh
@@ -15,4 +15,6 @@ done
 # Kill's processes running off the workspace cargo binary location
 ps aux | grep "$ROOT_DIR/target" | grep -v -e sudo -e grep | awk '{ print $2 }' | xargs -I% sudo kill -9 %
 
+sudo rm -rf /var/run/dpdk/*
+
 exit 0

--- a/shell.nix
+++ b/shell.nix
@@ -75,11 +75,12 @@ mkShell {
     ${pkgs.lib.optionalString (nospdk) "export CFLAGS=-msse4"}
     ${pkgs.lib.optionalString (nospdk) "echo"}
 
-    echo
-
     # SRCDIR is needed by docker-compose files as it requires absolute paths
     export SRCDIR=`pwd`
-    pre-commit install
-    pre-commit install --hook commit-msg
+    if [ -z "$CI" ]; then
+      echo
+      pre-commit install
+      pre-commit install --hook commit-msg
+    fi
   '';
 }


### PR DESCRIPTION
    ci: don't use pre-commit for ci
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    ci: create and cleanup /var/run/dpdk
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    ci: account for build times separately
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>
