### PR TITLE
test(wipe): allow wipes on snapshots

### DIFF
--- a/io-engine/src/grpc/v1/test.rs
+++ b/io-engine/src/grpc/v1/test.rs
@@ -111,8 +111,10 @@ impl TestRpc for TestService {
                                 ),
                                 None => None,
                             };
+                            let args = FindReplicaArgs::new(&args.uuid);
                             let repl = GrpcReplicaFactory::finder(
-                                &FindReplicaArgs::new(&args.uuid),
+                                // until API is modified to allow snapshots
+                                &args.allow_snapshots(),
                             )
                             .await?;
                             validate_pool(&repl, pool).await?;

--- a/io-engine/src/replica_backend.rs
+++ b/io-engine/src/replica_backend.rs
@@ -153,12 +153,22 @@ impl ListReplicaArgs {
 pub struct FindReplicaArgs {
     /// The replica uuid to find for.
     pub uuid: String,
+    /// Finds Replicas which may also be snapshots.
+    pub allow_snapshots: bool,
 }
 impl FindReplicaArgs {
     /// Create `Self` with the replica uuid.
     pub fn new(uuid: &str) -> Self {
         Self {
             uuid: uuid.to_string(),
+            allow_snapshots: false,
+        }
+    }
+    /// Allow finding replicas which may also be snapshots.
+    pub fn allow_snapshots(self) -> Self {
+        Self {
+            allow_snapshots: true,
+            ..self
         }
     }
 }
@@ -290,7 +300,7 @@ impl ReplicaFactory {
             match factory.0.find(args).await {
                 Ok(Some(replica)) => {
                     // should this be an error?
-                    if !replica.is_snapshot() {
+                    if !replica.is_snapshot() || args.allow_snapshots {
                         return Ok(replica);
                     }
                 }


### PR DESCRIPTION
This is actually not the correct behaviour, but previously e2e was dependent on this.
Until the API is modified to handle this properly, revert to the previous behaviour to ensure tests are running.