### PR TITLE
Introduce new CSAL ftl bdev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1856,6 +1856,7 @@ dependencies = [
  "nix",
  "once_cell",
  "parking_lot",
+ "percent-encoding",
  "pin-utils",
  "prettytable-rs",
  "prost",

--- a/doc/build.md
+++ b/doc/build.md
@@ -127,7 +127,7 @@ cargo build --release
 ```
 
 **Want to run or hack on Mayastor?** _You need more configuration!_ See
-[running][doc-running], then [testing][doc-testing].
+[running][doc-run], then [testing][doc-test].
 
 Whilst the nix develop will allow you to build mayastor exactly as the image build, it might not have all the necessary
 components required for testing.

--- a/doc/test.md
+++ b/doc/test.md
@@ -29,8 +29,12 @@ Mayastor's unit tests, integration tests, and documentation tests via the conven
 Mayastor uses [spdk][spdk] which is quite senistive to threading. This means tests need to run one at a time:
 
 ```bash
-cargo test -- --test-threads 1
+cd io-engine
+RUST_LOG=TRACE cargo test -- --test-threads 1 --nocapture
 ```
+
+## Testing your own SPDK version
+To test your custom SPDK version please refere to the [spdk-rs documentation](https://github.com/openebs/spdk-rs/blob/develop/README.md#custom-spdk)
 
 ## Running the end-to-end test suite
 
@@ -54,6 +58,29 @@ Then, to run the tests:
 ```bash
 ./node_modules/mocha/bin/mocha test_csi.js
 ```
+
+## Using PCIe NVMe devices in cargo tests while developing
+
+When developing new features, testing those with real PCIe devices in the process might come in handy.
+In order to do so, the PCIe device first needs to be bound to the vfio driver:
+
+```bash
+sudo PCI_ALLOWED="<PCI-ADDRESS>" ./spdk-rs/spdk/scripts/setup.sh
+```
+
+The bdev name in the cargo test case can then follow the PCIe URI pattern:
+
+```rust
+static BDEVNAME1: &str = "pcie:///<PCI-ADDRESS>";
+```
+
+After testing the device may be rebound to the NVMe driver:
+
+```bash
+sudo PCI_ALLOWED="<PCI-ADDRESS>" ./spdk-rs/spdk/scripts/setup.sh reset
+```
+
+Please do not submit pull requests with active cargo test cases that require PCIe devices to be present.
 
 [spdk]: https://spdk.io/
 [doc-run]: ./run.md

--- a/io-engine/Cargo.toml
+++ b/io-engine/Cargo.toml
@@ -13,6 +13,7 @@ extended-tests = [] # Extended I/O engine tests: not intended for daily runs.
 fault-injection = [] # Enables fault injection code.
 nexus-io-tracing = [] # Enables nexus I/O tracing code.
 spdk-async-qpair-connect = [] # Enables async qpair connection.
+nvme-pci-tests = []
 
 [[bin]]
 name = "io-engine"
@@ -77,6 +78,7 @@ merge = "0.1.0"
 nix = { version = "0.29.0", default-features = false, features = ["hostname", "net", "socket", "ioctl"] }
 once_cell = "1.20.2"
 parking_lot = "0.12.3"
+percent-encoding = "2.3.1"
 pin-utils = "0.1.0"
 prost = "0.13.3"
 prost-derive = "0.13.3"

--- a/io-engine/src/bdev/dev.rs
+++ b/io-engine/src/bdev/dev.rs
@@ -39,6 +39,7 @@ pub(crate) mod uri {
     use crate::{
         bdev::{
             aio,
+            ftl,
             loopback,
             lvs,
             malloc,
@@ -64,6 +65,7 @@ pub(crate) mod uri {
             "bdev" | "loopback" => {
                 Ok(Box::new(loopback::Loopback::try_from(&url)?))
             }
+            "ftl" => Ok(Box::new(ftl::Ftl::try_from(&url)?)),
             "malloc" => Ok(Box::new(malloc::Malloc::try_from(&url)?)),
             "null" => Ok(Box::new(null_bdev::Null::try_from(&url)?)),
             // keeping nvmf scheme so existing tests(if any, setting this

--- a/io-engine/src/bdev/ftl.rs
+++ b/io-engine/src/bdev/ftl.rs
@@ -1,0 +1,325 @@
+//! The Ftl device is a representation of an SPDK (CSAL) ftl bdev, which allows
+//! to create a layered device with a persistent (fast) cache device for
+//! buffering writes that get eventually flushed out sequentially to a base
+//! device.
+//!
+//! # Uri
+//! ftl:///$ftl_device_name?bbdev=$bbdev_uri_percent_encoded&
+//! cbdev=$cbdev_uri_percent_encoded
+//!
+//! The bbdev_uri and cbdev_uri need to use percent encoding on '?' (= '%3F')
+//! and '&' (= '%26') segment dividers. This is needed so we can successfully
+//! parse the ftl uri. Optionally, the sub-uris may also be fully
+//! percent-encoded.
+//!
+//! # Parameters
+//! name: A name for the ftl device, example: "ftl-1".
+//! alias: Ftl device URI which can be used to open the bdev.
+//! uuid: A UUID that can be set to reference the resulting SPDK bdev.
+//! bbdev_uri: Nested device uri for the ftl base bdev, which is (partially)
+//!            percent encoded. This device currently requires to be a
+//!            non-volatile memory device which is has an LBA format of 4KiB
+//!            and is at least 20GB large.
+//! cbdev_uri: Nested device uri for the ftl base bdev, which is (partially)
+//!            percent encoded. This device currently requires to be a
+//!            non-volatile memory device which is has an LBA format of 4KiB
+//!            data size, 64B metadata size and is at least 20GB large.
+//!            From SPDK v24.09 on there is no requirement for the metadata
+//!            portion as Variable Sector Size (VSS) emulation is enabled.
+//!
+//! # Examples
+//! ftl:///ftl-1?bbdev=pcie:///0000:01:00.0&cbdev=pcie:///0000:02:00.0
+//!
+//! ftl:///ftl-1?bbdev=pcie%3A%2F%2F%2F0000%3A01%3A00.0&cbdev=pcie%3A%2F%2F%
+//! 2F0000%3A02%3A00.0
+//!
+//! ftl:///ftl-1?bbdev=pcie:///0000:01:00.0%
+//! 3Finvalidoption=test&cbdev=pcie:///0000:02:00.0
+//!
+//! ftl:///ftl-2?bbdev=aio:///tmp/basedev.img%3Fblk_size=4096&cbdev=aio:///tmp/
+//! cachedev.img%3Fblk_size=4096
+use std::{
+    collections::HashMap,
+    convert::TryFrom,
+    fmt::{Debug, Formatter},
+};
+
+use core::ffi::c_void;
+
+use async_trait::async_trait;
+use futures::channel::oneshot;
+use log::info;
+use nix::errno::Errno;
+use percent_encoding::percent_decode_str;
+use snafu::{OptionExt, ResultExt};
+use std::mem;
+use url::Url;
+
+use spdk_rs::{
+    ffihelper::errno_result_from_i32,
+    libspdk::{
+        bdev_ftl_create_bdev,
+        bdev_ftl_delete_bdev,
+        ftl_bdev_info,
+        spdk_ftl_conf,
+        spdk_ftl_get_default_conf,
+        spdk_ftl_mode,
+    },
+    UntypedBdev,
+};
+
+use crate::{
+    bdev::{dev::reject_unknown_parameters, util::uri, CreateDestroy, GetName},
+    bdev_api::{self, bdev_create, bdev_destroy, BdevError},
+    core::VerboseError,
+    ffihelper::{cb_arg, done_errno_cb, ErrnoResult},
+};
+
+/// An ftl bdev specified via URI.
+pub struct Ftl {
+    /// The name of the ftl-bdev we created.
+    name: String,
+    /// Alias which can be used to open the bdev.
+    alias: String,
+    /// Uuid of the spdk bdev.
+    uuid: Option<uuid::Uuid>,
+    /// Ftl's base bdev URI.
+    bbdev_uri: String,
+    /// Ftl's cache bdev URI.
+    cbdev_uri: String,
+}
+
+impl Debug for Ftl {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Ftl '{}' (bbdev_uri {} cbdev_uri {})",
+            self.name, self.bbdev_uri, self.cbdev_uri
+        )
+    }
+}
+
+impl TryFrom<&Url> for Ftl {
+    type Error = BdevError;
+
+    fn try_from(uri: &Url) -> Result<Self, Self::Error> {
+        let segments = uri::segments(uri);
+        if segments.is_empty() {
+            return Err(BdevError::InvalidUri {
+                uri: uri.to_string(),
+                message: "empty path".to_string(),
+            });
+        }
+
+        let mut parameters: HashMap<String, String> =
+            uri.query_pairs().into_owned().collect();
+
+        let uuid = uri::uuid(parameters.remove("uuid")).context(
+            bdev_api::UuidParamParseFailed {
+                uri: uri.to_string(),
+            },
+        )?;
+
+        let encoded_bbdev_uri =
+            parameters.remove("bbdev").context(bdev_api::InvalidUri {
+                uri: uri.to_string(),
+                message: String::from("No bbdev parameter found"),
+            })?;
+
+        let bbdev_uri = percent_decode_str(&encoded_bbdev_uri)
+            .decode_utf8()
+            .map_err(|e| BdevError::InvalidUri {
+                uri: uri.to_string(),
+                message: format!(
+                    "Could not percent decode bbdev_uri sub-uri - {}",
+                    e
+                ),
+            })?
+            .to_string();
+
+        let encoded_cbdev_uri =
+            parameters.remove("cbdev").context(bdev_api::InvalidUri {
+                uri: uri.to_string(),
+                message: String::from("No cbdev parameter found"),
+            })?;
+
+        let cbdev_uri = percent_decode_str(&encoded_cbdev_uri)
+            .decode_utf8()
+            .map_err(|e| BdevError::InvalidUri {
+                uri: uri.to_string(),
+                message: format!(
+                    "Could not percent decode cbdev_uri sub-uri - {}",
+                    e
+                ),
+            })?
+            .to_string();
+
+        // Device parameter checking for bbdev and cbdev are done in
+        // bdev_ftl_create_bdev
+        reject_unknown_parameters(uri, parameters)?;
+
+        Ok(Self {
+            name: uri.path()[1 ..].into(),
+            alias: uri.to_string(),
+            uuid,
+            bbdev_uri,
+            cbdev_uri,
+        })
+    }
+}
+
+impl GetName for Ftl {
+    fn get_name(&self) -> String {
+        self.name.clone()
+    }
+}
+
+pub extern "C" fn ftl_bdev_init_fn_cb(
+    _ptr: *const ftl_bdev_info,
+    sender_ptr: *mut c_void,
+    errno: i32,
+) {
+    info!("{:?}: ftl_bdev_init_fn_cb", errno);
+    let sender = unsafe {
+        Box::from_raw(sender_ptr as *mut oneshot::Sender<ErrnoResult<()>>)
+    };
+    sender
+        .send(errno_result_from_i32((), errno))
+        .expect("done callback receiver side disappeared");
+}
+
+#[async_trait(?Send)]
+impl CreateDestroy for Ftl {
+    type Error = BdevError;
+
+    async fn create(&self) -> Result<String, Self::Error> {
+        if UntypedBdev::lookup_by_name(&self.name).is_some() {
+            return Err(BdevError::BdevExists {
+                name: self.name.clone(),
+            });
+        }
+
+        let ftl_dev_name = CString::new(self.name.clone()).unwrap();
+
+        debug!(
+            "{:?}: Creating ftl-bdev '{:?}' with bbdev {:?} and cbdev {:?}.",
+            self, ftl_dev_name, self.bbdev_uri, self.cbdev_uri
+        );
+
+        use std::ffi::CString;
+
+        let base_dev_name = bdev_create(&self.bbdev_uri).await?;
+        let cache_dev_name = match bdev_create(&self.cbdev_uri).await {
+            Ok(dev_name) => dev_name,
+            Err(err) => {
+                if let Err(e) = bdev_destroy(&self.bbdev_uri).await {
+                    error!("{:?} bbdev cleanup error: {}", self, e);
+                }
+                return Err(err);
+            }
+        };
+
+        let (s, r) = oneshot::channel::<ErrnoResult<()>>();
+
+        let spdk_ftl_conf_size = mem::size_of::<spdk_ftl_conf>() as u64;
+        let mut ftl_conf = spdk_ftl_conf {
+            ..unsafe { mem::zeroed() }
+        };
+        unsafe { spdk_ftl_get_default_conf(&mut ftl_conf, spdk_ftl_conf_size) };
+        ftl_conf.name = ftl_dev_name.as_ptr() as *mut i8;
+        ftl_conf.base_bdev = base_dev_name.as_ptr() as *mut i8;
+        ftl_conf.cache_bdev = cache_dev_name.as_ptr() as *mut i8;
+        ftl_conf.fast_shutdown = true;
+        ftl_conf.verbose_mode = true;
+        ftl_conf.mode = spdk_ftl_mode::SPDK_FTL_MODE_CREATE as u32;
+
+        let errno = unsafe {
+            bdev_ftl_create_bdev(
+                &ftl_conf,
+                Some(ftl_bdev_init_fn_cb),
+                cb_arg(s),
+            )
+        };
+
+        if errno != 0 {
+            let err = BdevError::CreateBdevFailed {
+                source: Errno::from_raw(errno.abs()),
+                name: self.name.clone(),
+            };
+
+            error!("{:?} error: {}", self, err.verbose());
+
+            if let Err(e) = bdev_destroy(&self.bbdev_uri).await {
+                error!("{:?} bbdev cleanup error: {}", self, e);
+            }
+            if let Err(e) = bdev_destroy(&self.cbdev_uri).await {
+                error!("{:?} cbdev cleanup error: {}", self, e);
+            }
+
+            return Err(err);
+        }
+
+        r.await
+            .context(bdev_api::BdevCommandCanceled {
+                name: self.name.clone(),
+            })?
+            .context(bdev_api::CreateBdevFailed {
+                name: self.name.clone(),
+            })?;
+
+        if let Some(mut bdev) = UntypedBdev::lookup_by_name(&self.name) {
+            if let Some(uuid) = self.uuid {
+                unsafe { bdev.set_raw_uuid(uuid.into()) };
+            }
+
+            if !bdev.add_alias(&self.alias) {
+                warn!("{:?}: failed to add alias '{}'", self, self.alias);
+            }
+
+            return Ok(self.get_name());
+        }
+
+        Err(BdevError::BdevNotFound {
+            name: self.get_name(),
+        })
+    }
+
+    async fn destroy(self: Box<Self>) -> Result<(), Self::Error> {
+        debug!("{:?}: deleting", self);
+
+        let Some(mut bdev) = UntypedBdev::lookup_by_name(&self.name) else {
+            return Err(BdevError::BdevNotFound {
+                name: self.name,
+            });
+        };
+
+        bdev.remove_alias(&self.alias);
+        let (s, r) = oneshot::channel::<ErrnoResult<()>>();
+
+        unsafe {
+            bdev_ftl_delete_bdev(
+                (*bdev.unsafe_inner_ptr()).name,
+                true,
+                Some(done_errno_cb),
+                cb_arg(s),
+            );
+        }
+
+        r.await
+            .context(bdev_api::BdevCommandCanceled {
+                name: self.name.clone(),
+            })?
+            .context(bdev_api::DestroyBdevFailed {
+                name: self.name,
+            })?;
+
+        let mut result = bdev_destroy(&self.bbdev_uri).await;
+
+        if let Err(e) = bdev_destroy(&self.cbdev_uri).await {
+            if result.is_ok() {
+                result = Err(e);
+            }
+        }
+        result
+    }
+}

--- a/io-engine/src/bdev/mod.rs
+++ b/io-engine/src/bdev/mod.rs
@@ -16,6 +16,7 @@ use crate::core::{MayastorEnvironment, PtplProps};
 pub(crate) use dev::uri;
 
 pub(crate) mod device;
+mod ftl;
 mod loopback;
 mod lvs;
 mod malloc;

--- a/io-engine/src/core/env.rs
+++ b/io-engine/src/core/env.rs
@@ -44,6 +44,9 @@ use spdk_rs::{
         spdk_thread_lib_fini,
         spdk_thread_send_critical_msg,
         spdk_trace_cleanup,
+        spdk_trace_create_tpoint_group_mask,
+        spdk_trace_init,
+        spdk_trace_set_tpoints,
         SPDK_LOG_DEBUG,
         SPDK_LOG_INFO,
         SPDK_RPC_RUNTIME,
@@ -1020,6 +1023,45 @@ impl MayastorEnvironment {
         None
     }
 
+    fn init_spdk_tracing(&self) {
+        const MAX_GROUP_IDS: u32 = 16;
+        const NUM_THREADS: u32 = 1;
+        let cshm_name = if self.shm_id >= 0 {
+            CString::new(
+                format!("/{}_trace.{}", self.name, self.shm_id).as_str(),
+            )
+            .unwrap()
+        } else {
+            CString::new(
+                format!("/{}_trace.pid{}", self.name, std::process::id())
+                    .as_str(),
+            )
+            .unwrap()
+        };
+        unsafe {
+            if spdk_trace_init(
+                cshm_name.as_ptr(),
+                self.num_entries,
+                NUM_THREADS,
+            ) != 0
+            {
+                error!("SPDK tracing init error");
+            }
+        }
+        let tpoint_group_name = CString::new("all").unwrap();
+        let tpoint_group_mask = unsafe {
+            spdk_trace_create_tpoint_group_mask(tpoint_group_name.as_ptr())
+        };
+
+        for group_id in 0 .. MAX_GROUP_IDS {
+            if (tpoint_group_mask & (1 << group_id) as u64) > 0 {
+                unsafe {
+                    spdk_trace_set_tpoints(group_id, u64::MAX);
+                }
+            }
+        }
+    }
+
     /// initialize the core, call this before all else
     pub fn init(mut self) -> Self {
         // setup the logger as soon as possible
@@ -1087,6 +1129,11 @@ impl MayastorEnvironment {
 
         // ensure we are within the context of a spdk thread from here
         Mthread::primary().set_current();
+
+        // To enable SPDK tracing set self.num_entries (eg. to 32768).
+        if self.num_entries > 0 {
+            self.init_spdk_tracing();
+        }
 
         Reactor::block_on(async {
             let (sender, receiver) = oneshot::channel::<bool>();

--- a/io-engine/src/core/env.rs
+++ b/io-engine/src/core/env.rs
@@ -330,7 +330,7 @@ impl Default for MayastorCliArgs {
             reactor_mask: "0x1".into(),
             mem_size: 0,
             rpc_address: "/var/tmp/mayastor.sock".to_string(),
-            no_pci: true,
+            no_pci: false,
             log_components: vec![],
             log_format: None,
             mayastor_config: None,

--- a/io-engine/tests/ftl_mount_fs.rs
+++ b/io-engine/tests/ftl_mount_fs.rs
@@ -1,0 +1,140 @@
+#![cfg(feature = "nvme-pci-tests")]
+//! TODO: with spdk v24.09 ftl devices support variable sector size emulation.
+//! At that point we can enable testing with aio devices, which do not require a
+//! metadata section in the LBA format. For now we are hiding this test case
+//! behind the `nvme-pci-tests` feature flag.
+use once_cell::sync::OnceCell;
+use std::convert::TryFrom;
+extern crate libnvme_rs;
+
+use io_engine::{
+    bdev::nexus::{nexus_create, nexus_lookup_mut},
+    core::{MayastorCliArgs, Protocol, UntypedBdevHandle},
+};
+
+pub mod common;
+use common::compose::MayastorTest;
+
+// See ftl.rs for uri pattern
+static FTL_URI_PREFIX: &str = "ftl:///";
+static FTL_BDEV: &str = "ftl0";
+
+// BASE_DEV has to be formated with flbas 4KiB
+static BASE_DEV: &str = "pcie:///0000:82:00.0";
+// CACHE_DEV has to be formated with flbas 4KiB+64
+static CACHE_DEV: &str = "pcie:///0000:83:00.0";
+
+/*
+static BASE_DISK: &str = "/tmp/basedev.img";
+static BASE_DEV: &str = "aio:///tmp/basedev.img%3Fblk_size=4096";
+static CACHE_DISK: &str = "/tmp/cachedev.img";
+static CACHE_DEV: &str = "aio:///tmp/cachedev.img%3Fblk_size=4096";
+
+// FTL devices require a minimum of 20 GiB capacity
+static DISK_SIZE_MB: u64 = 25000;
+
+macro_rules! prepare_storage {
+    () => {
+        common::delete_file(&[BASE_DISK.into(), CACHE_DISK.into()]);
+        common::truncate_file(BASE_DISK, DISK_SIZE_MB * 1024);
+        common::truncate_file(CACHE_DISK, DISK_SIZE_MB * 1024);
+    };
+}
+*/
+
+static MAYASTOR: OnceCell<MayastorTest> = OnceCell::new();
+
+fn get_ms() -> &'static MayastorTest<'static> {
+    MAYASTOR.get_or_init(|| MayastorTest::new(MayastorCliArgs::default()))
+}
+
+async fn create_connected_nvmf_nexus(
+    ms: &'static MayastorTest<'static>,
+) -> (libnvme_rs::NvmeTarget, String) {
+    let uri = ms
+        .spawn(async {
+            create_nexus().await;
+            // Claim the bdev
+            let hdl = UntypedBdevHandle::open(&FTL_BDEV, true, true);
+            let nexus = nexus_lookup_mut("nexus").unwrap();
+            let ret = nexus.share(Protocol::Nvmf, None).await.unwrap();
+            drop(hdl);
+            ret
+        })
+        .await;
+
+    // Create and connect NVMF target.
+    let target = libnvme_rs::NvmeTarget::try_from(uri)
+        .unwrap()
+        .with_rand_hostnqn(true);
+    target.connect().unwrap();
+    let devices = target.block_devices(2).unwrap();
+
+    assert_eq!(devices.len(), 1);
+    (target, devices[0].to_string())
+}
+
+#[tokio::test]
+async fn ftl_mount_fs_multiple() {
+    let ms = get_ms();
+
+    //prepare_storage!();
+    let (target, nvmf_dev) = create_connected_nvmf_nexus(ms).await;
+
+    for _i in 0 .. 10 {
+        common::mount_umount(&nvmf_dev).unwrap();
+    }
+
+    target.disconnect().unwrap();
+    ms.spawn(async move {
+        let mut nexus = nexus_lookup_mut("nexus").unwrap();
+        nexus.as_mut().unshare_nexus().await.unwrap();
+        nexus.destroy().await.unwrap();
+    })
+    .await;
+}
+
+pub fn csal_fio_run_verify(device: &str) -> Result<String, String> {
+    let (exit, stdout, stderr) = run_script::run(
+        r#"
+        fio --name=randrw --rw=randrw --ioengine=libaio --direct=1 --time_based=1 \
+        --runtime=10 --bs=64k --verify=crc32 --group_reporting=1  \
+        --verify_fatal=1 --verify_async=2 --filename=$1
+        "#,
+        &vec![device.into()],
+        &run_script::ScriptOptions::new(),
+    ).unwrap();
+    if exit == 0 {
+        Ok(stdout)
+    } else {
+        Err(stderr)
+    }
+}
+
+#[tokio::test]
+async fn ftl_mount_fs_fio() {
+    let ms = get_ms();
+
+    //prepare_storage!();
+    let (target, nvmf_dev) = create_connected_nvmf_nexus(ms).await;
+
+    let _ = csal_fio_run_verify(&nvmf_dev).unwrap();
+
+    target.disconnect().unwrap();
+    ms.spawn(async move {
+        let mut nexus = nexus_lookup_mut("nexus").unwrap();
+        nexus.as_mut().unshare_nexus().await.unwrap();
+        nexus.destroy().await.unwrap();
+    })
+    .await;
+}
+
+async fn create_nexus() {
+    let bdev_uri: String = format!(
+        "{FTL_URI_PREFIX}{FTL_BDEV}?bbdev={BASE_DEV}&cbdev={CACHE_DEV}"
+    );
+    let ch = vec![bdev_uri];
+    nexus_create("nexus", 8 * 1024 * 1024 * 1024, None, &ch)
+        .await
+        .unwrap();
+}


### PR DESCRIPTION
For this PR to be merged the PR https://github.com/openebs/spdk-rs/pull/67
for spdk-rs needs to be resolved and the submodule reference must be
updated accordingly. :)

The SPDK ftl bdev allows to create a layered device with a (fast) cache
device for buffering writes that get eventually flushed out sequentially
to a base device. SDPK ftl is also known as the Cloud Storage
Acceleration Layer (CSAL).

This kind of device potentially enables the use of emerging storage
interfaces like Zoned Namespace (ZNS) or Flexible Data Placement (FDP)
capable NVMe devices. Up to this point, those NVMe command sets are not
yet supported in SPDK upstream. However, the acceleration aspect of a
fast cache device already adds value.
With future support of new devices for SDPK ftl, Mayastor would already
be capable of utilizing those features simply by upgrading SDPK.

For now, the `ftl_mount_fs` test cases are hidden behind the `ignore`
attribute because PCIe devices are required for this test until
SPDK v24.09 is picked up, which introduces variable sector size emulation
for ftl devices.
To run these tests use the following:
```
RUST_LOG=TRACE cargo test -- --test-threads 1 --test ftl_mount_fs --nocapture --ignored
```

This patch introduces a new ftl device uri scheme:
```
ftl:///<ftl-device-name>?bbdev=<dev-uri-nested-encoding>&cbdev=<dev-uri-nested-encoding>
```

`<dev-uri-nested-encoding>` can be any already valid device uri where '?'
are replaced with '!' and '&' are replaced with '|'.
With SPDK v24.05 only PCIe devices will work where the cache device is
formatted to 4KiB+64B LBA format and the base device to 4KiB LBA format.

From SPDK v24.09 on, any device with a block size of 4KiB will work for
both cache and base device.

CSAL paper reference:
https://dl.acm.org/doi/10.1145/3627703.3629566