### PR TITLE
Several Fixes

### DIFF
--- a/io-engine-tests/src/replica.rs
+++ b/io-engine-tests/src/replica.rs
@@ -73,6 +73,11 @@ impl ReplicaBuilder {
         self
     }
 
+    pub fn with_size_b(mut self, size_b: u64) -> Self {
+        self.size = Some(size_b);
+        self
+    }
+
     pub fn with_size_mb(mut self, size_mb: u64) -> Self {
         self.size = Some(size_mb * 1024 * 1024);
         self

--- a/io-engine/src/core/wiper.rs
+++ b/io-engine/src/core/wiper.rs
@@ -397,6 +397,14 @@ impl WipeIterator {
     ) -> Result<Self, Error> {
         snafu::ensure!(total_bytes > 0, ZeroBdev {});
 
+        let size_blks = total_bytes / block_len;
+        // todo: add knobs for this within the Wipe Proto API.
+        let skip_gpt_backup_blocks = 33;
+        let size_blks = size_blks
+            .checked_sub(skip_gpt_backup_blocks)
+            .unwrap_or(size_blks);
+        let total_bytes = size_blks * block_len;
+
         let chunk_size_bytes = if chunk_size_bytes == 0 {
             total_bytes
         } else {

--- a/io-engine/src/grpc/v1/pool.rs
+++ b/io-engine/src/grpc/v1/pool.rs
@@ -360,7 +360,8 @@ impl PoolService {
 }
 
 impl PoolBackend {
-    fn enabled(&self) -> Result<(), Status> {
+    /// Check if this backend type is enabled.
+    pub(crate) fn enabled(&self) -> Result<(), Status> {
         match self {
             PoolBackend::Lvs => Ok(()),
             PoolBackend::Lvm => crate::grpc::lvm_enabled(),


### PR DESCRIPTION
    chore(wiper): temporarily reduce replica checksum size
    
    This change is required because otherwise e2e checksum tests incorrectly
    report data mismatch.
    To better explain this, the nexus used to format replicas with a gpt
    partition table. This is no longer the case, but for back-compat the nexus
    ignores the blocks which were used for this.
    As such the gpt backup is never read or written to by an application and
    it is also not rebuilt! So this data may not be the same among the nexus
    replicas.
    
    As a short term solution, we simply discount these last 33 sectors from
    the replica checksum.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    fix(replica): don't use disabled backends
    
    Check if backend is enabled before using its function.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    fix(grpc/replica): keep behaviour for replica destroy
    
    On replica destruction, if the pool doesn't match, then return aborted, rather
    than invalid argument.
    In case of replica not found, also set "gtm-602" in the error header.
    Both these are for back-compat.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>
