### PR TITLE
Fix stuck rebuilds and stuck nexus subsystems

### DIFF
--- a/io-engine/src/bdev/nexus/nexus_channel.rs
+++ b/io-engine/src/bdev/nexus/nexus_channel.rs
@@ -32,13 +32,14 @@ impl<'n> Debug for NexusChannel<'n> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "{io} chan '{nex}' core:{core}({cur}) [R:{r} W:{w} L:{l} C:{c}]",
+            "{io} chan '{nex}' core:{core}({cur}) [R:{r} W:{w} D:{d} L:{l} C:{c}]",
             io = if self.is_io_chan { "I/O" } else { "Aux" },
             nex = self.nexus.nexus_name(),
             core = self.core,
             cur = Cores::current(),
             r = self.readers.len(),
             w = self.writers.len(),
+            d = self.detached.len(),
             l = self.io_logs.len(),
             c = self.nexus.child_count(),
         )

--- a/io-engine/src/core/device_events.rs
+++ b/io-engine/src/core/device_events.rs
@@ -19,8 +19,14 @@ pub enum DeviceEventType {
     DeviceResized,
     /// TODO
     MediaManagement,
-    /// TODO
+    /// Sent when admin q polling fails for the first time.
     AdminCommandCompletionFailed,
+    /// When the adminq poll fails the first time, the controller may not yet
+    /// be failed.
+    /// Next time the admin q poll fails, if the controller is noticed as
+    /// failed for the first time, this event is sent, allowing further
+    /// clean up to be performed.
+    AdminQNoticeCtrlFailed,
 }
 
 /// TODO

--- a/io-engine/src/core/env.rs
+++ b/io-engine/src/core/env.rs
@@ -381,7 +381,7 @@ type Result<T, E = EnvError> = std::result::Result<T, E>;
 #[allow(dead_code)]
 pub struct MayastorEnvironment {
     pub node_name: String,
-    node_nqn: Option<String>,
+    pub node_nqn: Option<String>,
     pub grpc_endpoint: Option<std::net::SocketAddr>,
     pub registration_endpoint: Option<Uri>,
     ps_endpoint: Option<String>,
@@ -420,7 +420,7 @@ pub struct MayastorEnvironment {
     nvmf_tgt_interface: Option<String>,
     /// NVMF target Command Retry Delay in x100 ms.
     pub nvmf_tgt_crdt: [u16; TARGET_CRDT_LEN],
-    api_versions: Vec<ApiVersion>,
+    pub api_versions: Vec<ApiVersion>,
     skip_sig_handler: bool,
     enable_io_all_thrd_nexus_channels: bool,
     developer_delay: bool,

--- a/io-engine/src/rebuild/rebuild_job.rs
+++ b/io-engine/src/rebuild/rebuild_job.rs
@@ -320,7 +320,7 @@ impl RebuildJob {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 struct RebuildFBendChan {
     sender: async_channel::Sender<RebuildJobRequest>,
 }

--- a/io-engine/src/subsys/config/opts.rs
+++ b/io-engine/src/subsys/config/opts.rs
@@ -416,7 +416,7 @@ impl Default for NvmeBdevOpts {
             nvme_adminq_poll_period_us: time_try_from_env(
                 "NVME_ADMINQ_POLL_PERIOD",
                 1_000,
-                TimeUnit::MilliSeconds,
+                TimeUnit::MicroSeconds,
             ),
             nvme_ioq_poll_period_us: time_try_from_env(
                 "NVME_IOQ_POLL_PERIOD",

--- a/io-engine/tests/block_device_nvmf.rs
+++ b/io-engine/tests/block_device_nvmf.rs
@@ -1842,6 +1842,9 @@ async fn nvmf_device_hot_remove() {
 
     impl DeviceEventListener for TestEventListener {
         fn handle_device_event(&self, event: DeviceEventType, device: &str) {
+            if event == DeviceEventType::AdminQNoticeCtrlFailed {
+                return; // Not interested in this one
+            }
             // Check event type and device name.
             assert_eq!(event, DeviceEventType::DeviceRemoved);
             assert_eq!(


### PR DESCRIPTION
    fix(nvmx/retire): disconnect failed controllers
    
    When we are pausing the nexus, all IO must get flushed before
    the subsystem pausing completes.
    If we can't flush the IO then pausing is stuck forever...
    
    The issue we have seen is that when IO's are stuck there's
    nothing which can fail them and allow pause to complete.
    One way this can happen is when the controller is failed as
    it seems in this case the io queues are not getting polled.
    
    A first fix that can be done is to piggy back on the adminq
    polling failure and use this to drive the removal of the
    failed child devices from the nexus per-core channels.
    
    A better approach might be needed in the future to be able
    to timeout the IOs even when no completions are processed
    in a given I/O qpair.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    fix(opts): convert adminq poll period to us
    
    This seems to have been mistakenly added as ms.
    In practice this would have caused no harm as this value is not
    currently being overrided by the helm chart.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    fix(rebuild): ensure comms channel is drained on drop
    
    When the rebuild backend is dropped, we must also drain the async channel.
    This covers a corner case where a message may be sent at the same time as
    we're dropping and in this case the message would hang.
    
    This is not a hang for prod as there we have timeouts which would
    eventually cancel the future and allow the drop, though this can still
    lead to timeouts and confusion.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>
