### PR TITLE
Backport fixes for release/2.7

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "spdk-rs"]
 	path = spdk-rs
-	url = https://github.com/openebs/spdk-rs
+	url = ../spdk-rs.git
 	branch = release/2.7
 [submodule "utils/dependencies"]
 	path = utils/dependencies

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1592,6 +1592,7 @@ dependencies = [
  "crossbeam",
  "derive_builder",
  "devinfo",
+ "either",
  "env_logger",
  "etcd-client",
  "event-publisher",

--- a/io-engine-tests/src/lib.rs
+++ b/io-engine-tests/src/lib.rs
@@ -188,6 +188,28 @@ pub fn truncate_file_bytes(path: &str, size: u64) {
     assert!(output.status.success());
 }
 
+/// Automatically assign a loopdev to path
+pub fn setup_loopdev_file(path: &str, sector_size: Option<u64>) -> String {
+    let log_sec = sector_size.unwrap_or(512);
+
+    let output = Command::new("losetup")
+        .args(["-f", "--show", "-b", &format!("{log_sec}"), path])
+        .output()
+        .expect("failed exec losetup");
+    assert!(output.status.success());
+    // return the assigned loop device
+    String::from_utf8(output.stdout).unwrap().trim().to_string()
+}
+
+/// Detach the provided loop device.
+pub fn detach_loopdev(dev: &str) {
+    let output = Command::new("losetup")
+        .args(["-d", dev])
+        .output()
+        .expect("failed exec losetup");
+    assert!(output.status.success());
+}
+
 pub fn fscheck(device: &str) {
     let output = Command::new("fsck")
         .args([device, "-n"])

--- a/io-engine/Cargo.toml
+++ b/io-engine/Cargo.toml
@@ -70,7 +70,7 @@ libc = "0.2.149"
 log = "0.4.20"
 md5 = "0.7.0"
 merge = "0.1.0"
-nix = { version = "0.27.1", default-features = false, features = [ "hostname", "net", "socket", "ioctl" ] }
+nix = { version = "0.27.1", default-features = false, features = ["hostname", "net", "socket", "ioctl"] }
 once_cell = "1.18.0"
 parking_lot = "0.12.1"
 pin-utils = "0.1.0"
@@ -98,9 +98,10 @@ async-process = { version = "1.8.1" }
 rstack = { version = "0.3.3" }
 tokio-stream = "0.1.14"
 rustls = "0.21.12"
+either = "1.9.0"
 
 devinfo = { path = "../utils/dependencies/devinfo" }
-jsonrpc = { path = "../jsonrpc"}
+jsonrpc = { path = "../jsonrpc" }
 io-engine-api = { path = "../utils/dependencies/apis/io-engine" }
 spdk-rs = { path = "../spdk-rs" }
 sysfs = { path = "../sysfs" }

--- a/io-engine/src/bdev/nexus/nexus_bdev_children.rs
+++ b/io-engine/src/bdev/nexus/nexus_bdev_children.rs
@@ -1152,10 +1152,11 @@ impl<'n> Nexus<'n> {
         // Cancel rebuild job for this child, if any.
         if let Some(job) = child.rebuild_job() {
             debug!("{self:?}: retire: stopping rebuild job...");
-            let terminated = job.force_fail();
-            Reactors::master().send_future(async move {
-                terminated.await.ok();
-            });
+            if let either::Either::Left(terminated) = job.force_fail() {
+                Reactors::master().send_future(async move {
+                    terminated.await.ok();
+                });
+            }
         }
 
         debug!("{child:?}: retire: enqueuing device '{dev}' to retire");

--- a/io-engine/src/bdev/nvmx/utils.rs
+++ b/io-engine/src/bdev/nvmx/utils.rs
@@ -40,8 +40,9 @@ pub enum NvmeAerInfoNvmCommandSet {
 
 /// Check if the Completion Queue Entry indicates abnormal termination of
 /// request due to any of the following conditions:
-///   - Any media specific errors that occur in the NVM or data integrity type
-///     errors.
+///   - An Status Code Type(SCT) of media specific errors that occur in the NVM
+///     or data integrity type errors, AND a Status Code(SC) value pertaining to
+///     one of the below:
 ///   - The command was aborted due to an end-to-end guard check failure.
 ///   - The command was aborted due to an end-to-end application tag check
 ///     failure.
@@ -59,9 +60,9 @@ pub(crate) fn nvme_cpl_is_pi_error(cpl: *const spdk_nvme_cpl) -> bool {
     }
 
     sct == NvmeStatusCodeType::MediaError as u16
-        || sc == NvmeMediaErrorStatusCode::Guard as u16
-        || sc == NvmeMediaErrorStatusCode::ApplicationTag as u16
-        || sc == NvmeMediaErrorStatusCode::ReferenceTag as u16
+        && (sc == NvmeMediaErrorStatusCode::Guard as u16
+            || sc == NvmeMediaErrorStatusCode::ApplicationTag as u16
+            || sc == NvmeMediaErrorStatusCode::ReferenceTag as u16)
 }
 
 #[inline]

--- a/io-engine/src/grpc/v1/snapshot_rebuild.rs
+++ b/io-engine/src/grpc/v1/snapshot_rebuild.rs
@@ -110,7 +110,10 @@ impl SnapshotRebuildRpc for SnapshotRebuildService {
             let Ok(job) = SnapshotRebuildJob::lookup(&args.uuid) else {
                 return Err(tonic::Status::not_found(""));
             };
-            let rx = job.force_stop().await.ok();
+            let rx = match job.force_stop() {
+                either::Either::Left(chan) => chan.await,
+                either::Either::Right(stopped) => Ok(stopped),
+            };
             info!("Snapshot Rebuild stopped: {rx:?}");
             job.destroy();
             Ok(())

--- a/io-engine/src/rebuild/mod.rs
+++ b/io-engine/src/rebuild/mod.rs
@@ -57,7 +57,10 @@ impl WithinRange<u64> for std::ops::Range<u64> {
 /// Shutdown all pending snapshot rebuilds.
 pub(crate) async fn shutdown_snapshot_rebuilds() {
     let jobs = SnapshotRebuildJob::list().into_iter();
-    for recv in jobs.map(|job| job.force_stop()).collect::<Vec<_>>() {
+    for recv in jobs
+        .flat_map(|job| job.force_stop().left())
+        .collect::<Vec<_>>()
+    {
         recv.await.ok();
     }
 }

--- a/scripts/clean-cargo-tests.sh
+++ b/scripts/clean-cargo-tests.sh
@@ -1,7 +1,26 @@
+#!/usr/bin/env bash
+
 SCRIPT_DIR="$(dirname "$0")"
 ROOT_DIR=$(realpath "$SCRIPT_DIR/..")
 
 sudo nvme disconnect-all
+
+# Detach any loop devices created for test purposes
+for back_file in "/tmp/io-engine-tests"/*; do
+    # Find loop devices associated with the disk image
+    devices=$(losetup -j "$back_file" -O NAME --noheadings)
+
+    # Detach each loop device found
+    while IFS= read -r device; do
+        if [ -n "$device" ]; then
+            echo "Detaching loop device: $device"
+            losetup -d "$device"
+        fi
+    done <<< "$devices"
+done
+# Delete the directory too
+rmdir --ignore-fail-on-non-empty "/tmp/io-engine-tests"
+
 
 for c in $(docker ps -a --filter "label=io.composer.test.name" --format '{{.ID}}') ; do
   docker kill "$c"

--- a/scripts/pytest-tests.sh
+++ b/scripts/pytest-tests.sh
@@ -36,6 +36,15 @@ function clean_all()
   echo "Done"
 }
 
+function is_test()
+{
+  file="${1:-}"
+  if [ -d "$file" ] || [ -f "$file" ] || [ -f "${file%::*}" ]; then
+    return 0
+  fi
+  return 1
+}
+
 function run_tests()
 {
   while read name extra
@@ -95,10 +104,13 @@ while [ "$#" -gt 0 ]; do
     *)
       set +e
       real_1="$(realpath $1 2>/dev/null)"
+      real_2="$(realpath $SRCDIR/test/python/$1 2>/dev/null)"
       set -e
       param="$1"
-      if [ -d "$real_1" ] || [ -f "$real_1" ] || [ -f "${real_1%::*}" ]; then
+      if is_test "$real_1"; then
         param="$real_1"
+      elif is_test "$real_2"; then
+        param="$real_2"
       else
         TEST_ARGS="${TEST_ARGS:-}$1"
       fi

--- a/test/python/tests/nexus_fault/test_nexus_fault.py
+++ b/test/python/tests/nexus_fault/test_nexus_fault.py
@@ -16,7 +16,12 @@ from retrying import retry
 from common.command import run_cmd
 from common.fio import Fio
 from common.mayastor import container_mod, mayastor_mod
-from common.nvme import nvme_connect, nvme_disconnect, nvme_disconnect_controller
+from common.nvme import (
+    nvme_connect,
+    nvme_disconnect,
+    nvme_disconnect_controller,
+    nvme_find_ctrl,
+)
 
 import nexus_pb2 as pb
 
@@ -119,13 +124,12 @@ def _(recreate_pool, republish_nexus_ana):
 
 
 @when("the initiator swaps the nexuses")
-def _(recreate_pool, republish_nexus_ana):
+def _(publish_nexus, recreate_pool, republish_nexus_ana):
     """the initiator swaps the nexuses."""
     print(republish_nexus_ana)
-    device = nvme_connect(republish_nexus_ana)
-    # disconnect previous nexus: /dev/nvme*n*
-    split_dev = device.split("n")
-    nvme_disconnect_controller(f"{split_dev[0]}n{split_dev[1]}")
+    prev_ctrl = nvme_find_ctrl(publish_nexus)
+    nvme_connect(republish_nexus_ana)
+    nvme_disconnect_controller(f"/dev/{prev_ctrl}")
 
 
 @then("the fio workload should complete gracefully")


### PR DESCRIPTION
    test(bdd): make nvme controller usage more robust
    
    Caters for when the device is /dev/nvmeX but X not the same as the controller!
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    Merge #1755
    
    1755: Reuse Rebuild IO handles r=tiagolobocastro a=tiagolobocastro
    
        fix(rebuild): reuse rebuild IO handles
    
        Reuses the rebuild IO handles, rather than attempting to allocate
        them per rebuild task.
        The main issue with handle allocation on the fly is that the target
        may have not cleaned up a previous IO qpair connection, and so the
        connect may fail. We started seeing this more on CI because we forgot
        to cherry-pick a commit increasing the retry delay.
        However, after inspecting a bunch of user support bundles I see that
        we still have occasional connect errors. Rather than increasing the
        timeout, we attempt here to reuse the handles, thus avoid the
        problem almost entirely.
    
        Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>
    
    ---
    
        refactor(rebuild): rebuild completion is not an error
    
        When the rebuild has been complete, if we wait for it this fails because
        the channels are not longer available.
        Instead, simply return the rebuild state, since this is what we want anyway.
    
        Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>
    
    Co-authored-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    fix: check valid sct and sc combinations for pi error
    
    Signed-off-by: Diwakar Sharma <diwakar.sharma@datacore.com>

---

    fix: use auto-detected sector size for blockdev
    
    This fixes the behaviour where we pass 512 as sector size if the
    disk uri doesn't contain blk_size parameter. This causes pool creation
    failure if the underlying disk has a different sector size e.g. 4096.
    Instead of passing 512, we now pass 0 which lets spdk detect the
    device's sector size and use that value.
    
    Signed-off-by: Diwakar Sharma <diwakar.sharma@datacore.com>
