### PR TITLE
fix(rebuild): connect the io log when detaching

### DIFF
--- a/io-engine/src/bdev/nexus/nexus_channel.rs
+++ b/io-engine/src/bdev/nexus/nexus_channel.rs
@@ -237,6 +237,12 @@ impl<'n> NexusChannel<'n> {
             self.detached.push(t);
         }
 
+        // Since we've removed the device from the IO path, make sure we
+        // reconnect the io logs in case we haven't done so yet.
+        // Otherwise, a given channel might never see an error for this device
+        // and will therefore not log the IOs until a reconnect_io_logs.
+        self.reconnect_io_logs();
+
         debug!("{self:?}: device '{device_name}' detached");
     }
 


### PR DESCRIPTION
When we detach a device, ensure that the io logs are connected. This usually happens on the fault path, however this change ensures that this happens during the detach itself and thus hardening it against races.