### PR TITLE
Refactor backend pool

### DIFF
--- a/io-engine/src/bdev/mod.rs
+++ b/io-engine/src/bdev/mod.rs
@@ -52,7 +52,7 @@ pub trait GetName {
 /// of a power loss.
 /// This can be implemented by each resource that deals with persistent nvme
 /// reservations.
-pub(crate) trait PtplFileOps {
+pub trait PtplFileOps {
     /// Create the necessary directory path roots.
     fn create(&self) -> Result<Option<PtplProps>, std::io::Error> {
         if let Some(path) = self.path() {

--- a/io-engine/src/bdev/nexus/mod.rs
+++ b/io-engine/src/bdev/nexus/mod.rs
@@ -106,7 +106,7 @@ pub fn register_module(register_json: bool) {
     }
 
     use crate::{
-        core::{Share, ShareProps, UntypedBdev},
+        core::{NvmfShareProps, Share, UntypedBdev},
         jsonrpc::{jsonrpc_register, Code, JsonRpcError, Result},
     };
 
@@ -126,7 +126,7 @@ pub fn register_module(register_json: bool) {
                     let mut bdev = Pin::new(&mut bdev);
                     match proto.as_str() {
                         "nvmf" => {
-                            let share = ShareProps::new().with_range(Some((args.cntlid_min, args.cntlid_max))).with_ana(true);
+                            let share = NvmfShareProps::new().with_range(Some((args.cntlid_min, args.cntlid_max))).with_ana(true);
                             bdev.as_mut().share_nvmf(Some(share))
                                 .await
                                 .map_err(|e| {

--- a/io-engine/src/core/bdev.rs
+++ b/io-engine/src/core/bdev.rs
@@ -14,10 +14,11 @@ use crate::{
     bdev::bdev_event_callback,
     bdev_api::bdev_uri_eq,
     core::{
-        share::{Protocol, Share, ShareProps, UpdateProps},
+        share::{NvmfShareProps, Protocol, Share, UpdateProps},
         BlockDeviceIoStats,
         CoreError,
         DescriptorGuard,
+        PtplProps,
         ShareNvmf,
         UnshareNvmf,
     },
@@ -205,10 +206,10 @@ where
     /// share the bdev over NVMe-OF TCP
     async fn share_nvmf(
         self: Pin<&mut Self>,
-        props: Option<ShareProps>,
+        props: Option<NvmfShareProps>,
     ) -> Result<Self::Output, Self::Error> {
         let me = unsafe { self.get_unchecked_mut() };
-        let props = ShareProps::from(props);
+        let props = NvmfShareProps::from(props);
 
         let ptpl = props.ptpl().as_ref().map(|ptpl| ptpl.path());
 
@@ -232,6 +233,10 @@ where
             .context(ShareNvmf {})?;
 
         subsystem.start().await.context(ShareNvmf {})
+    }
+
+    fn create_ptpl(&self) -> Result<Option<PtplProps>, Self::Error> {
+        Ok(None)
     }
 
     async fn update_properties<P: Into<Option<UpdateProps>>>(

--- a/io-engine/src/core/mod.rs
+++ b/io-engine/src/core/mod.rs
@@ -64,7 +64,14 @@ pub use lock::{
 
 pub use runtime::spawn;
 pub(crate) use segment_map::SegmentMap;
-pub use share::{Protocol, PtplProps, Share, ShareProps, UpdateProps};
+pub use share::{
+    NvmfShareProps,
+    Protocol,
+    PtplProps,
+    Share,
+    ShareProps,
+    UpdateProps,
+};
 pub use spdk_rs::{cpu_cores, IoStatus, IoType, NvmeStatus};
 pub use thread::Mthread;
 

--- a/io-engine/src/core/runtime.rs
+++ b/io-engine/src/core/runtime.rs
@@ -54,7 +54,7 @@ static RUNTIME: Lazy<Runtime> = Lazy::new(|| {
     let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .worker_threads(4)
-        .max_blocking_threads(2)
+        .max_blocking_threads(6)
         .on_thread_start(Mthread::unaffinitize)
         .build()
         .unwrap();
@@ -65,6 +65,11 @@ static RUNTIME: Lazy<Runtime> = Lazy::new(|| {
 });
 
 impl Runtime {
+    pub fn new(rt: tokio::runtime::Runtime) -> Self {
+        Self {
+            rt,
+        }
+    }
     fn block_on(&self, f: impl Future<Output = ()> + Send + 'static) {
         self.rt.block_on(f);
     }

--- a/io-engine/src/core/share.rs
+++ b/io-engine/src/core/share.rs
@@ -41,6 +41,26 @@ impl Display for Protocol {
     }
 }
 
+/// Share properties when sharing a device.
+#[derive(Debug)]
+pub enum ShareProps {
+    Nvmf(NvmfShareProps),
+}
+impl ShareProps {
+    /// Get the share protocol.
+    pub fn protocol(&self) -> Protocol {
+        match self {
+            ShareProps::Nvmf(_) => Protocol::Nvmf,
+        }
+    }
+    /// Get the allowed hosts list.
+    pub fn allowed_hosts(self) -> Vec<String> {
+        match self {
+            Self::Nvmf(props) => props.allowed_hosts,
+        }
+    }
+}
+
 /// Persist Through Power Loss properties
 #[derive(Debug)]
 pub struct PtplProps {
@@ -62,7 +82,7 @@ impl PtplProps {
 
 /// Share properties when sharing a device.
 #[derive(Default, Debug)]
-pub struct ShareProps {
+pub struct NvmfShareProps {
     /// Controller Id range.
     cntlid_range: Option<(u16, u16)>,
     /// Enable ANA reporting.
@@ -72,7 +92,7 @@ pub struct ShareProps {
     /// Persistent-Power-Loss settings.
     ptpl: Option<PtplProps>,
 }
-impl ShareProps {
+impl NvmfShareProps {
     /// Returns a new `Self`.
     pub fn new() -> Self {
         Self::default()
@@ -122,17 +142,24 @@ impl ShareProps {
         &self.ptpl
     }
 }
-impl From<Option<ShareProps>> for ShareProps {
-    fn from(opts: Option<ShareProps>) -> Self {
+impl From<Option<NvmfShareProps>> for NvmfShareProps {
+    fn from(opts: Option<NvmfShareProps>) -> Self {
         match opts {
             None => Self::new(),
             Some(props) => props,
         }
     }
 }
-impl From<ShareProps> for UpdateProps {
-    fn from(value: ShareProps) -> Self {
+impl From<NvmfShareProps> for UpdateProps {
+    fn from(value: NvmfShareProps) -> Self {
         UpdateProps::new().with_allowed_hosts(value.allowed_hosts)
+    }
+}
+impl From<ShareProps> for NvmfShareProps {
+    fn from(value: ShareProps) -> Self {
+        match value {
+            ShareProps::Nvmf(props) => props,
+        }
     }
 }
 
@@ -170,16 +197,22 @@ impl From<Option<UpdateProps>> for UpdateProps {
         }
     }
 }
+impl From<ShareProps> for UpdateProps {
+    fn from(opts: ShareProps) -> Self {
+        Self::new().with_allowed_hosts(opts.allowed_hosts())
+    }
+}
 
-#[async_trait(? Send)]
+#[async_trait(?Send)]
 pub trait Share: std::fmt::Debug {
     type Error;
     type Output: std::fmt::Display + std::fmt::Debug;
 
     async fn share_nvmf(
         self: Pin<&mut Self>,
-        props: Option<ShareProps>,
+        props: Option<NvmfShareProps>,
     ) -> Result<Self::Output, Self::Error>;
+    fn create_ptpl(&self) -> Result<Option<PtplProps>, Self::Error>;
 
     async fn update_properties<P: Into<Option<UpdateProps>>>(
         self: Pin<&mut Self>,

--- a/io-engine/src/core/share.rs
+++ b/io-engine/src/core/share.rs
@@ -42,6 +42,7 @@ impl Display for Protocol {
 }
 
 /// Persist Through Power Loss properties
+#[derive(Debug)]
 pub struct PtplProps {
     /// The path to the json file where the reservations will be stored.
     file: std::path::PathBuf,
@@ -60,7 +61,7 @@ impl PtplProps {
 }
 
 /// Share properties when sharing a device.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct ShareProps {
     /// Controller Id range.
     cntlid_range: Option<(u16, u16)>,

--- a/io-engine/src/grpc/v0/bdev_grpc.rs
+++ b/io-engine/src/grpc/v0/bdev_grpc.rs
@@ -17,7 +17,7 @@ use io_engine_api::v0::{
 
 use crate::{
     bdev_api::{bdev_create, bdev_destroy, BdevError},
-    core::{CoreError, Share, ShareProps, UntypedBdev},
+    core::{CoreError, NvmfShareProps, Share, UntypedBdev},
     grpc::{rpc_submit, GrpcResult},
 };
 
@@ -124,7 +124,7 @@ impl BdevRpc for BdevSvc {
             "nvmf" => rpc_submit::<_, String, CoreError>(async move {
                 let mut bdev = UntypedBdev::get_by_name(&bdev_name)?;
                 let props =
-                    ShareProps::new().with_allowed_hosts(r.allowed_hosts);
+                    NvmfShareProps::new().with_allowed_hosts(r.allowed_hosts);
                 let share = Pin::new(&mut bdev).share_nvmf(Some(props)).await?;
                 let bdev = UntypedBdev::get_by_name(&bdev_name)?;
                 Ok(bdev.share_uri().unwrap_or(share))

--- a/io-engine/src/grpc/v0/mayastor_grpc.rs
+++ b/io-engine/src/grpc/v0/mayastor_grpc.rs
@@ -26,9 +26,9 @@ use crate::{
         BlockDeviceIoStats,
         CoreError,
         MayastorFeatures,
+        NvmfShareProps,
         Protocol,
         Share,
-        ShareProps,
         SnapshotParams,
         ToErrno,
         UntypedBdev,
@@ -724,7 +724,7 @@ impl mayastor_server::Mayastor for MayastorSvc {
                             if Protocol::try_from(args.share)?
                                 == Protocol::Nvmf =>
                         {
-                            let props = ShareProps::new()
+                            let props = NvmfShareProps::new()
                                 .with_allowed_hosts(args.allowed_hosts)
                                 .with_ptpl(lvol.ptpl().create().map_err(
                                     |source| LvsError::LvolShare {
@@ -822,7 +822,7 @@ impl mayastor_server::Mayastor for MayastorSvc {
                             if Protocol::try_from(args.share)?
                                 == Protocol::Nvmf =>
                         {
-                            let props = ShareProps::new()
+                            let props = NvmfShareProps::new()
                                 .with_allowed_hosts(args.allowed_hosts)
                                 .with_ptpl(lvol.ptpl().create().map_err(
                                     |source| LvsError::LvolShare {
@@ -1026,7 +1026,7 @@ impl mayastor_server::Mayastor for MayastorSvc {
                                     lvol.as_mut().unshare().await?;
                                 }
                                 Protocol::Nvmf => {
-                                    let props = ShareProps::new()
+                                    let props = NvmfShareProps::new()
                                         .with_allowed_hosts(args.allowed_hosts)
                                         .with_ptpl(lvol.ptpl().create().map_err(
                                             |source| LvsError::LvolShare {

--- a/io-engine/src/grpc/v1/bdev.rs
+++ b/io-engine/src/grpc/v1/bdev.rs
@@ -1,7 +1,7 @@
 use crate::{
     bdev_api::{bdev_create, bdev_destroy, BdevError},
     core,
-    core::{CoreError, Protocol, Share, ShareProps},
+    core::{CoreError, NvmfShareProps, Protocol, Share},
     grpc::{rpc_submit, GrpcResult},
 };
 use io_engine_api::v1::bdev::{
@@ -141,8 +141,8 @@ impl BdevRpc for BdevService {
             Ok(Protocol::Nvmf) => {
                 rpc_submit::<_, Bdev, CoreError>(async move {
                     let mut bdev = core::UntypedBdev::get_by_name(&bdev_name)?;
-                    let props =
-                        ShareProps::new().with_allowed_hosts(r.allowed_hosts);
+                    let props = NvmfShareProps::new()
+                        .with_allowed_hosts(r.allowed_hosts);
                     Pin::new(&mut bdev).share_nvmf(Some(props)).await?;
                     let bdev = core::UntypedBdev::get_by_name(&bdev_name)?;
                     Ok(bdev.into())

--- a/io-engine/src/grpc/v1/lvm/mod.rs
+++ b/io-engine/src/grpc/v1/lvm/mod.rs
@@ -1,0 +1,14 @@
+pub mod pool;
+pub mod replica;
+
+#[macro_export]
+macro_rules! lvm_run {
+    ($fut:expr) => {{
+        $crate::core::runtime::spawn_blocking(|| {
+            tokio::runtime::Handle::current().block_on($fut)
+        })
+        .await
+        .map_err(|_| Status::cancelled("cancelled"))?
+        .map(Response::new)
+    }};
+}

--- a/io-engine/src/grpc/v1/lvm/pool.rs
+++ b/io-engine/src/grpc/v1/lvm/pool.rs
@@ -3,7 +3,7 @@ use crate::{
     grpc::{
         acquire_subsystem_lock,
         lvm_enabled,
-        v1::pool::PoolProbe,
+        v1::pool::{PoolGrpc, PoolProbe},
         GrpcResult,
     },
     lvm::{CmnQueryArgs, Error as LvmError, VolumeGroup},
@@ -50,6 +50,7 @@ impl PoolService {
             Err(error) => Err(error.into()),
         }
     }
+
     pub(crate) async fn list_svc_pools(
         &self,
         args: &ListPoolOptions,
@@ -68,6 +69,38 @@ impl PoolService {
     }
 }
 
+async fn ensure_unique_pool(args: PoolArgs) -> Result<PoolArgs, tonic::Status> {
+    let args = crate::lvs_run!(async move {
+        // bail if an lvs pool already exists with the same name
+        if let Some(_pool) = Lvs::lookup(args.name.as_str()) {
+            return Err(Status::invalid_argument(
+                "lvs pool with the same name already exists",
+            ));
+        }
+        // check if the disks are used by existing lvs pool
+        if Lvs::iter()
+            .map(|l| l.base_bdev().name().to_string())
+            .any(|d| args.disks.contains(&d))
+        {
+            return Err(Status::invalid_argument(
+                "an lvs pool already uses the disk",
+            ));
+        }
+        Ok(args)
+    })?;
+    Ok(args.into_inner())
+}
+
+async fn find_pool(
+    name: &str,
+    uuid: &Option<String>,
+) -> Result<VolumeGroup, tonic::Status> {
+    let pool =
+        VolumeGroup::lookup(CmnQueryArgs::ours().named(name).uuid_opt(uuid))
+            .await?;
+    Ok(pool)
+}
+
 #[tonic::async_trait]
 impl PoolRpc for PoolService {
     async fn create_pool(
@@ -83,21 +116,7 @@ impl PoolRpc for PoolService {
         let _lock_guard =
             acquire_subsystem_lock(pool_subsystem, Some(&args.name)).await?;
 
-        // bail if an lvs pool already exists with the same name
-        if let Some(_pool) = Lvs::lookup(args.name.as_str()) {
-            return Err(Status::invalid_argument(
-                "lvs pool with the same name already exists",
-            ));
-        };
-        // check if the disks are used by existing lvs pool
-        if Lvs::iter()
-            .map(|l| l.base_bdev().name().to_string())
-            .any(|d| args.disks.contains(&d))
-        {
-            return Err(Status::invalid_argument(
-                "an lvs pool already uses the disk",
-            ));
-        };
+        let args = ensure_unique_pool(args).await?;
         VolumeGroup::create(args)
             .await
             .map_err(Status::from)
@@ -109,57 +128,41 @@ impl PoolRpc for PoolService {
         &self,
         request: Request<DestroyPoolRequest>,
     ) -> GrpcResult<()> {
+        let args = request.into_inner();
         lvm_enabled()?;
 
-        let args = request.into_inner();
-        let pool = VolumeGroup::lookup(
-            CmnQueryArgs::ours().named(&args.name).uuid_opt(&args.uuid),
-        )
-        .await?;
-        pool.destroy()
-            .await
-            .map_err(Status::from)
-            .map(Response::new)
+        crate::lvm_run!(async move {
+            let pool = find_pool(&args.name, &args.uuid).await?;
+            PoolGrpc::new(pool).destroy().await
+        })
     }
 
     async fn export_pool(
         &self,
         request: Request<ExportPoolRequest>,
     ) -> GrpcResult<()> {
+        let args = request.into_inner();
         lvm_enabled()?;
 
-        let args = request.into_inner();
-        let mut pool = VolumeGroup::lookup(
-            CmnQueryArgs::ours().named(&args.name).uuid_opt(&args.uuid),
-        )
-        .await?;
-        pool.export().await?;
-        return Ok(Response::new(()));
+        crate::lvm_run!(async move {
+            let pool = find_pool(&args.name, &args.uuid).await?;
+            PoolGrpc::new(pool).export().await
+        })
     }
 
     async fn import_pool(
         &self,
         request: Request<ImportPoolRequest>,
     ) -> GrpcResult<Pool> {
+        let args = PoolArgs::try_from(request.into_inner())?;
         lvm_enabled()?;
 
-        let args = PoolArgs::try_from(request.into_inner())?;
+        let pool_subsystem = ResourceLockManager::get_instance()
+            .get_subsystem(ProtectedSubsystems::POOL);
+        let _lock_guard =
+            acquire_subsystem_lock(pool_subsystem, Some(&args.name)).await?;
 
-        // bail if an lvs pool already exists with the same name
-        if let Some(_pool) = Lvs::lookup(args.name.as_str()) {
-            return Err(Status::invalid_argument(
-                "lvs pool with the same name already exists",
-            ));
-        };
-        // check if the disks are used by existing lvs pool
-        if Lvs::iter()
-            .map(|l| l.base_bdev().name().to_string())
-            .any(|d| args.disks.contains(&d))
-        {
-            return Err(Status::invalid_argument(
-                "an lvs pool already uses the disk",
-            ));
-        };
+        let args = ensure_unique_pool(args).await?;
         VolumeGroup::import(args)
             .await
             .map_err(Status::from)

--- a/io-engine/src/grpc/v1/lvm/replica.rs
+++ b/io-engine/src/grpc/v1/lvm/replica.rs
@@ -146,7 +146,7 @@ impl ReplicaService {
                         }
                     })?);
 
-                if let Err(error) = lvol.share_bdev_nvmf(Some(props)).await {
+                if let Err(error) = lvol.share_nvmf(Some(props)).await {
                     error!("Failed to share lvol: {error}...");
                     if created {
                         // if we have created it here, then let's undo it
@@ -157,7 +157,7 @@ impl ReplicaService {
             }
             Protocol::Off => {
                 if lvol.share() != Protocol::Off {
-                    lvol.unshare_bdev().await?;
+                    lvol.unshare().await?;
                 }
             }
         }
@@ -236,7 +236,7 @@ impl ReplicaService {
                             },
                         }
                     })?);
-                lvol.share_bdev_nvmf(Some(props)).await?;
+                lvol.share_nvmf(Some(props)).await?;
             }
         }
 
@@ -256,7 +256,7 @@ impl ReplicaService {
         .await?;
 
         if lvol.share_proto().is_some() {
-            lvol.unshare_bdev().await?;
+            lvol.unshare().await?;
         }
 
         Ok(Response::new(lvol.into()))

--- a/io-engine/src/grpc/v1/lvs/replica.rs
+++ b/io-engine/src/grpc/v1/lvs/replica.rs
@@ -12,7 +12,7 @@ use crate::{
         v1::{pool::PoolGrpc, replica::ReplicaGrpc},
         GrpcResult,
     },
-    lvs::{LvsError, BsError, Lvol, Lvs, LvsLvol},
+    lvs::{BsError, Lvol, Lvs, LvsError, LvsLvol},
 };
 use io_engine_api::v1::{pool::PoolType, replica::*};
 use std::convert::TryFrom;

--- a/io-engine/src/grpc/v1/lvs/replica.rs
+++ b/io-engine/src/grpc/v1/lvs/replica.rs
@@ -4,20 +4,29 @@ use crate::{
         logical_volume::LogicalVolume,
         Bdev,
         CloneXattrs,
-        NvmfShareProps,
-        ProtectedSubsystems,
-        Protocol,
-        ResourceLockManager,
         Share,
         UntypedBdev,
-        UpdateProps,
     },
-    grpc::{acquire_subsystem_lock, rpc_submit, rpc_submit_ext, GrpcResult},
-    lvs::{BsError, Lvol, Lvs, LvsError, LvsLvol, PropValue},
+    grpc::{
+        rpc_submit_ext,
+        v1::{pool::PoolGrpc, replica::ReplicaGrpc},
+        GrpcResult,
+    },
+    lvs::{LvsError, BsError, Lvol, Lvs, LvsLvol},
 };
 use io_engine_api::v1::{pool::PoolType, replica::*};
-use std::{convert::TryFrom, pin::Pin};
+use std::convert::TryFrom;
 use tonic::{Request, Response, Status};
+
+#[macro_export]
+macro_rules! lvs_run {
+    ($fut:expr) => {{
+        let r = $crate::grpc::rpc_submit_ext2($fut)?;
+        r.await
+            .map_err(|_| Status::cancelled("cancelled"))?
+            .map(Response::new)
+    }};
+}
 
 #[derive(Debug, Clone)]
 pub(crate) struct ReplicaService {}
@@ -45,161 +54,31 @@ impl ReplicaRpc for ReplicaService {
         &self,
         request: Request<CreateReplicaRequest>,
     ) -> GrpcResult<Replica> {
-        self.create_lvs_replica(request.into_inner()).await
+        crate::lvs_run!(async move {
+            let args = request.into_inner();
+            let lvs = match Lvs::lookup_by_uuid(&args.pooluuid) {
+                Some(lvs) => Ok(lvs),
+                None => {
+                    // lookup takes care of backward compatibility
+                    match Lvs::lookup(&args.pooluuid) {
+                        Some(lvs) => Ok(lvs),
+                        None => Err(LvsError::Invalid {
+                            source: BsError::LvsNotFound {},
+                            msg: format!("Pool {} not found", args.pooluuid),
+                        }),
+                    }
+                }
+            }?;
+            PoolGrpc::new(lvs).create_replica(args).await
+        })
     }
 
     async fn destroy_replica(
         &self,
         request: Request<DestroyReplicaRequest>,
     ) -> GrpcResult<()> {
-        self.destroy_lvs_replica(request.into_inner()).await
-    }
-
-    async fn list_replicas(
-        &self,
-        _request: Request<ListReplicaOptions>,
-    ) -> GrpcResult<ListReplicasResponse> {
-        unimplemented!("Request is not cloneable, so we have to use another fn")
-    }
-
-    async fn share_replica(
-        &self,
-        request: Request<ShareReplicaRequest>,
-    ) -> GrpcResult<Replica> {
-        self.share_lvs_replica(request.into_inner()).await
-    }
-
-    async fn unshare_replica(
-        &self,
-        request: Request<UnshareReplicaRequest>,
-    ) -> GrpcResult<Replica> {
-        self.unshare_lvs_replica(request.into_inner()).await
-    }
-
-    async fn resize_replica(
-        &self,
-        request: Request<ResizeReplicaRequest>,
-    ) -> GrpcResult<Replica> {
-        self.resize_lvs_replica(request.into_inner()).await
-    }
-
-    async fn set_replica_entity_id(
-        &self,
-        request: Request<SetReplicaEntityIdRequest>,
-    ) -> GrpcResult<Replica> {
-        let args = request.into_inner();
-        info!("{args:?}");
-        let rx = rpc_submit::<_, _, LvsError>(async move {
-            if let Some(bdev) = UntypedBdev::lookup_by_uuid_str(&args.uuid) {
-                let mut lvol = Lvol::try_from(bdev)?;
-                Pin::new(&mut lvol)
-                    .set(PropValue::EntityId(args.entity_id))
-                    .await?;
-                Ok(Replica::from(lvol))
-            } else {
-                Err(LvsError::InvalidBdev {
-                    source: BdevError::BdevNotFound {
-                        name: args.uuid.clone(),
-                    },
-                    name: args.uuid,
-                })
-            }
-        })?;
-
-        rx.await
-            .map_err(|_| Status::cancelled("cancelled"))?
-            .map_err(Status::from)
-            .map(Response::new)
-    }
-}
-
-impl ReplicaService {
-    async fn create_lvs_replica(
-        &self,
-        args: CreateReplicaRequest,
-    ) -> GrpcResult<Replica> {
-        let rx = rpc_submit(async move {
-            let protocol = Protocol::try_from(args.share)?;
-            let lvs = match Lvs::lookup_by_uuid(&args.pooluuid) {
-                Some(lvs) => lvs,
-                None => {
-                    // lookup takes care of backward compatibility
-                    match Lvs::lookup(&args.pooluuid) {
-                        Some(lvs) => lvs,
-                        None => {
-                            return Err(LvsError::Invalid {
-                                source: BsError::LvsNotFound {},
-                                msg: format!(
-                                    "Pool {} not found",
-                                    args.pooluuid
-                                ),
-                            })
-                        }
-                    }
-                }
-            };
-            let pool_subsystem = ResourceLockManager::get_instance()
-                .get_subsystem(ProtectedSubsystems::POOL);
-            let _lock_guard =
-                acquire_subsystem_lock(pool_subsystem, Some(lvs.name()))
-                    .await
-                    .map_err(|_| LvsError::ResourceLockFailed {
-                        msg: format!(
-                            "resource {}, for pooluuid {}",
-                            lvs.name(),
-                            args.pooluuid
-                        ),
-                    })?;
-            // if pooltype is not Lvs, the provided replica uuid need to be
-            // added as a metadata on the volume.
-            match lvs
-                .create_lvol(
-                    &args.name,
-                    args.size,
-                    Some(&args.uuid),
-                    args.thin,
-                    args.entity_id,
-                )
-                .await
-            {
-                Ok(mut lvol) if protocol == Protocol::Nvmf => {
-                    let props = NvmfShareProps::new()
-                        .with_allowed_hosts(args.allowed_hosts)
-                        .with_ptpl(lvol.create_ptpl()?);
-                    match Pin::new(&mut lvol).share_nvmf(Some(props)).await {
-                        Ok(share_uri) => {
-                            debug!(
-                                "created and shared {lvol:?} as {share_uri}"
-                            );
-                            Ok(Replica::from(lvol))
-                        }
-                        Err(error) => {
-                            warn!(
-                                "failed to share created lvol {lvol:?}: {error} (destroying)"
-                            );
-                            let _ = lvol.destroy().await;
-                            Err(error)
-                        }
-                    }
-                }
-                Ok(lvol) => {
-                    debug!("created lvol {:?}", lvol);
-                    Ok(Replica::from(lvol))
-                }
-                Err(error) => Err(error),
-            }
-        })?;
-        rx.await
-            .map_err(|_| Status::cancelled("cancelled"))?
-            .map_err(Status::from)
-            .map(Response::new)
-    }
-
-    async fn destroy_lvs_replica(
-        &self,
-        args: DestroyReplicaRequest,
-    ) -> GrpcResult<()> {
-        let rx = rpc_submit::<_, _, LvsError>(async move {
+        crate::lvs_run!(async move {
+            let args = request.into_inner();
             // todo: is there still a race here, can the pool be exported
             //   right after the check here and before we
             //   probe for the replica?
@@ -248,161 +127,116 @@ impl ReplicaService {
                         source: BsError::LvsIdMismatch {},
                         name: args.uuid,
                         msg,
-                    });
+                    }
+                    .into());
                 }
             }
-            lvol.destroy_replica().await?;
-            Ok(())
-        })?;
-
-        rx.await
-            .map_err(|_| Status::cancelled("cancelled"))?
-            .map_err(Status::from)
-            .map(Response::new)
+            ReplicaGrpc::new(lvol).destroy().await
+        })
     }
 
-    async fn share_lvs_replica(
+    async fn list_replicas(
         &self,
-        args: ShareReplicaRequest,
+        _request: Request<ListReplicaOptions>,
+    ) -> GrpcResult<ListReplicasResponse> {
+        unimplemented!("Request is not cloneable, so we have to use another fn")
+    }
+
+    async fn share_replica(
+        &self,
+        request: Request<ShareReplicaRequest>,
     ) -> GrpcResult<Replica> {
-        let rx = rpc_submit(async move {
-            match Bdev::lookup_by_uuid_str(&args.uuid) {
-                Some(bdev) => {
-                    let mut lvol = Lvol::try_from(bdev)?;
-                    let pool_subsystem = ResourceLockManager::get_instance()
-                        .get_subsystem(ProtectedSubsystems::POOL);
-                    let _lock_guard = acquire_subsystem_lock(
-                        pool_subsystem,
-                        Some(lvol.lvs().name()),
-                    )
-                    .await
-                    .map_err(|_| {
-                        LvsError::ResourceLockFailed {
-                            msg: format!(
-                                "resource {}, for lvol {:?}",
-                                lvol.lvs().name(),
-                                lvol
-                            ),
-                        }
-                    })?;
-
-                    // if we are already shared with the same protocol
-                    if lvol.shared() == Some(Protocol::try_from(args.share)?) {
-                        Pin::new(&mut lvol)
-                            .update_properties(
-                                UpdateProps::new()
-                                    .with_allowed_hosts(args.allowed_hosts),
-                            )
-                            .await?;
-                        return Ok(Replica::from(lvol));
-                    }
-
-                    match Protocol::try_from(args.share)? {
-                        Protocol::Off => {
-                            return Err(LvsError::Invalid {
-                                source: BsError::InvalidArgument {},
-                                msg: "invalid share protocol NONE".to_string(),
-                            })
-                        }
-                        Protocol::Nvmf => {
-                            let props = NvmfShareProps::new()
-                                .with_allowed_hosts(args.allowed_hosts)
-                                .with_ptpl(lvol.create_ptpl()?);
-                            Pin::new(&mut lvol).share_nvmf(Some(props)).await?;
-                        }
-                    }
-
-                    Ok(Replica::from(lvol))
-                }
-
+        crate::lvs_run!(async move {
+            let args = request.into_inner();
+            let replica = match Bdev::lookup_by_uuid_str(&args.uuid) {
+                Some(bdev) => Lvol::try_from(bdev),
                 None => Err(LvsError::InvalidBdev {
                     source: BdevError::BdevNotFound {
                         name: args.uuid.clone(),
                     },
-                    name: args.uuid,
+                    name: args.uuid.clone(),
                 }),
-            }
-        })?;
-
-        rx.await
-            .map_err(|_| Status::cancelled("cancelled"))?
-            .map_err(Status::from)
-            .map(Response::new)
+            }?;
+            let mut replica = ReplicaGrpc::new(replica);
+            replica.share(args).await?;
+            Ok(replica.into())
+        })
     }
 
-    async fn unshare_lvs_replica(
+    async fn unshare_replica(
         &self,
-        args: UnshareReplicaRequest,
+        request: Request<UnshareReplicaRequest>,
     ) -> GrpcResult<Replica> {
-        let rx = rpc_submit(async move {
-            match Bdev::lookup_by_uuid_str(&args.uuid) {
-                Some(bdev) => {
-                    let mut lvol = Lvol::try_from(bdev)?;
-                    if lvol.shared().is_some() {
-                        Pin::new(&mut lvol).unshare().await?;
-                    }
-                    Ok(Replica::from(lvol))
-                }
+        crate::lvs_run!(async move {
+            let args = request.into_inner();
+            let replica = match Bdev::lookup_by_uuid_str(&args.uuid) {
+                Some(bdev) => Lvol::try_from(bdev),
                 None => Err(LvsError::InvalidBdev {
                     source: BdevError::BdevNotFound {
                         name: args.uuid.clone(),
                     },
-                    name: args.uuid,
+                    name: args.uuid.clone(),
                 }),
-            }
-        })?;
-        rx.await
-            .map_err(|_| Status::cancelled("cancelled"))?
-            .map_err(Status::from)
-            .map(Response::new)
+            }?;
+            let mut replica = ReplicaGrpc::new(replica);
+            replica.unshare().await?;
+            Ok(replica.into())
+        })
     }
 
-    async fn resize_lvs_replica(
+    async fn resize_replica(
         &self,
-        args: ResizeReplicaRequest,
+        request: Request<ResizeReplicaRequest>,
     ) -> GrpcResult<Replica> {
-        let rx = rpc_submit::<_, _, LvsError>(async move {
-            let mut lvol = Bdev::lookup_by_uuid_str(&args.uuid)
+        crate::lvs_run!(async move {
+            let args = request.into_inner();
+            let replica = Bdev::lookup_by_uuid_str(&args.uuid)
                 .and_then(|b| Lvol::try_from(b).ok())
                 .ok_or(LvsError::RepResize {
                     source: BsError::LvolNotFound {},
                     name: args.uuid.to_owned(),
                 })?;
-            let requested_size = args.requested_size;
-            lvol.resize_replica(requested_size).await?;
-            debug!("resized {:?}", lvol);
-            Ok(Replica::from(lvol))
-        })?;
-
-        rx.await
-            .map_err(|_| Status::cancelled("cancelled"))?
-            .map_err(Status::from)
-            .map(Response::new)
+            let mut replica = ReplicaGrpc::new(replica);
+            replica.resize(args.requested_size).await?;
+            Ok(replica.into())
+        })
     }
 
+    async fn set_replica_entity_id(
+        &self,
+        request: Request<SetReplicaEntityIdRequest>,
+    ) -> GrpcResult<Replica> {
+        crate::lvs_run!(async move {
+            let args = request.into_inner();
+            let replica = match Bdev::lookup_by_uuid_str(&args.uuid) {
+                Some(bdev) => Lvol::try_from(bdev),
+                None => Err(LvsError::InvalidBdev {
+                    source: BdevError::BdevNotFound {
+                        name: args.uuid.clone(),
+                    },
+                    name: args.uuid.clone(),
+                }),
+            }?;
+            let mut replica = ReplicaGrpc::new(replica);
+            replica.set_entity_id(args.entity_id).await?;
+            Ok(replica.into())
+        })
+    }
+}
+
+impl ReplicaService {
     pub(crate) async fn list_lvs_replicas(
         &self,
     ) -> Result<Vec<Replica>, tonic::Status> {
-        let rx = rpc_submit::<_, _, LvsError>(async move {
-            let mut lvols = Vec::new();
-            if let Some(bdev) = UntypedBdev::bdev_first() {
-                lvols = bdev
-                    .into_iter()
-                    .filter(|b| b.driver() == "lvol")
-                    .map(|b| Lvol::try_from(b).unwrap())
-                    .collect();
-            }
+        crate::lvs_run!(async move {
+            let Some(bdev) = UntypedBdev::bdev_first() else {
+                return Ok(vec![]);
+            };
 
-            // convert lvols to replicas
-            let replicas: Vec<Replica> =
-                lvols.into_iter().map(Replica::from).collect();
-
-            Ok(replicas)
-        })?;
-
-        rx.await
-            .map_err(|_| Status::cancelled("cancelled"))?
-            .map_err(Status::from)
+            let lvols = bdev.into_iter().filter_map(Lvol::ok_from);
+            Ok(lvols.map(Replica::from).collect())
+        })
+        .map(|r| r.into_inner())
     }
 }
 

--- a/io-engine/src/grpc/v1/pool.rs
+++ b/io-engine/src/grpc/v1/pool.rs
@@ -33,10 +33,36 @@ struct UnixStream(tokio::net::UnixStream);
 
 /// Probe for pools using this criteria.
 #[derive(Debug, Clone)]
-pub enum PoolProbe {
+pub enum PoolIdProbe {
     Uuid(String),
     UuidOrName(String),
     NameUuid { name: String, uuid: Option<String> },
+}
+impl PoolIdProbe {
+    fn name_uuid(name: &str, uuid: &Option<String>) -> Self {
+        Self::NameUuid {
+            name: name.to_owned(),
+            uuid: uuid.to_owned(),
+        }
+    }
+}
+
+/// The different types of probing.
+pub(crate) enum ProbeType {
+    /// Probing the specific pool type directly.
+    ByKind(PoolBackend),
+    /// Probing using identifiers.
+    ById(PoolIdProbe),
+}
+impl From<PoolIdProbe> for ProbeType {
+    fn from(value: PoolIdProbe) -> Self {
+        Self::ById(value)
+    }
+}
+impl From<PoolBackend> for ProbeType {
+    fn from(value: PoolBackend) -> Self {
+        Self::ByKind(value)
+    }
 }
 
 /// RPC service for mayastor pool operations
@@ -219,6 +245,11 @@ impl Default for PoolService {
     }
 }
 
+#[async_trait::async_trait]
+pub trait PoolSvcRpc: PoolRpc {
+    fn kind(&self) -> PoolBackend;
+}
+
 pub(crate) struct PoolGrpc<P: PoolOps> {
     pool: P,
 }
@@ -296,45 +327,31 @@ impl PoolService {
             client_context: std::sync::Arc::new(tokio::sync::RwLock::new(None)),
         }
     }
-    /// Return a backend for the given type.
-    fn backend(
-        &self,
-        pooltype: i32,
-    ) -> Result<Box<dyn PoolRpc>, tonic::Status> {
-        Ok(match PoolBackend::try_from(pooltype)? {
-            PoolBackend::Lvs => Box::new(LvsSvc::new()),
-            PoolBackend::Lvm => Box::new(LvmSvc::new()),
-        })
-    }
-    /// Probe backends for the given name and/or uuid and return the right one.
-    async fn probe_backend(
-        &self,
-        name: &str,
-        uuid: &Option<String>,
-    ) -> Result<Box<dyn PoolRpc>, tonic::Status> {
-        let probe = PoolProbe::NameUuid {
-            name: name.to_owned(),
-            uuid: uuid.to_owned(),
-        };
-        Ok(match self.probe_backend_kind(probe).await? {
-            PoolBackend::Lvm => Box::new(LvmSvc::new()),
-            PoolBackend::Lvs => Box::new(LvsSvc::new()),
-        })
-    }
 
-    pub(crate) async fn probe_backend_kind(
+    /// Probe backends for the given name and/or uuid and return the right one.
+    pub(crate) async fn probe<I: Into<ProbeType>>(
         &self,
-        probe: PoolProbe,
-    ) -> Result<PoolBackend, tonic::Status> {
-        match (
-            LvmSvc::probe(&probe).await,
-            LvsSvc::probe(probe.clone()).await,
-        ) {
-            (Ok(true), _) => Ok(PoolBackend::Lvm),
-            (_, Ok(true)) => Ok(PoolBackend::Lvs),
-            (Err(error), _) | (_, Err(error)) => Err(error),
-            _ => Err(Status::not_found(format!("Pool {probe:?} not found"))),
-        }
+        probe: I,
+    ) -> Result<Box<dyn PoolSvcRpc>, tonic::Status> {
+        let probe = probe.into();
+        let kind = match probe {
+            ProbeType::ByKind(kind) => kind,
+            ProbeType::ById(probe) => match (
+                LvmSvc::probe(&probe).await,
+                LvsSvc::probe(probe.clone()).await,
+            ) {
+                (Ok(true), _) => Ok(PoolBackend::Lvm),
+                (_, Ok(true)) => Ok(PoolBackend::Lvs),
+                (Err(error), _) | (_, Err(error)) => Err(error),
+                _ => {
+                    Err(Status::not_found(format!("Pool {probe:?} not found")))
+                }
+            }?,
+        };
+        Ok(match kind {
+            PoolBackend::Lvs => Box::new(LvsSvc::new()),
+            PoolBackend::Lvm => Box::new(LvmSvc::new()),
+        })
     }
 }
 
@@ -345,13 +362,15 @@ impl PoolRpc for PoolService {
         &self,
         request: Request<CreatePoolRequest>,
     ) -> GrpcResult<Pool> {
-        let backend = self.backend(request.get_ref().pooltype)?;
+        let backend = self
+            .probe(PoolBackend::try_from(request.get_ref().pooltype)?)
+            .await;
         self.locked(
             GrpcClientContext::new(&request, function_name!()),
             async move {
                 info!("{:?}", request.get_ref());
 
-                backend.create_pool(request).await
+                backend?.create_pool(request).await
             },
         )
         .await
@@ -363,14 +382,17 @@ impl PoolRpc for PoolService {
         request: Request<DestroyPoolRequest>,
     ) -> GrpcResult<()> {
         let backend = self
-            .probe_backend(&request.get_ref().name, &request.get_ref().uuid)
-            .await?;
+            .probe(PoolIdProbe::name_uuid(
+                &request.get_ref().name,
+                &request.get_ref().uuid,
+            ))
+            .await;
         self.locked(
             GrpcClientContext::new(&request, function_name!()),
             async move {
                 info!("{:?}", request.get_ref());
 
-                backend.destroy_pool(request).await
+                backend?.destroy_pool(request).await
             },
         )
         .await
@@ -382,14 +404,17 @@ impl PoolRpc for PoolService {
         request: Request<ExportPoolRequest>,
     ) -> GrpcResult<()> {
         let backend = self
-            .probe_backend(&request.get_ref().name, &request.get_ref().uuid)
-            .await?;
+            .probe(PoolIdProbe::name_uuid(
+                &request.get_ref().name,
+                &request.get_ref().uuid,
+            ))
+            .await;
         self.locked(
             GrpcClientContext::new(&request, function_name!()),
             async move {
                 info!("{:?}", request.get_ref());
 
-                backend.export_pool(request).await
+                backend?.export_pool(request).await
             },
         )
         .await
@@ -400,13 +425,15 @@ impl PoolRpc for PoolService {
         &self,
         request: Request<ImportPoolRequest>,
     ) -> GrpcResult<Pool> {
-        let backend = self.backend(request.get_ref().pooltype)?;
+        let backend = self
+            .probe(PoolBackend::try_from(request.get_ref().pooltype)?)
+            .await;
         self.locked(
             GrpcClientContext::new(&request, function_name!()),
             async move {
                 info!("{:?}", request.get_ref());
 
-                backend.import_pool(request).await
+                backend?.import_pool(request).await
             },
         )
         .await

--- a/io-engine/src/grpc/v1/replica.rs
+++ b/io-engine/src/grpc/v1/replica.rs
@@ -10,7 +10,7 @@ use crate::{
     },
     grpc::{
         acquire_subsystem_lock,
-        v1::pool::PoolProbe,
+        v1::pool::PoolIdProbe,
         GrpcClientContext,
         GrpcResult,
         RWLock,
@@ -108,6 +108,22 @@ impl RWLock for ReplicaService {
     }
 }
 
+enum Probe<'a> {
+    Replica(&'a str),
+    Pool(PoolIdProbe),
+    ReplicaPool(&'a str, Option<PoolIdProbe>),
+}
+impl<'a> From<&'a String> for Probe<'a> {
+    fn from(value: &'a String) -> Self {
+        Self::Replica(value.as_str())
+    }
+}
+impl From<PoolIdProbe> for Probe<'_> {
+    fn from(value: PoolIdProbe) -> Self {
+        Self::Pool(value)
+    }
+}
+
 impl ReplicaService {
     pub fn new(pool_svc: super::pool::PoolService) -> Self {
         Self {
@@ -118,34 +134,47 @@ impl ReplicaService {
     }
 
     /// Probe backends for the given replica uuid and return the right one.
-    async fn probe_backend(
+    async fn probe_backend<'a, P: Into<Probe<'a>>>(
         &self,
-        replica_uuid: &str,
+        probe: P,
     ) -> Result<Box<dyn ReplicaRpc>, tonic::Status> {
-        Ok(match self.probe_backend_kind(replica_uuid).await? {
-            PoolBackend::Lvs => Box::new(LvsSvc::new()),
-            PoolBackend::Lvm => Box::new(LvmSvc::new()),
-        })
+        let kind = match probe.into() {
+            Probe::Replica(replica_uuid)
+            | Probe::ReplicaPool(replica_uuid, None) => match (
+                LvsSvc::probe(replica_uuid).await,
+                LvmSvc::probe(replica_uuid).await,
+            ) {
+                (Ok(true), _) => Ok(PoolBackend::Lvs),
+                (_, Ok(true)) => Ok(PoolBackend::Lvm),
+                (Err(error), _) | (_, Err(error)) => Err(error),
+                _ => Err(Status::not_found(format!(
+                    "Replica {replica_uuid} not found"
+                ))),
+            }?,
+            Probe::Pool(probe) => self.pool_svc.probe(probe).await?.kind(),
+            Probe::ReplicaPool(_, Some(pool)) => {
+                match self.pool_svc.probe(pool).await {
+                    Err(status) if status.code() == tonic::Code::NotFound => {
+                        Err(Status::failed_precondition(status.to_string()))
+                    }
+                    _else => _else,
+                }?
+                .kind()
+            }
+        };
+        match kind {
+            PoolBackend::Lvs => Ok(Box::new(LvsSvc::new())),
+            PoolBackend::Lvm => Ok(Box::new(LvmSvc::new())),
+        }
     }
-    /// Probe backends for the given pool uuid and return the right one.
-    pub async fn probe_backend_pool(
-        &self,
-        probe: PoolProbe,
-    ) -> Result<Box<dyn ReplicaRpc>, tonic::Status> {
-        Ok(match self.pool_svc.probe_backend_kind(probe).await? {
-            PoolBackend::Lvs => Box::new(LvsSvc::new()),
-            PoolBackend::Lvm => Box::new(LvmSvc::new()),
-        })
-    }
-    async fn probe_backend_kind(
-        &self,
-        uuid: &str,
-    ) -> Result<PoolBackend, tonic::Status> {
-        match (LvsSvc::probe(uuid).await, LvmSvc::probe(uuid).await) {
-            (Ok(true), _) => Ok(PoolBackend::Lvs),
-            (_, Ok(true)) => Ok(PoolBackend::Lvm),
-            (Err(error), _) | (_, Err(error)) => Err(error),
-            _ => Err(Status::not_found(format!("Replica {uuid} not found"))),
+}
+impl From<destroy_replica_request::Pool> for PoolIdProbe {
+    fn from(value: destroy_replica_request::Pool) -> Self {
+        match value {
+            destroy_replica_request::Pool::PoolName(name) => {
+                Self::UuidOrName(name)
+            }
+            destroy_replica_request::Pool::PoolUuid(uuid) => Self::Uuid(uuid),
         }
     }
 }
@@ -269,8 +298,8 @@ impl ReplicaRpc for ReplicaService {
         request: Request<CreateReplicaRequest>,
     ) -> GrpcResult<Replica> {
         let probe =
-            PoolProbe::UuidOrName(request.get_ref().pooluuid.to_owned());
-        let backend = self.probe_backend_pool(probe).await?;
+            PoolIdProbe::UuidOrName(request.get_ref().pooluuid.to_owned());
+        let backend = self.probe_backend(probe).await;
         self.locked(
             GrpcClientContext::new(&request, function_name!()),
             async move {
@@ -286,7 +315,7 @@ impl ReplicaRpc for ReplicaService {
                     )));
                 }
 
-                backend.create_replica(request).await
+                backend?.create_replica(request).await
             },
         )
         .await
@@ -297,13 +326,17 @@ impl ReplicaRpc for ReplicaService {
         &self,
         request: Request<DestroyReplicaRequest>,
     ) -> GrpcResult<()> {
-        let backend = self.probe_backend(&request.get_ref().uuid).await?;
+        let probe = Probe::ReplicaPool(
+            &request.get_ref().uuid,
+            request.get_ref().pool.clone().map(Into::into),
+        );
+        let backend = self.probe_backend(probe).await;
         self.locked(
             GrpcClientContext::new(&request, function_name!()),
             async move {
                 info!("{:?}", request.get_ref());
 
-                backend.destroy_replica(request).await
+                backend?.destroy_replica(request).await
             },
         )
         .await
@@ -352,13 +385,13 @@ impl ReplicaRpc for ReplicaService {
         &self,
         request: Request<ShareReplicaRequest>,
     ) -> GrpcResult<Replica> {
-        let backend = self.probe_backend(&request.get_ref().uuid).await?;
+        let backend = self.probe_backend(&request.get_ref().uuid).await;
         self.locked(
             GrpcClientContext::new(&request, function_name!()),
             async move {
                 info!("{:?}", request.get_ref());
 
-                backend.share_replica(request).await
+                backend?.share_replica(request).await
             },
         )
         .await
@@ -369,13 +402,13 @@ impl ReplicaRpc for ReplicaService {
         &self,
         request: Request<UnshareReplicaRequest>,
     ) -> GrpcResult<Replica> {
-        let backend = self.probe_backend(&request.get_ref().uuid).await?;
+        let backend = self.probe_backend(&request.get_ref().uuid).await;
         self.locked(
             GrpcClientContext::new(&request, function_name!()),
             async move {
                 info!("{:?}", request.get_ref());
 
-                backend.unshare_replica(request).await
+                backend?.unshare_replica(request).await
             },
         )
         .await
@@ -386,13 +419,13 @@ impl ReplicaRpc for ReplicaService {
         &self,
         request: Request<ResizeReplicaRequest>,
     ) -> GrpcResult<Replica> {
-        let backend = self.probe_backend(&request.get_ref().uuid).await?;
+        let backend = self.probe_backend(&request.get_ref().uuid).await;
         self.locked(
             GrpcClientContext::new(&request, function_name!()),
             async move {
                 info!("{:?}", request.get_ref());
 
-                backend.resize_replica(request).await
+                backend?.resize_replica(request).await
             },
         )
         .await
@@ -403,13 +436,13 @@ impl ReplicaRpc for ReplicaService {
         &self,
         request: Request<SetReplicaEntityIdRequest>,
     ) -> GrpcResult<Replica> {
-        let backend = self.probe_backend(&request.get_ref().uuid).await?;
+        let backend = self.probe_backend(&request.get_ref().uuid).await;
         self.locked(
             GrpcClientContext::new(&request, function_name!()),
             async move {
                 info!("{:?}", request.get_ref());
 
-                backend.set_replica_entity_id(request).await
+                backend?.set_replica_entity_id(request).await
             },
         )
         .await

--- a/io-engine/src/lib.rs
+++ b/io-engine/src/lib.rs
@@ -31,6 +31,7 @@ pub mod lvs;
 pub mod persistent_store;
 pub mod pool_backend;
 pub mod rebuild;
+mod replica_backend;
 pub mod sleep;
 pub mod store;
 pub mod subsys;

--- a/io-engine/src/lvm/mod.rs
+++ b/io-engine/src/lvm/mod.rs
@@ -53,6 +53,19 @@ use crate::{
 };
 use futures::channel::oneshot::Receiver;
 
+pub(super) fn is_alphanumeric(name: &str, value: &str) -> Result<(), Error> {
+    if value.chars().any(|c| {
+        !(c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '.' | '+'))
+    }) {
+        return Err(Error::NotFound {
+            query: format!(
+                "{name}('{value}') invalid: must be [a-zA-Z0-9.-_+]"
+            ),
+        });
+    }
+    Ok(())
+}
+
 /// The LVM code currently uses an async executor which is not runnable within
 /// the spdk reactor, and as such we need a trampoline in order to use spdk
 /// functionality within the LVM code.

--- a/io-engine/src/lvm/mod.rs
+++ b/io-engine/src/lvm/mod.rs
@@ -45,6 +45,12 @@ pub(crate) use vg_pool::VolumeGroup;
 /// Logical volume and its query arguments.
 pub(crate) use lv_replica::{LogicalVolume, QueryArgs};
 
+use crate::{
+    core::{NvmfShareProps, Protocol, UpdateProps},
+    lvm::property::Property,
+    pool_backend::{PoolOps, ReplicaArgs},
+    replica_backend::ReplicaOps,
+};
 use futures::channel::oneshot::Receiver;
 
 /// The LVM code currently uses an async executor which is not runnable within
@@ -69,4 +75,73 @@ macro_rules! spdk_run {
         let r = $crate::lvm::spdk_submit($fut)?;
         r.await.map_err(|_| Error::ReactorSpawnChannel {})?
     }};
+}
+
+#[async_trait::async_trait(?Send)]
+impl PoolOps for VolumeGroup {
+    type Replica = LogicalVolume;
+    type Error = Error;
+
+    async fn replicas(&self) -> Result<Vec<Self::Replica>, Self::Error> {
+        self.list_lvs().await
+    }
+    async fn create_repl(
+        &self,
+        args: ReplicaArgs,
+    ) -> Result<Self::Replica, Self::Error> {
+        let replica = LogicalVolume::create(
+            self.uuid(),
+            &args.name,
+            args.size,
+            &args.uuid,
+            args.thin,
+            &args.entity_id,
+            Protocol::Off,
+        )
+        .await?;
+        Ok(replica)
+    }
+    async fn destroy(self) -> Result<(), Self::Error> {
+        self.destroy().await
+    }
+
+    async fn export(mut self) -> Result<(), Self::Error> {
+        self.export().await
+    }
+}
+
+#[async_trait::async_trait(?Send)]
+impl ReplicaOps for LogicalVolume {
+    type ReplError = Error;
+
+    async fn share_nvmf(
+        &mut self,
+        props: NvmfShareProps,
+    ) -> Result<String, Self::ReplError> {
+        self.share_nvmf(Some(props)).await
+    }
+    async fn unshare(&mut self) -> Result<(), Self::ReplError> {
+        self.unshare().await
+    }
+    async fn update_properties<P: Into<UpdateProps>>(
+        &mut self,
+        props: P,
+    ) -> Result<(), Self::ReplError> {
+        self.update_share_props(props.into()).await
+    }
+
+    async fn set_entity_id(
+        &mut self,
+        id: String,
+    ) -> Result<(), Self::ReplError> {
+        self.set_property(Property::LvEntityId(id)).await
+    }
+
+    async fn resize(&mut self, size: u64) -> Result<(), Self::ReplError> {
+        self.resize(size).await
+    }
+
+    async fn destroy(self) -> Result<(), Self::ReplError> {
+        self.destroy().await
+    }
 }

--- a/io-engine/src/lvm/property.rs
+++ b/io-engine/src/lvm/property.rs
@@ -10,7 +10,7 @@ macro_rules! impl_properties {
     ($tag:ident, $tag_key:literal, $($name:ident,$value:ty,$key:literal,)+) => {
         /// Various types of properties which we persist with LVM.
         #[derive(Eq, PartialEq, Debug, Clone)]
-        pub(super) enum Property {
+        pub(crate) enum Property {
             $tag,
             Unknown(String,String),
             $(

--- a/io-engine/src/lvm/vg_pool.rs
+++ b/io-engine/src/lvm/vg_pool.rs
@@ -172,7 +172,7 @@ impl VolumeGroup {
         self.list_lvs().await?;
         Ok(())
     }
-    async fn list_lvs(&self) -> Result<Vec<LogicalVolume>, Error> {
+    pub async fn list_lvs(&self) -> Result<Vec<LogicalVolume>, Error> {
         let query = super::QueryArgs::new()
             .with_lv(CmnQueryArgs::ours())
             .with_vg(CmnQueryArgs::ours().uuid(self.uuid()).named(self.name()));
@@ -253,7 +253,7 @@ impl VolumeGroup {
     }
 
     /// Exports the volume group by unloading all logical volumes and finally
-    /// removing our tag from it
+    /// removing our tag from it.
     pub(crate) async fn export(&mut self) -> Result<(), Error> {
         let lvs = self.list_lvs().await?;
         for mut lv in lvs {

--- a/io-engine/src/lvm/vg_pool.rs
+++ b/io-engine/src/lvm/vg_pool.rs
@@ -21,22 +21,26 @@ pub(crate) struct QueryArgs(CmnQueryArgs);
 impl QueryArgs {
     /// Get a comma-separated list of query selection args.
     /// todo: should be Display trait?
-    pub(super) fn query(&self) -> String {
+    pub(super) fn query(&self) -> Result<String, Error> {
         Self::query_args(&self.0)
     }
     /// Get a comma-separated list of query selection args.
-    pub(super) fn query_args(args: &CmnQueryArgs) -> String {
+    pub(super) fn query_args(args: &CmnQueryArgs) -> Result<String, Error> {
         let mut select = String::new();
         if let Some(vg_name) = &args.name {
+            super::is_alphanumeric("vg_name", vg_name)?;
             select.push_str(&format!("vg_name={vg_name},"));
         }
         if let Some(vg_uuid) = &args.uuid {
+            super::is_alphanumeric("vg_uuid", vg_uuid)?;
+            // todo: validate more...
             select.push_str(&format!("vg_uuid={vg_uuid},"));
         }
         if let Some(vg_tag) = &args.tag {
+            super::is_alphanumeric("vg_tag", vg_tag)?;
             select.push_str(&format!("vg_tags={vg_tag},"));
         }
-        select
+        Ok(select)
     }
 }
 impl From<CmnQueryArgs> for QueryArgs {
@@ -96,7 +100,7 @@ impl VolumeGroup {
     pub(crate) async fn lookup(args: CmnQueryArgs) -> Result<Self, Error> {
         let vgs = Self::list(&args).await?;
         vgs.into_iter().next().ok_or(Error::NotFound {
-            query: QueryArgs(args).query(),
+            query: QueryArgs(args).query().unwrap_or_else(|e| e.to_string()),
         })
     }
 
@@ -111,7 +115,7 @@ impl VolumeGroup {
             "--options=vg_name,vg_uuid,vg_size,vg_free,vg_tags,pv_name",
             "--report-format=json",
         ];
-        let select = QueryArgs::query_args(opts);
+        let select = QueryArgs::query_args(opts)?;
         let select_query = format!("--select={select}");
         if !select.is_empty() {
             args.push(select_query.trim_end_matches(','));

--- a/io-engine/src/lvs/lvs_store.rs
+++ b/io-engine/src/lvs/lvs_store.rs
@@ -7,6 +7,7 @@ use std::{
 };
 
 use byte_unit::Byte;
+use events_api::event::EventAction;
 use futures::channel::oneshot;
 use nix::errno::Errno;
 use pin_utils::core_reexport::fmt::Formatter;
@@ -51,18 +52,15 @@ use crate::{
         snapshot::{SnapshotOps, VolumeSnapshotDescriptor},
         Bdev,
         IoType,
+        NvmfShareProps,
         Share,
-        ShareProps,
         UntypedBdev,
     },
+    eventing::Event,
     ffihelper::{cb_arg, pair, AsStr, ErrnoResult, FfiResult, IntoCString},
     lvs::lvs_lvol::{LvsLvol, WIPE_SUPER_LEN},
     pool_backend::PoolArgs,
 };
-
-use events_api::event::EventAction;
-
-use crate::eventing::Event;
 
 static ROUND_TO_MB: u32 = 1024 * 1024;
 /// Default spdk cluster size is 4MiB.
@@ -650,7 +648,7 @@ impl Lvs {
                     match prop {
                         PropValue::Shared(true) => {
                             let name = l.name().clone();
-                            let props = ShareProps::new()
+                            let props = NvmfShareProps::new()
                                 .with_allowed_hosts(allowed_hosts)
                                 .with_ptpl(
                                     l.ptpl().create().unwrap_or_default(),

--- a/io-engine/src/lvs/mod.rs
+++ b/io-engine/src/lvs/mod.rs
@@ -1,9 +1,15 @@
+use crate::{
+    core::{Share, UntypedBdev, UpdateProps},
+    pool_backend::{PoolOps, ReplicaArgs},
+    replica_backend::ReplicaOps,
+};
 pub use lvol_snapshot::LvolSnapshotIter;
 pub use lvs_bdev::LvsBdev;
 pub use lvs_error::{BsError, ImportErrorReason, LvsError};
 pub use lvs_iter::{LvsBdevIter, LvsIter};
 pub use lvs_lvol::{Lvol, LvsLvol, PropName, PropValue};
 pub use lvs_store::Lvs;
+use std::pin::Pin;
 
 mod lvol_snapshot;
 mod lvs_bdev;
@@ -11,3 +17,74 @@ mod lvs_error;
 mod lvs_iter;
 pub mod lvs_lvol;
 mod lvs_store;
+
+#[async_trait::async_trait(?Send)]
+impl ReplicaOps for Lvol {
+    type ReplError = LvsError;
+
+    async fn share_nvmf(
+        &mut self,
+        props: crate::core::NvmfShareProps,
+    ) -> Result<String, Self::ReplError> {
+        Pin::new(self).share_nvmf(Some(props)).await
+    }
+    async fn unshare(&mut self) -> Result<(), Self::ReplError> {
+        Pin::new(self).unshare().await
+    }
+    async fn update_properties<P: Into<UpdateProps>>(
+        &mut self,
+        props: P,
+    ) -> Result<(), Self::ReplError> {
+        Pin::new(self).update_properties(props.into()).await
+    }
+
+    async fn resize(&mut self, size: u64) -> Result<(), Self::ReplError> {
+        self.resize_replica(size).await
+    }
+
+    async fn set_entity_id(
+        &mut self,
+        id: String,
+    ) -> Result<(), Self::ReplError> {
+        Pin::new(self).set(PropValue::EntityId(id)).await
+    }
+
+    async fn destroy(self) -> Result<(), Self::ReplError> {
+        self.destroy_replica().await?;
+        Ok(())
+    }
+}
+
+#[async_trait::async_trait(?Send)]
+impl PoolOps for Lvs {
+    type Replica = Lvol;
+    type Error = LvsError;
+
+    async fn replicas(&self) -> Result<Vec<Self::Replica>, Self::Error> {
+        let Some(bdev) = UntypedBdev::bdev_first() else {
+            return Ok(vec![]);
+        };
+
+        Ok(bdev.into_iter().filter_map(Lvol::ok_from).collect())
+    }
+    async fn create_repl(
+        &self,
+        args: ReplicaArgs,
+    ) -> Result<Self::Replica, Self::Error> {
+        self.create_lvol(
+            &args.name,
+            args.size,
+            Some(&args.uuid),
+            args.thin,
+            args.entity_id,
+        )
+        .await
+    }
+    async fn destroy(self) -> Result<(), Self::Error> {
+        self.destroy().await
+    }
+
+    async fn export(self) -> Result<(), Self::Error> {
+        self.export().await
+    }
+}

--- a/io-engine/src/pool_backend.rs
+++ b/io-engine/src/pool_backend.rs
@@ -1,3 +1,5 @@
+use crate::replica_backend::ReplicaOps;
+
 /// PoolArgs is used to translate the input for the grpc
 /// Create/Import requests which contains name, uuid & disks.
 /// This help us avoid importing grpc structs in the actual lvs mod
@@ -16,4 +18,36 @@ pub enum PoolBackend {
     #[default]
     Lvs,
     Lvm,
+}
+
+/// Arguments for replica creation.
+pub struct ReplicaArgs {
+    pub(crate) name: String,
+    pub(crate) size: u64,
+    pub(crate) uuid: String,
+    pub(crate) thin: bool,
+    pub(crate) entity_id: Option<String>,
+}
+
+/// This interface defines the high level operations which can be done on a
+/// pool. Pool-Specific details should be hidden away in the implementation as
+/// much as possible, though we can allow for extra pool specific options
+/// to be passed as parameters.
+#[async_trait::async_trait(?Send)]
+pub trait PoolOps {
+    type Replica: ReplicaOps + std::fmt::Debug;
+    type Error: Into<tonic::Status> + std::fmt::Display;
+
+    /// List all replicas which exist on this pool.
+    async fn replicas(&self) -> Result<Vec<Self::Replica>, Self::Error>;
+    /// Create a replica on this pool with the given arguments.
+    async fn create_repl(
+        &self,
+        args: ReplicaArgs,
+    ) -> Result<Self::Replica, Self::Error>;
+    /// Destroy the pool itself along with all its replicas.
+    async fn destroy(self) -> Result<(), Self::Error>;
+    /// Exports the volume group by unloading all logical volumes.
+    /// The pool will no longer be listable until it is imported again.
+    async fn export(self) -> Result<(), Self::Error>;
 }

--- a/io-engine/src/replica_backend.rs
+++ b/io-engine/src/replica_backend.rs
@@ -1,0 +1,56 @@
+use crate::core::{LogicalVolume, Share, UpdateProps};
+
+/// This interface defines the high level operations which can be done on a
+/// `Pool` replica. Replica-Specific details should be hidden away in the
+/// implementation as much as possible, though we can allow for extra pool
+/// specific options to be passed as parameters.
+/// A `Replica` is also a `LogicalVolume` and also has `Share` traits.
+#[async_trait::async_trait(?Send)]
+pub trait ReplicaOps: Share + LogicalVolume {
+    type ReplError: Into<tonic::Status> + std::fmt::Display;
+
+    /// Shares the replica with the given properties.
+    /// This handles the idempotence in case the replica is already shared on
+    /// the same protocol.
+    /// If the replica is shared on a different protocol then it must be first
+    /// unshared.
+    /// todo: handle != protocol
+    async fn share(
+        &mut self,
+        props: crate::core::ShareProps,
+    ) -> Result<String, Self::ReplError> {
+        if self.shared() == Some(props.protocol()) {
+            self.update_properties(props).await?;
+            return Ok(self.share_uri().unwrap_or_default());
+        }
+
+        self.share_nvmf(props.into()).await
+    }
+
+    /// Shares the replica via nvmf.
+    async fn share_nvmf(
+        &mut self,
+        props: crate::core::NvmfShareProps,
+    ) -> Result<String, Self::ReplError>;
+    /// Unshare the replica.
+    async fn unshare(&mut self) -> Result<(), Self::ReplError>;
+    /// Update share properties of a currently shared replica.
+    async fn update_properties<P: Into<UpdateProps>>(
+        &mut self,
+        props: P,
+    ) -> Result<(), Self::ReplError>;
+
+    /// Resize the replica to the given new size.
+    async fn resize(&mut self, size: u64) -> Result<(), Self::ReplError>;
+    /// Set the replica's entity id.
+    async fn set_entity_id(
+        &mut self,
+        id: String,
+    ) -> Result<(), Self::ReplError>;
+    /// Destroy the replica from its parent pool.
+    /// # Warning
+    /// Destroying implies unsharing, which might fail for some reason, example
+    /// if the target is in a bad state, or if IOs are stuck.
+    /// todo: return back `Self` in case of an error.
+    async fn destroy(self) -> Result<(), Self::ReplError>;
+}

--- a/io-engine/src/subsys/config/pool.rs
+++ b/io-engine/src/subsys/config/pool.rs
@@ -7,7 +7,7 @@ use tonic::Status;
 use crate::{
     core::{runtime, Cores, Reactor, Share, VerboseError},
     grpc::rpc_submit,
-    lvs::{LvsError, Lvs, LvsBdev},
+    lvs::{Lvs, LvsBdev, LvsError},
     pool_backend::{PoolArgs, PoolBackend},
 };
 

--- a/io-engine/tests/lvs_limits.rs
+++ b/io-engine/tests/lvs_limits.rs
@@ -60,8 +60,7 @@ async fn lvs_metadata_limit() {
             let repl_uuid = format!("45c23e54-dc86-45f6-b55b-e44d05f1{i:04}");
 
             let lvol = match lvs
-                .create_lvol
-                (
+                .create_lvol(
                     &repl_name,
                     REPL_SIZE * 1024 * 1024,
                     Some(&repl_uuid),

--- a/test/python/v1/replica/features/replica.feature
+++ b/test/python/v1/replica/features/replica.feature
@@ -95,6 +95,10 @@ Feature: Mayastor replica management
     When the user destroys a replica that does not exist
     Then the replica destroy command should fail
 
+  Scenario: destroying a replica that does not exist in the pool
+    When the user destroys a replica that does not exist in the pool
+    Then the replica destroy command should fail
+
   Scenario: writing to a shared replica
     Given a replica shared over "nvmf"
     When the user writes to the replica

--- a/test/python/v1/replica/test_bdd_replica.py
+++ b/test/python/v1/replica/test_bdd_replica.py
@@ -54,6 +54,13 @@ def test_fail_destroying_a_replica_that_does_not_exist():
     """Destroying a replica that does not exist."""
 
 
+@scenario(
+    "features/replica.feature", "destroying a replica that does not exist in the pool"
+)
+def test_fail_destroying_a_replica_that_does_not_exist_in_the_pool():
+    """Destroying a replica that does not exist in the pool."""
+
+
 @scenario("features/replica.feature", "listing replicas")
 def test_listing_replicas():
     """Listing replicas."""
@@ -315,6 +322,23 @@ def the_user_destroys_a_replica_that_does_not_exist(
             replica_pb.DestroyReplicaRequest(uuid=replica_uuid)
         )
     assert error.value.code() == grpc.StatusCode.NOT_FOUND
+
+
+@when(
+    "the user destroys a replica that does not exist in the pool",
+    target_fixture="the_user_destroys_a_replica_that_does_not_exist_in_the_pool",
+)
+def the_user_destroys_a_replica_that_does_not_exist(
+    mayastor_instance, find_replica, replica_name, replica_uuid
+):
+    assert find_replica(replica_name, replica_uuid) == None
+    with pytest.raises(grpc.RpcError) as error:
+        mayastor_instance.replica_rpc.DestroyReplica(
+            replica_pb.DestroyReplicaRequest(
+                uuid=replica_uuid, pool_name="does not exist"
+            )
+        )
+    assert error.value.code() == grpc.StatusCode.FAILED_PRECONDITION
 
 
 @when("the user destroys the replica")


### PR DESCRIPTION
    fix: replica destroy when pool not found
    
    Should return failed preconditions rather than NotFound.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    refactor(grpc): use new pool and replica traits
    
    Adds new GrpcPool and GrpcReplica types which make use of the Pool
    and Replica traits to ensure all pool/replica types are implemented the same.
    todo: add getters for the pools which will further simplify it.
    todo: how to handle creation?
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    refactor: add shared traits for pools and replicas
    
    This helps define shared behaviour as we now have different types
    of backends (lvs and lvm) whilst hiding the internal details.
    todo: gRPC can use these new traits.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    refactor(lvs/lvol): tidy up property management
    
    Reuse property modification rather than duplicate code on each arm.
    Add new batch property setting.
    Don't modify property if metadata is unchanged.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    refactor(lvm): tidy up lvm share bits
    
    Reuse property setting code and also rename some sharing functions.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>