### PR TITLE
fix(rebuild/partial): set bits for written blks only

### DIFF
--- a/io-engine/src/core/segment_map.rs
+++ b/io-engine/src/core/segment_map.rs
@@ -68,7 +68,8 @@ impl SegmentMap {
         assert_ne!(self.num_blocks, 0);
 
         let start_seg = self.lbn_to_seg(lbn);
-        let end_seg = self.lbn_to_seg(lbn + lbn_cnt);
+        // when `lbn_cnt` is 1 means we write only the `lbn` blk, not `lbn` + 1
+        let end_seg = self.lbn_to_seg(lbn + lbn_cnt - 1);
         for i in start_seg ..= end_seg {
             self.segments.set(i, value);
         }


### PR DESCRIPTION
The blk used to calculate the end segment was offset by 1 which can lead to rebuilding more data than the one which was actually written into. Example, if we write 1 blk to offset 4, then we only need to rebuild offset 4, and not offset 5 (4 + 1).