### PR TITLE
feat(stats): add nexus stats grpc

### DIFF
--- a/io-engine/src/bdev/nexus/nexus_bdev.rs
+++ b/io-engine/src/bdev/nexus/nexus_bdev.rs
@@ -61,7 +61,7 @@ use crate::{
     subsys::NvmfSubsystem,
 };
 
-use crate::core::IoCompletionStatus;
+use crate::core::{BlockDeviceIoStats, CoreError, IoCompletionStatus};
 use events_api::event::EventAction;
 use spdk_rs::{
     BdevIo,
@@ -518,6 +518,14 @@ impl<'n> Nexus<'n> {
         unsafe { self.bdev().name().to_string() }
     }
 
+    /// Returns io stats for underlying Bdev.
+    pub(crate) async fn bdev_stats(
+        &self,
+    ) -> Result<BlockDeviceIoStats, CoreError> {
+        let bdev = unsafe { self.bdev() };
+        bdev.stats_async().await
+    }
+
     /// TODO
     pub fn req_size(&self) -> u64 {
         self.req_size
@@ -538,7 +546,7 @@ impl<'n> Nexus<'n> {
         unsafe { self.bdev().num_blocks() }
     }
 
-    /// Returns the required alignment of the Nexus.
+    /// Returns the alignment of the Nexus.
     pub fn alignment(&self) -> u64 {
         unsafe { self.bdev().alignment() }
     }

--- a/io-engine/src/bin/io-engine-client/v1/stats_cli.rs
+++ b/io-engine/src/bin/io-engine-client/v1/stats_cli.rs
@@ -17,6 +17,13 @@ pub fn subcommands() -> Command {
             .help("Storage pool name"),
     );
 
+    let nexus = Command::new("nexus").about("Get Nexus IO Stats").arg(
+        Arg::new("name")
+            .required(false)
+            .index(1)
+            .help("Volume target/nexus name"),
+    );
+
     let reset = Command::new("reset").about("Reset all resource IO Stats");
 
     Command::new("stats")
@@ -24,12 +31,14 @@ pub fn subcommands() -> Command {
         .arg_required_else_help(true)
         .about("Resource IOStats")
         .subcommand(pool)
+        .subcommand(nexus)
         .subcommand(reset)
 }
 
 pub async fn handler(ctx: Context, matches: &ArgMatches) -> crate::Result<()> {
     match matches.subcommand().unwrap() {
         ("pool", args) => pool(ctx, args).await,
+        ("nexus", args) => nexus(ctx, args).await,
         ("reset", _) => reset(ctx).await,
         (cmd, _) => {
             Err(Status::not_found(format!("command {cmd} does not exist")))
@@ -38,13 +47,14 @@ pub async fn handler(ctx: Context, matches: &ArgMatches) -> crate::Result<()> {
     }
 }
 
-async fn pool(mut ctx: Context, _matches: &ArgMatches) -> crate::Result<()> {
+async fn pool(mut ctx: Context, matches: &ArgMatches) -> crate::Result<()> {
     ctx.v2("Requesting Pool metrics");
+    let pool_name = matches.get_one::<String>("name");
     let response = ctx
         .v1
         .stats
         .get_pool_io_stats(v1rpc::stats::ListStatsOption {
-            name: None,
+            name: pool_name.cloned(),
         })
         .await
         .context(GrpcStatus)?;
@@ -61,7 +71,108 @@ async fn pool(mut ctx: Context, _matches: &ArgMatches) -> crate::Result<()> {
         OutputFormat::Default => {
             let stats: &Vec<v1rpc::stats::IoStats> = &response.get_ref().stats;
             if stats.is_empty() {
-                ctx.v1("No Pool IoStats found");
+                if let Some(name) = pool_name {
+                    ctx.v1(&format!(
+                        "No IoStats found for {}, Check if device exist",
+                        name
+                    ));
+                } else {
+                    ctx.v1("No Pool IoStats found");
+                }
+                return Ok(());
+            }
+
+            let table = stats
+                .iter()
+                .map(|p| {
+                    let read_latency =
+                        ticks_to_time(p.read_latency_ticks, p.tick_rate);
+                    let write_latency =
+                        ticks_to_time(p.write_latency_ticks, p.tick_rate);
+                    let unmap_latency =
+                        ticks_to_time(p.unmap_latency_ticks, p.tick_rate);
+                    let max_read_latency =
+                        ticks_to_time(p.max_read_latency_ticks, p.tick_rate);
+                    let min_read_latency =
+                        ticks_to_time(p.min_read_latency_ticks, p.tick_rate);
+                    let max_write_latency =
+                        ticks_to_time(p.max_write_latency_ticks, p.tick_rate);
+                    let min_write_latency =
+                        ticks_to_time(p.min_write_latency_ticks, p.tick_rate);
+                    vec![
+                        p.name.clone(),
+                        p.num_read_ops.to_string(),
+                        adjust_bytes(p.bytes_read),
+                        p.num_write_ops.to_string(),
+                        adjust_bytes(p.bytes_written),
+                        p.num_unmap_ops.to_string(),
+                        adjust_bytes(p.bytes_unmapped),
+                        read_latency.to_string(),
+                        write_latency.to_string(),
+                        unmap_latency.to_string(),
+                        max_read_latency.to_string(),
+                        min_read_latency.to_string(),
+                        max_write_latency.to_string(),
+                        min_write_latency.to_string(),
+                    ]
+                })
+                .collect();
+            ctx.print_list(
+                vec![
+                    "NAME",
+                    "NUM_RD_OPS",
+                    "TOTAL_RD",
+                    "NUM_WR_OPS",
+                    "TOTAL_WR",
+                    "NUM_UNMAP_OPS",
+                    "TOTAL_UNMAPPED",
+                    "RD_LAT",
+                    "WR_LAT",
+                    "UNMAP_LATENCY",
+                    "MAX_RD_LAT",
+                    "MIN_RD_LAT",
+                    "MAX_WR_LAT",
+                    "MIN_WR_LAT",
+                ],
+                table,
+            );
+        }
+    };
+    Ok(())
+}
+
+async fn nexus(mut ctx: Context, matches: &ArgMatches) -> crate::Result<()> {
+    ctx.v2("Requesting Nexus metrics");
+    let nexus_name = matches.get_one::<String>("name");
+    let response = ctx
+        .v1
+        .stats
+        .get_nexus_io_stats(v1rpc::stats::ListStatsOption {
+            name: nexus_name.cloned(),
+        })
+        .await
+        .context(GrpcStatus)?;
+    match ctx.output {
+        OutputFormat::Json => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(response.get_ref())
+                    .unwrap()
+                    .to_colored_json_auto()
+                    .unwrap()
+            );
+        }
+        OutputFormat::Default => {
+            let stats: &Vec<v1rpc::stats::IoStats> = &response.get_ref().stats;
+            if stats.is_empty() {
+                if let Some(name) = nexus_name {
+                    ctx.v1(&format!(
+                        "No IoStats found for {}, Check if device exists",
+                        name
+                    ));
+                } else {
+                    ctx.v1("No Nexus IoStats found");
+                }
                 return Ok(());
             }
 


### PR DESCRIPTION
Sample nexus stats command

```
[nix-shell:~/dataplane/mayastor]# ./target/debug/io-engine-client -b 10.1.0.5 stats nexus
NAME                                 NUM_RD_OPS TOTAL_RD NUM_WR_OPS TOTAL_WR NUM_UNMAP_OPS TOTAL_UNMAPPED RD_LAT WR_LAT UNMAP_LATENCY MAX_RD_LAT MIN_RD_LAT       MAX_WR_LAT MIN_WR_LAT      
ec4e66fd-3b33-4439-b504-d49aba53da26 0          0 B      0          0 B      0             0 B            0      0      0             0          6611736227136040 0          6611736227136040
```

Added support to select a particular resource name as arg in io-engine-client command.

```
[nix-shell:~/dataplane/mayastor]# ./target/debug/io-engine-client -b 10.1.0.5 stats pool pool-1
NAME   NUM_RD_OPS TOTAL_RD  NUM_WR_OPS TOTAL_WR  NUM_UNMAP_OPS TOTAL_UNMAPPED RD_LAT WR_LAT UNMAP_LATENCY MAX_RD_LAT MIN_RD_LAT MAX_WR_LAT MIN_WR_LAT
pool-1 5          20.00 KiB 6          24.00 KiB 0             0 B            96     55     0             89         1          24         1         

[nix-shell:~/dataplane/mayastor]# ./target/debug/io-engine-client -b 10.1.0.5 stats pool pool-2
NAME   NUM_RD_OPS TOTAL_RD  NUM_WR_OPS TOTAL_WR  NUM_UNMAP_OPS TOTAL_UNMAPPED RD_LAT WR_LAT UNMAP_LATENCY MAX_RD_LAT MIN_RD_LAT MAX_WR_LAT MIN_WR_LAT
pool-2 3          12.00 KiB 4          16.00 KiB 0             0 B            88     15     0             84         1          9          1
  
[nix-shell:~/dataplane/mayastor]# ./target/debug/io-engine-client -b 10.1.0.5 stats nexus ec4e66fd-3b33-4439-b504-d49aba53da26
NAME                                 NUM_RD_OPS TOTAL_RD NUM_WR_OPS TOTAL_WR NUM_UNMAP_OPS TOTAL_UNMAPPED RD_LAT WR_LAT UNMAP_LATENCY MAX_RD_LAT MIN_RD_LAT       MAX_WR_LAT MIN_WR_LAT      
ec4e66fd-3b33-4439-b504-d49aba53da26 0          0 B      0          0 B      0             0 B            0      0      0             0          6611736227136040 0          6611736227136040



```