### PR TITLE
feat(lvs): special error code for out-of-metadata condition

### DIFF
--- a/io-engine/src/bdev/lvs.rs
+++ b/io-engine/src/bdev/lvs.rs
@@ -220,7 +220,7 @@ impl Lvs {
         match &self.mode {
             LvsMode::Create => {
                 match crate::lvs::Lvs::import_from_args(args.clone()).await {
-                    Err(crate::lvs::Error::Import {
+                    Err(crate::lvs::LvsError::Import {
                         ..
                     }) => crate::lvs::Lvs::create_or_import(args).await,
                     _ => {

--- a/io-engine/src/core/share.rs
+++ b/io-engine/src/core/share.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 use pin_utils::core_reexport::fmt::Formatter;
 use std::{convert::TryFrom, fmt::Display, pin::Pin};
 
-use crate::lvs::Error as LvsError;
+use crate::lvs::LvsError;
 
 /// Indicates what protocol the bdev is shared as.
 #[derive(Debug, Default, PartialOrd, Eq, PartialEq, Copy, Clone)]

--- a/io-engine/src/grpc/v1/pool.rs
+++ b/io-engine/src/grpc/v1/pool.rs
@@ -1,12 +1,11 @@
 use crate::{
     grpc::{GrpcClientContext, GrpcResult, RWLock, RWSerializer},
-    lvs::Error as LvsError,
+    lvs::{BsError, LvsError},
     pool_backend::{PoolArgs, PoolBackend},
 };
 use ::function_name::named;
 use futures::FutureExt;
 use io_engine_api::v1::pool::*;
-use nix::errno::Errno;
 use std::{convert::TryFrom, fmt::Debug, panic::AssertUnwindSafe};
 use tonic::{Request, Response, Status};
 
@@ -110,14 +109,14 @@ impl TryFrom<CreatePoolRequest> for PoolArgs {
     fn try_from(args: CreatePoolRequest) -> Result<Self, Self::Error> {
         if args.disks.is_empty() {
             return Err(LvsError::Invalid {
-                source: Errno::EINVAL,
+                source: BsError::InvalidArgument {},
                 msg: "invalid argument, missing devices".to_string(),
             });
         }
 
         let backend = PoolType::try_from(args.pooltype).map_err(|_| {
             LvsError::Invalid {
-                source: Errno::EINVAL,
+                source: BsError::InvalidArgument {},
                 msg: format!("invalid pooltype provided: {}", args.pooltype),
             }
         })?;
@@ -125,7 +124,7 @@ impl TryFrom<CreatePoolRequest> for PoolArgs {
             if let Some(s) = args.uuid.clone() {
                 let _uuid = uuid::Uuid::parse_str(s.as_str()).map_err(|e| {
                     LvsError::Invalid {
-                        source: Errno::EINVAL,
+                        source: BsError::InvalidArgument {},
                         msg: format!("invalid uuid provided, {e}"),
                     }
                 })?;
@@ -168,14 +167,14 @@ impl TryFrom<ImportPoolRequest> for PoolArgs {
     fn try_from(args: ImportPoolRequest) -> Result<Self, Self::Error> {
         if args.disks.is_empty() {
             return Err(LvsError::Invalid {
-                source: Errno::EINVAL,
+                source: BsError::InvalidArgument {},
                 msg: "invalid argument, missing devices".to_string(),
             });
         }
 
         let backend = PoolType::try_from(args.pooltype).map_err(|_| {
             LvsError::Invalid {
-                source: Errno::EINVAL,
+                source: BsError::InvalidArgument {},
                 msg: format!("invalid pooltype provided: {}", args.pooltype),
             }
         })?;
@@ -183,7 +182,7 @@ impl TryFrom<ImportPoolRequest> for PoolArgs {
             if let Some(s) = args.uuid.clone() {
                 let _uuid = uuid::Uuid::parse_str(s.as_str()).map_err(|e| {
                     LvsError::Invalid {
-                        source: Errno::EINVAL,
+                        source: BsError::InvalidArgument {},
                         msg: format!("invalid uuid provided, {e}"),
                     }
                 })?;

--- a/io-engine/src/grpc/v1/test.rs
+++ b/io-engine/src/grpc/v1/test.rs
@@ -6,7 +6,7 @@ use crate::{
         VerboseError,
     },
     grpc::{rpc_submit, GrpcClientContext, GrpcResult, RWSerializer},
-    lvs::{Error as LvsError, Lvol, Lvs, LvsLvol},
+    lvs::{BsError, Lvol, Lvs, LvsError, LvsLvol},
 };
 use ::function_name::named;
 use io_engine_api::{
@@ -21,7 +21,6 @@ use io_engine_api::{
         WipeReplicaResponse,
     },
 };
-use nix::errno::Errno;
 use std::convert::{TryFrom, TryInto};
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::{Request, Response, Status};
@@ -349,7 +348,7 @@ fn validate_pool(
     let msg = format!("Specified {lvs:?} does match the target {lvol:?}!");
     tracing::error!("{msg}");
     Err(LvsError::Invalid {
-        source: Errno::EINVAL,
+        source: BsError::InvalidArgument {},
         msg,
     })
 }
@@ -358,13 +357,13 @@ fn lookup_pool(pool: wipe_replica_request::Pool) -> Result<Lvs, LvsError> {
     match pool {
         wipe_replica_request::Pool::PoolUuid(uuid) => {
             Lvs::lookup_by_uuid(&uuid).ok_or(LvsError::PoolNotFound {
-                source: Errno::ENOMEDIUM,
+                source: BsError::LvsNotFound {},
                 msg: format!("Pool uuid={uuid} is not loaded"),
             })
         }
         wipe_replica_request::Pool::PoolName(name) => {
             Lvs::lookup(&name).ok_or(LvsError::PoolNotFound {
-                source: Errno::ENOMEDIUM,
+                source: BsError::LvsNotFound {},
                 msg: format!("Pool name={name} is not loaded"),
             })
         }

--- a/io-engine/src/lvs/mod.rs
+++ b/io-engine/src/lvs/mod.rs
@@ -1,6 +1,6 @@
 pub use lvol_snapshot::LvolSnapshotIter;
 pub use lvs_bdev::LvsBdev;
-pub use lvs_error::{Error, ImportErrorReason};
+pub use lvs_error::{BsError, ImportErrorReason, LvsError};
 pub use lvs_iter::{LvsBdevIter, LvsIter};
 pub use lvs_lvol::{Lvol, LvsLvol, PropName, PropValue};
 pub use lvs_store::Lvs;

--- a/io-engine/src/subsys/config/pool.rs
+++ b/io-engine/src/subsys/config/pool.rs
@@ -7,7 +7,7 @@ use tonic::Status;
 use crate::{
     core::{runtime, Cores, Reactor, Share, VerboseError},
     grpc::rpc_submit,
-    lvs::{Error as LvsError, Lvs, LvsBdev},
+    lvs::{LvsError, Lvs, LvsBdev},
     pool_backend::{PoolArgs, PoolBackend},
 };
 

--- a/io-engine/tests/lvs_limits.rs
+++ b/io-engine/tests/lvs_limits.rs
@@ -1,0 +1,129 @@
+pub mod common;
+
+use io_engine::{
+    core::{MayastorCliArgs, SnapshotOps},
+    lvs::{BsError, Lvs, LvsError},
+    pool_backend::PoolArgs,
+};
+
+use io_engine_tests::MayastorTest;
+
+use once_cell::sync::OnceCell;
+
+const DISK_SIZE: u64 = 10000;
+const REPL_SIZE: u64 = 16;
+const DISK_NAME: &str = "/tmp/disk0.img";
+const BDEV_NAME: &str = "aio:///tmp/disk0.img?blk_size=512";
+const POOL_NAME: &str = "pool_0";
+const POOL_UUID: &str = "40baf8b5-6256-4f29-b073-61ebf67d9b91";
+
+static MAYASTOR: OnceCell<MayastorTest> = OnceCell::new();
+
+fn get_ms() -> &'static MayastorTest<'static> {
+    MAYASTOR.get_or_init(|| {
+        MayastorTest::new(MayastorCliArgs {
+            log_format: Some("nodate,nohost,compact".parse().unwrap()),
+            reactor_mask: "0x3".into(),
+            enable_io_all_thrd_nexus_channels: true,
+            ..Default::default()
+        })
+    })
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn lvs_metadata_limit() {
+    const REPL_CNT: u64 = 100;
+    const SNAP_CNT: u64 = 100;
+
+    common::composer_init();
+
+    common::delete_file(&[DISK_NAME.to_string()]);
+    common::truncate_file_bytes(DISK_NAME, DISK_SIZE * 1024 * 1024);
+
+    let ms = get_ms();
+
+    ms.spawn(async {
+        let lvs_args = PoolArgs {
+            name: POOL_NAME.to_string(),
+            disks: vec![BDEV_NAME.to_string()],
+            uuid: Some(POOL_UUID.to_string()),
+            cluster_size: None,
+            backend: Default::default(),
+        };
+
+        // Create LVS.
+        let lvs = Lvs::create_or_import(lvs_args.clone()).await.unwrap();
+
+        // Create replicas.
+        for i in 0 .. REPL_CNT {
+            let repl_name = format!("r_{i}");
+            let repl_uuid = format!("45c23e54-dc86-45f6-b55b-e44d05f1{i:04}");
+
+            let lvol = match lvs
+                .create_lvol
+                (
+                    &repl_name,
+                    REPL_SIZE * 1024 * 1024,
+                    Some(&repl_uuid),
+                    true,
+                    None,
+                )
+                .await
+            {
+                Ok(lvol) => lvol,
+                Err(err) => {
+                    match err {
+                        LvsError::RepCreate {
+                            source, ..
+                        } => {
+                            assert!(matches!(
+                                source,
+                                BsError::OutOfMetadata {}
+                            ));
+                            break;
+                        }
+                        _ => {
+                            panic!("Unexpected error {:?}", err);
+                        }
+                    };
+                }
+            };
+
+            // Create snapshots for each replicas.
+            for j in 0 .. SNAP_CNT {
+                let snap_name = format!("r_{i}_snap_{j}");
+                let eid = format!("e_{i}_{j}");
+                let txn_id = format!("t_{i}_{j}");
+                let snap_uuid =
+                    format!("55c23e54-dc89-45f6-b55b-e44d{i:04}{j:04}");
+
+                let snap_config = lvol
+                    .prepare_snap_config(&snap_name, &eid, &txn_id, &snap_uuid)
+                    .unwrap();
+
+                if let Err(err) = lvol.create_snapshot(snap_config).await {
+                    match err {
+                        LvsError::SnapshotCreate {
+                            source, ..
+                        } => {
+                            assert!(matches!(
+                                source,
+                                BsError::OutOfMetadata {}
+                            ));
+                            break;
+                        }
+                        _ => {
+                            panic!("Unexpected error {:?}", err);
+                        }
+                    }
+                }
+            }
+
+            println!(
+                "Replica #{i} {repl_name} '{repl_uuid}' \
+                and its {SNAP_CNT} snapshots has been created"
+            );
+        }
+    })
+    .await;
+}

--- a/nix/pkgs/libspdk/default.nix
+++ b/nix/pkgs/libspdk/default.nix
@@ -56,13 +56,13 @@ let
   # 7. Copy SHA256 from 'got' of the error message to 'sha256' field.
   # 8. 'nix-shell' build must now succeed.
   drvAttrs = rec {
-    version = "23.05-e051030";
+    version = "23.05-8bf0f85";
 
     src = fetchFromGitHub {
       owner = "openebs";
       repo = "spdk";
-      rev = "e0510300f2c5b005a9ab32f0ab42740ac65b23ca";
-      sha256 = "sha256-pGeIiCjndKf82BVHIYhn6lXL2fNmKhjX11W7K9GqFvs=";
+      rev = "8bf0f85702e142302a43acd73eeee3de085597c0";
+      sha256 = "sha256-3X9eRe/8fO4E1bv3XT5mhRm795kT23TtmfPKli74yL0=";
       fetchSubmodules = true;
     };
 


### PR DESCRIPTION
* Previously, when a blob store ran out of free metadata page during volume creation, an ambigious ENOMEM error was returned. Now, in order to allow to have meaningful client-faced error message and codes, EMFILE is returned instead.
* A test for a proper error when exceeding pool metadata capacity was added.
* LVS errors refactored to eliminate the use of low-level Errno in high-level LVS code.
* Low-level Errno codes from SPDK are now mapped to high-level error enum.
* Several bugs in Errno conversion fixed in LVS code (negative vs positive errno in SPDK function return value).