### PR TITLE
feat(lvs): adding support for pool grow and related tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -826,6 +826,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "csv"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac574ff4d437a7b5ad237ef331c17ccca63c46479e5b5453eb8e10bb99a759fe"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efa2b3d7902f4b634a20cae3c9c4e6209dc4779feb6863329607560143efa70"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -968,6 +989,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
 name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1005,6 +1047,12 @@ name = "either"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "enum-primitive-derive"
@@ -1642,6 +1690,7 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "pin-utils",
+ "prettytable-rs",
  "prost",
  "prost-derive",
  "rand",
@@ -1924,6 +1973,16 @@ dependencies = [
  "snafu",
  "udev",
  "url",
+]
+
+[[package]]
+name = "libredox"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+dependencies = [
+ "bitflags 2.4.0",
+ "libc",
 ]
 
 [[package]]
@@ -2371,6 +2430,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettytable-rs"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eea25e07510aa6ab6547308ebe3c036016d162b8da920dbb079e3ba8acf3d95a"
+dependencies = [
+ "csv",
+ "encode_unicode",
+ "is-terminal",
+ "lazy_static",
+ "term",
+ "unicode-width",
+]
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2535,6 +2608,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
  "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891"
+dependencies = [
+ "getrandom",
+ "libredox",
+ "thiserror",
 ]
 
 [[package]]
@@ -3130,6 +3214,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "term"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
+dependencies = [
+ "dirs-next",
+ "rustversion",
+ "winapi",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3503,6 +3598,12 @@ checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
 
 [[package]]
 name = "unsafe-libyaml"

--- a/io-engine-tests/src/compose/mod.rs
+++ b/io-engine-tests/src/compose/mod.rs
@@ -78,8 +78,15 @@ impl<'a> MayastorTest<'a> {
     }
 
     pub fn new(args: MayastorCliArgs) -> MayastorTest<'static> {
+        Self::new_ex(args, None)
+    }
+
+    pub fn new_ex(
+        args: MayastorCliArgs,
+        log_level: Option<&str>,
+    ) -> MayastorTest<'static> {
         let (tx, rx) = bounded(1);
