### PR TITLE
Reuse Rebuild IO handles

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "spdk-rs"]
 	path = spdk-rs
-	url = https://github.com/openebs/spdk-rs
+	url = ../spdk-rs.git
 	branch = develop
 [submodule "utils/dependencies"]
 	path = utils/dependencies

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1665,6 +1665,7 @@ dependencies = [
  "crossbeam",
  "derive_builder",
  "devinfo",
+ "either",
  "env_logger",
  "etcd-client",
  "event-publisher",

--- a/io-engine/Cargo.toml
+++ b/io-engine/Cargo.toml
@@ -74,7 +74,7 @@ libc = "0.2.149"
 log = "0.4.20"
 md5 = "0.7.0"
 merge = "0.1.0"
-nix = { version = "0.27.1", default-features = false, features = [ "hostname", "net", "socket", "ioctl" ] }
+nix = { version = "0.27.1", default-features = false, features = ["hostname", "net", "socket", "ioctl"] }
 once_cell = "1.18.0"
 parking_lot = "0.12.1"
 pin-utils = "0.1.0"
@@ -102,9 +102,10 @@ async-process = { version = "1.8.1" }
 rstack = { version = "0.3.3" }
 tokio-stream = "0.1.14"
 rustls = "0.21.12"
+either = "1.9.0"
 
 devinfo = { path = "../utils/dependencies/devinfo" }
-jsonrpc = { path = "../jsonrpc"}
+jsonrpc = { path = "../jsonrpc" }
 io-engine-api = { path = "../utils/dependencies/apis/io-engine" }
 spdk-rs = { path = "../spdk-rs" }
 sysfs = { path = "../sysfs" }

--- a/io-engine/src/bdev/nexus/nexus_bdev_children.rs
+++ b/io-engine/src/bdev/nexus/nexus_bdev_children.rs
@@ -1152,10 +1152,11 @@ impl<'n> Nexus<'n> {
         // Cancel rebuild job for this child, if any.
         if let Some(job) = child.rebuild_job() {
             debug!("{self:?}: retire: stopping rebuild job...");
-            let terminated = job.force_fail();
-            Reactors::master().send_future(async move {
-                terminated.await.ok();
-            });
+            if let either::Either::Left(terminated) = job.force_fail() {
+                Reactors::master().send_future(async move {
+                    terminated.await.ok();
+                });
+            }
         }
 
         debug!("{child:?}: retire: enqueuing device '{dev}' to retire");

--- a/io-engine/src/grpc/v1/snapshot_rebuild.rs
+++ b/io-engine/src/grpc/v1/snapshot_rebuild.rs
@@ -110,7 +110,10 @@ impl SnapshotRebuildRpc for SnapshotRebuildService {
             let Ok(job) = SnapshotRebuildJob::lookup(&args.uuid) else {
                 return Err(tonic::Status::not_found(""));
             };
-            let rx = job.force_stop().await.ok();
+            let rx = match job.force_stop() {
+                either::Either::Left(chan) => chan.await,
+                either::Either::Right(stopped) => Ok(stopped),
+            };
             info!("Snapshot Rebuild stopped: {rx:?}");
             job.destroy();
             Ok(())

--- a/io-engine/src/rebuild/mod.rs
+++ b/io-engine/src/rebuild/mod.rs
@@ -57,7 +57,10 @@ impl WithinRange<u64> for std::ops::Range<u64> {
 /// Shutdown all pending snapshot rebuilds.
 pub(crate) async fn shutdown_snapshot_rebuilds() {
     let jobs = SnapshotRebuildJob::list().into_iter();
-    for recv in jobs.map(|job| job.force_stop()).collect::<Vec<_>>() {
+    for recv in jobs
+        .flat_map(|job| job.force_stop().left())
+        .collect::<Vec<_>>()
+    {
         recv.await.ok();
     }
 }


### PR DESCRIPTION
    fix(rebuild): reuse rebuild IO handles
    
    Reuses the rebuild IO handles, rather than attempting to allocate
    them per rebuild task.
    The main issue with handle allocation on the fly is that the target
    may have not cleaned up a previous IO qpair connection, and so the
    connect may fail. We started seeing this more on CI because we forgot
    to cherry-pick a commit increasing the retry delay.
    However, after inspecting a bunch of user support bundles I see that
    we still have occasional connect errors. Rather than increasing the
    timeout, we attempt here to reuse the handles, thus avoid the
    problem almost entirely.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    refactor(rebuild): rebuild completion is not an error
    
    When the rebuild has been complete, if we wait for it this fails because
    the channels are not longer available.
    Instead, simply return the rebuild state, since this is what we want anyway.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>