### PR TITLE
refactor(snapshots): use generic snapshot ops interface

### DIFF
--- a/io-engine-tests/src/nexus.rs
+++ b/io-engine-tests/src/nexus.rs
@@ -37,7 +37,7 @@ use super::{
 };
 use io_engine::{
     constants::NVME_NQN_PREFIX,
-    core::{SnapshotDescriptor, SnapshotParams},
+    core::{ISnapshotDescriptor, SnapshotParams},
     subsys::make_subsystem_serial,
 };
 use std::time::{Duration, Instant};

--- a/io-engine/src/bdev/nexus/nexus_bdev_snapshot.rs
+++ b/io-engine/src/bdev/nexus/nexus_bdev_snapshot.rs
@@ -7,7 +7,7 @@ use super::{Error, Nexus, NexusOperation, NexusState};
 use crate::{
     bdev::nexus::{nexus_lookup, NexusChild},
     core::{
-        snapshot::SnapshotDescriptor,
+        snapshot::ISnapshotDescriptor,
         CoreError,
         Reactor,
         SnapshotParams,

--- a/io-engine/src/core/logical_volume.rs
+++ b/io-engine/src/core/logical_volume.rs
@@ -26,9 +26,10 @@ pub trait LogicalVolume: std::fmt::Debug {
 
     /// Return the size of the Logical Volume in bytes.
     fn size(&self) -> u64;
-
     /// Return the committed size of the Logical Volume in bytes.
     fn committed(&self) -> u64;
+    /// Return the allocated size of the Logical Volume in bytes.
+    fn allocated(&self) -> u64;
 
     /// Returns Lvol disk space usage.
     fn usage(&self) -> LvolSpaceUsage;

--- a/io-engine/src/core/mod.rs
+++ b/io-engine/src/core/mod.rs
@@ -79,8 +79,9 @@ use crate::subsys::NvmfError;
 pub use snapshot::{
     CloneParams,
     CloneXattrs,
+    ISnapshotDescriptor,
+    LvolSnapshotOps,
     SnapshotDescriptor,
-    SnapshotOps,
     SnapshotParams,
     SnapshotXattrs,
 };

--- a/io-engine/src/eventing/snapshot_events.rs
+++ b/io-engine/src/eventing/snapshot_events.rs
@@ -7,7 +7,11 @@ use events_api::event::{
 };
 
 use crate::{
-    core::{MayastorEnvironment, SnapshotDescriptor, SnapshotParams},
+    core::{
+        snapshot::ISnapshotDescriptor,
+        MayastorEnvironment,
+        SnapshotParams,
+    },
     eventing::Event,
 };
 

--- a/io-engine/src/grpc/v1/lvm/mod.rs
+++ b/io-engine/src/grpc/v1/lvm/mod.rs
@@ -1,7 +1,7 @@
 use crate::lvm::Error as LvmError;
 use tonic::Status;
 
-impl From<LvmError> for Status {
+impl From<LvmError> for tonic::Status {
     fn from(e: LvmError) -> Self {
         match e {
             LvmError::InvalidPoolType {
@@ -22,6 +22,9 @@ impl From<LvmError> for Status {
             LvmError::NoSpace {
                 ..
             } => Status::resource_exhausted(e.to_string()),
+            LvmError::SnapshotNotSup {
+                ..
+            } => Status::failed_precondition(e.to_string()),
             _ => Status::internal(e.to_string()),
         }
     }

--- a/io-engine/src/grpc/v1/pool.rs
+++ b/io-engine/src/grpc/v1/pool.rs
@@ -26,7 +26,11 @@ use crate::{
 };
 use ::function_name::named;
 use futures::FutureExt;
-use io_engine_api::v1::{pool::*, replica::destroy_replica_request};
+use io_engine_api::v1::{
+    pool::*,
+    replica::destroy_replica_request,
+    snapshot::destroy_snapshot_request,
+};
 use std::{convert::TryFrom, fmt::Debug, ops::Deref, panic::AssertUnwindSafe};
 use tonic::{Request, Status};
 
@@ -48,6 +52,17 @@ impl From<&destroy_replica_request::Pool> for FindPoolArgs {
                 uuid: None,
             },
             destroy_replica_request::Pool::PoolUuid(uuid) => Self::Uuid(uuid),
+        }
+    }
+}
+impl From<&destroy_snapshot_request::Pool> for FindPoolArgs {
+    fn from(value: &destroy_snapshot_request::Pool) -> Self {
+        match value.clone() {
+            destroy_snapshot_request::Pool::PoolName(name) => Self::NameUuid {
+                name,
+                uuid: None,
+            },
+            destroy_snapshot_request::Pool::PoolUuid(uuid) => Self::Uuid(uuid),
         }
     }
 }

--- a/io-engine/src/lib.rs
+++ b/io-engine/src/lib.rs
@@ -31,7 +31,7 @@ pub mod lvs;
 pub mod persistent_store;
 pub mod pool_backend;
 pub mod rebuild;
-mod replica_backend;
+pub mod replica_backend;
 pub mod sleep;
 pub mod store;
 pub mod subsys;

--- a/io-engine/src/lvm/error.rs
+++ b/io-engine/src/lvm/error.rs
@@ -1,3 +1,5 @@
+use crate::core::ToErrno;
+use nix::errno::Errno;
 use snafu::Snafu;
 
 /// Errors which can be encountered whilst using the LVM backend module.
@@ -54,4 +56,79 @@ pub enum Error {
     },
     #[snafu(display("{error}"))]
     NoSpace { error: String },
+    #[snafu(display("Snapshots are not currently supported for LVM volumes"))]
+    SnapshotNotSup {},
+}
+
+impl ToErrno for Error {
+    fn to_errno(self) -> Errno {
+        match self {
+            Error::ReportMissing {
+                ..
+            } => Errno::EIO,
+            Error::JsonParsing {
+                ..
+            } => Errno::EIO,
+            Error::LvmBinErr {
+                ..
+            } => Errno::EIO,
+            Error::LvmBinSpawnErr {
+                ..
+            } => Errno::EIO,
+            Error::DisksMismatch {
+                ..
+            } => Errno::EINVAL,
+            Error::InvalidPoolType {
+                ..
+            } => Errno::EINVAL,
+            Error::NotFound {
+                ..
+            } => Errno::ENOENT,
+            Error::VgUuidSet {
+                ..
+            } => Errno::EINVAL,
+            Error::LvNotFound {
+                ..
+            } => Errno::ENOENT,
+            Error::ThinProv {
+                ..
+            } => Errno::ENOTSUP,
+            Error::ReactorSpawn {
+                ..
+            } => Errno::EXFULL,
+            Error::ReactorSpawnChannel {
+                ..
+            } => Errno::EPIPE,
+            Error::BdevImport {
+                ..
+            } => Errno::EIO,
+            Error::BdevExport {
+                ..
+            } => Errno::EIO,
+            Error::BdevOpen {
+                ..
+            } => Errno::EIO,
+            Error::BdevShare {
+                ..
+            } => Errno::EFAULT,
+            Error::BdevShareUri {
+                ..
+            } => Errno::EFAULT,
+            Error::BdevUnshare {
+                ..
+            } => Errno::EFAULT,
+            Error::BdevMissing {
+                ..
+            } => Errno::ENODEV,
+            Error::UpdateProps {
+                ..
+            } => Errno::EIO,
+            Error::NoSpace {
+                ..
+            } => Errno::ENOSPC,
+            Error::SnapshotNotSup {
+                ..
+            } => Errno::ENOTSUP,
+        }
+    }
 }

--- a/io-engine/src/lvm/lv_replica.rs
+++ b/io-engine/src/lvm/lv_replica.rs
@@ -854,11 +854,16 @@ impl crate::core::LogicalVolume for LogicalVolume {
         self.size
     }
 
+    fn allocated(&self) -> u64 {
+        self.size()
+    }
+
     fn usage(&self) -> crate::core::logical_volume::LvolSpaceUsage {
         crate::core::logical_volume::LvolSpaceUsage {
             capacity_bytes: self.size(),
-            allocated_bytes: self.size(),
+            allocated_bytes: self.allocated(),
             cluster_size: self.extent_size(),
+            // todo: missing this information
             num_clusters: 0,
             num_allocated_clusters: 0,
             allocated_bytes_snapshots: 0,

--- a/io-engine/src/lvs/lvs_store.rs
+++ b/io-engine/src/lvs/lvs_store.rs
@@ -49,7 +49,7 @@ use crate::{
     bdev_api::{bdev_destroy, BdevError},
     core::{
         logical_volume::LogicalVolume,
-        snapshot::{SnapshotOps, VolumeSnapshotDescriptor},
+        snapshot::LvolSnapshotOps,
         Bdev,
         IoType,
         NvmfShareProps,
@@ -58,7 +58,10 @@ use crate::{
     },
     eventing::Event,
     ffihelper::{cb_arg, pair, AsStr, ErrnoResult, FfiResult, IntoCString},
-    lvs::lvs_lvol::{LvsLvol, WIPE_SUPER_LEN},
+    lvs::{
+        lvs_lvol::{LvsLvol, WIPE_SUPER_LEN},
+        LvolSnapshotDescriptor,
+    },
     pool_backend::PoolArgs,
 };
 
@@ -731,7 +734,7 @@ impl Lvs {
     /// return an iterator for enumerating all snapshots that reside on the pool
     pub fn snapshots(
         &self,
-    ) -> Option<impl Iterator<Item = VolumeSnapshotDescriptor>> {
+    ) -> Option<impl Iterator<Item = LvolSnapshotDescriptor>> {
         if let Some(bdev) = UntypedBdev::bdev_first() {
             let pool_name = format!("{}/", self.name());
             Some(
@@ -745,7 +748,7 @@ impl Lvs {
                     .filter_map(|b| {
                         Lvol::try_from(b).ok().and_then(|l| {
                             if l.is_snapshot() {
-                                l.snapshot_descriptor(None)
+                                l.lvol_snapshot_descriptor(None)
                             } else {
                                 None
                             }

--- a/io-engine/src/pool_backend.rs
+++ b/io-engine/src/pool_backend.rs
@@ -1,4 +1,5 @@
-use crate::replica_backend::ReplicaOps;
+use crate::{core::ToErrno, replica_backend::ReplicaOps};
+use nix::errno::Errno;
 
 /// PoolArgs is used to translate the input for the grpc
 /// Create/Import requests which contains name, uuid & disks.
@@ -60,6 +61,18 @@ impl From<Error> for tonic::Status {
             Error::Lvm {
                 source,
             } => source.into(),
+        }
+    }
+}
+impl ToErrno for Error {
+    fn to_errno(self) -> Errno {
+        match self {
+            Error::Lvs {
+                source,
+            } => source.to_errno(),
+            Error::Lvm {
+                source,
+            } => source.to_errno(),
         }
     }
 }

--- a/io-engine/src/replica_backend.rs
+++ b/io-engine/src/replica_backend.rs
@@ -1,5 +1,14 @@
 use super::pool_backend::PoolBackend;
-use crate::core::{LogicalVolume, Protocol, PtplProps, UpdateProps};
+use crate::core::{
+    snapshot::SnapshotDescriptor,
+    CloneParams,
+    LogicalVolume,
+    Protocol,
+    PtplProps,
+    SnapshotParams,
+    UpdateProps,
+};
+use std::fmt::Debug;
 
 /// This interface defines the high level operations which can be done on a
 /// `Pool` replica. Replica-Specific details should be hidden away in the
@@ -8,26 +17,6 @@ use crate::core::{LogicalVolume, Protocol, PtplProps, UpdateProps};
 /// A `Replica` is also a `LogicalVolume` and also has `Share` traits.
 #[async_trait::async_trait(?Send)]
 pub trait ReplicaOps: LogicalVolume {
-    /// Shares the replica with the given properties.
-    /// This handles the idempotence in case the replica is already shared on
-    /// the same protocol.
-    /// If the replica is shared on a different protocol then it must be first
-    /// unshared.
-    /// todo: handle != protocol
-    async fn share(
-        &mut self,
-        props: crate::core::ShareProps,
-    ) -> Result<String, crate::pool_backend::Error> {
-        if self.shared() == Some(props.protocol()) {
-            self.update_properties(props.into()).await?;
-            //return Ok(self.share_uri().unwrap_or_default());
-            return Ok(String::new());
-        }
-
-        let share = self.share_nvmf(props.into()).await?;
-        Ok(share)
-    }
-
     fn shared(&self) -> Option<Protocol>;
     fn create_ptpl(
         &self,
@@ -63,6 +52,70 @@ pub trait ReplicaOps: LogicalVolume {
     /// todo: return back `Self` in case of an error.
     async fn destroy(self: Box<Self>)
         -> Result<(), crate::pool_backend::Error>;
+
+    /// Snapshot Operations
+    ///
+    /// Prepare Snapshot Config for Block/Nvmf Device, before snapshot create.
+    fn prepare_snap_config(
+        &self,
+        snap_name: &str,
+        entity_id: &str,
+        txn_id: &str,
+        snap_uuid: &str,
+    ) -> Option<SnapshotParams> {
+        SnapshotParams::prepare(
+            snap_name,
+            entity_id,
+            txn_id,
+            snap_uuid,
+            self.uuid(),
+        )
+    }
+    /// Create a snapshot using the given parameters and yields an object which
+    /// implements `SnapshotOps`. In turn this can be  used to create clones,
+    /// which are `ReplicaOps`.
+    async fn create_snapshot(
+        &mut self,
+        params: SnapshotParams,
+    ) -> Result<Box<dyn SnapshotOps>, crate::pool_backend::Error>;
+}
+
+/// Snapshot Operations for snapshots created by `ReplicaOps`.
+#[async_trait::async_trait(?Send)]
+pub trait SnapshotOps: LogicalVolume + Debug {
+    /// Destroys the snapshot itself.
+    async fn destroy_snapshot(
+        self: Box<Self>,
+    ) -> Result<(), crate::pool_backend::Error>;
+
+    /// Prepares a clone config for creating a clone from a snapshot.
+    fn prepare_clone_config(
+        &self,
+        clone_name: &str,
+        clone_uuid: &str,
+        source_uuid: &str,
+    ) -> Option<CloneParams> {
+        CloneParams::prepare(clone_name, clone_uuid, source_uuid)
+    }
+
+    /// Creates a **COW** clone from the snapshot.
+    /// The cloned object is essentially a replica, and as such it implements
+    /// `ReplicaOps`, though it returns its `ReplicaKind` as `Clone`.
+    async fn create_clone(
+        &self,
+        params: CloneParams,
+    ) -> Result<Box<dyn ReplicaOps>, crate::pool_backend::Error>;
+
+    /// Gets the `VolumeSnapshotDescriptor` which contains all snapshot related
+    /// information.
+    /// # Warning: This type is still containing `lvs::Lvol`, which needs to be
+    /// refactored out.
+    fn descriptor(&self) -> Option<SnapshotDescriptor>;
+    /// Check if the snapshot has been discarded.
+    /// A snapshot is discarded when it has been deleted but there are still >1
+    /// clones which reference its data. In this situation the snapshot may
+    /// still exist in the snapshot, but as discarded (and as such unusable).
+    fn discarded(&self) -> bool;
 }
 
 /// Find replica with filters.
@@ -97,13 +150,102 @@ impl FindReplicaArgs {
 /// listing operations, for a specific backend type.
 #[async_trait::async_trait(?Send)]
 pub trait ReplicaFactory {
+    /// If the bdev is a `ReplicaOps`, move and retrieve it as a `ReplicaOps`.
+    fn bdev_as_replica(
+        &self,
+        bdev: crate::core::UntypedBdev,
+    ) -> Option<Box<dyn ReplicaOps>>;
+    /// Finds the replica specified by the arguments, returning None if it
+    /// cannot be found.
     async fn find(
         &self,
         args: &FindReplicaArgs,
     ) -> Result<Option<Box<dyn ReplicaOps>>, crate::pool_backend::Error>;
+    /// Finds the snapshot specified by the arguments, returning None if it
+    /// cannot be found.
+    async fn find_snap(
+        &self,
+        args: &FindSnapshotArgs,
+    ) -> Result<Option<Box<dyn SnapshotOps>>, crate::pool_backend::Error>;
+    /// Lists all replicas specified by the arguments.
     async fn list(
         &self,
         args: &ListReplicaArgs,
     ) -> Result<Vec<Box<dyn ReplicaOps>>, crate::pool_backend::Error>;
+    /// Lists all snapshots specified by the arguments.
+    async fn list_snaps(
+        &self,
+        args: &ListSnapshotArgs,
+    ) -> Result<Vec<SnapshotDescriptor>, crate::pool_backend::Error>;
+    /// Lists all clones (replicas which have a snapshot parent) specified by
+    /// the arguments.
+    async fn list_clones(
+        &self,
+        args: &ListCloneArgs,
+    ) -> Result<Vec<Box<dyn ReplicaOps>>, crate::pool_backend::Error>;
     fn backend(&self) -> PoolBackend;
+}
+
+/// Find snapshots with filters.
+#[derive(Debug, Default)]
+pub struct ListSnapshotArgs {
+    /// Match the given snapshot uuid.
+    pub uuid: Option<String>,
+    /// Match the given source replica uuid.
+    pub source_uuid: Option<String>,
+}
+
+/// Find replica with filters.
+#[derive(Debug, Clone)]
+pub struct FindSnapshotArgs {
+    /// The snapshot uuid to find for.
+    pub uuid: String,
+}
+impl FindSnapshotArgs {
+    /// Create new `Self`.
+    pub fn new(uuid: String) -> Self {
+        Self {
+            uuid,
+        }
+    }
+}
+
+/// List clones with filters.
+#[derive(Debug, Default)]
+pub struct ListCloneArgs {
+    /// Match the given source snapshot uuid.
+    pub snapshot_uuid: Option<String>,
+}
+
+/// Get the `ReplicaFactory` for the given backend type.
+pub(crate) fn factory_enabled(
+    backend: PoolBackend,
+) -> Option<Box<dyn ReplicaFactory>> {
+    backend.enabled().ok()?;
+    Some(factory_unsafe(backend))
+}
+/// Get the `ReplicaFactory` for the given backend type.
+pub(crate) fn factory_unsafe(backend: PoolBackend) -> Box<dyn ReplicaFactory> {
+    match backend {
+        PoolBackend::Lvs => Box::new(crate::lvs::ReplLvsFactory {}) as _,
+        PoolBackend::Lvm => Box::new(crate::lvm::ReplLvmFactory {}) as _,
+    }
+}
+/// Get all the enabled `ReplicaFactory`.
+pub(crate) fn factories() -> Vec<Box<dyn ReplicaFactory>> {
+    vec![PoolBackend::Lvm, PoolBackend::Lvs]
+        .into_iter()
+        .filter_map(factory_enabled)
+        .collect()
+}
+/// Get the given bdev as a `ReplicaOps`.
+pub(crate) fn bdev_as_replica(
+    bdev: crate::core::UntypedBdev,
+) -> Option<Box<dyn ReplicaOps>> {
+    for factory in factories() {
+        if let Some(replica) = factory.bdev_as_replica(bdev) {
+            return Some(replica);
+        }
+    }
+    None
 }

--- a/io-engine/tests/lvs_import.rs
+++ b/io-engine/tests/lvs_import.rs
@@ -1,9 +1,10 @@
 pub mod common;
 
 use io_engine::{
-    core::{logical_volume::LogicalVolume, MayastorCliArgs, SnapshotOps},
+    core::{logical_volume::LogicalVolume, LvolSnapshotOps, MayastorCliArgs},
     lvs::Lvs,
     pool_backend::PoolArgs,
+    replica_backend::ReplicaOps,
 };
 
 use io_engine_tests::MayastorTest;

--- a/io-engine/tests/lvs_limits.rs
+++ b/io-engine/tests/lvs_limits.rs
@@ -1,9 +1,10 @@
 pub mod common;
 
 use io_engine::{
-    core::{MayastorCliArgs, SnapshotOps},
+    core::{LvolSnapshotOps, MayastorCliArgs},
     lvs::{BsError, Lvs, LvsError},
     pool_backend::PoolArgs,
+    replica_backend::ReplicaOps,
 };
 
 use io_engine_tests::MayastorTest;

--- a/io-engine/tests/snapshot_nexus.rs
+++ b/io-engine/tests/snapshot_nexus.rs
@@ -1,7 +1,7 @@
 pub mod common;
 
 use futures::channel::oneshot;
-use io_engine::{bdev::nexus::NexusSnapshotStatus, core::SnapshotDescriptor};
+use io_engine::{bdev::nexus::NexusSnapshotStatus, core::ISnapshotDescriptor};
 use once_cell::sync::OnceCell;
 
 use chrono::{DateTime, Utc};


### PR DESCRIPTION
The previous SnapshotOps interface was not generic, and rather dependent on Lvol.
Add a new SnapshotOps which attempts to be more generic. A single reference to Lvol remains which should still be removed.
The previous SnapshotOps is renamed to LvolSnapshotOps.

This also fixes a bug where destroy_snapshot was actually also destroying regular replicas! And vice versa!