### PR TITLE
refactor(snapshot/rebuild): support push/pull model

### DIFF
--- a/io-engine/src/bin/io-engine-client/v1/snapshot_rebuild_cli.rs
+++ b/io-engine/src/bin/io-engine-client/v1/snapshot_rebuild_cli.rs
@@ -86,10 +86,14 @@ async fn create(mut ctx: Context, matches: &ArgMatches) -> crate::Result<()> {
         .snapshot_rebuild
         .create_snapshot_rebuild(
             v1::snapshot_rebuild::CreateSnapshotRebuildRequest {
-                replica_uuid: uuid,
+                replica_uuid: uuid.to_string(),
+                uuid,
+                snapshot_uuid: "".to_string(),
+                replica_uri: "".to_string(),
+                snapshot_uri: uri,
                 resume: false,
-                source_uri: uri.clone(),
                 bitmap: None,
+                use_bitmap: false,
                 error_policy: None,
             },
         )
@@ -127,7 +131,7 @@ async fn destroy(mut ctx: Context, matches: &ArgMatches) -> crate::Result<()> {
         .snapshot_rebuild
         .destroy_snapshot_rebuild(
             v1::snapshot_rebuild::DestroySnapshotRebuildRequest {
-                replica_uuid: uuid.clone(),
+                uuid: uuid.to_string(),
             },
         )
         .await
@@ -145,7 +149,9 @@ async fn list(mut ctx: Context, matches: &ArgMatches) -> crate::Result<()> {
         .snapshot_rebuild
         .list_snapshot_rebuild(
             v1::snapshot_rebuild::ListSnapshotRebuildRequest {
-                replica_uuid,
+                uuid: replica_uuid,
+                replica_uuid: None,
+                snapshot_uuid: None,
             },
         )
         .await
@@ -172,7 +178,7 @@ async fn list(mut ctx: Context, matches: &ArgMatches) -> crate::Result<()> {
                     let status = r.status();
                     vec![
                         r.uuid,
-                        r.source_uri,
+                        r.snapshot_uri,
                         rebuild_status_to_str(status),
                         r.total.to_string(),
                         r.rebuilt.to_string(),

--- a/io-engine/src/bin/io-engine.rs
+++ b/io-engine/src/bin/io-engine.rs
@@ -90,11 +90,15 @@ fn start_tokio_runtime(args: &MayastorCliArgs) {
         warn!("Nexus reset is disabled");
     }
     if args.lvm {
-        env::set_var("LVM", "1");
+        env::set_var("ENABLE_LVM", "true");
         if env::var("LVM_SUPPRESS_FD_WARNINGS").is_err() {
             env::set_var("LVM_SUPPRESS_FD_WARNINGS", "1");
         }
         warn!("Experimental LVM pool backend is enabled");
+    }
+    if args.snap_rebuild {
+        env::set_var("ENABLE_SNAPSHOT_REBUILD", "true");
+        warn!("Experimental Snapshot Rebuild is enabled");
     }
 
     if args.enable_nexus_channel_debug {

--- a/io-engine/src/core/env.rs
+++ b/io-engine/src/core/env.rs
@@ -251,17 +251,23 @@ pub struct MayastorCliArgs {
     /// be set to 1.
     #[clap(long = "enable-lvm", env = "ENABLE_LVM")]
     pub lvm: bool,
+    /// Enables experimental Snapshot Rebuild support.
+    #[clap(long = "enable-snapshot-rebuild", env = "ENABLE_SNAPSHOT_REBUILD")]
+    pub snap_rebuild: bool,
 }
 
 /// Mayastor features.
 impl MayastorFeatures {
     fn init_features() -> MayastorFeatures {
         let ana = env::var("NEXUS_NVMF_ANA_ENABLE").as_deref() == Ok("1");
-        let lvm = env::var("LVM").as_deref() == Ok("1");
+        let lvm = env::var("ENABLE_LVM").as_deref() == Ok("true");
+        let snapshot_rebuild =
+            env::var("ENABLE_SNAPSHOT_REBUILD").as_deref() == Ok("true");
 
         MayastorFeatures {
             asymmetric_namespace_access: ana,
             logical_volume_manager: lvm,
+            snapshot_rebuild,
         }
     }
 
@@ -305,6 +311,7 @@ impl Default for MayastorCliArgs {
             events_url: None,
             enable_nexus_channel_debug: false,
             lvm: false,
+            snap_rebuild: false,
         }
     }
 }

--- a/io-engine/src/core/mod.rs
+++ b/io-engine/src/core/mod.rs
@@ -527,6 +527,8 @@ pub struct MayastorFeatures {
     pub asymmetric_namespace_access: bool,
     /// When set to true, support for lvm pools and volumes is enabled.
     pub logical_volume_manager: bool,
+    /// When set to true, support for snapshot rebuild is enabled.
+    pub snapshot_rebuild: bool,
 }
 impl MayastorFeatures {
     pub fn lvm(&self) -> bool {

--- a/io-engine/src/grpc/mod.rs
+++ b/io-engine/src/grpc/mod.rs
@@ -151,8 +151,8 @@ macro_rules! spdk_submit {
     ($fut:expr) => {{
         let r = $crate::grpc::rpc_submit_ext2($fut)?;
         r.await
-            .map_err(|_| Status::cancelled("cancelled"))?
-            .map(Response::new)
+            .map_err(|_| tonic::Status::cancelled("cancelled"))?
+            .map(tonic::Response::new)
     }};
 }
 

--- a/io-engine/src/grpc/v1/host.rs
+++ b/io-engine/src/grpc/v1/host.rs
@@ -100,6 +100,7 @@ impl From<MayastorFeatures> for host_rpc::MayastorFeatures {
         Self {
             asymmetric_namespace_access: f.asymmetric_namespace_access,
             logical_volume_manager: f.logical_volume_manager,
+            snapshot_rebuild: f.snapshot_rebuild,
         }
     }
 }

--- a/io-engine/src/grpc/v1/pool.rs
+++ b/io-engine/src/grpc/v1/pool.rs
@@ -28,7 +28,7 @@ use ::function_name::named;
 use futures::FutureExt;
 use io_engine_api::v1::{pool::*, replica::destroy_replica_request};
 use std::{convert::TryFrom, fmt::Debug, ops::Deref, panic::AssertUnwindSafe};
-use tonic::{Request, Response, Status};
+use tonic::{Request, Status};
 
 pub use crate::pool_backend::FindPoolArgs as PoolIdProbe;
 

--- a/io-engine/src/grpc/v1/replica.rs
+++ b/io-engine/src/grpc/v1/replica.rs
@@ -27,7 +27,7 @@ use ::function_name::named;
 use futures::FutureExt;
 use io_engine_api::v1::{pool::PoolType, replica::*};
 use std::{convert::TryFrom, ops::Deref, panic::AssertUnwindSafe};
-use tonic::{Request, Response, Status};
+use tonic::{Request, Status};
 
 #[derive(Debug, Clone)]
 pub struct ReplicaService {

--- a/io-engine/src/rebuild/mod.rs
+++ b/io-engine/src/rebuild/mod.rs
@@ -63,7 +63,7 @@ pub(crate) async fn shutdown_snapshot_rebuilds() {
 }
 
 /// Parse the given url as string into a `url::Url`.
-pub(crate) fn parse_url(url: &str) -> Result<url::Url, RebuildError> {
+pub fn parse_url(url: &str) -> Result<url::Url, RebuildError> {
     match url::Url::parse(url) {
         Ok(url) => Ok(url),
         Err(source) => Err(RebuildError::BdevInvalidUri {

--- a/io-engine/src/rebuild/rebuild_error.rs
+++ b/io-engine/src/rebuild/rebuild_error.rs
@@ -93,14 +93,14 @@ pub enum RebuildError {
 #[snafu(visibility(pub(crate)), context(suffix(false)))]
 #[allow(missing_docs)]
 pub enum SnapshotRebuildError {
-    #[snafu(display("Destination replica bdev not found"))]
-    ReplicaBdevNotFound {},
-    #[snafu(display("Destination replica bdev uri is missing"))]
-    ReplicaNoUri {},
-    #[snafu(display("Given destination uuid is not a replica"))]
+    #[snafu(display("Local bdev not found"))]
+    LocalBdevNotFound {},
+    #[snafu(display("Remote bdev uri is missing"))]
+    RemoteNoUri {},
+    #[snafu(display("Local bdev is not a replica"))]
     NotAReplica {},
-    #[snafu(display("Failed to open the source uri as a bdev: {source}"))]
-    SourceUriBdev { source: BdevError },
+    #[snafu(display("Failed to open {uri} as a bdev: {source}"))]
+    UriBdevOpen { uri: String, source: BdevError },
 }
 
 impl From<SnapshotRebuildError> for RebuildError {

--- a/io-engine/src/rebuild/rebuild_instances.rs
+++ b/io-engine/src/rebuild/rebuild_instances.rs
@@ -84,22 +84,6 @@ macro_rules! gen_rebuild_instances {
                     })
                     .collect()
             }
-
-            /// Lookup a rebuild job by its target uri and return it.
-            pub fn lookup_dst_uri(
-                dst_uri: &str,
-            ) -> Result<std::sync::Arc<Self>, super::RebuildError> {
-                let not_found = || RebuildError::JobNotFound {
-                    job: dst_uri.to_owned(),
-                };
-                let url = url::Url::parse(dst_uri).map_err(|_| not_found())?;
-                let name = url.path().strip_prefix('/').unwrap_or(url.path());
-                let job = Self::lookup(name)?;
-                if job.dst_uri != dst_uri {
-                    return Err(not_found());
-                }
-                Ok(job)
-            }
         }
     };
 }


### PR DESCRIPTION
Allows doing the snapshot rebuild from either the snapshot or replica node. This is done by allowing specification of either URI's. If a URI is not specified, then the uuid must be specified.