-        mayastor_test_init_ex(args.log_format.unwrap_or_default());
+        mayastor_test_init_ex(args.log_format.unwrap_or_default(), log_level);
         let thdl = std::thread::Builder::new()
             .name("mayastor_master".into())
             .spawn(move || {

--- a/io-engine-tests/src/lib.rs
+++ b/io-engine-tests/src/lib.rs
@@ -130,10 +130,10 @@ macro_rules! test_init {
 }
 
 pub fn mayastor_test_init() {
-    mayastor_test_init_ex(LogFormat::default());
+    mayastor_test_init_ex(LogFormat::default(), None);
 }
 
-pub fn mayastor_test_init_ex(log_format: LogFormat) {
+pub fn mayastor_test_init_ex(log_format: LogFormat, log_level: Option<&str>) {
     fn binary_present(name: &str) -> Result<bool, std::env::VarError> {
         std::env::var("PATH").map(|paths| {
             paths
@@ -151,7 +151,11 @@ pub fn mayastor_test_init_ex(log_format: LogFormat) {
             }
         });
 
-    logger::init_ex("info,io_engine=DEBUG", log_format, None);
+    logger::init_ex(
+        log_level.unwrap_or("info,io_engine=DEBUG"),
+        log_format,
+        None,
+    );
 
     io_engine::CPS_INIT!();
 }

--- a/io-engine/Cargo.toml
+++ b/io-engine/Cargo.toml
@@ -42,6 +42,10 @@ path = "src/bin/jsonrpc.rs"
 name = "casperf"
 path = "src/bin/casperf.rs"
 
+[[example]]
+name = "lvs-eval"
+path = "examples/lvs-eval/main.rs"
+
 [dependencies]
 ansi_term = "0.12.1"
 async-channel = "1.9.0"
@@ -125,4 +129,5 @@ version = "1.4.1"
 assert_matches = "1.5.0"
 io-engine-tests = { path = "../io-engine-tests" }
 libnvme-rs = { path = "../libnvme-rs", version = "0.1.0" }
+prettytable-rs = "0.10.0"
 run_script = "0.10.1"

--- a/io-engine/examples/lvs-eval/display.rs
+++ b/io-engine/examples/lvs-eval/display.rs
@@ -1,0 +1,244 @@
+use io_engine::{
+    core::{LogicalVolume, UntypedBdev},
+    lvs::{Lvol, Lvs, LvsLvol},
+};
+use prettytable::{row, Table};
+use spdk_rs::libspdk::{
+    spdk_bit_array,
+    spdk_bit_array_capacity,
+    spdk_bit_array_get,
+    spdk_bit_pool,
+    spdk_bit_pool_capacity,
+    spdk_bit_pool_is_allocated,
+    spdk_blob_calc_used_clusters,
+    spdk_blob_is_thin_provisioned,
+    spdk_blob_mut_data,
+    spdk_blob_store,
+};
+
+/// TODO
+pub async fn print_lvs(lvs: &Lvs) {
+    print_separator("LVS", 0);
+
+    print_bdev(lvs.base_bdev());
+    print_lvs_data(lvs);
+    print_replicas(lvs);
+}
+
+/// TODO
+pub fn print_bdev(bdev: UntypedBdev) {
+    print_separator("Bdev", 0);
+
+    let mut tab = Table::new();
+
+    tab.add_row(row!["name", bdev.name()]);
+    tab.add_row(row!["size", bdev.size_in_bytes(), "bytes"]);
+    tab.add_row(row!["  |-", bdev.size_in_bytes() / (1024 * 1024), "Mb"]);
+    tab.add_row(row!["block_len", bdev.block_len(), "bytes"]);
+    tab.add_row(row!["num_blocks", bdev.num_blocks(), "blocks"]);
+
+    print_table(tab);
+
+    println!();
+}
+
+/// TODO
+pub fn print_lvs_data(lvs: &Lvs) {
+    print_separator("Blob store", 0);
+
+    let bs = unsafe { &*lvs.blob_store() };
+
+    let mut tab = Table::new();
+
+    tab.add_row(row!["md_start", bs.md_start, "pages"]);
+    tab.add_row(row!["md_len", bs.md_len, "pages"]);
+    tab.add_row(row!["cluster_sz", bs.cluster_sz, "bytes"]);
+    tab.add_row(row!["  |-------", bs.cluster_sz / (1024 * 1024), "Mb"]);
+    tab.add_row(row!["total_clusters", bs.total_clusters]);
+    tab.add_row(row!["total_data_clusters", bs.total_data_clusters]);
+    tab.add_row(row![
+        "md_clusters",
+        bs.total_clusters - bs.total_data_clusters
+    ]);
+    tab.add_row(row!["num_free_clusters", bs.num_free_clusters]);
+    tab.add_row(row!["pages_per_cluster", bs.pages_per_cluster]);
+    tab.add_row(row!["io_unit_size", bs.io_unit_size, "bytes"]);
+    tab.add_row(row![]);
+    tab.add_row(row!["page_size", lvs.page_size(), "bytes"]);
+    tab.add_row(row!["md_pages", lvs.md_pages()]);
+    tab.add_row(row!["md_used_pages", lvs.md_used_pages()]);
+
+    print_table(tab);
+    println!();
+
+    // Used MD pages.
+    println!("Used MD pages:");
+    print!("  ");
+    print_used_array_bits(bs.used_md_pages, Some(bs.md_len));
+    println!();
+
+    // Used clusters.
+    println!("Used clusters:");
+    print!("  ");
+    print_used_pool_bits(bs.used_clusters, Some(bs.total_clusters as u32));
+    println!();
+
+    // Used blob IDs.
+    println!("Used blob IDs:");
+    print!("  ");
+    print_used_array_bits(bs.used_blobids, None);
+    println!();
+
+    // Open blobs.
+    println!("Open blob IDs:");
+    print!("  ");
+    print_used_array_bits(bs.open_blobids, None);
+    println!();
+}
+
+/// TODO
+pub fn print_replicas(lvs: &Lvs) {
+    print_separator("Replicas", 0);
+
+    for (idx, lvol) in lvs.lvols().unwrap().enumerate() {
+        print_separator(&format!("Replica #{idx}:"), 1);
+        print_replica(&lvol);
+    }
+
+    print_separator("End of replicas", 0);
+}
+
+/// TODO
+pub fn print_replica(lvol: &Lvol) {
+    let blob = unsafe { &*lvol.blob_checked() };
+    let bs = unsafe { &*blob.bs };
+
+    let mut tab = Table::new();
+
+    let num_allocated_clusters =
+        unsafe { spdk_blob_calc_used_clusters(blob as *const _ as *mut _) };
+
+    tab.add_row(row!["id", format!("0x{:x}", blob.id)]);
+    tab.add_row(row!["parent_id", format!("0x{:x}", blob.parent_id)]);
+    tab.add_row(row!["name", lvol.name()]);
+    tab.add_row(row!["uuid", lvol.uuid()]);
+    tab.add_row(row!["is thin", unsafe {
+        spdk_blob_is_thin_provisioned(blob as *const _ as *mut _)
+    }]);
+    tab.add_row(row!["num_clusters", blob.active.num_clusters]);
+    tab.add_row(row!["alloc clusters", num_allocated_clusters]);
+    tab.add_row(row![
+        "size",
+        blob.active.num_clusters * bs.cluster_sz as u64,
+        "bytes"
+    ]);
+
+    print_table(tab);
+
+    println!();
+    print_blob_data("Active data", bs, &blob.active);
+
+    println!();
+}
+
+/// TODO
+pub fn print_blob_data(
+    name: &str,
+    bs: &spdk_blob_store,
+    blob: &spdk_blob_mut_data,
+) {
+    println!("{name}:");
+
+    // Clusters.
+    println!(
+        "  Clusters: {} / {}",
+        blob.num_clusters, blob.num_allocated_clusters
+    );
+    print!("    ");
+    for i in 0 .. blob.num_allocated_clusters as isize {
+        let lba = unsafe { *blob.clusters.offset(i) };
+        let num = lba_to_cluster(bs, lba);
+        print!("0x{num:x} ");
+    }
+    println!("\n");
+
+    // LBAs.
+    println!(
+        "  LBAs: {} / {}",
+        blob.num_clusters, blob.num_allocated_clusters
+    );
+    print!("    ");
+    for i in 0 .. blob.num_allocated_clusters as isize {
+        let c = unsafe { *blob.clusters.offset(i) };
+        print!("0x{c:x} ");
+    }
+    println!("\n");
+
+    // EPs.
+    println!(
+        "  Extent_pages: {} / {}",
+        blob.num_extent_pages, blob.extent_pages_array_size
+    );
+    print!("    ");
+    for i in 0 .. blob.extent_pages_array_size as isize {
+        let c = unsafe { *blob.extent_pages.offset(i) };
+        print!("0x{c:x} ");
+    }
+    println!();
+}
+
+/// TODO
+fn print_table(mut tab: Table) {
+    tab.set_titles(row!["Name", "Value", "Units"]);
+    tab.set_format(*prettytable::format::consts::FORMAT_NO_LINESEP_WITH_TITLE);
+    tab.printstd();
+}
+
+/// TODO
+fn print_used_array_bits(ba: *const spdk_bit_array, cnt: Option<u32>) {
+    let cnt = cnt.unwrap_or_else(|| unsafe { spdk_bit_array_capacity(ba) });
+    let mut total = 0;
+
+    for i in 0 .. cnt {
+        let v = unsafe { spdk_bit_array_get(ba, i) };
+        if v {
+            print!("0x{i:x} ");
+            total += 1;
+        }
+    }
+
+    println!();
+    println!("  Total: {total}");
+}
+
+/// TODO
+fn print_used_pool_bits(bp: *const spdk_bit_pool, cnt: Option<u32>) {
+    let cnt = cnt.unwrap_or_else(|| unsafe { spdk_bit_pool_capacity(bp) });
+    let mut total = 0;
+
+    for i in 0 .. cnt {
+        let v = unsafe { spdk_bit_pool_is_allocated(bp, i) };
+        if v {
+            print!("0x{i:x} ");
+            total += 1;
+        }
+    }
+
+    println!();
+    println!("  Total: {total}");
+}
+
+/// TODO
+fn print_separator(title: &str, level: u8) {
+    let title = format!(" {title} ");
+    if level == 0 {
+        println!("{:=^1$}\n", title, 70);
+    } else {
+        println!("{:-^1$}\n", title, 50);
+    }
+}
+
+/// TODO
+fn lba_to_cluster(bs: &spdk_blob_store, lba: u64) -> u64 {
+    unsafe { lba / (bs.cluster_sz / (*bs.dev).blocklen) as u64 }
+}

--- a/io-engine/examples/lvs-eval/main.rs
+++ b/io-engine/examples/lvs-eval/main.rs
@@ -1,0 +1,196 @@
+mod display;
+
+use clap::Parser;
+use version_info::{package_description, version_info_str};
+
+use io_engine_tests::MayastorTest;
+
+use crate::display::print_lvs;
+use io_engine::{
+    core::{LogicalVolume, MayastorCliArgs},
+    lvs::{Lvol, Lvs, LvsError, LvsLvol},
+    pool_backend::{IPoolProps, PoolArgs, PoolMetadataArgs, ReplicaArgs},
+};
+
+/// TODO
+#[derive(Debug, Clone, Parser)]
+#[clap(
+    name = package_description!(),
+    about = "LVS Evaluation",
+    version = version_info_str!(),
+)]
+pub struct CliArgs {
+    pub disk: String,
+    #[clap(short = 'r', default_value_t = 1)]
+    pub replicas: u32,
+    #[clap(short = 'N', default_value_t = 1)]
+    pub replica_clusters: u64,
+    /// Cluster size in Mb.
+    #[clap(short = 'C')]
+    pub cluster_size: Option<u32>,
+    /// Thin provisioned.
+    #[clap(short = 't', default_value_t = false)]
+    pub thin: bool,
+    /// MD reservation ratio.
+    #[clap(short = 'M')]
+    pub md_resv_ratio: Option<f32>,
+    /// Use extent table.
+    #[clap(short = 'E')]
+    pub use_extent_table: Option<bool>,
+    /// Pool name.
+    #[clap(default_value = "pool0")]
+    pub pool_name: String,
+    /// Destroy pool on exit (pool is exported by default).
+    #[clap(long = "destroy")]
+    pub destroy_pool: bool,
+    /// Create a temporary filler replica before each replica.
+    #[clap(short = 'F', default_value_t = false)]
+    pub fillers: bool,
+}
+
+static mut G_USE_EXTENT_TABLE: bool = true;
+
+/// TODO
+#[tokio::main(worker_threads = 4)]
+async fn main() {
+    let args = CliArgs::parse();
+
+    unsafe {
+        G_USE_EXTENT_TABLE = args.use_extent_table.unwrap_or(true);
+    }
+
+    let ms_args = MayastorCliArgs {
+        log_format: Some("nodate,nohost,color".parse().unwrap()),
+        reactor_mask: "0x3".into(),
+        ..Default::default()
+    };
+
+    // let ms = MayastorTest::new_ex(ms_args,
+    // Some("debug,io_engine::lvs::lvs_store=info"));
+    let ms = MayastorTest::new_ex(ms_args, Some("info"));
+
+    ms.spawn(async move {
+        println!();
+        println!("-------------------------");
+        println!("{args:#?}");
+        println!("-------------------------");
+
+        println!("Creating LVS ...");
+        let lvs = create_lvs(&args).await;
+
+        let mut fillers = Vec::new();
+
+        // Create replicas.
+        println!("Creating {n} replicas ...", n = args.replicas);
+        for idx in 0 .. args.replicas {
+            if args.fillers {
+                match create_filler_replica(&lvs, idx, 1).await {
+                    Ok(lvol) => fillers.push(lvol),
+                    Err(_) => break,
+                }
+            }
+
+            if create_replica(&lvs, idx, args.replica_clusters, args.thin)
+                .await
+                .is_err()
+            {
+                break;
+            }
+        }
+
+        println!("Created pool.");
+        print_lvs(&lvs).await;
+
+        if !fillers.is_empty() {
+            // Destroy fillers.
+            for lvol in fillers.into_iter() {
+                println!("Destroying filler '{name}'", name = lvol.name());
+                lvol.destroy().await.unwrap();
+            }
+
+            println!("Destroyed fillers.");
+            print_lvs(&lvs).await;
+        }
+
+        if args.destroy_pool {
+            println!("Destroying pool ...");
+            lvs.destroy().await.unwrap();
+        } else {
+            println!("Exporting pool ...");
+            lvs.export().await.unwrap();
+        }
+    })
+    .await;
+}
+
+/// TODO
+async fn create_lvs(args: &CliArgs) -> Lvs {
+    const POOL_UUID: &str = "b8589388-295c-4859-a88a-72a60d3902e8";
+
+    let lvs_args = PoolArgs {
+        name: args.pool_name.clone(),
+        disks: vec![args.disk.to_string()],
+        uuid: Some(POOL_UUID.to_string()),
+        cluster_size: args.cluster_size.map(|sz| sz * 1024 * 1024),
+        md_args: Some(PoolMetadataArgs {
+            md_resv_ratio: args.md_resv_ratio,
+        }),
+        backend: Default::default(),
+    };
+
+    Lvs::create_or_import(lvs_args.clone()).await.unwrap()
+}
+
+/// TODO
+async fn create_replica(
+    lvs: &Lvs,
+    serial: u32,
+    n: u64,
+    thin: bool,
+) -> Result<Lvol, LvsError> {
+    let name = format!("replica_{serial}");
+    let uuid = format!("45c23e54-dc86-45f6-b55b-e44d05f1{serial:04}");
+
+    create_lvol(lvs, &name, &uuid, n, thin).await
+}
+
+/// TODO
+async fn create_filler_replica(
+    lvs: &Lvs,
+    serial: u32,
+    n: u64,
+) -> Result<Lvol, LvsError> {
+    let name = format!("filler_{serial}");
+    let uuid = format!("56723e54-dc86-45f6-b55b-e44d05f1{serial:04}");
+
+    create_lvol(lvs, &name, &uuid, n, false).await
+}
+
+/// TODO
+async fn create_lvol(
+    lvs: &Lvs,
+    name: &str,
+    uuid: &str,
+    n: u64,
+    thin: bool,
+) -> Result<Lvol, LvsError> {
+    let et = unsafe { G_USE_EXTENT_TABLE };
+
+    println!(
+        "Creating lvol '{name}': size = {n} cluster(s), thin: {thin}, et: {et}",
+    );
+
+    let opts = ReplicaArgs {
+        name: name.to_owned(),
+        size: lvs.cluster_size() as u64 * n,
+        uuid: uuid.to_string(),
+        thin,
+        entity_id: None,
+        use_extent_table: Some(et),
+    };
+
+    lvs.create_lvol_with_opts(opts).await.map_err(|err| {
+        println!("Failed to create lvol '{name}': {err}");
+        err
+    })
+}

--- a/io-engine/src/bdev/lvs.rs
+++ b/io-engine/src/bdev/lvs.rs
@@ -215,6 +215,7 @@ impl Lvs {
             disks: vec![self.disk.to_owned()],
             uuid: None,
             cluster_size: None,
+            md_args: None,
             backend: PoolBackend::Lvs,
         };
         match &self.mode {

--- a/io-engine/src/bdev_api.rs
+++ b/io-engine/src/bdev_api.rs
@@ -88,6 +88,9 @@ pub enum BdevError {
     // Generic destruction failure.
     #[snafu(display("Failed to destroy a BDEV '{}'", name))]
     DestroyBdevFailed { source: Errno, name: String },
+    // Generic resize failure.
+    #[snafu(display("Failed to resize a BDEV '{}'", name))]
+    ResizeBdevFailed { source: Errno, name: String },
     #[snafu(display("Failed to create BDEV '{name}': {error}"))]
     CreateBdevFailedStr { name: String, error: String },
     #[snafu(display("Failed to destroy BDEV '{name}': {error}"))]

--- a/io-engine/src/bin/io-engine-client/v1/bdev_cli.rs
+++ b/io-engine/src/bin/io-engine-client/v1/bdev_cli.rs
@@ -6,6 +6,7 @@ use crate::{
     ClientError,
     GrpcStatus,
 };
+use byte_unit::Byte;
 use clap::{Arg, ArgMatches, Command};
 use colored_json::prelude::*;
 use io_engine_api::v1 as v1rpc;
@@ -103,6 +104,7 @@ async fn list(mut ctx: Context, _args: &ArgMatches) -> crate::Result<()> {
                 "UUID",
                 "NUM_BLOCKS",
                 "BLK_SIZE",
+                "CAPACITY",
                 "CLAIMED_BY",
                 "NAME",
                 "SHARE_URI",
@@ -110,10 +112,14 @@ async fn list(mut ctx: Context, _args: &ArgMatches) -> crate::Result<()> {
             let table = bdevs
                 .iter()
                 .map(|bdev| {
+                    let cap = Byte::from_bytes(
+                        (bdev.num_blocks * bdev.blk_size as u64).into(),
+                    );
                     vec![
                         bdev.uuid.to_string(),
                         bdev.num_blocks.to_string(),
                         bdev.blk_size.to_string(),
+                        ctx.units(cap),
                         bdev.claimed_by.to_string(),
                         bdev.name.to_string(),
                         bdev.share_uri.to_string(),

--- a/io-engine/src/lvm/error.rs
+++ b/io-engine/src/lvm/error.rs
@@ -58,6 +58,10 @@ pub enum Error {
     NoSpace { error: String },
     #[snafu(display("Snapshots are not currently supported for LVM volumes"))]
     SnapshotNotSup {},
+    #[snafu(display(
+        "Pool expansion is not currently supported for LVM volumes"
+    ))]
+    GrowNotSup {},
 }
 
 impl ToErrno for Error {
@@ -127,6 +131,9 @@ impl ToErrno for Error {
                 ..
             } => Errno::ENOSPC,
             Error::SnapshotNotSup {
+                ..
+            } => Errno::ENOTSUP,
+            Error::GrowNotSup {
                 ..
             } => Errno::ENOTSUP,
         }

--- a/io-engine/src/lvm/mod.rs
+++ b/io-engine/src/lvm/mod.rs
@@ -68,6 +68,7 @@ use crate::{
         ListPoolArgs,
         PoolArgs,
         PoolBackend,
+        PoolMetadataInfo,
         PoolOps,
         ReplicaArgs,
     },
@@ -150,6 +151,7 @@ impl PoolOps for VolumeGroup {
         .await?;
         Ok(Box::new(replica))
     }
+
     async fn destroy(
         self: Box<Self>,
     ) -> Result<(), crate::pool_backend::Error> {
@@ -162,6 +164,10 @@ impl PoolOps for VolumeGroup {
     ) -> Result<(), crate::pool_backend::Error> {
         VolumeGroup::export(&mut self).await?;
         Ok(())
+    }
+
+    async fn grow(&self) -> Result<(), crate::pool_backend::Error> {
+        Err(Error::GrowNotSup {}.into())
     }
 }
 
@@ -312,6 +318,10 @@ impl SnapshotOps for LogicalVolume {
 }
 
 impl IPoolProps for VolumeGroup {
+    fn pool_type(&self) -> PoolBackend {
+        PoolBackend::Lvm
+    }
+
     fn name(&self) -> &str {
         self.name()
     }
@@ -324,6 +334,22 @@ impl IPoolProps for VolumeGroup {
         self.disks().clone()
     }
 
+    fn disk_capacity(&self) -> u64 {
+        self.capacity()
+    }
+
+    fn cluster_size(&self) -> u32 {
+        self.cluster_size() as u32
+    }
+
+    fn page_size(&self) -> Option<u32> {
+        None
+    }
+
+    fn capacity(&self) -> u64 {
+        self.capacity()
+    }
+
     fn used(&self) -> u64 {
         self.used()
     }
@@ -332,16 +358,8 @@ impl IPoolProps for VolumeGroup {
         self.committed()
     }
 
-    fn capacity(&self) -> u64 {
-        self.capacity()
-    }
-
-    fn pool_type(&self) -> PoolBackend {
-        PoolBackend::Lvm
-    }
-
-    fn cluster_size(&self) -> u32 {
-        self.cluster_size() as u32
+    fn md_props(&self) -> Option<PoolMetadataInfo> {
+        None
     }
 }
 

--- a/io-engine/src/lvm/vg_pool.rs
+++ b/io-engine/src/lvm/vg_pool.rs
@@ -358,6 +358,7 @@ impl VolumeGroup {
     pub(crate) fn committed(&self) -> u64 {
         self.size
     }
+
     /// Get the volume group cluster size.
     pub(crate) fn cluster_size(&self) -> u64 {
         4 * 1024 * 1024

--- a/io-engine/src/lvs/lvs_error.rs
+++ b/io-engine/src/lvs/lvs_error.rs
@@ -136,6 +136,11 @@ pub enum LvsError {
         source: BdevError,
         name: String,
     },
+    #[snafu(display("{source}, failed to grow pool {name}"))]
+    Grow {
+        source: BsError,
+        name: String,
+    },
     #[snafu(display("{}", msg))]
     PoolNotFound {
         source: BsError,
@@ -158,6 +163,11 @@ pub enum LvsError {
     ))]
     InvalidClusterSize {
         source: BsError,
+        name: String,
+        msg: String,
+    },
+    #[snafu(display("pool {name}: invalid metadata parameter: {msg}"))]
+    InvalidMetadataParam {
         name: String,
         msg: String,
     },
@@ -291,6 +301,9 @@ impl ToErrno for LvsError {
             Self::Destroy {
                 ..
             } => Errno::ENXIO,
+            Self::Grow {
+                ..
+            } => Errno::ENXIO,
             Self::PoolNotFound {
                 source, ..
             } => source.to_errno(),
@@ -303,6 +316,9 @@ impl ToErrno for LvsError {
             Self::InvalidClusterSize {
                 source, ..
             } => source.to_errno(),
+            Self::InvalidMetadataParam {
+                ..
+            } => Errno::EINVAL,
             Self::RepExists {
                 source, ..
             } => source.to_errno(),

--- a/io-engine/src/lvs/lvs_lvol.rs
+++ b/io-engine/src/lvs/lvs_lvol.rs
@@ -286,7 +286,7 @@ impl Lvol {
 
     /// TODO
     #[inline(always)]
-    fn as_inner_ref(&self) -> &spdk_lvol {
+    pub fn as_inner_ref(&self) -> &spdk_lvol {
         unsafe { self.inner.as_ref() }
     }
 

--- a/io-engine/src/subsys/config/pool.rs
+++ b/io-engine/src/subsys/config/pool.rs
@@ -175,6 +175,7 @@ impl From<&Pool> for PoolArgs {
             disks: pool.disks.clone(),
             uuid: None,
             cluster_size: None,
+            md_args: None,
             backend: pool.backend,
         }
     }

--- a/io-engine/tests/lvs_grow.rs
+++ b/io-engine/tests/lvs_grow.rs
@@ -1,0 +1,383 @@
+pub mod common;
+
+use async_trait::async_trait;
+use once_cell::sync::OnceCell;
+use std::future::Future;
+
+use spdk_rs::{
+    ffihelper::IntoCString,
+    libspdk::resize_malloc_disk,
+    UntypedBdev,
+};
+
+use io_engine::{
+    core::MayastorCliArgs,
+    lvs::Lvs,
+    pool_backend::{IPoolProps, PoolArgs},
+};
+
+use io_engine_tests::{
+    bdev::{create_bdev, find_bdev_by_name},
+    compose::{
+        rpc::v1::{pool::Pool, GrpcConnect, SharedRpcHandle},
+        Binary,
+        Builder,
+        ComposeTest,
+    },
+    pool::PoolBuilder,
+    MayastorTest,
+};
+
+static MAYASTOR: OnceCell<MayastorTest> = OnceCell::new();
+
+fn ms() -> &'static MayastorTest<'static> {
+    MAYASTOR.get_or_init(|| {
+        MayastorTest::new(MayastorCliArgs {
+            log_format: Some("nodate,nohost,compact".parse().unwrap()),
+            reactor_mask: "0x3".into(),
+            enable_io_all_thrd_nexus_channels: true,
+            ..Default::default()
+        })
+    })
+}
+
+/// Tests if 'a' is approximately equal to 'b' up to the given tolerance (in
+/// percents).
+fn approx_eq(a: f64, b: f64, t: f64) -> bool {
+    assert!(a > 0.0 && b > 0.0 && (0.0 .. 100.0).contains(&t));
+    let d = 100.0 * (a - b).abs() / f64::max(a, b);
+    d <= t
+}
+
+/// Pool stats.
+struct TestPoolStats {
+    capacity: u64,
+    disk_capacity: u64,
+}
+
+impl TestPoolStats {
+    fn capacity_approx_matches(&self) -> bool {
+        approx_eq(self.disk_capacity as f64, self.capacity as f64, 10.0)
+    }
+}
+
+impl From<&Lvs> for TestPoolStats {
+    fn from(lvs: &Lvs) -> Self {
+        Self {
+            capacity: lvs.capacity(),
+            disk_capacity: lvs.disk_capacity(),
+        }
+    }
+}
+
+impl From<Lvs> for TestPoolStats {
+    fn from(lvs: Lvs) -> Self {
+        Self::from(&lvs)
+    }
+}
+
+impl From<Pool> for TestPoolStats {
+    fn from(p: Pool) -> Self {
+        Self {
+            capacity: p.capacity,
+            disk_capacity: p.disk_capacity,
+        }
+    }
+}
+
+/// Grow test interface.
+#[async_trait(?Send)]
+trait GrowTest {
+    async fn create_pool(&mut self) -> TestPoolStats;
+    async fn pool_stats(&self) -> TestPoolStats;
+    async fn grow_pool(&mut self) -> (TestPoolStats, TestPoolStats);
+    async fn device_size(&mut self) -> u64;
+    async fn grow_device(&mut self) -> u64;
+}
+
+/// Implements logic for pool grow test.
+async fn test_grow(create: impl Future<Output = Box<dyn GrowTest>>) {
+    common::composer_init();
+
+    let mut gt = create.await;
+
+    let initial = gt.create_pool().await;
+
+    assert_eq!(initial.disk_capacity, gt.device_size().await);
+    assert!(initial.capacity <= initial.disk_capacity);
+    assert!(initial.capacity_approx_matches());
+
+    // Resize the device.
+    let new_dev_cap = gt.grow_device().await;
+
+    // Pool capacity must not change, disk capacity must reflect disk size
+    // change.
+    let after_dev_grow = gt.pool_stats().await;
+    assert_eq!(after_dev_grow.capacity, initial.capacity);
+    assert_eq!(after_dev_grow.disk_capacity, new_dev_cap);
+
+    // Grow the pool.
+    let (before_pool_grow, after_pool_grow) = gt.grow_pool().await;
+    assert_eq!(before_pool_grow.capacity, initial.capacity);
+    assert_eq!(before_pool_grow.disk_capacity, new_dev_cap);
+
+    // Pool must have grown.
+    assert!(after_pool_grow.capacity > before_pool_grow.capacity);
+
+    // New pool capacity must be close to the disk capacity.
+    assert!(after_pool_grow.capacity <= after_pool_grow.disk_capacity);
+    assert!(after_pool_grow.capacity_approx_matches());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn lvs_grow_ms_malloc() {
+    const SIZE_AFTER_MB: u64 = 128;
+    const BDEV_NAME: &str = "mem0";
+    const BDEV_URI: &str = "malloc:///mem0?size_mb=64";
+    const POOL_NAME: &str = "pool0";
+    const POOL_UUID: &str = "40baf8b5-6256-4f29-b073-61ebf67d9b91";
+
+    /// Pool grow test based on LVS code, malloc bdev.
+    struct GrowTestMsMalloc {}
+
+    #[async_trait(?Send)]
+    impl GrowTest for GrowTestMsMalloc {
+        async fn create_pool(&mut self) -> TestPoolStats {
+            ms().spawn(async {
+                let lvs_args = PoolArgs {
+                    name: POOL_NAME.to_string(),
+                    disks: vec![BDEV_URI.to_string()],
+                    uuid: Some(POOL_UUID.to_string()),
+                    cluster_size: None,
+                    md_args: None,
+                    backend: Default::default(),
+                };
+
+                // Create LVS.
+                Lvs::create_or_import(lvs_args.clone())
+                    .await
+                    .unwrap()
+                    .into()
+            })
+            .await
+        }
+
+        async fn pool_stats(&self) -> TestPoolStats {
+            ms().spawn(async { Lvs::lookup(POOL_NAME).unwrap().into() })
+                .await
+        }
+
+        async fn grow_pool(&mut self) -> (TestPoolStats, TestPoolStats) {
+            ms().spawn(async {
+                let lvs = Lvs::lookup(POOL_NAME).unwrap();
+                let before = lvs.clone().into();
+                lvs.grow().await.unwrap();
+                let after = Lvs::lookup(POOL_NAME).unwrap().into();
+                (before, after)
+            })
+            .await
+        }
+
+        async fn device_size(&mut self) -> u64 {
+            ms().spawn(async {
+                UntypedBdev::lookup_by_name(BDEV_NAME)
+                    .unwrap()
+                    .size_in_bytes()
+            })
+            .await
+        }
+
+        async fn grow_device(&mut self) -> u64 {
+            ms().spawn(async {
+                unsafe {
+                    // Resize the malloc bdev.
+                    let name = BDEV_NAME.to_owned();
+                    resize_malloc_disk(
+                        name.into_cstring().as_ptr(),
+                        SIZE_AFTER_MB,
+                    );
+                };
+            })
+            .await;
+            self.device_size().await
+        }
+    }
+
+    test_grow(async { Box::new(GrowTestMsMalloc {}) as Box<dyn GrowTest> })
+        .await;
+}
+
+/// Pool grow test based on gRPC API and malloc bdev.
+#[tokio::test]
+async fn lvs_grow_api_malloc() {
+    const BDEV_NAME: &str = "mem0";
+    const BDEV_URI: &str = "malloc:///mem0?size_mb=64";
+    const BDEV_URI_RESIZE: &str = "malloc:///mem0?size_mb=128&resize";
+    const POOL_NAME: &str = "pool0";
+    const POOL_UUID: &str = "40baf8b5-6256-4f29-b073-61ebf67d9b91";
+
+    struct GrowTestApiMalloc {
+        #[allow(dead_code)]
+        test: ComposeTest,
+        ms: SharedRpcHandle,
+        pool: PoolBuilder,
+    }
+
+    impl GrowTestApiMalloc {
+        async fn new() -> GrowTestApiMalloc {
+            let test = Builder::new()
+                .name("cargo-test")
+                .network("10.1.0.0/16")
+                .unwrap()
+                .add_container_bin(
+                    "ms_0",
+                    Binary::from_dbg("io-engine").with_args(vec!["-l", "1,2"]),
+                )
+                .with_clean(true)
+                .build()
+                .await
+                .unwrap();
+
+            let conn = GrpcConnect::new(&test);
+            let ms = conn.grpc_handle_shared("ms_0").await.unwrap();
+
+            let pool = PoolBuilder::new(ms.clone())
+                .with_name(POOL_NAME)
+                .with_uuid(POOL_UUID)
+                .with_bdev(BDEV_URI);
+
+            Self {
+                test,
+                ms,
+                pool,
+            }
+        }
+    }
+
+    #[async_trait(?Send)]
+    impl GrowTest for GrowTestApiMalloc {
+        async fn create_pool(&mut self) -> TestPoolStats {
+            self.pool.create().await.unwrap();
+            self.pool_stats().await
+        }
+
+        async fn pool_stats(&self) -> TestPoolStats {
+            self.pool.get_pool().await.unwrap().into()
+        }
+
+        async fn grow_pool(&mut self) -> (TestPoolStats, TestPoolStats) {
+            let (a, b) = self.pool.grow().await.unwrap();
+            (a.into(), b.into())
+        }
+
+        async fn device_size(&mut self) -> u64 {
+            let bdev =
+                find_bdev_by_name(self.ms.clone(), BDEV_NAME).await.unwrap();
+            bdev.num_blocks * bdev.blk_size as u64
+        }
+
+        async fn grow_device(&mut self) -> u64 {
+            let bdev =
+                create_bdev(self.ms.clone(), BDEV_URI_RESIZE).await.unwrap();
+            bdev.num_blocks * bdev.blk_size as u64
+        }
+    }
+
+    test_grow(async {
+        Box::new(GrowTestApiMalloc::new().await) as Box<dyn GrowTest>
+    })
+    .await;
+}
+
+/// Pool grow test based on gRPC API and file-based AIO device.
+#[tokio::test]
+async fn lvs_grow_api_aio() {
+    const DISK_NAME: &str = "/tmp/disk1.img";
+    const BDEV_NAME: &str = "/host/tmp/disk1.img";
+    const BDEV_URI: &str = "aio:///host/tmp/disk1.img?blk_size=512";
+    const BDEV_URI_RESCAN: &str =
+        "aio:///host/tmp/disk1.img?blk_size=512&rescan";
+    const POOL_NAME: &str = "pool0";
+    const POOL_UUID: &str = "40baf8b5-6256-4f29-b073-61ebf67d9b91";
+
+    struct GrowTestApiAio {
+        #[allow(dead_code)]
+        test: ComposeTest,
+        ms: SharedRpcHandle,
+        pool: PoolBuilder,
+    }
+
+    impl GrowTestApiAio {
+        async fn new() -> GrowTestApiAio {
+            common::delete_file(&[DISK_NAME.into()]);
+            common::truncate_file(DISK_NAME, 64 * 1024);
+
+            let test = Builder::new()
+                .name("cargo-test")
+                .network("10.1.0.0/16")
+                .unwrap()
+                .add_container_bin(
+                    "ms_0",
+                    Binary::from_dbg("io-engine")
+                        .with_args(vec!["-l", "1,2"])
+                        .with_bind("/tmp", "/host/tmp"),
+                )
+                .with_clean(true)
+                .build()
+                .await
+                .unwrap();
+
+            let conn = GrpcConnect::new(&test);
+            let ms = conn.grpc_handle_shared("ms_0").await.unwrap();
+
+            let pool = PoolBuilder::new(ms.clone())
+                .with_name(POOL_NAME)
+                .with_uuid(POOL_UUID)
+                .with_bdev(BDEV_URI);
+
+            Self {
+                test,
+                ms,
+                pool,
+            }
+        }
+    }
+
+    #[async_trait(?Send)]
+    impl GrowTest for GrowTestApiAio {
+        async fn create_pool(&mut self) -> TestPoolStats {
+            self.pool.create().await.unwrap();
+            self.pool_stats().await
+        }
+
+        async fn pool_stats(&self) -> TestPoolStats {
+            self.pool.get_pool().await.unwrap().into()
+        }
+
+        async fn grow_pool(&mut self) -> (TestPoolStats, TestPoolStats) {
+            let (a, b) = self.pool.grow().await.unwrap();
+            (a.into(), b.into())
+        }
+
+        async fn device_size(&mut self) -> u64 {
+            let bdev =
+                find_bdev_by_name(self.ms.clone(), BDEV_NAME).await.unwrap();
+            bdev.num_blocks * bdev.blk_size as u64
+        }
+
+        async fn grow_device(&mut self) -> u64 {
+            // Resize bdev's backing file.
+            common::truncate_file(DISK_NAME, 128 * 1024);
+
+            // Rescan AIO bdev (re-read its size from the backing media).
+            let bdev =
+                create_bdev(self.ms.clone(), BDEV_URI_RESCAN).await.unwrap();
+            bdev.num_blocks * bdev.blk_size as u64
+        }
+    }
+
+    test_grow(async {
+        Box::new(GrowTestApiAio::new().await) as Box<dyn GrowTest>
+    })
+    .await;
+}

--- a/io-engine/tests/lvs_import.rs
+++ b/io-engine/tests/lvs_import.rs
@@ -54,6 +54,7 @@ async fn lvs_import_many_volume() {
             disks: vec![BDEV_NAME.to_string()],
             uuid: Some(POOL_UUID.to_string()),
             cluster_size: None,
+            md_args: None,
             backend: Default::default(),
         };
 

--- a/io-engine/tests/lvs_limits.rs
+++ b/io-engine/tests/lvs_limits.rs
@@ -49,6 +49,7 @@ async fn lvs_metadata_limit() {
             disks: vec![BDEV_NAME.to_string()],
             uuid: Some(POOL_UUID.to_string()),
             cluster_size: None,
+            md_args: None,
             backend: Default::default(),
         };
 

--- a/io-engine/tests/lvs_pool.rs
+++ b/io-engine/tests/lvs_pool.rs
@@ -57,17 +57,21 @@ async fn lvs_pool_test() {
     })
     .await;
 
+    let pool_args = PoolArgs {
+        name: "tpool".into(),
+        disks: vec![format!("aio://{DISKNAME1}")],
+        uuid: None,
+        cluster_size: None,
+        md_args: None,
+        backend: PoolBackend::Lvs,
+    };
+
     // should succeed to create a pool we can not import
-    ms.spawn(async {
-        Lvs::create_or_import(PoolArgs {
-            name: "tpool".into(),
-            disks: vec![format!("aio://{DISKNAME1}")],
-            uuid: None,
-            cluster_size: None,
-            backend: PoolBackend::Lvs,
-        })
-        .await
-        .unwrap();
+    ms.spawn({
+        let pool_args = pool_args.clone();
+        async {
+            Lvs::create_or_import(pool_args).await.unwrap();
+        }
     })
     .await;
 
@@ -76,14 +80,7 @@ async fn lvs_pool_test() {
     // have an idempotent snafu, we dont crash and
     // burn
     ms.spawn(async {
-        assert!(Lvs::create(
-            "tpool",
-            format!("aio://{DISKNAME1}").as_str(),
-            None,
-            None
-        )
-        .await
-        .is_err())
+        assert!(Lvs::create_from_args_inner(pool_args).await.is_err())
     })
     .await;
 
@@ -147,12 +144,14 @@ async fn lvs_pool_test() {
             .is_err());
 
         assert_eq!(Lvs::iter().count(), 0);
-        assert!(Lvs::create(
-            "tpool",
-            format!("aio://{DISKNAME1}").as_str(),
-            None,
-            None
-        )
+        assert!(Lvs::create_from_args_inner(PoolArgs {
+            name: "tpool".to_string(),
+            disks: vec![format!("aio://{DISKNAME1}")],
+            uuid: None,
+            cluster_size: None,
+            md_args: None,
+            backend: PoolBackend::Lvs,
+        })
         .await
         .is_ok());
 
@@ -188,6 +187,7 @@ async fn lvs_pool_test() {
             disks: vec!["malloc:///malloc0?size_mb=64".to_string()],
             uuid: None,
             cluster_size: None,
+            md_args: None,
             backend: PoolBackend::Lvs,
         })
         .await
@@ -225,6 +225,7 @@ async fn lvs_pool_test() {
             disks: vec![format!("aio://{DISKNAME1}")],
             uuid: None,
             cluster_size: None,
+            md_args: None,
             backend: PoolBackend::Lvs,
         })
         .await
@@ -369,6 +370,7 @@ async fn lvs_pool_test() {
             disks: vec![format!("aio://{DISKNAME1}")],
             uuid: None,
             cluster_size: None,
+            md_args: None,
             backend: PoolBackend::Lvs,
         })
         .await
@@ -390,6 +392,7 @@ async fn lvs_pool_test() {
             disks: vec![format!("aio://{pool_dev_aio}")],
             uuid: None,
             cluster_size: None,
+            md_args: None,
             backend: PoolBackend::Lvs,
         })
         .await
@@ -417,6 +420,7 @@ async fn lvs_pool_test() {
             disks: vec![format!("uring://{pool_dev_uring}")],
             uuid: None,
             cluster_size: None,
+            md_args: None,
             backend: PoolBackend::Lvs,
         })
         .await
@@ -454,6 +458,7 @@ async fn lvs_pool_test() {
             disks: vec![format!("aio://{DISKNAME1}")],
             uuid: None,
             cluster_size: None,
+            md_args: None,
             backend: PoolBackend::Lvs,
         })
         .await
@@ -471,6 +476,7 @@ async fn lvs_pool_test() {
             disks: vec![format!("aio://{DISKNAME2}")],
             uuid: None,
             cluster_size: None,
+            md_args: None,
             backend: PoolBackend::Lvs,
         })
         .await

--- a/io-engine/tests/nexus_with_local.rs
+++ b/io-engine/tests/nexus_with_local.rs
@@ -51,6 +51,7 @@ async fn create_replicas(h: &mut RpcHandle) {
             pooltype: 0,
             disks: vec!["malloc:///disk0?size_mb=64".into()],
             cluster_size: None,
+            md_args: None,
         })
         .await
         .unwrap();

--- a/io-engine/tests/replica_snapshot.rs
+++ b/io-engine/tests/replica_snapshot.rs
@@ -98,6 +98,7 @@ async fn replica_snapshot() {
                 disks: vec![format!("aio://{DISKNAME1}")],
                 uuid: None,
                 cluster_size: None,
+                md_args: None,
                 backend: PoolBackend::Lvs,
             })
             .await

--- a/io-engine/tests/snapshot_lvol.rs
+++ b/io-engine/tests/snapshot_lvol.rs
@@ -68,6 +68,7 @@ async fn create_test_pool(
         disks: vec![disk],
         uuid: None,
         cluster_size,
+        md_args: None,
         backend: PoolBackend::Lvs,
     })
     .await

--- a/io-engine/tests/snapshot_nexus.rs
+++ b/io-engine/tests/snapshot_nexus.rs
@@ -144,6 +144,7 @@ async fn launch_instance(create_replicas: bool) -> (ComposeTest, Vec<String>) {
             pooltype: 0,
             disks: vec!["malloc:///disk0?size_mb=128".into()],
             cluster_size: None,
+            md_args: None,
         })
         .await
         .unwrap();


### PR DESCRIPTION
* Pool grow API support added to LVS.
* Additional pool stats added.
* Added support for MD reservation hint.
* Related CLI subcommand added. 'pool list' subcommand extended to print additional pool info.
* Related tests added.
* For testing purposes, a non-safe support for resizing malloc bdev added.
* To simplify adding new pool and replica parameters, LVS inner create-related APIs refactored to accept parameters via PoolArgs and ReplicaArgs instead of function arguments.
* Added a example tool (lvs-eval) that creates an LVS with the given parameters and prints it internal configuration (allocated clusters, extent pages, etc.)