### PR TITLE
fix(rebuild): reconnect log on own channel when faulting

### DIFF
--- a/io-engine/src/bdev/nexus/nexus_channel.rs
+++ b/io-engine/src/bdev/nexus/nexus_channel.rs
@@ -373,8 +373,14 @@ impl<'n> NexusChannel<'n> {
         child_device: &str,
         reason: FaultReason,
     ) -> Option<IOLogChannel> {
-        self.nexus_mut()
-            .retire_child_device(child_device, reason, true)
+        let Some(io_log) =
+            self.nexus_mut()
+                .retire_child_device(child_device, reason, true)
+        else {
+            return None;
+        };
+        self.reconnect_io_logs();
+        Some(io_log)
     }
 
     /// Returns core on which channel was created.


### PR DESCRIPTION
When an IO fails to submit the channel is removed right away. This means if another IO reaches the channel before the retire or the channel traversal then it might not get logged.
This change ensures it is logged by reconnecting the IO log straight away.