### PR TITLE
fix(lock): make import pool, create replica and share replica operations mutually exclusive

### DIFF
--- a/io-engine/src/bin/io-engine.rs
+++ b/io-engine/src/bin/io-engine.rs
@@ -100,7 +100,9 @@ fn start_tokio_runtime(args: &MayastorCliArgs) {
 
     // Initialize Lock manager.
     let cfg = ResourceLockManagerConfig::default()
-        .with_subsystem(ProtectedSubsystems::NEXUS, 512);
+        .with_subsystem(ProtectedSubsystems::POOL, 32)
+        .with_subsystem(ProtectedSubsystems::NEXUS, 512)
+        .with_subsystem(ProtectedSubsystems::REPLICA, 1024);
     ResourceLockManager::initialize(cfg);
 
     Mthread::spawn_unaffinitized(move || {

--- a/io-engine/src/grpc/v1/nexus.rs
+++ b/io-engine/src/grpc/v1/nexus.rs
@@ -81,7 +81,7 @@ impl NexusService {
         match tokio::spawn(async move {
             // Grab global operation lock, if requested.
             let _global_guard = if global_operation {
-                match lock_manager.lock(Some(ctx.timeout)).await {
+                match lock_manager.lock(Some(ctx.timeout), false).await {
                     Some(g) => Some(g),
                     None => return Err(Status::deadline_exceeded(
                         "Failed to acquire access to object within given timeout"
@@ -95,7 +95,7 @@ impl NexusService {
             // Grab per-object lock before executing the future.
             let _resource_guard = match lock_manager
                 .get_subsystem(ProtectedSubsystems::NEXUS)
-                .lock_resource(nexus_uuid, Some(ctx.timeout))
+                .lock_resource(nexus_uuid, Some(ctx.timeout), false)
                 .await {
                     Some(g) => g,
                     None => return Err(Status::deadline_exceeded(

--- a/io-engine/src/grpc/v1/snapshot.rs
+++ b/io-engine/src/grpc/v1/snapshot.rs
@@ -241,7 +241,7 @@ impl SnapshotService {
         match tokio::spawn(async move {
             // Grab global operation lock, if requested.
             let _global_guard = if global_operation {
-                match lock_manager.lock(Some(ctx.timeout)).await {
+                match lock_manager.lock(Some(ctx.timeout), false).await {
                     Some(g) => Some(g),
                     None => return Err(Status::deadline_exceeded(
                         "Failed to acquire access to object within given timeout"
@@ -255,7 +255,7 @@ impl SnapshotService {
             // Grab per-object lock before executing the future.
             let _resource_guard = match lock_manager
                 .get_subsystem(ProtectedSubsystems::NEXUS)
-                .lock_resource(nexus_uuid, Some(ctx.timeout))
+                .lock_resource(nexus_uuid, Some(ctx.timeout), false)
                 .await {
                     Some(g) => g,
                     None => return Err(Status::deadline_exceeded(

--- a/io-engine/src/grpc/v1/stats.rs
+++ b/io-engine/src/grpc/v1/stats.rs
@@ -50,7 +50,7 @@ where
         let lock_manager = ResourceLockManager::get_instance();
         // For nexus global lock.
         let _global_guard =
-            match lock_manager.lock(Some(ctx.timeout)).await {
+            match lock_manager.lock(Some(ctx.timeout), false).await {
                 Some(g) => Some(g),
                 None => return Err(Status::deadline_exceeded(
                     "Failed to acquire access to object within given timeout",
@@ -96,7 +96,7 @@ impl StatsService {
         let lock_manager = ResourceLockManager::get_instance();
         // For nexus global lock.
         let _global_guard =
-            match lock_manager.lock(Some(ctx.timeout)).await {
+            match lock_manager.lock(Some(ctx.timeout), false).await {
                 Some(g) => Some(g),
                 None => return Err(Status::deadline_exceeded(
                     "Failed to acquire access to object within given timeout",

--- a/io-engine/src/lvs/lvs_error.rs
+++ b/io-engine/src/lvs/lvs_error.rs
@@ -178,6 +178,10 @@ pub enum Error {
     WipeFailed {
         source: crate::core::wiper::Error,
     },
+    #[snafu(display("Failed to acquire resource lock, {}", msg))]
+    ResourceLockFailed {
+        msg: String,
+    },
 }
 
 /// Map CoreError to errno code.
@@ -265,6 +269,9 @@ impl ToErrno for Error {
             Self::WipeFailed {
                 ..
             } => Errno::EINVAL,
+            Self::ResourceLockFailed {
+                ..
+            } => Errno::EBUSY,
         }
     }
 }

--- a/io-engine/tests/lock.rs
+++ b/io-engine/tests/lock.rs
@@ -38,18 +38,40 @@ async fn test_lock_level(level: LockLevel) {
 
         // Step 1: acquire lock.
         let guard = match level {
-            LockLevel::Global => lock_mgr.lock(None).await,
+            LockLevel::Global => lock_mgr.lock(None, false).await,
             LockLevel::Subsystem => {
-                lock_mgr.get_subsystem(TEST_SUBSYSTEM).lock(None).await
+                lock_mgr
+                    .get_subsystem(TEST_SUBSYSTEM)
+                    .lock(None, false)
+                    .await
             }
             LockLevel::Resource => {
                 lock_mgr
                     .get_subsystem(TEST_SUBSYSTEM)
-                    .lock_resource(TEST_RESOURCE, None)
+                    .lock_resource(TEST_RESOURCE, None, false)
                     .await
             }
         };
         assert!(guard.is_some(), "Failed to acquire the lock");
+
+        if guard.is_some() {
+            let try_lock_guard = match level {
+                LockLevel::Global => lock_mgr.lock(None, true).await,
+                LockLevel::Subsystem => {
+                    lock_mgr
+                        .get_subsystem(TEST_SUBSYSTEM)
+                        .lock(None, true)
+                        .await
+                }
+                LockLevel::Resource => {
+                    lock_mgr
+                        .get_subsystem(TEST_SUBSYSTEM)
+                        .lock_resource(TEST_RESOURCE, None, true)
+                        .await
+                }
+            };
+            assert!(try_lock_guard.is_none(), "Double Lock acquired");
+        }
 
         // Notify that the lock is acquired.
         tx.send(0).expect("Failed to notify the peer ");
@@ -81,14 +103,17 @@ async fn test_lock_level(level: LockLevel) {
         // Try to grab the lock - we must wait, since the lock is already
         // acquired.
         let guard = match level {
-            LockLevel::Global => lock_mgr.lock(None).await,
+            LockLevel::Global => lock_mgr.lock(None, false).await,
             LockLevel::Subsystem => {
-                lock_mgr.get_subsystem(TEST_SUBSYSTEM).lock(None).await
+                lock_mgr
+                    .get_subsystem(TEST_SUBSYSTEM)
+                    .lock(None, false)
+                    .await
             }
             LockLevel::Resource => {
                 lock_mgr
                     .get_subsystem(TEST_SUBSYSTEM)
-                    .lock_resource(TEST_RESOURCE, None)
+                    .lock_resource(TEST_RESOURCE, None, false)
                     .await
             }
         };
@@ -113,14 +138,17 @@ async fn test_lock_timed_level(level: LockLevel) {
 
         // Step 1: acquire lock.
         let guard = match level {
-            LockLevel::Global => lock_mgr.lock(None).await,
+            LockLevel::Global => lock_mgr.lock(None, false).await,
             LockLevel::Subsystem => {
-                lock_mgr.get_subsystem(TEST_SUBSYSTEM).lock(None).await
+                lock_mgr
+                    .get_subsystem(TEST_SUBSYSTEM)
+                    .lock(None, false)
+                    .await
             }
             LockLevel::Resource => {
                 lock_mgr
                     .get_subsystem(TEST_SUBSYSTEM)
-                    .lock_resource(TEST_RESOURCE, None)
+                    .lock_resource(TEST_RESOURCE, None, false)
                     .await
             }
         };
@@ -147,14 +175,17 @@ async fn test_lock_timed_level(level: LockLevel) {
         // Try to grab the lock - we must wait, since the lock is already
         // acquired.
         let guard = match level {
-            LockLevel::Global => lock_mgr.lock(duration).await,
+            LockLevel::Global => lock_mgr.lock(duration, false).await,
             LockLevel::Subsystem => {
-                lock_mgr.get_subsystem(TEST_SUBSYSTEM).lock(duration).await
+                lock_mgr
+                    .get_subsystem(TEST_SUBSYSTEM)
+                    .lock(duration, false)
+                    .await
             }
             LockLevel::Resource => {
                 lock_mgr
                     .get_subsystem(TEST_SUBSYSTEM)
-                    .lock_resource(TEST_RESOURCE, duration)
+                    .lock_resource(TEST_RESOURCE, duration, false)
                     .await
             }
         };


### PR DESCRIPTION
1. Current PR handles concurrent gRPC request of `import pool`, `create replica`, `share replica`. All are kept under resource mutex lock, where resource is `pool_name`.