### PR TITLE
fix: use auto-detected sector size for blockdev

### DIFF
--- a/io-engine-tests/src/lib.rs
+++ b/io-engine-tests/src/lib.rs
@@ -188,6 +188,28 @@ pub fn truncate_file_bytes(path: &str, size: u64) {
     assert!(output.status.success());
 }
 
+/// Automatically assign a loopdev to path
+pub fn setup_loopdev_file(path: &str, sector_size: Option<u64>) -> String {
+    let log_sec = sector_size.unwrap_or(512);
+
+    let output = Command::new("losetup")
+        .args(["-f", "--show", "-b", &format!("{log_sec}"), path])
+        .output()
+        .expect("failed exec losetup");
+    assert!(output.status.success());
+    // return the assigned loop device
+    String::from_utf8(output.stdout).unwrap().trim().to_string()
+}
+
+/// Detach the provided loop device.
+pub fn detach_loopdev(dev: &str) {
+    let output = Command::new("losetup")
+        .args(["-d", dev])
+        .output()
+        .expect("failed exec losetup");
+    assert!(output.status.success());
+}
+
 pub fn fscheck(device: &str) {
     let output = Command::new("fsck")
         .args([device, "-n"])

--- a/scripts/clean-cargo-tests.sh
+++ b/scripts/clean-cargo-tests.sh
@@ -1,7 +1,26 @@
+#!/usr/bin/env bash
+
 SCRIPT_DIR="$(dirname "$0")"
 ROOT_DIR=$(realpath "$SCRIPT_DIR/..")
 
 sudo nvme disconnect-all
+
+# Detach any loop devices created for test purposes
+for back_file in "/tmp/io-engine-tests"/*; do
+    # Find loop devices associated with the disk image
+    devices=$(losetup -j "$back_file" -O NAME --noheadings)
+
+    # Detach each loop device found
+    while IFS= read -r device; do
+        if [ -n "$device" ]; then
+            echo "Detaching loop device: $device"
+            losetup -d "$device"
+        fi
+    done <<< "$devices"
+done
+# Delete the directory too
+rmdir --ignore-fail-on-non-empty "/tmp/io-engine-tests"
+
 
 for c in $(docker ps -a --filter "label=io.composer.test.name" --format '{{.ID}}') ; do
   docker kill "$c"


### PR DESCRIPTION
This fixes the behaviour where we pass 512 as sector size if the disk uri doesn't contain blk_size parameter. This causes pool creation failure if the underlying disk has a different sector size e.g. 4096. Instead of passing 512, we now pass 0 which lets spdk detect the device's sector size and use that value.