### PR TITLE
Cherry-pick 1711 - reactor block_on is harmful as it delays message polling

### DIFF
--- a/io-engine/src/bdev/nexus/nexus_bdev_children.rs
+++ b/io-engine/src/bdev/nexus/nexus_bdev_children.rs
@@ -900,7 +900,7 @@ impl<'n> Nexus<'n> {
                         nexus_name,
                         child_device, "Unplugging nexus child device",
                     );
-                    child.unplug();
+                    child.unplug().await;
                 }
                 None => {
                     warn!(

--- a/io-engine/src/bdev/nvmx/controller.rs
+++ b/io-engine/src/bdev/nvmx/controller.rs
@@ -1072,8 +1072,11 @@ pub(crate) mod options {
             self.admin_timeout_ms = Some(timeout);
             self
         }
-        pub fn with_fabrics_connect_timeout_us(mut self, timeout: u64) -> Self {
-            self.fabrics_connect_timeout_us = Some(timeout);
+        pub fn with_fabrics_connect_timeout_us<T: Into<Option<u64>>>(
+            mut self,
+            timeout: T,
+        ) -> Self {
+            self.fabrics_connect_timeout_us = timeout.into();
             self
         }
 

--- a/io-engine/src/bdev/nvmx/qpair.rs
+++ b/io-engine/src/bdev/nvmx/qpair.rs
@@ -468,9 +468,9 @@ impl<'a> Connection<'a> {
             0 => Ok(false),
             // Connection is still in progress, keep polling.
             1 => Ok(true),
-            // Error occured during polling.
+            // Error occurred during polling.
             e => {
-                let e = Errno::from_i32(-e);
+                let e = Errno::from_i32(e.abs());
                 error!(?self, "I/O qpair async connection polling error: {e}");
                 Err(e)
             }

--- a/io-engine/src/bdev/nvmx/uri.rs
+++ b/io-engine/src/bdev/nvmx/uri.rs
@@ -227,6 +227,12 @@ impl<'probe> NvmeControllerContext<'probe> {
             )
             .with_transport_retry_count(
                 Config::get().nvme_bdev_opts.transport_retry_count as u8,
+            )
+            .with_fabrics_connect_timeout_us(
+                crate::subsys::config::opts::try_from_env(
+                    "NVMF_FABRICS_CONNECT_TIMEOUT",
+                    1_000_000,
+                ),
             );
 
         let hostnqn = template.hostnqn.clone().or_else(|| {

--- a/io-engine/src/core/reactor.rs
+++ b/io-engine/src/core/reactor.rs
@@ -362,8 +362,15 @@ impl Reactor {
         task
     }
 
-    /// spawn a future locally on the current core block until the future is
+    /// Spawns a future locally on the current core block until the future is
     /// completed. The master core is used.
+    /// # Warning
+    /// This code should only be used for testing and not running production!
+    /// This is because when calling block_on from a thread_poll callback, we
+    /// may be leaving messages behind, which can lead to timeouts etc...
+    /// A work-around to make this safe could be to potentially "pull" the
+    /// messages which haven't been polled, and poll them here before
+    /// proceeding to re-poll via thread_poll again.
     pub fn block_on<F, R>(future: F) -> Option<R>
     where
         F: Future<Output = R> + 'static,

--- a/io-engine/src/grpc/mod.rs
+++ b/io-engine/src/grpc/mod.rs
@@ -2,7 +2,6 @@ use futures::channel::oneshot::Receiver;
 use nix::errno::Errno;
 pub use server::MayastorGrpcServer;
 use std::{
-    error::Error,
     fmt::{Debug, Display},
     future::Future,
     time::Duration,
@@ -157,22 +156,6 @@ macro_rules! spdk_submit {
 }
 
 pub type GrpcResult<T> = std::result::Result<Response<T>, Status>;
-
-/// call the given future within the context of the reactor on the first core
-/// on the init thread, while the future is waiting to be completed the reactor
-/// is continuously polled so that forward progress can be made
-pub fn rpc_call<G, I, L, A>(future: G) -> Result<Response<A>, tonic::Status>
-where
-    G: Future<Output = Result<I, L>> + 'static,
-    I: 'static,
-    L: Into<Status> + Error + 'static,
-    A: 'static + From<I>,
-{
-    Reactor::block_on(future)
-        .unwrap()
-        .map(|r| Response::new(A::from(r)))
-        .map_err(|e| e.into())
-}
 
 /// Submit rpc code to the primary reactor.
 pub fn rpc_submit<F, R, E>(

--- a/io-engine/src/subsys/config/opts.rs
+++ b/io-engine/src/subsys/config/opts.rs
@@ -174,7 +174,7 @@ pub struct NvmfTcpTransportOpts {
 }
 
 /// try to read an env variable or returns the default when not found
-fn try_from_env<T>(name: &str, default: T) -> T
+pub(crate) fn try_from_env<T>(name: &str, default: T) -> T
 where
     T: FromStr + Display + Copy,
     <T as FromStr>::Err: Debug + Display,


### PR DESCRIPTION
Reactor block_on may prevent spdk thread messages from running and therefore this can lead to starvation of messages pulled from the thread ring, which are not polled during the block_on.
There are still a few uses remaining, most during init setup, so mostly harmless, though the Nexus Bdev destruction which runs on blocking code, does still contain a block_on.

---

    fix(nvmf/target): remove usage of block_on
    
    Split creating from starting the subsystem.
    This way we can start the subsystem in master reactor, and then move
    to the next spdk subsystem.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    fix(nexus-child/unplug): remove usage of block_on
    
    Initially this block_on was added because the remove callback was running in blocking
    fashion, but this has since changed and unplug is actually called from async context.
    As such, we don't need the block_on and simply call the async code directly.
    Also, simplify complete notification, as we can simply close the sender.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    fix(nvmx/qpair): return errno with absolute value
    
    Otherwise a returned negative value translates into an unknown Errno.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    feat: allow custom fabrics connect timeout
    
    Allows passing this via env NVMF_FABRICS_CONNECT_TIMEOUT.
    Also defaults it to 1s for now, rather than 500ms.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>