### PR TITLE
fix: crash when there are no bdevs and lvm export

### DIFF
--- a/io-engine/src/core/env.rs
+++ b/io-engine/src/core/env.rs
@@ -493,10 +493,12 @@ async fn do_shutdown(arg: *mut c_void) {
     crate::rebuild::shutdown_snapshot_rebuilds().await;
     crate::lvs::Lvs::export_all().await;
 
-    runtime::spawn_await(async {
-        crate::lvm::VolumeGroup::export_all().await;
-    })
-    .await;
+    if MayastorFeatures::get_features().lvm() {
+        runtime::spawn_await(async {
+            crate::lvm::VolumeGroup::export_all().await;
+        })
+        .await;
+    }
 
     unsafe {
         spdk_rpc_finish();


### PR DESCRIPTION
    fix: crash when there are no bdevs
    
    When there are no bdevs the iterator will return nothing.
    In this case we should not crash.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    fix(lvm): don't export if not enabled
    
    There's no point trying and erroring with message..
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>
