### PR TITLE
build: harden build by pre-fetching dependencies

### DIFF
--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -14,5 +14,5 @@ self: super: rec {
   ms-buildenv = super.callPackage ./pkgs/ms-buildenv { };
   nvme-cli = super.callPackage ./pkgs/nvme-cli { };
   nvmet-cli = super.callPackage ./pkgs/nvmet-cli { };
-  units = (super.callPackage ./pkgs/io-engine/units.nix { });
+  units = (super.callPackage ./pkgs/io-engine/units.nix { inherit tag sourcer; });
 }

--- a/nix/pkgs/io-engine/cargo-package.nix
+++ b/nix/pkgs/io-engine/cargo-package.nix
@@ -95,6 +95,9 @@ let
   };
 in
 {
+  cargoDeps = rustPlatform.importCargoLock {
+    lockFile = ../../../Cargo.lock;
+  };
   release = rustPlatform.buildRustPackage (buildProps // {
     cargoBuildFlags = "--bin io-engine --bin io-engine-client --bin casperf";
     buildType = "release";

--- a/nix/pkgs/io-engine/units.nix
+++ b/nix/pkgs/io-engine/units.nix
@@ -1,36 +1,18 @@
 { stdenv
-, clang
-, dockerTools
-, e2fsprogs
 , lib
-, libaio
-, libspdk
-, libspdk-dev
-, udev
-, liburing
-, makeRustPlatform
-, numactl
-, openssl
-, pkg-config
-, protobuf
-, sources
-, xfsprogs
-, utillinux
-, llvmPackages
-, targetPackages
-, buildPackages
-, targetPlatform
 , pkgs
+, git
+, tag
 , sourcer
 }:
 let
   versionDrv = import ../../lib/version.nix { inherit lib stdenv git tag sourcer; };
   versions = {
-    "version" = version;
+    "version" = "${versionDrv}";
     "long" = builtins.readFile "${versionDrv.long}";
     "tag_or_long" = builtins.readFile "${versionDrv.tag_or_long}";
   };
-  project-builder = { cargoBuildFlags }: pkgs.callPackage ./cargo-package.nix { inherit versions cargoBuildFlags; };
+  project-builder = { cargoBuildFlags ? [ ] }: pkgs.callPackage ./cargo-package.nix { inherit versions cargoBuildFlags; };
   components = { build }: {
     io-engine = (project-builder { cargoBuildFlags = [ "--bin io-engine" ]; }).${build};
     io-engine-cli = (project-builder { cargoBuildFlags = [ "--bin io-engine-cli" ]; }).${build};
@@ -39,6 +21,7 @@ let
   };
 in
 {
+  cargoDeps = (project-builder { }).cargoDeps;
   release = components { build = "release"; };
   debug = components { build = "debug"; };
 }


### PR DESCRIPTION
Attempt to vendor the cargo deps for up to 25 times Supports linking the resulting derivation into a global location through env var CARGO_VENDOR_DIR, example:
> CARGO_VENDOR_DIR=/tmp ./scripts/release.sh --image ""
/nix/store/2x03mh7l1q0jx4xfsd3nw4h4ks0pxxya-cargo-vendor-dir
    Cargo vendored dependencies pre-fetched into /tmp/mayastor-io-engine/develop
after 1 attempt(s)

This can allow us to create a place holder in the jenkins nodes to keep the last dependencies for each main branch of each repo.