### PR TITLE
refactor(rebuild/bdev): use builder pattern

### DIFF
--- a/io-engine/src/core/mod.rs
+++ b/io-engine/src/core/mod.rs
@@ -98,7 +98,7 @@ mod nic;
 pub mod partition;
 mod reactor;
 pub mod runtime;
-pub(crate) mod segment_map;
+pub mod segment_map;
 mod share;
 pub mod snapshot;
 pub(crate) mod thread;

--- a/io-engine/src/rebuild/rebuild_error.rs
+++ b/io-engine/src/rebuild/rebuild_error.rs
@@ -13,8 +13,10 @@ pub enum RebuildError {
     JobAlreadyExists { job: String },
     #[snafu(display("Failed to allocate buffer for the rebuild copy"))]
     NoCopyBuffer { source: DmaError },
-    #[snafu(display("Failed to validate rebuild job creation parameters"))]
-    InvalidParameters {},
+    #[snafu(display("Source and Destination size range is not compatible"))]
+    InvalidSrcDstRange {},
+    #[snafu(display("Map range is not compatible with rebuild range"))]
+    InvalidMapRange {},
     #[snafu(display(
         "The same device was specified for both source and destination: {bdev}"
     ))]

--- a/io-engine/src/rebuild/rebuild_job_backend.rs
+++ b/io-engine/src/rebuild/rebuild_job_backend.rs
@@ -313,7 +313,12 @@ impl RebuildJobBackendManager {
         let blocks_remaining = self.backend.blocks_remaining();
 
         let progress = (blocks_recovered * 100) / blocks_total;
-        assert!(progress < 100 || blocks_remaining == 0);
+        assert!(
+            progress < 100 || blocks_remaining == 0,
+            "progress is {}% but there are {} blocks remaining",
+            progress,
+            blocks_remaining
+        );
 
         RebuildStats {
             start_time: descriptor.start_time,

--- a/io-engine/src/rebuild/rebuild_map.rs
+++ b/io-engine/src/rebuild/rebuild_map.rs
@@ -62,11 +62,6 @@ impl RebuildMap {
     pub(crate) fn count_dirty_blks(&self) -> u64 {
         self.segments.count_dirty_blks()
     }
-
-    /// Get the rebuild map segment size in blocks.
-    pub(crate) fn segment_size_blks(&self) -> u64 {
-        self.segments.segment_size_blks()
-    }
 }
 
 impl From<RebuildMap> for BitVec {

--- a/io-engine/src/rebuild/rebuilders.rs
+++ b/io-engine/src/rebuild/rebuilders.rs
@@ -1,8 +1,11 @@
-use crate::rebuild::{
-    rebuild_descriptor::RebuildDescriptor,
-    rebuild_task::{RebuildTask, RebuildTaskCopier},
-    RebuildError,
-    RebuildMap,
+use crate::{
+    core::SegmentMap,
+    rebuild::{
+        rebuild_descriptor::RebuildDescriptor,
+        rebuild_task::{RebuildTask, RebuildTaskCopier},
+        RebuildError,
+        RebuildMap,
+    },
 };
 use bit_vec::BitVec;
 use std::{ops::Range, rc::Rc};
@@ -84,7 +87,7 @@ impl<T: RebuildTaskCopier> PartialRebuild<T> {
     /// Create a partial sequential rebuild with the given copier and segment
     /// map.
     #[allow(dead_code)]
-    pub(super) fn new(map: RebuildMap, copier: T) -> Self {
+    pub(super) fn new(map: SegmentMap, copier: T) -> Self {
         let total_blks = map.count_dirty_blks();
         let segment_size_blks = map.segment_size_blks();
         let bit_vec: BitVec = map.into();


### PR DESCRIPTION
Allows for either full or partial rebuild from bdev to bdev. Adds tests ensuring both full and partial rebuild are correct.