### PR TITLE
Rebuild Rangers

### DIFF
--- a/io-engine/src/core/segment_map.rs
+++ b/io-engine/src/core/segment_map.rs
@@ -96,4 +96,15 @@ impl SegmentMap {
     pub(crate) fn count_dirty_blks(&self) -> u64 {
         self.count_ones() * self.segment_size / self.block_len
     }
+
+    /// Get the segment size in blocks.
+    pub(crate) fn segment_size_blks(&self) -> u64 {
+        self.segment_size / self.block_len
+    }
+}
+
+impl From<SegmentMap> for BitVec {
+    fn from(value: SegmentMap) -> Self {
+        value.segments
+    }
 }

--- a/io-engine/src/rebuild/mod.rs
+++ b/io-engine/src/rebuild/mod.rs
@@ -9,6 +9,7 @@ mod rebuild_map;
 mod rebuild_state;
 mod rebuild_stats;
 mod rebuild_task;
+mod rebuilders;
 
 pub use bdev_rebuild::BdevRebuildJob;
 pub use nexus_rebuild::NexusRebuildJob;

--- a/io-engine/src/rebuild/mod.rs
+++ b/io-engine/src/rebuild/mod.rs
@@ -12,7 +12,7 @@ mod rebuild_task;
 mod rebuilders;
 
 pub use bdev_rebuild::BdevRebuildJob;
-pub use nexus_rebuild::NexusRebuildJob;
+pub use nexus_rebuild::{NexusRebuildJob, NexusRebuildJobStarter};
 use rebuild_descriptor::RebuildDescriptor;
 pub(crate) use rebuild_error::RebuildError;
 use rebuild_job::RebuildOperation;

