### PR TITLE
Resize Test and dependabot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2028,9 +2028,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.9"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dce281c5e46beae905d4de1870d8b1509a9142b62eedf18b443b011ca8343d0"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "log",
@@ -2871,9 +2871,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7cee0529a6d40f580e7a5e6c495c8fbfe21b7b52795ed4bb5e62cdf92bc6380"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook"
@@ -3459,9 +3459,9 @@ dependencies = [
 
 [[package]]
 name = "unsafe-libyaml"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28467d3e1d3c6586d8f25fa243f544f5800fec42d97032474e17222c2b75cfa"
+checksum = "ab4c90930b95a82d00dc9e9ac071b4991924390d46cbd0dfe566148667605e4b"
 
 [[package]]
 name = "untrusted"

--- a/test/python/requirements.txt
+++ b/test/python/requirements.txt
@@ -1,5 +1,5 @@
 asyncio==3.4.3
-asyncssh==2.14.1
+asyncssh==2.14.2
 black==22.10.0
 protobuf==4.21.8
 pytest==7.4.4


### PR DESCRIPTION
    test(resize/nexus): add delay between resizes
    
    Due to the async nature of AEN when we attempt to resize the nexus
    after resizing the replica, the replica may not be seen as resized by
    the nexus.
    This is not a test fix but a WA until we handle this properly.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    chore: address dependabot alerts
    
    Update h2, mio, shlex, unsafe-yaml and asyncssh
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>
