### PR TITLE
Cherry pick PR #1780

### DIFF
--- a/io-engine/src/bdev/nexus/nexus_persistence.rs
+++ b/io-engine/src/bdev/nexus/nexus_persistence.rs
@@ -104,6 +104,15 @@ impl<'n> Nexus<'n> {
                     };
                     nexus_info.children.push(child_info);
                 });
+                // We started with this child because it was healthy in etcd, or isn't there at all.
+                // Being unhealthy here means it is undergoing a fault/retire before nexus is open.
+                if nexus_info.children.len() == 1 && !nexus_info.children[0].healthy {
+                    warn!("{self:?} Not persisting: the only child went unhealthy during nexus creation");
+                    return Err(Error::NexusCreate {
+                        name: self.name.clone(),
+                        reason: "only child is unhealthy".to_string(),
+                    });
+                }
             }
             PersistOp::AddChild {
                 child_uri,


### PR DESCRIPTION
When nexus is being created with a single child, and that child goes into retire path before nexus is open, then the child gets persisted as unhealthy. This will cause volume to never be able to attach later on.