### PR TITLE
Refactor more explicit uses of Lvol with the backend interface

### DIFF
--- a/io-engine/src/bdev/device.rs
+++ b/io-engine/src/bdev/device.rs
@@ -67,7 +67,7 @@ use crate::core::fault_injection::{
     FaultDomain,
     InjectIoCtx,
 };
-use crate::replica_backend::bdev_as_replica;
+use crate::replica_backend::ReplicaFactory;
 
 /// TODO
 type EventDispatcherMap = HashMap<String, DeviceEventDispatcher>;
@@ -584,14 +584,14 @@ impl BlockDeviceHandle for SpdkBlockDeviceHandle {
         })
     }
 
-    // NVMe commands are not applicable for non-NVMe devices.
+    /// NVMe commands are not applicable for non-NVMe devices.
     async fn create_snapshot(
         &self,
         snapshot: SnapshotParams,
     ) -> Result<u64, CoreError> {
         let bdev = self.handle.get_bdev();
 
-        let Some(mut replica) = bdev_as_replica(bdev) else {
+        let Some(mut replica) = ReplicaFactory::bdev_as_replica(bdev) else {
             return Err(CoreError::NotSupported {
                 source: Errno::ENXIO,
             });

--- a/io-engine/src/core/mod.rs
+++ b/io-engine/src/core/mod.rs
@@ -8,7 +8,7 @@ use std::{
 use nix::errno::Errno;
 use snafu::Snafu;
 
-pub use bdev::{Bdev, BdevIter, UntypedBdev};
+pub use bdev::{Bdev, BdevIter, BdevStater, BdevStats, UntypedBdev};
 pub use block_device::{
     BlockDevice,
     BlockDeviceDescriptor,

--- a/io-engine/src/grpc/v1/pool.rs
+++ b/io-engine/src/grpc/v1/pool.rs
@@ -41,7 +41,7 @@ struct UnixStream(tokio::net::UnixStream);
 
 impl From<DestroyPoolRequest> for FindPoolArgs {
     fn from(value: DestroyPoolRequest) -> Self {
-        Self::name_uuid(&value.name, &value.uuid)
+        Self::name_uuid(value.name, &value.uuid)
     }
 }
 impl From<&destroy_replica_request::Pool> for FindPoolArgs {
@@ -68,7 +68,7 @@ impl From<&destroy_snapshot_request::Pool> for FindPoolArgs {
 }
 impl From<ExportPoolRequest> for FindPoolArgs {
     fn from(value: ExportPoolRequest) -> Self {
-        Self::name_uuid(&value.name, &value.uuid)
+        Self::name_uuid(value.name, &value.uuid)
     }
 }
 

--- a/io-engine/src/grpc/v1/replica.rs
+++ b/io-engine/src/grpc/v1/replica.rs
@@ -259,12 +259,19 @@ impl GrpcReplicaFactory {
         }
         Ok(replica)
     }
-    async fn list(
+    pub(crate) async fn list(
         &self,
         args: &ListReplicaArgs,
     ) -> Result<Vec<Replica>, Status> {
         let replicas = self.as_factory().list(args).await?;
         Ok(replicas.into_iter().map(Into::into).collect::<Vec<_>>())
+    }
+    pub(crate) async fn list_ops(
+        &self,
+        args: &ListReplicaArgs,
+    ) -> Result<Vec<Box<dyn ReplicaOps>>, Status> {
+        let replicas = self.as_factory().list(args).await?;
+        Ok(replicas)
     }
     pub(crate) async fn list_snaps(
         &self,

--- a/io-engine/src/grpc/v1/snapshot.rs
+++ b/io-engine/src/grpc/v1/snapshot.rs
@@ -16,7 +16,6 @@ use crate::{
         GrpcResult,
         RWSerializer,
     },
-    replica_backend,
 };
 use ::function_name::named;
 use chrono::{DateTime, Utc};
@@ -227,6 +226,7 @@ use crate::{
         FindSnapshotArgs,
         ListCloneArgs,
         ListSnapshotArgs,
+        ReplicaFactory,
         SnapshotOps,
     },
 };
@@ -291,8 +291,8 @@ impl SnapshotGrpc {
     async fn finder(args: &FindSnapshotArgs) -> Result<Self, Status> {
         let mut error = None;
 
-        for factory in replica_backend::factories() {
-            match factory.find_snap(args).await {
+        for factory in ReplicaFactory::factories() {
+            match factory.as_factory().find_snap(args).await {
                 Ok(Some(snapshot)) => {
                     return Ok(Self(snapshot));
                 }

--- a/io-engine/src/lvm/mod.rs
+++ b/io-engine/src/lvm/mod.rs
@@ -49,7 +49,10 @@ use crate::{
     bdev::PtplFileOps,
     core::{
         snapshot::SnapshotDescriptor,
+        BdevStater,
+        BdevStats,
         CloneParams,
+        CoreError,
         NvmfShareProps,
         Protocol,
         PtplProps,
@@ -73,6 +76,7 @@ use crate::{
         ListCloneArgs,
         ListReplicaArgs,
         ListSnapshotArgs,
+        ReplicaBdevStats,
         ReplicaFactory,
         ReplicaOps,
         SnapshotOps,
@@ -161,6 +165,23 @@ impl PoolOps for VolumeGroup {
 }
 
 #[async_trait::async_trait(?Send)]
+impl BdevStater for VolumeGroup {
+    type Stats = BdevStats;
+
+    async fn stats(&self) -> Result<BdevStats, CoreError> {
+        Err(CoreError::NotSupported {
+            source: nix::errno::Errno::ENOSYS,
+        })
+    }
+
+    async fn reset_stats(&self) -> Result<(), CoreError> {
+        Err(CoreError::NotSupported {
+            source: nix::errno::Errno::ENOSYS,
+        })
+    }
+}
+
+#[async_trait::async_trait(?Send)]
 impl ReplicaOps for LogicalVolume {
     async fn share_nvmf(
         &mut self,
@@ -235,6 +256,24 @@ impl ReplicaOps for LogicalVolume {
         Err(Error::SnapshotNotSup {}.into())
     }
 }
+
+#[async_trait::async_trait(?Send)]
+impl BdevStater for LogicalVolume {
+    type Stats = ReplicaBdevStats;
+
+    async fn stats(&self) -> Result<ReplicaBdevStats, CoreError> {
+        Err(CoreError::NotSupported {
+            source: nix::errno::Errno::ENOSYS,
+        })
+    }
+
+    async fn reset_stats(&self) -> Result<(), CoreError> {
+        Err(CoreError::NotSupported {
+            source: nix::errno::Errno::ENOSYS,
+        })
+    }
+}
+
 #[async_trait::async_trait(?Send)]
 impl SnapshotOps for LogicalVolume {
     async fn destroy_snapshot(
@@ -369,6 +408,7 @@ impl PoolFactory for PoolLvmFactory {
             .map(|p| Box::new(p) as _)
             .collect::<Vec<_>>())
     }
+
     fn backend(&self) -> PoolBackend {
         PoolBackend::Lvm
     }

--- a/io-engine/src/lvm/mod.rs
+++ b/io-engine/src/lvm/mod.rs
@@ -62,22 +62,22 @@ use crate::{
     lvm::property::Property,
     pool_backend::{
         FindPoolArgs,
+        IPoolFactory,
         IPoolProps,
         ListPoolArgs,
         PoolArgs,
         PoolBackend,
-        PoolFactory,
         PoolOps,
         ReplicaArgs,
     },
     replica_backend::{
         FindReplicaArgs,
         FindSnapshotArgs,
+        IReplicaFactory,
         ListCloneArgs,
         ListReplicaArgs,
         ListSnapshotArgs,
         ReplicaBdevStats,
-        ReplicaFactory,
         ReplicaOps,
         SnapshotOps,
     },
@@ -343,7 +343,7 @@ impl IPoolProps for VolumeGroup {
 #[derive(Default)]
 pub struct PoolLvmFactory {}
 #[async_trait::async_trait(?Send)]
-impl PoolFactory for PoolLvmFactory {
+impl IPoolFactory for PoolLvmFactory {
     async fn create(
         &self,
         args: PoolArgs,
@@ -418,7 +418,7 @@ impl PoolFactory for PoolLvmFactory {
 #[derive(Default)]
 pub struct ReplLvmFactory {}
 #[async_trait::async_trait(?Send)]
-impl ReplicaFactory for ReplLvmFactory {
+impl IReplicaFactory for ReplLvmFactory {
     fn bdev_as_replica(
         &self,
         _bdev: crate::core::UntypedBdev,

--- a/io-engine/src/lvm/mod.rs
+++ b/io-engine/src/lvm/mod.rs
@@ -57,6 +57,7 @@ use crate::{
         Protocol,
         PtplProps,
         SnapshotParams,
+        UntypedBdev,
         UpdateProps,
     },
     lvm::property::Property,
@@ -254,6 +255,11 @@ impl ReplicaOps for LogicalVolume {
         _params: SnapshotParams,
     ) -> Result<Box<dyn SnapshotOps>, crate::pool_backend::Error> {
         Err(Error::SnapshotNotSup {}.into())
+    }
+
+    fn try_as_bdev(&self) -> Result<UntypedBdev, crate::pool_backend::Error> {
+        let bdev = Self::bdev(self.bdev_opts()?.uri())?;
+        Ok(bdev)
     }
 }
 

--- a/io-engine/src/lvs/lvol_iter.rs
+++ b/io-engine/src/lvs/lvol_iter.rs
@@ -1,0 +1,28 @@
+use super::Lvol;
+use crate::core::BdevIter;
+
+/// Iterator over available Lvs Lvol's.
+pub(crate) struct LvolIter(BdevIter<()>);
+
+impl LvolIter {
+    /// Returns a new Lvol iterator.
+    pub(crate) fn new() -> Self {
+        Self(BdevIter::new())
+    }
+}
+
+impl Iterator for LvolIter {
+    type Item = Lvol;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // notice we're hiding a potential inner loop here
+        // only way around this would be to have the iterator return an
+        // Option<Option<>> which perhaps is a bit confusing
+        for bdev in self.0.by_ref() {
+            if let Some(lvol) = Lvol::ok_from(bdev) {
+                return Some(lvol);
+            }
+        }
+        None
+    }
+}

--- a/io-engine/src/lvs/lvs_lvol.rs
+++ b/io-engine/src/lvs/lvs_lvol.rs
@@ -40,7 +40,6 @@ use crate::{
     bdev::PtplFileOps,
     core::{
         logical_volume::{LogicalVolume, LvolSpaceUsage},
-        wiper::{WipeMethod, Wiper},
         Bdev,
         CloneXattrs,
         LvolSnapshotOps,
@@ -49,7 +48,6 @@ use crate::{
         PtplProps,
         Share,
         SnapshotXattrs,
-        ToErrno,
         UntypedBdev,
         UpdateProps,
     },
@@ -338,22 +336,6 @@ impl Lvol {
             })?;
         }
         Ok(())
-    }
-
-    /// Get a wiper for this replica.
-    pub(crate) fn wiper(
-        &self,
-        wipe_method: WipeMethod,
-    ) -> Result<Wiper, LvsError> {
-        let hdl = Bdev::open(&self.as_bdev(), true)
-            .and_then(|desc| desc.into_handle())
-            .map_err(|e| LvsError::Invalid {
-                msg: e.to_string(),
-                source: BsError::from_errno(e.to_errno()),
-            })?;
-
-        let wiper = Wiper::new(hdl, wipe_method)?;
-        Ok(wiper)
     }
 
     /// generic callback for lvol operations
@@ -654,7 +636,7 @@ pub trait LvsLvol: LogicalVolume + Share {
     async fn resize_replica(&mut self, resize_to: u64) -> Result<(), LvsError>;
 }
 
-///  LogicalVolume implement Generic interface for Lvol.
+/// LogicalVolume implement Generic interface for Lvol.
 impl LogicalVolume for Lvol {
     /// Returns the name of the Snapshot.
     fn name(&self) -> String {

--- a/io-engine/src/lvs/lvs_lvol.rs
+++ b/io-engine/src/lvs/lvs_lvol.rs
@@ -371,11 +371,6 @@ impl Lvol {
             .send(errno_result_from_i32(lvol_ptr, errno))
             .expect("Receiver is gone");
     }
-    /// Format snapshot name
-    /// base_name is the nexus or replica UUID
-    pub fn format_snapshot_name(base_name: &str, snapshot_time: u64) -> String {
-        format!("{base_name}-snap-{snapshot_time}")
-    }
     /// Get a `PtplFileOps` from `&self`.
     pub(crate) fn ptpl(&self) -> impl PtplFileOps {
         LvolPtpl::from(self)

--- a/io-engine/src/lvs/mod.rs
+++ b/io-engine/src/lvs/mod.rs
@@ -48,7 +48,7 @@ pub mod lvs_lvol;
 mod lvs_store;
 
 use crate::{
-    core::{BdevStater, BdevStats, CoreError},
+    core::{BdevStater, BdevStats, CoreError, UntypedBdev},
     replica_backend::{FindSnapshotArgs, ReplicaBdevStats},
 };
 pub use lvol_snapshot::{LvolResult, LvolSnapshotDescriptor, LvolSnapshotOps};
@@ -120,6 +120,10 @@ impl ReplicaOps for Lvol {
     ) -> Result<Box<dyn SnapshotOps>, Error> {
         let snapshot = LvolSnapshotOps::create_snapshot(self, params).await?;
         Ok(Box::new(snapshot))
+    }
+
+    fn try_as_bdev(&self) -> Result<UntypedBdev, Error> {
+        Ok(self.as_bdev())
     }
 }
 

--- a/io-engine/src/lvs/mod.rs
+++ b/io-engine/src/lvs/mod.rs
@@ -13,20 +13,20 @@ use crate::{
     pool_backend::{
         Error,
         FindPoolArgs,
+        IPoolFactory,
         IPoolProps,
         ListPoolArgs,
         PoolArgs,
         PoolBackend,
-        PoolFactory,
         PoolOps,
         ReplicaArgs,
     },
     replica_backend::{
         FindReplicaArgs,
+        IReplicaFactory,
         ListCloneArgs,
         ListReplicaArgs,
         ListSnapshotArgs,
-        ReplicaFactory,
         ReplicaOps,
         SnapshotOps,
     },
@@ -242,7 +242,7 @@ impl IPoolProps for Lvs {
 #[derive(Default)]
 pub struct PoolLvsFactory {}
 #[async_trait::async_trait(?Send)]
-impl PoolFactory for PoolLvsFactory {
+impl IPoolFactory for PoolLvsFactory {
     async fn create(
         &self,
         args: PoolArgs,
@@ -315,7 +315,7 @@ impl PoolFactory for PoolLvsFactory {
 #[derive(Default)]
 pub struct ReplLvsFactory {}
 #[async_trait::async_trait(?Send)]
-impl ReplicaFactory for ReplLvsFactory {
+impl IReplicaFactory for ReplLvsFactory {
     fn bdev_as_replica(
         &self,
         bdev: crate::core::UntypedBdev,

--- a/io-engine/src/pool_backend.rs
+++ b/io-engine/src/pool_backend.rs
@@ -3,10 +3,11 @@ use crate::{
     replica_backend::ReplicaOps,
 };
 use nix::errno::Errno;
+use std::ops::Deref;
 
 /// PoolArgs is used to translate the input for the grpc
 /// Create/Import requests which contains name, uuid & disks.
-/// This help us avoid importing grpc structs in the actual lvs mod
+/// This helps us avoid importing grpc structs in the actual lvs mod
 #[derive(Clone, Debug, Default)]
 pub struct PoolArgs {
     pub name: String,
@@ -33,6 +34,34 @@ pub struct ReplicaArgs {
     pub(crate) entity_id: Option<String>,
 }
 
+/// Generic Errors shared by all backends.
+/// todo: most common errors should be moved here.
+#[derive(Debug, snafu::Snafu)]
+#[snafu(visibility(pub(crate)))]
+pub enum GenericError {
+    #[snafu(display("{message}"))]
+    NotFound { message: String },
+}
+impl From<GenericError> for tonic::Status {
+    fn from(e: GenericError) -> Self {
+        match e {
+            GenericError::NotFound {
+                message,
+            } => tonic::Status::not_found(message),
+        }
+    }
+}
+impl ToErrno for GenericError {
+    fn to_errno(self) -> Errno {
+        match self {
+            GenericError::NotFound {
+                ..
+            } => Errno::ENODEV,
+        }
+    }
+}
+
+/// Aggregated errors for all backends.
 #[derive(Debug, snafu::Snafu)]
 #[snafu(visibility(pub(crate)))]
 pub enum Error {
@@ -40,6 +69,8 @@ pub enum Error {
     Lvs { source: crate::lvs::LvsError },
     #[snafu(display("{source}"))]
     Lvm { source: crate::lvm::Error },
+    #[snafu(display("{source}"))]
+    Gen { source: GenericError },
 }
 impl From<crate::lvs::LvsError> for Error {
     fn from(source: crate::lvs::LvsError) -> Self {
@@ -55,6 +86,13 @@ impl From<crate::lvm::Error> for Error {
         }
     }
 }
+impl From<GenericError> for Error {
+    fn from(source: GenericError) -> Self {
+        Self::Gen {
+            source,
+        }
+    }
+}
 impl From<Error> for tonic::Status {
     fn from(e: Error) -> Self {
         match e {
@@ -62,6 +100,9 @@ impl From<Error> for tonic::Status {
                 source,
             } => source.into(),
             Error::Lvm {
+                source,
+            } => source.into(),
+            Error::Gen {
                 source,
             } => source.into(),
         }
@@ -74,6 +115,9 @@ impl ToErrno for Error {
                 source,
             } => source.to_errno(),
             Error::Lvm {
+                source,
+            } => source.to_errno(),
+            Error::Gen {
                 source,
             } => source.to_errno(),
         }
@@ -103,7 +147,7 @@ pub trait PoolOps:
 /// Interface for a pool factory which can be used for various
 /// pool creation and listings, for a specific backend type.
 #[async_trait::async_trait(?Send)]
-pub trait PoolFactory {
+pub trait IPoolFactory {
     /// Create a pool using the provided arguments.
     async fn create(&self, args: PoolArgs) -> Result<Box<dyn PoolOps>, Error>;
     /// Import a pool (do not create it!) using the provided arguments.
@@ -185,4 +229,61 @@ pub trait IPoolProps {
     fn committed(&self) -> u64;
     fn pool_type(&self) -> PoolBackend;
     fn cluster_size(&self) -> u32;
+}
+
+/// A pool factory helper.
+pub struct PoolFactory(Box<dyn IPoolFactory>);
+impl PoolFactory {
+    /// Get all available backends.
+    pub fn all_backends() -> Vec<PoolBackend> {
+        vec![PoolBackend::Lvm, PoolBackend::Lvs]
+    }
+    /// Get all **enabled** backends.
+    pub fn backends() -> Vec<PoolBackend> {
+        let backends = Self::all_backends().into_iter();
+        backends.filter(|b| b.enabled().is_ok()).collect()
+    }
+    /// Get factories for all **enabled** backends.
+    pub fn factories() -> Vec<Self> {
+        Self::backends().into_iter().map(Self::new).collect()
+    }
+    /// Returns the factory for the given backend kind.
+    pub fn new(backend: PoolBackend) -> Self {
+        Self(match backend {
+            PoolBackend::Lvs => {
+                Box::<crate::lvs::PoolLvsFactory>::default() as _
+            }
+            PoolBackend::Lvm => {
+                Box::<crate::lvm::PoolLvmFactory>::default() as _
+            }
+        })
+    }
+    /// Probe backends for the given name and/or uuid and return the right one.
+    pub async fn find<I: Into<FindPoolArgs>>(
+        args: I,
+    ) -> Result<Box<dyn PoolOps>, Error> {
+        let args = args.into();
+        let mut error = None;
+
+        for factory in Self::factories() {
+            match factory.0.find(&args).await {
+                Ok(Some(pool)) => {
+                    return Ok(pool);
+                }
+                Ok(None) => {}
+                Err(err) => {
+                    error = Some(err);
+                }
+            }
+        }
+        Err(error.unwrap_or_else(|| Error::Gen {
+            source: GenericError::NotFound {
+                message: format!("Pool {args:?} not found"),
+            },
+        }))
+    }
+    /// Get the inner factory interface.
+    pub fn as_factory(&self) -> &dyn IPoolFactory {
+        self.0.deref()
+    }
 }

--- a/io-engine/src/pool_backend.rs
+++ b/io-engine/src/pool_backend.rs
@@ -203,15 +203,15 @@ impl From<&PoolArgs> for FindPoolArgs {
 }
 impl FindPoolArgs {
     /// Find pools by name and optional uuid.
-    pub fn name_uuid(name: &str, uuid: &Option<String>) -> Self {
+    pub fn name_uuid(name: String, uuid: &Option<String>) -> Self {
         Self::NameUuid {
-            name: name.to_owned(),
+            name,
             uuid: uuid.to_owned(),
         }
     }
     /// Find pools by uuid.
-    pub fn uuid(uuid: &String) -> Self {
-        Self::Uuid(uuid.to_string())
+    pub fn uuid(uuid: String) -> Self {
+        Self::Uuid(uuid)
     }
     /// Back compat which finds pools by uuid and fallback to name.
     pub fn uuid_or_name(id: &String) -> Self {

--- a/io-engine/src/replica_backend.rs
+++ b/io-engine/src/replica_backend.rs
@@ -8,6 +8,7 @@ use crate::core::{
     Protocol,
     PtplProps,
     SnapshotParams,
+    UntypedBdev,
     UpdateProps,
 };
 use std::{fmt::Debug, ops::Deref};
@@ -82,6 +83,9 @@ pub trait ReplicaOps:
         &mut self,
         params: SnapshotParams,
     ) -> Result<Box<dyn SnapshotOps>, crate::pool_backend::Error>;
+
+    /// Returns the underlying bdev of the Logical Volume, if open.
+    fn try_as_bdev(&self) -> Result<UntypedBdev, crate::pool_backend::Error>;
 }
 
 /// Snapshot Operations for snapshots created by `ReplicaOps`.

--- a/io-engine/src/subsys/mod.rs
+++ b/io-engine/src/subsys/mod.rs
@@ -8,7 +8,6 @@ pub use config::{
     ConfigSubsystem,
 };
 pub use nvmf::{
-    create_snapshot,
     set_snapshot_time,
     Error as NvmfError,
     NvmeCpl,

--- a/io-engine/src/subsys/nvmf/admin_cmd.rs
+++ b/io-engine/src/subsys/nvmf/admin_cmd.rs
@@ -13,7 +13,7 @@ use crate::{
 
 use crate::{
     core::{ToErrno, UntypedBdev},
-    replica_backend::bdev_as_replica,
+    replica_backend::ReplicaFactory,
 };
 use spdk_rs::{
     libspdk::{
@@ -220,7 +220,7 @@ async fn create_remote_snapshot(
     params: SnapshotParams,
     nvmf_req: NvmfReq,
 ) {
-    let Some(mut replica_ops) = bdev_as_replica(bdev) else {
+    let Some(mut replica_ops) = ReplicaFactory::bdev_as_replica(bdev) else {
         debug!("unsupported bdev driver");
         nvmf_req.complete_error(nix::errno::Errno::ENOTSUP as i32);
         return;

--- a/io-engine/src/subsys/nvmf/admin_cmd.rs
+++ b/io-engine/src/subsys/nvmf/admin_cmd.rs
@@ -8,31 +8,20 @@ use std::{
 
 use crate::{
     bdev::{nexus, nvmx::NvmeSnapshotMessage},
-    core::{
-        logical_volume::LogicalVolume,
-        snapshot::LvolSnapshotOps,
-        Bdev,
-        Reactors,
-        SnapshotParams,
-    },
-    lvs::Lvol,
+    core::{Bdev, Reactors, SnapshotParams},
 };
 
 use crate::{
     core::{ToErrno, UntypedBdev},
     replica_backend::bdev_as_replica,
 };
-use chrono::Utc;
 use spdk_rs::{
     libspdk::{
         nvme_cmd_cdw10_get,
-        nvme_cmd_cdw10_get_val,
         nvme_cmd_cdw11_get,
-        nvme_cmd_cdw11_get_val,
         nvme_status_get,
         spdk_bdev,
         spdk_bdev_desc,
-        spdk_bdev_io,
         spdk_io_channel,
         spdk_nvme_cmd,
         spdk_nvme_cpl,
@@ -49,7 +38,6 @@ use spdk_rs::{
         spdk_nvmf_subsystem_get_max_nsid,
     },
     nvme_admin_opc,
-    Uuid,
 };
 
 #[warn(unused_variables)]
@@ -256,37 +244,6 @@ async fn create_remote_snapshot(
             nvmf_req.complete_error(error.to_errno() as i32)
         }
     }
-}
-pub fn create_snapshot(
-    lvol: Lvol,
-    cmd: &spdk_nvme_cmd,
-    _io: *mut spdk_bdev_io,
-) {
-    let snapshot_time = unsafe {
-        nvme_cmd_cdw10_get_val(cmd) as u64
-            | (nvme_cmd_cdw11_get_val(cmd) as u64) << 32
-    };
-    let snapshot_name = Lvol::format_snapshot_name(&lvol.name(), snapshot_time);
-    let snap_param = SnapshotParams::new(
-        Some(lvol.name()),
-        Some(lvol.name()),
-        Some(Uuid::generate().to_string()),
-        Some(snapshot_name),
-        Some(Uuid::generate().to_string()),
-        Some(Utc::now().to_string()),
-        false,
-    );
-    // Blobfs operations must be on md_thread
-    Reactors::master().send_future(async move {
-        match lvol.create_snapshot(snap_param).await {
-            Ok(lvol) => {
-                info!("Create Snapshot {:?} Success!", lvol);
-            }
-            Err(e) => {
-                error!("Create Snapshot Failed with Error: {:?}", e);
-            }
-        }
-    });
 }
 
 /// Register custom NVMe admin command handler

--- a/io-engine/src/subsys/nvmf/mod.rs
+++ b/io-engine/src/subsys/nvmf/mod.rs
@@ -13,7 +13,7 @@ use std::{cell::RefCell, mem::zeroed};
 use nix::errno::Errno;
 use snafu::Snafu;
 
-pub use admin_cmd::{create_snapshot, set_snapshot_time, NvmeCpl, NvmfReq};
+pub use admin_cmd::{set_snapshot_time, NvmeCpl, NvmfReq};
 use poll_groups::PollGroup;
 use spdk_rs::libspdk::{
     spdk_subsystem,

--- a/io-engine/tests/replica_snapshot.rs
+++ b/io-engine/tests/replica_snapshot.rs
@@ -2,7 +2,7 @@ use io_engine::{
     bdev::nexus::nexus_create,
     constants::NVME_NQN_PREFIX,
     core::{CoreError, MayastorCliArgs, SnapshotParams, UntypedBdevHandle},
-    lvs::{Lvol, Lvs},
+    lvs::Lvs,
     pool_backend::{PoolArgs, PoolBackend},
 };
 use tracing::info;
@@ -169,13 +169,18 @@ async fn create_nexus(t: u64, ip: &std::net::IpAddr) {
     if t > 0 {
         children
             .iter_mut()
-            .for_each(|c| *c = Lvol::format_snapshot_name(c, t));
+            .for_each(|c| *c = format_snapshot_name(c, t));
         nexus_name = NXNAME_SNAP;
     }
 
     nexus_create(nexus_name, 64 * 1024 * 1024, None, &children)
         .await
         .unwrap();
+}
+/// Format snapshot name
+/// base_name is the nexus or replica UUID
+fn format_snapshot_name(base_name: &str, snapshot_time: u64) -> String {
+    format!("{base_name}-snap-{snapshot_time}")
 }
 
 async fn create_snapshot() -> Result<u64, CoreError> {

--- a/scripts/cargo-test.sh
+++ b/scripts/cargo-test.sh
@@ -5,6 +5,7 @@ SCRIPTDIR="$(realpath "$(dirname "$0")")"
 cleanup_handler() {
   ERROR=$?
   "$SCRIPTDIR"/clean-cargo-tests.sh || true
+  trap '' EXIT
   if [ $ERROR != 0 ]; then exit $ERROR; fi
 }
 
@@ -15,8 +16,9 @@ rustc --version
 cleanup_handler
 trap cleanup_handler INT QUIT TERM HUP EXIT
 
-set -euxo pipefail
 export PATH=$PATH:${HOME}/.cargo/bin
+set -euxo pipefail
+
 ( cd jsonrpc && cargo test )
 # test dependencies
 cargo build --bins --features=io-engine-testing

--- a/scripts/clean-cargo-tests.sh
+++ b/scripts/clean-cargo-tests.sh
@@ -3,7 +3,7 @@
 SCRIPT_DIR="$(dirname "$0")"
 ROOT_DIR=$(realpath "$SCRIPT_DIR/..")
 
-sudo nvme disconnect-all
+nix-sudo nvme disconnect-all
 
 # Detach any loop devices created for test purposes
 for back_file in "/tmp/io-engine-tests"/*; do
@@ -14,12 +14,12 @@ for back_file in "/tmp/io-engine-tests"/*; do
     while IFS= read -r device; do
         if [ -n "$device" ]; then
             echo "Detaching loop device: $device"
-            losetup -d "$device"
+            sudo losetup -d "$device"
         fi
     done <<< "$devices"
 done
 # Delete the directory too
-rmdir --ignore-fail-on-non-empty "/tmp/io-engine-tests"
+nix-sudo rmdir --ignore-fail-on-non-empty "/tmp/io-engine-tests" 2>/dev/null
 
 
 for c in $(docker ps -a --filter "label=io.composer.test.name" --format '{{.ID}}') ; do


### PR DESCRIPTION
    ci: use sudo to remove test files
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    refactor(wipe): use new backend traits
    
    Use traits rather than explicitly use Lvol.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    refactor(backends): reuse common factory code
    
    Move common code to the factories allowing us to reuse code between
    core components and grpc service.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    refactor(snapshot): remove unused create-snapshot
    
    Removes unused function still making use of Lvol.
    Probably not previously detected because it was being exposed as pub.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    refactor(stats): use new ops interface
    
    Use new ops interfaces rather than hardcoded lvs/lvol.
    This will help support stats for other pool backends.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>