### PR TITLE
Snapshot Rebuild

### DIFF
--- a/io-engine/src/bdev/dev.rs
+++ b/io-engine/src/bdev/dev.rs
@@ -98,7 +98,7 @@ pub(crate) fn reject_unknown_parameters(
     }
 }
 
-// Lookup up a block device via its symbolic name.
+/// Lookup up a block device via its symbolic name.
 pub fn device_lookup(name: &str) -> Option<Box<dyn BlockDevice>> {
     // First try to lookup NVMF devices, then try to lookup SPDK native devices.
     nvmx::lookup_by_name(name).or_else(|| SpdkBlockDevice::lookup_by_name(name))

--- a/io-engine/src/bdev/nexus/nexus_bdev_rebuild.rs
+++ b/io-engine/src/bdev/nexus/nexus_bdev_rebuild.rs
@@ -186,6 +186,7 @@ impl<'n> Nexus<'n> {
 
         let opts = RebuildJobOptions {
             verify_mode,
+            read_opts: crate::core::ReadOptions::UnwrittenFail,
         };
 
         NexusRebuildJob::new_starter(

--- a/io-engine/src/bdev/nvmx/handle.rs
+++ b/io-engine/src/bdev/nvmx/handle.rs
@@ -25,7 +25,6 @@ use spdk_rs::{
         spdk_nvme_ns_cmd_write,
         spdk_nvme_ns_cmd_write_zeroes,
         spdk_nvme_ns_cmd_writev,
-        SPDK_NVME_IO_FLAGS_UNWRITTEN_READ_FAIL,
         SPDK_NVME_SC_INTERNAL_DEVICE_ERROR,
     },
     nvme_admin_opc,
@@ -740,12 +739,7 @@ impl BlockDeviceHandle for NvmeDeviceHandle {
         check_io_args(IoType::Read, iovs, offset_blocks, num_blocks)?;
 
         // Get read flags.
-        let flags = match opts {
-            ReadOptions::None => self.prchk_flags,
-            ReadOptions::UnwrittenFail => {
-                self.prchk_flags | SPDK_NVME_IO_FLAGS_UNWRITTEN_READ_FAIL
-            }
-        };
+        let flags = self.prchk_flags | u32::from(opts);
 
         let channel = self.io_channel.as_ptr();
         let inner = NvmeIoChannel::inner_from_channel(channel);

--- a/io-engine/src/bin/io-engine-client/context.rs
+++ b/io-engine/src/bin/io-engine-client/context.rs
@@ -66,6 +66,8 @@ mod v1 {
     pub type HostRpcClient = host::HostRpcClient<Channel>;
     pub type NexusRpcClient = nexus::NexusRpcClient<Channel>;
     pub type SnapshotRpcClient = snapshot::SnapshotRpcClient<Channel>;
+    pub type SnapshotRebuildRpcClient =
+        snapshot_rebuild::SnapshotRebuildRpcClient<Channel>;
     pub type TestRpcClient = test::TestRpcClient<Channel>;
     pub type StatsRpcClient = stats::StatsRpcClient<Channel>;
 
@@ -77,6 +79,7 @@ mod v1 {
         pub host: HostRpcClient,
         pub nexus: NexusRpcClient,
         pub snapshot: SnapshotRpcClient,
+        pub snapshot_rebuild: SnapshotRebuildRpcClient,
         pub test: TestRpcClient,
         pub stats: StatsRpcClient,
     }
@@ -90,6 +93,8 @@ mod v1 {
             let host = HostRpcClient::connect(h.clone()).await.unwrap();
             let nexus = NexusRpcClient::connect(h.clone()).await.unwrap();
             let snapshot = SnapshotRpcClient::connect(h.clone()).await.unwrap();
+            let snapshot_rebuild =
+                SnapshotRebuildRpcClient::connect(h.clone()).await.unwrap();
             let test = TestRpcClient::connect(h.clone()).await.unwrap();
             let stats = StatsRpcClient::connect(h).await.unwrap();
 
@@ -101,6 +106,7 @@ mod v1 {
                 host,
                 nexus,
                 snapshot,
+                snapshot_rebuild,
                 test,
                 stats,
             })

--- a/io-engine/src/bin/io-engine-client/v1/mod.rs
+++ b/io-engine/src/bin/io-engine-client/v1/mod.rs
@@ -9,6 +9,7 @@ pub mod pool_cli;
 pub mod rebuild_cli;
 pub mod replica_cli;
 pub mod snapshot_cli;
+mod snapshot_rebuild_cli;
 pub mod stats_cli;
 mod test_cli;
 
@@ -73,6 +74,7 @@ pub(super) async fn main_() -> crate::Result<()> {
         .subcommand(device_cli::subcommands())
         .subcommand(perf_cli::subcommands())
         .subcommand(rebuild_cli::subcommands())
+        .subcommand(snapshot_rebuild_cli::subcommands())
         .subcommand(snapshot_cli::subcommands())
         .subcommand(jsonrpc_cli::subcommands())
         .subcommand(controller_cli::subcommands())
@@ -94,6 +96,9 @@ pub(super) async fn main_() -> crate::Result<()> {
         ("pool", args) => pool_cli::handler(ctx, args).await,
         ("replica", args) => replica_cli::handler(ctx, args).await,
         ("rebuild", args) => rebuild_cli::handler(ctx, args).await,
+        ("snapshot-rebuild", args) => {
+            snapshot_rebuild_cli::handler(ctx, args).await
+        }
         ("snapshot", args) => snapshot_cli::handler(ctx, args).await,
         ("stats", args) => stats_cli::handler(ctx, args).await,
         ("controller", args) => controller_cli::handler(ctx, args).await,

--- a/io-engine/src/bin/io-engine-client/v1/snapshot_rebuild_cli.rs
+++ b/io-engine/src/bin/io-engine-client/v1/snapshot_rebuild_cli.rs
@@ -1,0 +1,218 @@
+//!
+//! methods to interact with the rebuild process
+
+use crate::{
+    context::{Context, OutputFormat},
+    ClientError,
+    GrpcStatus,
+};
+use clap::{Arg, ArgMatches, Command};
+use colored_json::ToColoredJson;
+use io_engine_api::{v1, v1::snapshot_rebuild::RebuildStatus};
+use snafu::ResultExt;
+use tonic::Status;
+
+pub async fn handler(ctx: Context, matches: &ArgMatches) -> crate::Result<()> {
+    match matches.subcommand().unwrap() {
+        ("create", args) => create(ctx, args).await,
+        ("destroy", args) => destroy(ctx, args).await,
+        ("list", args) => list(ctx, args).await,
+        (cmd, _) => {
+            Err(Status::not_found(format!("command {cmd} does not exist")))
+                .context(GrpcStatus)
+        }
+    }
+}
+
+pub fn subcommands() -> Command {
+    let create = Command::new("create")
+        .about("create and start a snapshot rebuild")
+        .arg(
+            Arg::new("uuid")
+                .required(true)
+                .index(1)
+                .help("uuid of the replica to snap rebuild"),
+        )
+        .arg(
+            Arg::new("uri")
+                .required(true)
+                .index(2)
+                .help("uri of the snapshot source to rebuild from"),
+        );
+
+    let destroy = Command::new("destroy")
+        .about("destroy a snapshot rebuild")
+        .arg(
+            Arg::new("uuid")
+                .required(true)
+                .index(1)
+                .help("uuid of the snapshot rebuild"),
+        );
+
+    let list = Command::new("list")
+        .about("list a specific one or all snapshot rebuilds")
+        .arg(
+            Arg::new("uuid")
+                .required(false)
+                .index(1)
+                .help("uuid of the snapshot rebuild"),
+        );
+
+    Command::new("snapshot-rebuild")
+        .subcommand_required(true)
+        .arg_required_else_help(true)
+        .about("Snapshot Rebuild Management")
+        .subcommand(create)
+        .subcommand(destroy)
+        .subcommand(list)
+}
+
+async fn create(mut ctx: Context, matches: &ArgMatches) -> crate::Result<()> {
+    let uuid = matches
+        .get_one::<String>("uuid")
+        .ok_or_else(|| ClientError::MissingValue {
+            field: "uuid".to_string(),
+        })?
+        .to_string();
+    let uri = matches
+        .get_one::<String>("uri")
+        .ok_or_else(|| ClientError::MissingValue {
+            field: "uri".to_string(),
+        })?
+        .to_string();
+
+    let response = ctx
+        .v1
+        .snapshot_rebuild
+        .create_snapshot_rebuild(
+            v1::snapshot_rebuild::CreateSnapshotRebuildRequest {
+                replica_uuid: uuid,
+                resume: false,
+                source_uri: uri.clone(),
+                bitmap: None,
+                error_policy: None,
+            },
+        )
+        .await
+        .context(GrpcStatus)?;
+    match ctx.output {
+        OutputFormat::Json => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&response.get_ref())
+                    .unwrap()
+                    .to_colored_json_auto()
+                    .unwrap()
+            );
+        }
+        OutputFormat::Default => {
+            let uuid = response.into_inner().uuid;
+            println!("Snapshot Rebuild {uuid} created");
+        }
+    };
+
+    Ok(())
+}
+
+async fn destroy(mut ctx: Context, matches: &ArgMatches) -> crate::Result<()> {
+    let uuid = matches
+        .get_one::<String>("uuid")
+        .ok_or_else(|| ClientError::MissingValue {
+            field: "uuid".to_string(),
+        })?
+        .to_string();
+
+    let _response = ctx
+        .v1
+        .snapshot_rebuild
+        .destroy_snapshot_rebuild(
+            v1::snapshot_rebuild::DestroySnapshotRebuildRequest {
+                replica_uuid: uuid.clone(),
+            },
+        )
+        .await
+        .context(GrpcStatus)?;
+    println!("Snapshot Rebuild {uuid} deleted");
+
+    Ok(())
+}
+
+async fn list(mut ctx: Context, matches: &ArgMatches) -> crate::Result<()> {
+    let replica_uuid = matches.get_one::<String>("uuid").cloned();
+
+    let response = ctx
+        .v1
+        .snapshot_rebuild
+        .list_snapshot_rebuild(
+            v1::snapshot_rebuild::ListSnapshotRebuildRequest {
+                replica_uuid,
+            },
+        )
+        .await
+        .context(GrpcStatus)?;
+    match ctx.output {
+        OutputFormat::Json => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&response.get_ref())
+                    .unwrap()
+                    .to_colored_json_auto()
+                    .unwrap()
+            );
+        }
+        OutputFormat::Default => {
+            let response = response.into_inner();
+            if response.rebuilds.is_empty() {
+                return Ok(());
+            }
+            let table = response
+                .rebuilds
+                .into_iter()
+                .map(|r| {
+                    let status = r.status();
+                    vec![
+                        r.uuid,
+                        r.source_uri,
+                        rebuild_status_to_str(status),
+                        r.total.to_string(),
+                        r.rebuilt.to_string(),
+                        r.remaining.to_string(),
+                        r.start_timestamp
+                            .map(|s| s.to_string())
+                            .unwrap_or_default(),
+                        r.end_timestamp
+                            .map(|s| s.to_string())
+                            .unwrap_or_default(),
+                    ]
+                })
+                .collect();
+            ctx.print_list(
+                vec![
+                    "REPLICA",
+                    "SNAPSHOT",
+                    "STATUS",
+                    "TOTAL",
+                    "REBUILT",
+                    "REMAINING",
+                    "START",
+                    "END",
+                ],
+                table,
+            );
+        }
+    };
+
+    Ok(())
+}
+
+fn rebuild_status_to_str(status: RebuildStatus) -> String {
+    match status {
+        RebuildStatus::Unknown => "unknown",
+        RebuildStatus::Created => "created",
+        RebuildStatus::Running => "running",
+        RebuildStatus::Paused => "paused",
+        RebuildStatus::Successful => "successful",
+        RebuildStatus::Failed => "failed",
+    }
+    .to_string()
+}

--- a/io-engine/src/core/block_device.rs
+++ b/io-engine/src/core/block_device.rs
@@ -144,11 +144,15 @@ pub type OpCompletionCallbackArg = *mut c_void;
 pub type OpCompletionCallback = fn(bool, OpCompletionCallbackArg) -> ();
 
 /// Read options.
+#[derive(Default, Debug, Copy, Clone)]
 pub enum ReadOptions {
     /// Normal read operation.
+    #[default]
     None,
     /// Fail when reading an unwritten block of a thin-provisioned device.
     UnwrittenFail,
+    /// Fail when reading an unwritten block of a thin-provisioned device.
+    CurrentUnwrittenFail,
 }
 
 /// Core trait that represents a device I/O handle.

--- a/io-engine/src/core/env.rs
+++ b/io-engine/src/core/env.rs
@@ -490,6 +490,7 @@ async fn do_shutdown(arg: *mut c_void) {
         reg.fini();
     }
     nexus::shutdown_nexuses().await;
+    crate::rebuild::shutdown_snapshot_rebuilds().await;
     crate::lvs::Lvs::export_all().await;
 
     runtime::spawn_await(async {

--- a/io-engine/src/grpc/mod.rs
+++ b/io-engine/src/grpc/mod.rs
@@ -170,6 +170,7 @@ where
         .map_err(|e| e.into())
 }
 
+/// Submit rpc code to the primary reactor.
 pub fn rpc_submit<F, R, E>(
     future: F,
 ) -> Result<Receiver<Result<R, E>>, tonic::Status>
@@ -181,6 +182,8 @@ where
     Reactor::spawn_at_primary(future)
         .map_err(|_| Status::resource_exhausted("ENOMEM"))
 }
+/// Submit rpc code to the primary reactor.
+/// Similar to `rpc_submit` but with a more generic response abstraction.
 pub fn rpc_submit_ext<F, R>(future: F) -> Result<Receiver<R>, tonic::Status>
 where
     F: Future<Output = R> + 'static,

--- a/io-engine/src/grpc/v1/snapshot_rebuild.rs
+++ b/io-engine/src/grpc/v1/snapshot_rebuild.rs
@@ -1,13 +1,26 @@
-use crate::grpc::GrpcResult;
-use io_engine_api::v1::snapshot_rebuild::{
-    CreateSnapshotRebuildRequest,
-    DestroySnapshotRebuildRequest,
-    ListSnapshotRebuildRequest,
-    ListSnapshotRebuildResponse,
-    SnapshotRebuild,
-    SnapshotRebuildRpc,
+use crate::{
+    grpc::{rpc_submit_ext, GrpcResult},
+    rebuild::{
+        RebuildError,
+        RebuildState,
+        RebuildStats,
+        SnapshotRebuildError,
+        SnapshotRebuildJob,
+    },
 };
-use tonic::{Request, Status};
+use io_engine_api::v1::{
+    snapshot_rebuild,
+    snapshot_rebuild::{
+        CreateSnapshotRebuildRequest,
+        DestroySnapshotRebuildRequest,
+        ListSnapshotRebuildRequest,
+        ListSnapshotRebuildResponse,
+        SnapshotRebuild,
+        SnapshotRebuildRpc,
+    },
+};
+use std::sync::Arc;
+use tonic::Request;
 
 #[derive(Debug)]
 pub struct SnapshotRebuildService {
@@ -30,20 +43,192 @@ impl SnapshotRebuildService {
 impl SnapshotRebuildRpc for SnapshotRebuildService {
     async fn create_snapshot_rebuild(
         &self,
-        _request: Request<CreateSnapshotRebuildRequest>,
+        request: Request<CreateSnapshotRebuildRequest>,
     ) -> GrpcResult<SnapshotRebuild> {
-        GrpcResult::Err(Status::unimplemented(""))
+        let request = request.into_inner();
+
+        let rx = rpc_submit_ext(async move {
+            info!("{:?}", request);
+
+            let None = request.bitmap else {
+                return Err(tonic::Status::invalid_argument(
+                    "BitMap not supported",
+                ));
+            };
+            if let Ok(job) = SnapshotRebuildJob::lookup(&request.replica_uuid) {
+                return Ok(SnapshotRebuild::from(SnapRebuild::from(job).await));
+            }
+            SnapshotRebuildJob::builder()
+                .build(&request.source_uri, &request.replica_uuid)
+                .await?
+                .store()?;
+
+            let job = SnapRebuild::lookup(&request.replica_uuid).await?;
+            job.start().await?;
+            Ok(SnapshotRebuild::from(job))
+        })?;
+
+        rx.await
+            .map_err(|_| tonic::Status::cancelled("cancelled"))?
+            .map(tonic::Response::new)
     }
     async fn list_snapshot_rebuild(
         &self,
-        _request: Request<ListSnapshotRebuildRequest>,
+        request: Request<ListSnapshotRebuildRequest>,
     ) -> GrpcResult<ListSnapshotRebuildResponse> {
-        GrpcResult::Err(Status::unimplemented(""))
+        let rx = rpc_submit_ext(async move {
+            let args = request.into_inner();
+            trace!("{:?}", args);
+            match args.replica_uuid {
+                None => {
+                    let jobs = SnapshotRebuildJob::list();
+                    let mut rebuilds = Vec::with_capacity(jobs.len());
+                    for job in jobs {
+                        rebuilds.push(SnapRebuild::from(job).await.into());
+                    }
+                    Ok(ListSnapshotRebuildResponse {
+                        rebuilds,
+                    })
+                }
+                Some(uuid) => {
+                    let job = SnapRebuild::lookup(&uuid).await?;
+                    Ok(ListSnapshotRebuildResponse {
+                        rebuilds: vec![job.into()],
+                    })
+                }
+            }
+        })?;
+        rx.await
+            .map_err(|_| tonic::Status::cancelled("cancelled"))?
+            .map(tonic::Response::new)
     }
     async fn destroy_snapshot_rebuild(
         &self,
-        _request: Request<DestroySnapshotRebuildRequest>,
+        request: Request<DestroySnapshotRebuildRequest>,
     ) -> GrpcResult<()> {
-        GrpcResult::Err(Status::unimplemented(""))
+        let rx = rpc_submit_ext(async move {
+            let args = request.into_inner();
+            info!("{:?}", args);
+            let Ok(job) = SnapshotRebuildJob::lookup(&args.replica_uuid) else {
+                return Err(tonic::Status::not_found(""));
+            };
+            let rx = job.force_stop().await.ok();
+            info!("Snapshot Rebuild stopped: {rx:?}");
+            job.destroy();
+            Ok(())
+        })?;
+        rx.await
+            .map_err(|_| tonic::Status::cancelled("cancelled"))?
+            .map(tonic::Response::new)
+    }
+}
+
+struct SnapRebuild {
+    stats: RebuildStats,
+    job: Arc<SnapshotRebuildJob>,
+}
+impl SnapRebuild {
+    async fn from(job: Arc<SnapshotRebuildJob>) -> Self {
+        let stats = job.stats().await;
+        Self {
+            stats,
+            job,
+        }
+    }
+    async fn lookup(uuid: &str) -> Result<Self, tonic::Status> {
+        let job = SnapshotRebuildJob::lookup(uuid)?;
+        Ok(Self::from(job).await)
+    }
+    async fn start(&self) -> Result<(), tonic::Status> {
+        let _receiver = self.job.start().await?;
+        Ok(())
+    }
+}
+
+impl From<SnapRebuild> for SnapshotRebuild {
+    fn from(value: SnapRebuild) -> Self {
+        let stats = value.stats;
+        let job = value.job;
+        Self {
+            uuid: job.name().to_string(),
+            source_uri: job.src_uri().to_string(),
+            status: snapshot_rebuild::RebuildStatus::from(job.state()) as i32,
+            total: stats.blocks_total * stats.block_size,
+            rebuilt: stats.blocks_transferred * stats.block_size,
+            remaining: stats.blocks_remaining * stats.block_size,
+            persisted_checkpoint: 0,
+            start_timestamp: Some(stats.start_time.into()),
+            end_timestamp: stats.end_time.map(Into::into),
+        }
+    }
+}
+
+impl From<RebuildState> for snapshot_rebuild::RebuildStatus {
+    fn from(value: RebuildState) -> Self {
+        use snapshot_rebuild::RebuildStatus;
+        match value {
+            RebuildState::Init => RebuildStatus::Created,
+            RebuildState::Running => RebuildStatus::Running,
+            RebuildState::Stopped => RebuildStatus::Failed,
+            RebuildState::Paused => RebuildStatus::Paused,
+            RebuildState::Failed => RebuildStatus::Failed,
+            RebuildState::Completed => RebuildStatus::Successful,
+        }
+    }
+}
+
+impl From<RebuildError> for tonic::Status {
+    fn from(value: RebuildError) -> Self {
+        let message = value.to_string();
+        match value {
+            RebuildError::JobAlreadyExists {
+                ..
+            } => tonic::Status::already_exists(message),
+            RebuildError::NoCopyBuffer {
+                ..
+            } => tonic::Status::internal(message),
+            RebuildError::InvalidSrcDstRange {
+                ..
+            } => tonic::Status::out_of_range(message),
+            RebuildError::InvalidMapRange {
+                ..
+            } => tonic::Status::out_of_range(message),
+            RebuildError::SameBdev {
+                ..
+            } => tonic::Status::invalid_argument(message),
+            RebuildError::NoBdevHandle {
+                ..
+            } => tonic::Status::failed_precondition(message),
+            RebuildError::BdevNotFound {
+                ..
+            } => tonic::Status::failed_precondition(message),
+            RebuildError::JobNotFound {
+                ..
+            } => tonic::Status::not_found(message),
+            RebuildError::BdevInvalidUri {
+                ..
+            } => tonic::Status::invalid_argument(message),
+            RebuildError::RebuildTasksChannel {
+                ..
+            } => tonic::Status::resource_exhausted(message),
+            RebuildError::SnapshotRebuild {
+                source,
+            } => match source {
+                SnapshotRebuildError::ReplicaBdevNotFound {
+                    ..
+                } => tonic::Status::not_found(message),
+                SnapshotRebuildError::ReplicaNoUri {
+                    ..
+                } => tonic::Status::internal(message),
+                SnapshotRebuildError::NotAReplica {
+                    ..
+                } => tonic::Status::invalid_argument(message),
+                // todo better error check here, what if bdev uri is invalid?
+                SnapshotRebuildError::SourceUriBdev {
+                    ..
+                } => tonic::Status::not_found(message),
+            },
+            _ => tonic::Status::internal(message),
+        }
     }
 }

--- a/io-engine/src/rebuild/mod.rs
+++ b/io-engine/src/rebuild/mod.rs
@@ -15,7 +15,7 @@ mod snapshot_rebuild;
 pub use bdev_rebuild::BdevRebuildJob;
 pub use nexus_rebuild::{NexusRebuildJob, NexusRebuildJobStarter};
 use rebuild_descriptor::RebuildDescriptor;
-pub(crate) use rebuild_error::RebuildError;
+pub(crate) use rebuild_error::{RebuildError, SnapshotRebuildError};
 use rebuild_job::RebuildOperation;
 pub use rebuild_job::{RebuildJob, RebuildJobOptions, RebuildVerifyMode};
 use rebuild_job_backend::{

--- a/io-engine/src/rebuild/mod.rs
+++ b/io-engine/src/rebuild/mod.rs
@@ -10,6 +10,7 @@ mod rebuild_state;
 mod rebuild_stats;
 mod rebuild_task;
 mod rebuilders;
+mod snapshot_rebuild;
 
 pub use bdev_rebuild::BdevRebuildJob;
 pub use nexus_rebuild::{NexusRebuildJob, NexusRebuildJobStarter};
@@ -28,6 +29,7 @@ use rebuild_state::RebuildStates;
 pub(crate) use rebuild_stats::HistoryRecord;
 pub use rebuild_stats::RebuildStats;
 use rebuild_task::{RebuildTasks, TaskResult};
+pub use snapshot_rebuild::SnapshotRebuildJob;
 
 /// Number of concurrent copy tasks per rebuild job
 const SEGMENT_TASKS: usize = 16;
@@ -49,5 +51,27 @@ impl WithinRange<u64> for std::ops::Range<u64> {
             && right.start < right.end
             && self.start >= right.start
             && self.end <= right.end
+    }
+}
+
+/// Shutdown all pending snapshot rebuilds.
+pub(crate) async fn shutdown_snapshot_rebuilds() {
+    let jobs = SnapshotRebuildJob::list().into_iter();
+    for recv in jobs.map(|job| job.force_stop()).collect::<Vec<_>>() {
+        recv.await.ok();
+    }
+}
+
+/// Parse the given url as string into a `url::Url`.
+pub(crate) fn parse_url(url: &str) -> Result<url::Url, RebuildError> {
+    match url::Url::parse(url) {
+        Ok(url) => Ok(url),
+        Err(source) => Err(RebuildError::BdevInvalidUri {
+            source: crate::bdev_api::BdevError::UriParseFailed {
+                uri: url.to_owned(),
+                source,
+            },
+            uri: url.to_owned(),
+        }),
     }
 }

--- a/io-engine/src/rebuild/rebuild_descriptor.rs
+++ b/io-engine/src/rebuild/rebuild_descriptor.rs
@@ -143,7 +143,7 @@ impl RebuildDescriptor {
     }
 
     /// Check if the rebuild range is compatible with the rebuild segment map.
-    pub(crate) fn validate_map(
+    pub(super) fn validate_map(
         &self,
         map: &SegmentMap,
     ) -> Result<(), RebuildError> {
@@ -227,6 +227,7 @@ impl RebuildDescriptor {
         &self,
         offset_blk: u64,
         iovs: &mut [IoVec],
+        opts: ReadOptions,
     ) -> Result<bool, RebuildError> {
         match self
             .src_io_handle()
@@ -235,7 +236,7 @@ impl RebuildDescriptor {
                 iovs,
                 offset_blk,
                 self.get_segment_size_blks(offset_blk),
-                ReadOptions::UnwrittenFail,
+                opts,
             )
             .await
         {

--- a/io-engine/src/rebuild/rebuild_error.rs
+++ b/io-engine/src/rebuild/rebuild_error.rs
@@ -84,4 +84,29 @@ pub enum RebuildError {
     BackendGone,
     #[snafu(display("The rebuild task pool channel is unexpectedly closed with {} active tasks", active))]
     RebuildTasksChannel { active: usize },
+    #[snafu(display("Snapshot Rebuild: {source}"))]
+    SnapshotRebuild { source: SnapshotRebuildError },
+}
+
+/// Various snapshot rebuild errors.
+#[derive(Debug, Snafu, Clone)]
+#[snafu(visibility(pub(crate)), context(suffix(false)))]
+#[allow(missing_docs)]
+pub enum SnapshotRebuildError {
+    #[snafu(display("Destination replica bdev not found"))]
+    ReplicaBdevNotFound {},
+    #[snafu(display("Destination replica bdev uri is missing"))]
+    ReplicaNoUri {},
+    #[snafu(display("Given destination uuid is not a replica"))]
+    NotAReplica {},
+    #[snafu(display("Failed to open the source uri as a bdev: {source}"))]
+    SourceUriBdev { source: BdevError },
+}
+
+impl From<SnapshotRebuildError> for RebuildError {
+    fn from(source: SnapshotRebuildError) -> Self {
+        Self::SnapshotRebuild {
+            source,
+        }
+    }
 }

--- a/io-engine/src/rebuild/rebuild_instances.rs
+++ b/io-engine/src/rebuild/rebuild_instances.rs
@@ -8,8 +8,7 @@ macro_rules! gen_rebuild_instances {
         impl $T {
             /// Get the rebuild job instances container, we ensure that this can
             /// only ever be called on a properly allocated thread
-            fn get_instances<'a>(
-            ) -> parking_lot::MutexGuard<'a, RebuildJobInstances> {
+            fn get_instances<'a>() -> parking_lot::MutexGuard<'a, RebuildJobInstances> {
                 assert!(
                     spdk_rs::Thread::is_spdk_thread(),
                     "not called from SPDK thread"
@@ -29,8 +28,7 @@ macro_rules! gen_rebuild_instances {
                 Self::get_instances().len()
             }
 
-            /// Lookup a rebuild job by its destination uri then remove and drop
-            /// it.
+            /// Lookup a rebuild job by its name then remove and drop it.
             pub fn remove(
                 name: &str,
             ) -> Result<std::sync::Arc<Self>, super::RebuildError> {
@@ -43,36 +41,37 @@ macro_rules! gen_rebuild_instances {
             }
 
             /// Stores a rebuild job in the rebuild job list.
-            pub fn store(self) -> Result<(), super::RebuildError> {
+            pub fn store(self) -> Result<std::sync::Arc<Self>, super::RebuildError> {
                 let mut rebuild_list = Self::get_instances();
 
-                if rebuild_list.contains_key(&self.dst_uri) {
+                if rebuild_list.contains_key(self.name()) {
                     Err(RebuildError::JobAlreadyExists {
                         job: self.dst_uri().to_string(),
                     })
                 } else {
+                    let job = std::sync::Arc::new(self);
                     let _ = rebuild_list.insert(
-                        self.dst_uri.clone(),
-                        std::sync::Arc::new(self),
+                        job.name().to_owned(),
+                        job.clone(),
                     );
-                    Ok(())
+                    Ok(job)
                 }
             }
 
-            /// Lookup a rebuild job by its destination uri and return it.
+            /// Lookup a rebuild job by its name and return it.
             pub fn lookup(
-                dst_uri: &str,
+                name: &str,
             ) -> Result<std::sync::Arc<Self>, super::RebuildError> {
-                if let Some(job) = Self::get_instances().get(dst_uri) {
+                if let Some(job) = Self::get_instances().get(name) {
                     Ok(job.clone())
                 } else {
                     Err(RebuildError::JobNotFound {
-                        job: dst_uri.to_owned(),
+                        job: name.to_owned(),
                     })
                 }
             }
 
-            /// Lookup all rebuilds jobs with name as its source.
+            /// Lookup all rebuilds jobs with `src_uri` as its source uri.
             pub fn lookup_src(src_uri: &str) -> Vec<std::sync::Arc<Self>> {
                 Self::get_instances()
                     .iter_mut()
@@ -84,6 +83,22 @@ macro_rules! gen_rebuild_instances {
                         }
                     })
                     .collect()
+            }
+
+            /// Lookup a rebuild job by its target uri and return it.
+            pub fn lookup_dst_uri(
+                dst_uri: &str,
+            ) -> Result<std::sync::Arc<Self>, super::RebuildError> {
+                let not_found = || RebuildError::JobNotFound {
+                    job: dst_uri.to_owned(),
+                };
+                let url = url::Url::parse(dst_uri).map_err(|_| not_found())?;
+                let name = url.path().strip_prefix('/').unwrap_or(url.path());
+                let job = Self::lookup(name)?;
+                if job.dst_uri != dst_uri {
+                    return Err(not_found());
+                }
+                Ok(job)
             }
         }
     };

--- a/io-engine/src/rebuild/rebuild_job.rs
+++ b/io-engine/src/rebuild/rebuild_job.rs
@@ -13,7 +13,7 @@ use super::{
     RebuildStats,
 };
 use crate::{
-    core::{Reactors, VerboseError},
+    core::{Reactors, ReadOptions, VerboseError},
     rebuild::{
         rebuild_descriptor::RebuildDescriptor,
         rebuild_job_backend::{RebuildBackend, RebuildJobManager},
@@ -33,9 +33,17 @@ pub enum RebuildVerifyMode {
 }
 
 /// Rebuild job options.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Default)]
 pub struct RebuildJobOptions {
     pub verify_mode: RebuildVerifyMode,
+    pub read_opts: ReadOptions,
+}
+impl RebuildJobOptions {
+    /// Use the given `ReadOptions`.
+    pub fn with_read_opts(mut self, read_opts: ReadOptions) -> Self {
+        self.read_opts = read_opts;
+        self
+    }
 }
 
 /// Operations used to control the state of the job.
@@ -242,6 +250,11 @@ impl RebuildJob {
     /// Get the uri of the rebuild source.
     pub fn src_uri(&self) -> &str {
         &self.src_uri
+    }
+
+    /// Get the name of this rebuild job (ie the rebuild target).
+    pub fn name(&self) -> &str {
+        self.dst_uri()
     }
 
     /// Get the uri of the rebuild destination.

--- a/io-engine/src/rebuild/rebuild_job_backend.rs
+++ b/io-engine/src/rebuild/rebuild_job_backend.rs
@@ -332,6 +332,7 @@ impl RebuildJobBackendManager {
             block_size: descriptor.block_size,
             tasks_total: self.task_pool().total as u64,
             tasks_active: self.task_pool().active as u64,
+            end_time: None,
         }
     }
 

--- a/io-engine/src/rebuild/rebuild_state.rs
+++ b/io-engine/src/rebuild/rebuild_state.rs
@@ -1,5 +1,6 @@
 use super::{RebuildError, RebuildOperation};
 use crate::rebuild::RebuildStats;
+use chrono::Utc;
 
 /// Allowed states for a rebuild job.
 #[derive(Default, Debug, PartialEq, Copy, Clone)]
@@ -72,7 +73,8 @@ impl RebuildStates {
         &self.final_stats
     }
     /// Set the final rebuild statistics.
-    pub(super) fn set_final_stats(&mut self, stats: RebuildStats) {
+    pub(super) fn set_final_stats(&mut self, mut stats: RebuildStats) {
+        stats.end_time = Some(Utc::now());
         self.final_stats = Some(stats);
     }
 

--- a/io-engine/src/rebuild/rebuild_stats.rs
+++ b/io-engine/src/rebuild/rebuild_stats.rs
@@ -27,6 +27,8 @@ pub struct RebuildStats {
     pub start_time: DateTime<Utc>,
     /// Is this a partial rebuild?
     pub is_partial: bool,
+    /// End time of this rebuild.
+    pub end_time: Option<DateTime<Utc>>,
 }
 
 impl Default for RebuildStats {
@@ -43,6 +45,7 @@ impl Default for RebuildStats {
             tasks_active: 0,
             start_time: Utc::now(),
             is_partial: false,
+            end_time: None,
         }
     }
 }

--- a/io-engine/src/rebuild/rebuild_task.rs
+++ b/io-engine/src/rebuild/rebuild_task.rs
@@ -61,7 +61,10 @@ impl RebuildTask {
         let iov = desc.adjusted_iov(&self.buffer, offset_blk);
         let iovs = &mut [iov];
 
-        if !desc.read_src_segment(offset_blk, iovs).await? {
+        if !desc
+            .read_src_segment(offset_blk, iovs, desc.options.read_opts)
+            .await?
+        {
             // Segment is not allocated in the source, skip the write.
             return Ok(false);
         }
@@ -127,7 +130,7 @@ impl RebuildTasks {
 
         Ok(RebuildTasks {
             total: tasks.len(),
-            tasks: tasks.collect::<Result<_, _>>()?,
+            tasks: tasks.collect::<Result<_, RebuildError>>()?,
             channel,
             active: 0,
             segments_done: 0,

--- a/io-engine/src/rebuild/snapshot_rebuild.rs
+++ b/io-engine/src/rebuild/snapshot_rebuild.rs
@@ -1,0 +1,168 @@
+use snafu::ResultExt;
+use std::{convert::TryFrom, ops::Deref, sync::Arc};
+
+use super::{rebuild_error::RebuildError, RebuildJob, RebuildJobOptions};
+
+use crate::{
+    bdev::{device_create, device_destroy},
+    core::{Bdev, Reactors, ReadOptions, SegmentMap},
+    gen_rebuild_instances,
+    lvs::Lvol,
+    rebuild::{
+        bdev_rebuild::BdevRebuildJobBuilder,
+        rebuild_error::{SnapshotRebuildError, SourceUriBdev},
+        BdevRebuildJob,
+    },
+};
+
+/// A Snapshot rebuild job is responsible for managing a rebuild (copy) which
+/// reads from a source snapshot and writes into a local replica from specified
+/// start to end.
+pub struct SnapshotRebuildJob {
+    inner: BdevRebuildJob,
+    destroy_src_uri: bool,
+    name: String,
+}
+
+impl std::fmt::Debug for SnapshotRebuildJob {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SnapshotRebuildJob")
+            .field("name", &self.name)
+            .field("inner", &self.inner)
+            .finish()
+    }
+}
+impl Deref for SnapshotRebuildJob {
+    type Target = RebuildJob;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+/// Builder for the `SnapshotRebuildJob`.
+#[derive(Default)]
+pub struct SnapshotRebuildJobBuilder(BdevRebuildJobBuilder);
+impl SnapshotRebuildJobBuilder {
+    /// Specify the rebuild options.
+    pub fn with_option(self, options: RebuildJobOptions) -> Self {
+        Self(self.0.with_option(options))
+    }
+    /// Specify a notification function.
+    pub fn with_notify_fn(self, notify_fn: fn(&str, &str) -> ()) -> Self {
+        Self(self.0.with_notify_fn(notify_fn))
+    }
+    /// Specify a rebuild map, turning it into a partial rebuild.
+    pub fn with_bitmap(self, rebuild_map: SegmentMap) -> Self {
+        Self(self.0.with_bitmap(rebuild_map))
+    }
+    /// Builds a `SnapshotRebuildJob` which differs from `Self::build` by
+    /// rebuilding into any target uri and not only replicas.
+    pub async fn build_uris(
+        self,
+        (src_uri, src_cr): (&str, bool),
+        dst_uri: &str,
+    ) -> Result<SnapshotRebuildJob, RebuildError> {
+        let url = super::parse_url(dst_uri)?;
+        let name = url.path().strip_prefix('/').unwrap_or(url.path());
+
+        if src_cr {
+            device_create(src_uri).await.context(SourceUriBdev)?;
+        }
+
+        match self.0.build(src_uri, dst_uri).await {
+            Ok(job) => Ok(SnapshotRebuildJob::new(name, src_cr, job)),
+            Err(error) => {
+                if src_cr {
+                    device_destroy(src_uri).await.ok();
+                }
+                Err(error)
+            }
+        }
+    }
+    /// Builds a `SnapshotRebuildJob` which can be started and which will then
+    /// rebuild from source uri to target local replica.
+    /// todo: probably target could still be a uri, example: lvol:///$uuid
+    ///  and then this would be handled the same way for non-replica targets.
+    pub async fn build(
+        self,
+        src_uri: &str,
+        replica_uuid: &str,
+    ) -> Result<SnapshotRebuildJob, RebuildError> {
+        // ensure that replica exists
+        // todo: when we have new backends, we can't just use `Lvol` directly.
+        let _lvol = Bdev::lookup_by_uuid_str(replica_uuid)
+            .ok_or(SnapshotRebuildError::ReplicaBdevNotFound {})
+            .and_then(|bdev| {
+                Lvol::try_from(bdev)
+                    .map_err(|_| SnapshotRebuildError::NotAReplica {})
+            })?;
+
+        device_create(src_uri).await.context(SourceUriBdev)?;
+
+        let dst_uri = format!("bdev:///{replica_uuid}");
+        match self.0.build(src_uri, &dst_uri).await {
+            Ok(job) => Ok(SnapshotRebuildJob::new(replica_uuid, true, job)),
+            Err(error) => {
+                device_destroy(src_uri).await.ok();
+                Err(error)
+            }
+        }
+    }
+}
+
+impl SnapshotRebuildJob {
+    /// Helps create a `Self` using a builder: `SnapshotRebuildJobBuilder`.
+    pub fn builder() -> SnapshotRebuildJobBuilder {
+        SnapshotRebuildJobBuilder::default().with_option(
+            RebuildJobOptions::default()
+                .with_read_opts(ReadOptions::CurrentUnwrittenFail),
+        )
+    }
+    fn new(name: &str, destroy_src_uri: bool, job: BdevRebuildJob) -> Self {
+        Self {
+            name: name.to_owned(),
+            inner: job,
+            destroy_src_uri,
+        }
+    }
+    /// Get a list of all snapshot rebuild jobs.
+    pub fn list() -> Vec<std::sync::Arc<SnapshotRebuildJob>> {
+        Self::get_instances().values().cloned().collect()
+    }
+    /// Get the name of this rebuild job.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+    /// Destroy this snapshot rebuild job itself.
+    pub fn destroy(self: std::sync::Arc<Self>) {
+        let _ = Self::remove(self.name());
+    }
+    /// Lookup a rebuild job by its name or target uri and return it.
+    pub fn lookup_any(name_or_uri: &str) -> Result<Arc<Self>, RebuildError> {
+        if let Ok(job) = Self::lookup(name_or_uri) {
+            return Ok(job);
+        }
+        Self::lookup_dst_uri(name_or_uri)
+    }
+}
+
+impl Drop for SnapshotRebuildJob {
+    fn drop(&mut self) {
+        let src_uri = self.src_uri().to_owned();
+        if !self.destroy_src_uri {
+            return;
+        }
+        Reactors::master().send_future(async move {
+            if let Err(error) = device_destroy(&src_uri).await {
+                // todo: how do we know it's safe to destroy?
+                //  we don't use refcounts for this, but maybe we should?
+                tracing::error!(
+                    "Failed to close source of rebuild job: {error}"
+                );
+            }
+        });
+    }
+}
+
+gen_rebuild_instances!(SnapshotRebuildJob);

--- a/io-engine/tests/snapshot_rebuild.rs
+++ b/io-engine/tests/snapshot_rebuild.rs
@@ -1,0 +1,228 @@
+use nix::errno::Errno;
+use once_cell::sync::OnceCell;
+use std::time::Duration;
+
+use io_engine::{
+    bdev::{device_create, device_destroy},
+    core::MayastorCliArgs,
+    rebuild::RebuildState,
+};
+
+pub mod common;
+use common::compose::MayastorTest;
+use io_engine::{
+    core::{LogicalVolume, ReadOptions, Share, ToErrno},
+    lvs::{Lvol, Lvs, LvsLvol},
+    pool_backend::PoolArgs,
+    rebuild::{RebuildJobOptions, SnapshotRebuildJob},
+    sleep::mayastor_sleep,
+};
+
+static MAYASTOR: OnceCell<MayastorTest> = OnceCell::new();
+
+fn get_ms() -> &'static MayastorTest<'static> {
+    MAYASTOR.get_or_init(|| {
+        MayastorTest::new(MayastorCliArgs {
+            ..Default::default()
+        })
+    })
+}
+
+async fn create_pool() -> Result<Lvs, String> {
+    match Lvs::create_or_import(PoolArgs {
+        name: "tpool".into(),
+        disks: vec!["malloc:///md?size_mb=100".into()],
+        uuid: None,
+        cluster_size: None,
+        backend: Default::default(),
+    })
+    .await
+    {
+        Err(error) => {
+            let err_str = error.to_string();
+            if error.to_errno() == Errno::EEXIST {
+                Lvs::lookup("tpool").ok_or("Failed to lookup".into())
+            } else {
+                Err(err_str)
+            }
+        }
+        Ok(pool) => Ok(pool),
+    }
+}
+async fn create_replica(pool: &Lvs, uuid: &str) -> Result<Lvol, String> {
+    pool.create_lvol(uuid, SIZE_MB * 1024 * 1024, Some(uuid), true, None)
+        .await
+        .map_err(|error| error.to_string())
+}
+async fn destroy_replica(replica: Lvol) -> Result<(), String> {
+    replica
+        .destroy_replica()
+        .await
+        .map_err(|error| error.to_string())?;
+    Ok(())
+}
+
+const BLOCK_SIZE: u64 = 512;
+fn mb_to_blocks(mb: u64) -> u64 {
+    (mb * 1024 * 1024) / BLOCK_SIZE
+}
+const SIZE_MB: u64 = 32;
+
+#[tokio::test]
+async fn malloc_to_malloc() {
+    let ms = get_ms();
+
+    ms.spawn(async move {
+        let src_uri = format!("malloc:///d?size_mb={SIZE_MB}");
+        let dst_uri = format!("malloc:///d2?size_mb={SIZE_MB}");
+
+        device_create(&src_uri).await.unwrap();
+        device_create(&dst_uri).await.unwrap();
+
+        let job = SnapshotRebuildJob::builder()
+            .build_uris((&src_uri, false), &dst_uri)
+            .await
+            .unwrap()
+            .store()
+            .unwrap();
+        println!("job: {job:?}");
+
+        let chan = job.start().await.unwrap();
+        {
+            assert!(SnapshotRebuildJob::lookup("d2").is_ok());
+            assert!(SnapshotRebuildJob::lookup(&dst_uri).is_err());
+            assert!(SnapshotRebuildJob::lookup_any(&dst_uri).is_ok());
+        }
+
+        let state = chan.await.unwrap();
+        // todo: use completion channel with stats rather than just state?
+        let stats = job.stats().await;
+
+        device_destroy(&src_uri).await.unwrap();
+        device_destroy(&dst_uri).await.unwrap();
+        job.destroy();
+
+        assert_eq!(state, RebuildState::Completed, "Rebuild should succeed");
+        assert_eq!(stats.blocks_transferred, mb_to_blocks(SIZE_MB));
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn malloc_to_replica() {
+    let ms = get_ms();
+
+    ms.spawn(async move {
+        let src_uri = format!("malloc:///d?size_mb={SIZE_MB}");
+
+        let pool = create_pool().await.unwrap();
+        let replica =
+            create_replica(&pool, "3be1219f-682b-4672-b88b-8b9d07e8104a")
+                .await
+                .unwrap();
+
+        let job = SnapshotRebuildJob::builder()
+            .build(&src_uri, &replica.uuid())
+            .await
+            .unwrap()
+            .store()
+            .unwrap();
+        println!("job: {job:?}");
+
+        let chan = job.start().await.unwrap();
+        assert!(SnapshotRebuildJob::lookup(&replica.uuid()).is_ok());
+
+        let state = chan.await.unwrap();
+        let stats = job.stats().await;
+
+        destroy_replica(replica).await.unwrap();
+        job.destroy();
+
+        assert_eq!(state, RebuildState::Completed, "Rebuild should succeed");
+        assert_eq!(stats.blocks_transferred, mb_to_blocks(SIZE_MB));
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn replica_to_rebuild_full() {
+    let ms = get_ms();
+
+    ms.spawn(async move {
+        let pool = create_pool().await.unwrap();
+        let replica_src =
+            create_replica(&pool, "2be1219f-682b-4672-b88b-8b9d07e8104a")
+                .await
+                .unwrap();
+        let replica_dst =
+            create_replica(&pool, "3be1219f-682b-4672-b88b-8b9d07e8104a")
+                .await
+                .unwrap();
+
+        let job = SnapshotRebuildJob::builder()
+            .with_option(
+                RebuildJobOptions::default().with_read_opts(ReadOptions::None),
+            )
+            .build(&replica_src.share_uri().unwrap(), &replica_dst.uuid())
+            .await
+            .unwrap()
+            .store()
+            .unwrap();
+        println!("job: {job:?}");
+
+        let chan = job.start().await.unwrap();
+        assert!(SnapshotRebuildJob::lookup(&replica_dst.uuid()).is_ok());
+
+        let state = chan.await.unwrap();
+        let stats = job.stats().await;
+
+        destroy_replica(replica_src).await.unwrap();
+        destroy_replica(replica_dst).await.unwrap();
+        job.destroy();
+
+        assert_eq!(state, RebuildState::Completed, "Rebuild should succeed");
+        assert_eq!(stats.blocks_transferred, mb_to_blocks(SIZE_MB));
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn replica_to_rebuild_partial() {
+    let ms = get_ms();
+
+    ms.spawn(async move {
+        let pool = create_pool().await.unwrap();
+        let replica_src =
+            create_replica(&pool, "2be1219f-682b-4672-b88b-8b9d07e8104a")
+                .await
+                .unwrap();
+        let replica_dst =
+            create_replica(&pool, "3be1219f-682b-4672-b88b-8b9d07e8104a")
+                .await
+                .unwrap();
+
+        let job = SnapshotRebuildJob::builder()
+            .build(&replica_src.share_uri().unwrap(), &replica_dst.uuid())
+            .await
+            .unwrap()
+            .store()
+            .unwrap();
+        println!("job: {job:?}");
+
+        let chan = job.start().await.unwrap();
+        assert!(SnapshotRebuildJob::lookup(&replica_dst.uuid()).is_ok());
+
+        let state = chan.await.unwrap();
+        let stats = job.stats().await;
+
+        destroy_replica(replica_src).await.unwrap();
+        destroy_replica(replica_dst).await.unwrap();
+        job.destroy();
+
+        assert_eq!(state, RebuildState::Completed, "Rebuild should succeed");
+        // 8MiB which are write-zeroes at src replica creation
+        assert_eq!(stats.blocks_transferred, mb_to_blocks(8));
+        mayastor_sleep(Duration::from_millis(1)).await.unwrap();
+    })
+    .await;
+}


### PR DESCRIPTION
    feat(snap-rebuild/grpc): impl grpc backend
    
    Replaces the dummy impls with the actual implementation.
    Snapshot Rebuilds are now created, destroyed and listed.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    feat(snap-rebuild/cli): add snap rebuild cli commands
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    feat(rebuild/snapshot): initial dummy snapshot rebuild
    
    Adds snapshot rebuild module, which only makes use of bdev
    rebuild internally.
    Adds rebuild option to copy only cluster allocated to the
    current blob. This is a simply way of copying the allocated
    snapshot without before the bitmap is in place.
    
    Adds tests for simple snapshot rebuilds.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>