--- a/io-engine/src/rebuild/nexus_rebuild.rs
+++ b/io-engine/src/rebuild/nexus_rebuild.rs
@@ -215,6 +215,10 @@ impl NexusRebuildJobBackend {
 
 #[async_trait::async_trait(?Send)]
 impl RebuildTaskCopier for NexusRebuildDescriptor {
+    fn descriptor(&self) -> &RebuildDescriptor {
+        &self.common
+    }
+
     /// Copies one segment worth of data from source into destination. During
     /// this time the LBA range being copied is locked so that there cannot be
     /// front end I/O to the same LBA range.

--- a/io-engine/src/rebuild/rebuild_map.rs
+++ b/io-engine/src/rebuild/rebuild_map.rs
@@ -1,3 +1,4 @@
+use bit_vec::BitVec;
 use std::fmt::{Debug, Formatter};
 
 use crate::core::SegmentMap;
@@ -60,5 +61,16 @@ impl RebuildMap {
     /// Counts the total number of dirty (to be transferred) blocks.
     pub(crate) fn count_dirty_blks(&self) -> u64 {
         self.segments.count_dirty_blks()
+    }
+
+    /// Get the rebuild map segment size in blocks.
+    pub(crate) fn segment_size_blks(&self) -> u64 {
+        self.segments.segment_size_blks()
+    }
+}
+
+impl From<RebuildMap> for BitVec {
+    fn from(value: RebuildMap) -> Self {
+        value.segments.into()
     }
 }

--- a/io-engine/src/rebuild/rebuilders.rs
+++ b/io-engine/src/rebuild/rebuilders.rs
@@ -1,0 +1,257 @@
+use crate::rebuild::{
+    rebuild_descriptor::RebuildDescriptor,
+    rebuild_task::{RebuildTask, RebuildTaskCopier},
+    RebuildError,
+    RebuildMap,
+};
+use bit_vec::BitVec;
+use std::{ops::Range, rc::Rc};
+
+/// A rebuild may rebuild a device by walking it differently, for example:
+/// 1. full rebuild - walk the entire device range and copy every segment
+///    (current nexus full rebuild behaviour).
+/// 2. partial rebuild - walk the allocated segments only and copy them.
+/// 3. partial seq rebuild - walk the entire device range and copy only
+///    allocated segments (current nexus partial rebuild behaviour).
+pub(super) trait RangeRebuilder<T: RebuildTaskCopier> {
+    /// Fetch the next block to rebuild.
+    fn next(&mut self) -> Option<u64>;
+    /// Peek the next block to rebuild.
+    fn peek_next(&self) -> Option<u64>;
+    /// Get the remaining blocks we have yet to be rebuilt.
+    fn blocks_remaining(&self) -> u64;
+    /// Check if this is a partial rebuild.
+    fn is_partial(&self) -> bool;
+    /// Get the rebuild descriptor reference.
+    fn desc(&self) -> &RebuildDescriptor;
+    /// Get the copier which can copy a segment.
+    fn copier(&self) -> Rc<T>;
+}
+
+/// The range is the full range of the request, in steps of segment size.
+pub(super) struct FullRebuild<T: RebuildTaskCopier> {
+    range: PeekableIterator<std::iter::StepBy<Range<u64>>>,
+    copier: Rc<T>,
+}
+impl<T: RebuildTaskCopier> FullRebuild<T> {
+    /// Create a full rebuild with the given copier.
+    #[allow(dead_code)]
+    pub(super) fn new(copier: T) -> Self {
+        let desc = copier.descriptor();
+        let range = desc.range.clone();
+        Self {
+            range: PeekableIterator::new(
+                range.step_by(desc.segment_size_blks as usize),
+            ),
+            copier: Rc::new(copier),
+        }
+    }
+}
+impl<T: RebuildTaskCopier> RangeRebuilder<T> for FullRebuild<T> {
+    fn next(&mut self) -> Option<u64> {
+        self.range.next()
+    }
+    fn peek_next(&self) -> Option<u64> {
+        self.range.peek().cloned()
+    }
+
+    fn blocks_remaining(&self) -> u64 {
+        self.peek_next()
+            .map(|r| self.desc().range.end.max(r) - r)
+            .unwrap_or_default()
+    }
+    fn is_partial(&self) -> bool {
+        false
+    }
+
+    fn desc(&self) -> &RebuildDescriptor {
+        self.copier.descriptor()
+    }
+    fn copier(&self) -> Rc<T> {
+        self.copier.clone()
+    }
+}
+
+/// A partial rebuild range which steps through each segment but triggers
+/// the copy only if the segment dirty bit is set.
+pub(super) struct PartialRebuild<T: RebuildTaskCopier> {
+    range: PeekableIterator<std::iter::Enumerate<bit_vec::IntoIter>>,
+    segment_size_blks: u64,
+    total_blks: u64,
+    rebuilt_blks: u64,
+    copier: Rc<T>,
+}
+impl<T: RebuildTaskCopier> PartialRebuild<T> {
+    /// Create a partial sequential rebuild with the given copier and segment
+    /// map.
+    #[allow(dead_code)]
+    pub(super) fn new(map: RebuildMap, copier: T) -> Self {
+        let total_blks = map.count_dirty_blks();
+        let segment_size_blks = map.segment_size_blks();
+        let bit_vec: BitVec = map.into();
+        Self {
+            range: PeekableIterator::new(bit_vec.into_iter().enumerate()),
+            total_blks,
+            rebuilt_blks: 0,
+            segment_size_blks,
+            copier: Rc::new(copier),
+        }
+    }
+}
+impl<T: RebuildTaskCopier> RangeRebuilder<T> for PartialRebuild<T> {
+    fn next(&mut self) -> Option<u64> {
+        for (blk, is_set) in self.range.by_ref() {
+            if is_set {
+                self.rebuilt_blks += self.segment_size_blks;
+                return Some(blk as u64);
+            }
+        }
+        None
+    }
+    fn peek_next(&self) -> Option<u64> {
+        // todo: should we add a wrapper to ensure we peek only set bits?
+        self.range.peek().map(|(blk, _)| *blk as u64)
+    }
+
+    fn blocks_remaining(&self) -> u64 {
+        self.total_blks - self.rebuilt_blks
+    }
+    fn is_partial(&self) -> bool {
+        false
+    }
+
+    fn desc(&self) -> &RebuildDescriptor {
+        self.copier.descriptor()
+    }
+    fn copier(&self) -> Rc<T> {
+        self.copier.clone()
+    }
+}
+
+/// The range is the full range of the request, in steps of segment size
+/// and a copy is triggered for each segment.
+/// However, during the copy itself, clean segments are skipped.
+pub(super) struct PartialSeqRebuild<T: RebuildTaskCopier> {
+    range: PeekableIterator<std::iter::StepBy<Range<u64>>>,
+    copier: Rc<PartialSeqCopier<T>>,
+}
+impl<T: RebuildTaskCopier> PartialSeqRebuild<T> {
+    /// Create a partial sequential rebuild with the given copier and segment
+    /// map.
+    #[allow(dead_code)]
+    pub(super) fn new(map: RebuildMap, copier: T) -> Self {
+        let desc = copier.descriptor();
+        let range = desc.range.clone();
+        Self {
+            range: PeekableIterator::new(
+                range.step_by(desc.segment_size_blks as usize),
+            ),
+            copier: Rc::new(PartialSeqCopier::new(map, copier)),
+        }
+    }
+}
+impl<T: RebuildTaskCopier> RangeRebuilder<PartialSeqCopier<T>>
+    for PartialSeqRebuild<T>
+{
+    fn next(&mut self) -> Option<u64> {
+        self.range.next()
+    }
+    fn peek_next(&self) -> Option<u64> {
+        self.range.peek().cloned()
+    }
+
+    fn blocks_remaining(&self) -> u64 {
+        self.copier.map.lock().count_dirty_blks()
+    }
+    fn is_partial(&self) -> bool {
+        true
+    }
+
+    fn desc(&self) -> &RebuildDescriptor {
+        self.copier.descriptor()
+    }
+    fn copier(&self) -> Rc<PartialSeqCopier<T>> {
+        self.copier.clone()
+    }
+}
+/// The partial sequential rebuild copier, which uses a bitmap to determine if a
+/// particular block range must be copied.
+pub(super) struct PartialSeqCopier<T: RebuildTaskCopier> {
+    map: parking_lot::Mutex<RebuildMap>,
+    copier: T,
+}
+impl<T: RebuildTaskCopier> PartialSeqCopier<T> {
+    fn new(map: RebuildMap, copier: T) -> Self {
+        Self {
+            map: parking_lot::Mutex::new(map),
+            copier,
+        }
+    }
+    /// Checks if the block has to be transferred.
+    /// If no rebuild map is present, all blocks are considered unsynced.
+    #[inline(always)]
+    fn is_blk_sync(&self, blk: u64) -> bool {
+        self.map.lock().is_blk_clean(blk)
+    }
+
+    /// Marks the rebuild segment starting from the given logical block as
+    /// already transferred.
+    #[inline(always)]
+    fn blk_synced(&self, blk: u64) {
+        self.map.lock().blk_clean(blk);
+    }
+}
+#[async_trait::async_trait(?Send)]
+impl<T: RebuildTaskCopier> RebuildTaskCopier for PartialSeqCopier<T> {
+    fn descriptor(&self) -> &RebuildDescriptor {
+        self.copier.descriptor()
+    }
+
+    /// Copies one segment worth of data from source into destination.
+    async fn copy_segment(
+        &self,
+        blk: u64,
+        task: &mut RebuildTask,
+    ) -> Result<bool, RebuildError> {
+        if self.is_blk_sync(blk) {
+            return Ok(false);
+        }
+
+        let result = self.copier.copy_segment(blk, task).await;
+
+        // In the case of success, mark the segment as already transferred.
+        if result.is_ok() {
+            self.blk_synced(blk);
+        }
+
+        result
+    }
+}
+
+/// Adds peekable functionality to a generic iterator.
+/// > Note: the peekable from the std library is not sufficient here because it
+/// > requires a mutable reference to peek. We get around this limitation by
+/// > always setting the peek at a small performance cost.
+struct PeekableIterator<I: Iterator> {
+    iter: I,
+    peek: Option<I::Item>,
+}
+impl<I: Iterator> PeekableIterator<I> {
+    fn new(mut iter: I) -> Self {
+        Self {
+            peek: iter.next(),
+            iter,
+        }
+    }
+    /// Peek into the future for the next value which next would yield.
+    fn peek(&self) -> Option<&I::Item> {
+        self.peek.as_ref()
+    }
+}
+impl<I: Iterator> Iterator for PeekableIterator<I> {
+    type Item = I::Item;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        std::mem::replace(&mut self.peek, self.iter.next())
+    }
+}

--- a/io-engine/src/rebuild/rebuilders.rs
+++ b/io-engine/src/rebuild/rebuilders.rs
@@ -35,7 +35,6 @@ pub(super) struct FullRebuild<T: RebuildTaskCopier> {
 }
 impl<T: RebuildTaskCopier> FullRebuild<T> {
     /// Create a full rebuild with the given copier.
-    #[allow(dead_code)]
     pub(super) fn new(copier: T) -> Self {
         let desc = copier.descriptor();
         let range = desc.range.clone();
@@ -138,7 +137,6 @@ pub(super) struct PartialSeqRebuild<T: RebuildTaskCopier> {
 impl<T: RebuildTaskCopier> PartialSeqRebuild<T> {
     /// Create a partial sequential rebuild with the given copier and segment
     /// map.
-    #[allow(dead_code)]
     pub(super) fn new(map: RebuildMap, copier: T) -> Self {
         let desc = copier.descriptor();
         let range = desc.range.clone();

--- a/io-engine/tests/nexus_rebuild.rs
+++ b/io-engine/tests/nexus_rebuild.rs
@@ -346,7 +346,7 @@ async fn rebuild_bdev() {
         )
         .await
         .unwrap();
-        let chan = job.start(None).await.unwrap();
+        let chan = job.start().await.unwrap();
         let state = chan.await.unwrap();
         assert_eq!(state, RebuildState::Completed, "Rebuild should succeed");
     })

--- a/test/python/requirements.txt
+++ b/test/python/requirements.txt
@@ -2,6 +2,7 @@ asyncio==3.4.3
 asyncssh==2.14.1
 black==22.10.0
 protobuf==4.21.8
+pytest==7.4.4
 pytest-asyncio==0.21.1
 pytest-bdd==6.1.1
 pytest-black==0.3.12


### PR DESCRIPTION
    refactor(rebuild): use new rebuild rangers
    
    Make use of the rebuild rangers to configure rebuild types.
    This allows us to remove the setting of the rebuild map being done
    after the rebuild job is created for the nexus and removing it from
    the shared rebuild descriptor.
    
    The nexus still uses the partial but sequential rebuild to reduce
    the scope of changes.
    Once the fully partial rebuild is validated we can switch the nexus
    to it.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    feat(rebuild): add rebuild rangers
    
    Adds a set of rebuild rangers which can be used by different rebuilds:
    1. full rebuild - walk the entire device range and copy every segment
       (current nexus full rebuild behaviour).
    2. partial rebuild - walk the allocated segments only and copy them.
    3. partial eq rebuild - walk the entire device range and copy only allocated
       segments (current nexus partial rebuild behaviour).
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>
