### PR TITLE
fix(nvmf/uri): use nvmf:// scheme for tcp

### DIFF
--- a/io-engine/src/subsys/nvmf/transport.rs
+++ b/io-engine/src/subsys/nvmf/transport.rs
@@ -145,13 +145,13 @@ impl Display for TransportId {
         // trstring for uri scheme to explicitly indicate the tcp support
         // also by default when there is rdma available.
         let trstring = match self.0.trstring.as_str() {
-            "RDMA" => "rdma+tcp".to_string(),
-            _else => _else.to_lowercase(),
+            "RDMA" => "+rdma+tcp".to_string(),
+            _else => "".to_string(),
         };
 
         write!(
             f,
-            "nvmf+{}://{}:{}",
+            "nvmf{}://{}:{}",
             trstring,
             self.0.traddr.as_str(),
             self.0.trsvcid.as_str()

--- a/io-engine/tests/nvmf.rs
+++ b/io-engine/tests/nvmf.rs
@@ -189,7 +189,7 @@ async fn nvmf_set_target_interface() {
             .into_inner()
             .uri;
 
-        let re = Regex::new(r"^nvmf(\+rdma\+tcp|\+tcp)://([0-9.]+):[0-9]+/.*$").unwrap();
+        let re = Regex::new(r"^nvmf(\+rdma\+tcp|\+tcp)?://([0-9.]+):[0-9]+/.*$").unwrap();
         let cap = re.captures(&bdev_uri).unwrap();
         let shared_ip = cap.get(2).unwrap().as_str();
 

--- a/test/grpc/test_common.js
+++ b/test/grpc/test_common.js
@@ -21,7 +21,7 @@ const CSI_ID = 'test-node-id';
 const LOCALHOST = '127.0.0.1';
 const NVME_MODEL_ID = 'Mayastor NVMe controller';
 const NVME_NQN_PREFIX = 'nqn.2019-05.io.openebs';
-const NVMF_URI = /^nvmf\+(tcp|rdma\+tcp):\/\/(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}):\d{1,5}\/nqn.2019-05.io.openebs:/;
+const NVMF_URI = /^nvmf(\+tcp|\+rdma\+tcp)?:\/\/(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}):\d{1,5}\/nqn.2019-05.io.openebs:/;
 
 const testPort = process.env.TEST_PORT || GRPC_PORT;
 const myIp = getMyIp() || LOCALHOST;


### PR DESCRIPTION
- Fixes issue where a nexus on old version gets an AddChild request for a child with new nvmf+tcp:// uri. It resulted in Unsupported uri scheme error.
- Replicas always use nvmf:// uri scheme now.
- Nexus use nvmf:// scheme when shared over tcp, and uses nvmf+rdma+tcp:// scheme when shared over rdma and tcp both.