### PR TITLE
Reconnect IO log on Detach

### DIFF
--- a/io-engine/src/bdev/nexus/nexus_channel.rs
+++ b/io-engine/src/bdev/nexus/nexus_channel.rs
@@ -238,6 +238,12 @@ impl<'n> NexusChannel<'n> {
             self.detached.push(t);
         }
 
+        // Since we've removed the device from the IO path, make sure we
+        // reconnect the io logs in case we haven't done so yet.
+        // Otherwise, a given channel might never see an error for this device
+        // and will therefore not log the IOs until a reconnect_io_logs.
+        self.reconnect_io_logs();
+
         debug!("{self:?}: device '{device_name}' detached");
 
         if is_channel_debug_enabled() {

--- a/nix/pkgs/fio/default.nix
+++ b/nix/pkgs/fio/default.nix
@@ -11,13 +11,13 @@
 
 stdenv.mkDerivation rec {
   pname = "fio";
-  version = "3.33";
+  version = "3.37";
 
   src = fetchFromGitHub {
     owner = "axboe";
     repo = "fio";
     rev = "fio-${version}";
-    sha256 = "sha256-d4Fx2QdO+frt+gcBzegJ9CW5NJQRLNkML/iD3te/1d0=";
+    sha256 = "sha256-dKHTxVglH10aV44RuSeIFATn83DVdmCYtuaiS3b0+zo=";
   };
 
   buildInputs = [ python3 zlib ]


### PR DESCRIPTION
    fix(fio): bump fio to 3.37
    
    This fixes an issue seen with fio 3.33 reporting an invalid miscompare.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    fix(rebuild): connect the io log when detaching
    
    When we detach a device, ensure that the io logs are connected.
    This usually happens on the fault path, however this change
    ensures that this happens during the detach itself and thus
    hardening it against races.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>
