### PR TITLE
ci: pin pyyaml to 5.3.1

### DIFF
--- a/scripts/clean-cargo-tests.sh
+++ b/scripts/clean-cargo-tests.sh
@@ -3,12 +3,12 @@ ROOT_DIR=$(realpath "$SCRIPT_DIR/..")
 
 sudo nvme disconnect-all
 
-for c in $(docker ps -a --filter "label=io.mayastor.test.name" --format '{{.ID}}') ; do
+for c in $(docker ps -a --filter "label=io.composer.test.name" --format '{{.ID}}') ; do
   docker kill "$c"
   docker rm "$c"
 done
 
-for n in $(docker network ls --filter "label=io.mayastor.test.name" --format '{{.ID}}') ; do
+for n in $(docker network ls --filter "label=io.composer.test.name" --format '{{.ID}}') ; do
   docker network rm "$n" || ( sudo systemctl restart docker && docker network rm "$n" )
 done
 

--- a/test/python/requirements.txt
+++ b/test/python/requirements.txt
@@ -12,3 +12,4 @@ pytest-variables==3.0.0
 retrying==1.3.4
 requests==2.31.0
 docker==6.1.3
+pyyaml==5.3.1


### PR DESCRIPTION
    ci: use correct label when cleaning up
    
    When the composer crate was modified seems someone forgot to tell the test cleanup :)
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    ci: pin pyyaml to 5.3.1
    
    Newer 5.4 versions fail to build due to some issue with cpython.
    Version 6 seems to build but docker-compose depends on <6.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>
