### PR TITLE
feat(callhome): add bustype and rotational properties to block device

### DIFF
--- a/io-engine/src/grpc/v1/host.rs
+++ b/io-engine/src/grpc/v1/host.rs
@@ -117,6 +117,8 @@ impl From<blk_device::BlockDevice> for host_rpc::BlockDevice {
             partition: b.partition.map(host_rpc::Partition::from),
             filesystem: b.filesystem.map(host_rpc::Filesystem::from),
             available: b.available,
+            connection_type: b.connection_type,
+            is_rotational: b.is_rotational,
         }
     }
 }

--- a/io-engine/src/host/blk_device.rs
+++ b/io-engine/src/host/blk_device.rs
@@ -67,6 +67,8 @@ pub struct BlockDevice {
     pub partition: Option<Partition>,
     pub filesystem: Option<FileSystem>,
     pub available: bool,
+    pub connection_type: String,
+    pub is_rotational: Option<bool>,
 }
 
 impl From<Property<'_>> for String {
@@ -249,6 +251,9 @@ fn new_device(
             && (partition.is_none() || usable_partition(&partition))
             && filesystem.is_none();
 
+        let rotational_attribute: Option<String> =
+            Property(device.attribute_value("queue/rotational")).into();
+
         return Some(BlockDevice {
             devname: String::from(devname.to_str().unwrap_or("")),
             devtype: Property(device.property_value("DEVTYPE")).into(),
@@ -256,6 +261,8 @@ fn new_device(
             devmin: Property(device.property_value("MINOR")).into(),
             model: Property(device.property_value("ID_MODEL")).into(),
             devpath: Property(device.property_value("DEVPATH")).into(),
+            connection_type: Property(device.property_value("ID_BUS")).into(),
+            is_rotational: rotational_attribute.map(|s| s == "1"),
             devlinks: device
                 .property_value("DEVLINKS")
                 .and_then(|s| s.to_str())


### PR DESCRIPTION
Added bus type("connection_type") and rotational ("is_rotational") properties to block device to be able to generate storage media metrics.

connection_type: the type of bus through which the device is connected to the system
is_rotational: indicates whether the device is rotational or non-rotational