### PR TITLE
ci: switch from jenkins to github actions

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -1,4 +1,4 @@
-status = [ "continuous-integration/jenkins/branch" ]
+status = [ "bors-ci" ]
 pr_status = [ "commitlint", "DCO" ]
 timeout_sec = 10000
 required_approvals = 2

--- a/.github/workflows/bdd.yml
+++ b/.github/workflows/bdd.yml
@@ -1,0 +1,62 @@
+name: BDD CI
+on:
+  workflow_call:
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+  CI: 1
+
+jobs:
+  bdd-tests:
+    runs-on: ubuntu-latest-16-cores
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: 'recursive'
+      - uses: DeterminateSystems/nix-installer-action@v14
+      - uses: DeterminateSystems/magic-nix-cache-action@v8
+      - name: Pre-populate nix-shell
+        run: |
+          export NIX_PATH=nixpkgs=$(jq '.nixpkgs.url' nix/sources.json -r)
+          echo "NIX_PATH=$NIX_PATH" >> $GITHUB_ENV
+          nix-shell --run "echo" shell.nix
+      - name: Handle Rust dependencies caching
+        uses: Swatinem/rust-cache@v2
+      - name: Build binaries
+        run: nix-shell --run "cargo build --bins --features=io-engine-testing"
+      - name: Setup Test Pre-Requisites
+        run: |
+          sudo sysctl -w vm.nr_hugepages=2560
+          sudo apt-get install linux-modules-extra-$(uname -r)
+          for module in nvme_tcp nbd nvme_rdma; do
+            sudo modprobe $module
+          done
+          # for the coredump check
+          sudo apt-get install gdb
+      - name: Setup VENV
+        run: nix-shell --run "./test/python/setup.sh"
+      - name: Run BDD Tests
+        run: |
+          echo "TEST_START_DATE=$(date +"%Y-%m-%d %H:%M:%S")" >> $GITHUB_ENV
+          nix-shell --run "./scripts/pytest-tests.sh"
+      - name: Test Report
+        if: always()
+        uses: pmeier/pytest-results-action@main
+        with:
+          path: test/python/reports/**/xunit-report.xml
+          summary: true
+          display-options: a
+          fail-on-empty: true
+          title: Test results
+      - name: Cleanup
+        if: always()
+        run: nix-shell --run "./scripts/pytest-tests.sh --clean-all-exit"
+      - name: Check Coredumps
+        run: sudo ./scripts/check-coredumps.sh --since "${TEST_START_DATE}"
+# debugging
+      # - name: Setup tmate session
+      #   if: ${{ failure() }}
+      #   timeout-minutes: 240
+      #   uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/image-pr.yml
+++ b/.github/workflows/image-pr.yml
@@ -1,0 +1,20 @@
+name: ImageBuild CI
+on:
+  workflow_call:
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+  CI: 1
+
+jobs:
+  image-build-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
+      - uses: DeterminateSystems/nix-installer-action@v14
+      - uses: DeterminateSystems/magic-nix-cache-action@v8
+      - name: Test building the release images
+        run: ./scripts/release.sh --skip-publish --build-bins

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -1,0 +1,30 @@
+name: Image Push
+on:
+  push:
+    branches:
+      - develop
+      - 'release/**'
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+**'
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+  CI: 1
+
+jobs:
+  image-build-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
+      - uses: DeterminateSystems/nix-installer-action@v14
+      - uses: DeterminateSystems/magic-nix-cache-action@v8
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push the release images
+        run: ./scripts/release.sh

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,35 @@
+name: Linter CI
+on:
+  workflow_call:
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+  CI: 1
+
+jobs:
+  code-linter:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
+      - uses: DeterminateSystems/nix-installer-action@v14
+      - uses: DeterminateSystems/magic-nix-cache-action@v8
+      - name: Pre-populate nix-shell
+        run: |
+          export NIX_PATH=nixpkgs=$(jq '.nixpkgs.url' nix/sources.json -r)
+          echo "NIX_PATH=$NIX_PATH" >> $GITHUB_ENV
+          nix-shell --run "echo" shell.nix
+      - name: Handle Rust dependencies caching
+        uses: Swatinem/rust-cache@v2
+      - name: Lint rust code
+        run: |
+          nix-shell --run "FMT_OPTS=--check ./scripts/rust-style.sh"
+          nix-shell --run "./scripts/rust-linter.sh"
+      - name: Lint JS code
+        run: nix-shell --run "./scripts/js-check.sh"
+      - name: Lint python code
+        run: nix-shell --run "black --diff --check test/python"
+      - name: Lint Nix code
+        run: nix-shell --run "nixpkgs-fmt --check ."

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -1,0 +1,15 @@
+name: Nightly CI
+on:
+  workflow_dispatch:
+
+jobs:
+  ci:
+    uses: ./.github/workflows/pr-ci.yml
+  nightly-ci:
+    if: ${{ success() }}
+    needs:
+      - ci
+    runs-on: ubuntu-latest
+    steps:
+      - name: CI succeeded
+        run: exit 0

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -1,0 +1,28 @@
+name: Bors CI
+on:
+  workflow_call:
+  push:
+    branches:
+      - staging
+      - trying
+
+jobs:
+  lint-ci:
+    uses: ./.github/workflows/lint.yml
+  int-ci:
+    uses: ./.github/workflows/unit-int.yml
+  bdd-ci:
+    uses: ./.github/workflows/bdd.yml
+  image-ci:
+    uses: ./.github/workflows/image-pr.yml
+  bors-ci:
+    if: ${{ success() }}
+    needs:
+      - lint-ci
+      - int-ci
+      - bdd-ci
+      - image-ci
+    runs-on: ubuntu-latest
+    steps:
+      - name: CI succeeded
+        run: exit 0

--- a/.github/workflows/unit-int.yml
+++ b/.github/workflows/unit-int.yml
@@ -1,0 +1,76 @@
+name: Integration CI
+on:
+  workflow_call:
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+  CI: 1
+
+jobs:
+  int-tests:
+    runs-on: ubuntu-latest-16-cores
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: 'recursive'
+      - uses: DeterminateSystems/nix-installer-action@v14
+      - uses: DeterminateSystems/magic-nix-cache-action@v8
+      - name: Pre-populate nix-shell
+        run: |
+          export NIX_PATH=nixpkgs=$(jq '.nixpkgs.url' nix/sources.json -r)
+          echo "NIX_PATH=$NIX_PATH" >> $GITHUB_ENV
+          nix-shell --run "echo" shell.nix
+      - name: Handle Rust dependencies caching
+        uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ startsWith(github.ref_name, 'release/') || github.ref_name == 'develop' }}
+      - name: Build binaries
+        run: nix-shell --run "cargo build --bins --features=io-engine-testing"
+      - name: Setup Test Pre-Requisites
+        run: |
+          sudo sysctl -w vm.nr_hugepages=3584
+          sudo apt-get install linux-modules-extra-$(uname -r)
+          for module in nvme_tcp nbd nvme_rdma; do
+            sudo modprobe $module
+          done
+          sudo apt-get install gdb
+      - name: Run Rust Tests
+        run: |
+          echo "TEST_START_DATE=$(date +"%Y-%m-%d %H:%M:%S")" >> $GITHUB_ENV
+          nix-shell --run "./scripts/cargo-test.sh"
+      - name: Cleanup
+        if: always()
+        run: nix-shell --run "./scripts/clean-cargo-tests.sh"
+      - name: Check Coredumps
+        run: sudo ./scripts/check-coredumps.sh --since "${TEST_START_DATE}"
+      - name: Run JS Grpc Tests
+        run: |
+          echo "TEST_START_DATE=$(date +"%Y-%m-%d %H:%M:%S")" >> $GITHUB_ENV
+          nix-shell --run "./scripts/grpc-test.sh"
+          mkdir js-reports
+          for file in *-xunit-report.xml; do
+            echo "<testsuites>" > "js-reports/$file"
+            cat $file >> "js-reports/$file"
+            echo "</testsuites>" >> "js-reports/$file"
+          done
+      - name: Test Report
+        if: always()
+        uses: pmeier/pytest-results-action@main
+        with:
+          path: 'js-reports/*-xunit-report.xml'
+          summary: true
+          display-options: a
+          fail-on-empty: true
+          title: Test results
+      - name: Cleanup
+        if: always()
+        run: nix-shell --run "./scripts/clean-cargo-tests.sh"
+      - name: Check Coredumps
+        run: sudo ./scripts/check-coredumps.sh --since "${TEST_START_DATE}"
+# debugging
+      # - name: Setup tmate session
+      #   if: ${{ failure() }}
+      #   timeout-minutes: 240
+      #   uses: mxschmitt/action-tmate@v3

--- a/io-engine-tests/src/lib.rs
+++ b/io-engine-tests/src/lib.rs
@@ -342,7 +342,7 @@ pub fn mount_and_get_md5(device: &str) -> Result<String, String> {
 pub fn fio_run_verify(device: &str) -> Result<String, String> {
     let (exit, stdout, stderr) = run_script::run(
         r"
-        fio --name=randrw --rw=randrw --ioengine=libaio --direct=1 --time_based=1 \
+        $FIO --name=randrw --rw=randrw --ioengine=libaio --direct=1 --time_based=1 \
         --runtime=5 --bs=4k --verify=crc32 --group_reporting=1 --output-format=terse \
         --verify_fatal=1 --verify_async=2 --filename=$1
     ",
@@ -511,11 +511,11 @@ pub async fn wait_for_rebuild(dst_uri: String, state: RebuildState, timeout: Dur
 pub fn fio_verify_size(device: &str, size: u64) -> i32 {
     let (exit, stdout, stderr) = run_script::run(
         r"
-        fio --thread=1 --numjobs=1 --iodepth=16 --bs=512 \
+        $FIO --thread=1 --numjobs=1 --iodepth=16 --bs=512 \
         --direct=1 --ioengine=libaio --rw=randwrite --verify=crc32 \
         --verify_fatal=1 --name=write_verify --filename=$1 --size=$2
 
-        fio --thread=1 --numjobs=1 --iodepth=16 --bs=512 \
+        $FIO --thread=1 --numjobs=1 --iodepth=16 --bs=512 \
         --direct=1 --ioengine=libaio --verify=crc32 --verify_only \
         --verify_fatal=1 --name=verify --filename=$1
     ",

--- a/io-engine/.cargo/runner.sh
+++ b/io-engine/.cargo/runner.sh
@@ -4,7 +4,7 @@
 ARGS="${@}"
 
 if [[ $EUID -ne 0 ]]; then
-  MAYBE_SUDO='sudo -E'
+  MAYBE_SUDO='sudo -E --preserve-env=PATH'
 else
   MAYBE_SUDO=''
 fi

--- a/io-engine/tests/ftl_mount_fs.rs
+++ b/io-engine/tests/ftl_mount_fs.rs
@@ -97,7 +97,7 @@ async fn ftl_mount_fs_multiple() {
 pub fn csal_fio_run_verify(device: &str) -> Result<String, String> {
     let (exit, stdout, stderr) = run_script::run(
         r#"
-        fio --name=randrw --rw=randrw --ioengine=libaio --direct=1 --time_based=1 \
+        $FIO --name=randrw --rw=randrw --ioengine=libaio --direct=1 --time_based=1 \
         --runtime=10 --bs=64k --verify=crc32 --group_reporting=1  \
         --verify_fatal=1 --verify_async=2 --filename=$1
         "#,

--- a/libnvme-rs/src/nvme_uri.rs
+++ b/libnvme-rs/src/nvme_uri.rs
@@ -347,6 +347,12 @@ impl NvmeTarget {
     }
 }
 
+impl Drop for NvmeTarget {
+    fn drop(&mut self) {
+        self.disconnect().ok();
+    }
+}
+
 #[test]
 fn nvme_parse_uri() {
     let target = NvmeTarget::try_from("nvmf://1.2.3.4:1234/testnqn.what-ever.foo").unwrap();

--- a/scripts/grpc-test.sh
+++ b/scripts/grpc-test.sh
@@ -16,7 +16,7 @@ set -euxo pipefail
 export PATH="$PATH:${HOME}/.cargo/bin"
 export npm_config_jobs=$(nproc)
 
-cargo build --all
+cargo build --bins --features=io-engine-testing
 cd "$(dirname "$0")/../test/grpc"
 npm install --legacy-peer-deps
 

--- a/scripts/nvmx-test.sh
+++ b/scripts/nvmx-test.sh
@@ -1,4 +1,0 @@
-#!/bin/env bash
-cd mayastor || exit
-cargo test --lib -- --nocapture --test-threads=1
-cargo test --test block_device_nvmf -- --nocapture --test-threads=1

--- a/test/python/common/hdl.py
+++ b/test/python/common/hdl.py
@@ -1,4 +1,5 @@
 """Common code that represents a mayastor handle."""
+
 import mayastor_pb2 as pb
 import grpc
 import mayastor_pb2_grpc as rpc

--- a/test/python/cross-grpc-version/nexus/docker-compose.yml
+++ b/test/python/cross-grpc-version/nexus/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: "ms0"
     image: rust:latest
     environment:
-      - MY_POD_IP=10.0.0.2
+      - MY_POD_IP=10.1.0.2
       - NEXUS_NVMF_ANA_ENABLE=1
       - NEXUS_NVMF_RESV_ENABLE=1
       - PATH=${LLVM_SYMBOLIZER_DIR:-}
@@ -16,7 +16,7 @@ services:
     command: ${SRCDIR}/${IO_ENGINE_DIR}/io-engine -g 0.0.0.0 -l 1,2 -r /tmp/ms0.sock
     networks:
       mayastor_net:
-        ipv4_address: 10.0.0.2
+        ipv4_address: 10.1.0.2
     cap_add:
       # NUMA related
       - SYS_ADMIN
@@ -36,7 +36,7 @@ services:
     container_name: "ms1"
     image: rust:latest
     environment:
-      - MY_POD_IP=10.0.0.3
+      - MY_POD_IP=10.1.0.3
       - NEXUS_NVMF_ANA_ENABLE=1
       - NEXUS_NVMF_RESV_ENABLE=1
       - PATH=${LLVM_SYMBOLIZER_DIR:-}
@@ -44,7 +44,7 @@ services:
     command: ${SRCDIR}/${IO_ENGINE_DIR}/io-engine -g 0.0.0.0 -l 3,4 -r /tmp/ms1.sock
     networks:
       mayastor_net:
-        ipv4_address: 10.0.0.3
+        ipv4_address: 10.1.0.3
     cap_add:
       # NUMA related
       - SYS_ADMIN
@@ -66,4 +66,4 @@ networks:
     ipam:
       driver: default
       config:
-        - subnet: "10.0.0.0/16"
+        - subnet: "10.1.0.0/16"

--- a/test/python/cross-grpc-version/pool/docker-compose.yml
+++ b/test/python/cross-grpc-version/pool/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: "ms0"
     image: rust:latest
     environment:
-      - MY_POD_IP=10.0.0.2
+      - MY_POD_IP=10.1.0.2
       - NEXUS_NVMF_ANA_ENABLE=1
       - NEXUS_NVMF_RESV_ENABLE=1
       - PATH=${LLVM_SYMBOLIZER_DIR:-}
@@ -16,7 +16,7 @@ services:
     command: ${SRCDIR}/${IO_ENGINE_DIR}/io-engine -g 0.0.0.0 -l 1,2 -r /tmp/ms0.sock --env-context=--iova-mode=pa
     networks:
       mayastor_net:
-        ipv4_address: 10.0.0.2
+        ipv4_address: 10.1.0.2
     cap_add:
       # NUMA related
       - SYS_ADMIN
@@ -38,4 +38,4 @@ networks:
     ipam:
       driver: default
       config:
-        - subnet: "10.0.0.0/16"
+        - subnet: "10.1.0.0/16"

--- a/test/python/cross-grpc-version/pool/test_bdd_pool.py
+++ b/test/python/cross-grpc-version/pool/test_bdd_pool.py
@@ -156,6 +156,7 @@ def create_pool_that_already_exists(create_v1_pool, get_pool_name):
         create_v1_pool(get_pool_name, ["malloc:///disk0?size_mb=100"], None)
     return error
 
+
 @when(
     "the user creates a v1 version pool with the same name and different disk of an existing pool",
     target_fixture="create_pool_with_same_name_different_disk",
@@ -202,12 +203,17 @@ def destroy_pool(v1_mayastor_instance, v0_replica_pools, get_pool_name):
 
 @then("the pool create command should fail")
 def the_pool_create_command_should_fail(create_pool_that_already_exists):
-    assert create_pool_that_already_exists.value.code() == grpc.StatusCode.ALREADY_EXISTS
+    assert (
+        create_pool_that_already_exists.value.code() == grpc.StatusCode.ALREADY_EXISTS
+    )
 
 
 @then("the pool create request should fail")
 def the_pool_create_request_should_fail(create_pool_with_same_name_different_disk):
-    assert create_pool_with_same_name_different_disk.value.code() == grpc.StatusCode.INVALID_ARGUMENT
+    assert (
+        create_pool_with_same_name_different_disk.value.code()
+        == grpc.StatusCode.INVALID_ARGUMENT
+    )
 
 
 @then("the pool should appear in the output list")

--- a/test/python/cross-grpc-version/rebuild/docker-compose.yml
+++ b/test/python/cross-grpc-version/rebuild/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: "ms0"
     image: rust:latest
     environment:
-      - MY_POD_IP=10.0.0.2
+      - MY_POD_IP=10.1.0.2
       - NEXUS_NVMF_ANA_ENABLE=1
       - NEXUS_NVMF_RESV_ENABLE=1
       - PATH=${LLVM_SYMBOLIZER_DIR:-}
@@ -16,7 +16,7 @@ services:
     command: ${SRCDIR}/${IO_ENGINE_DIR}/io-engine -g 0.0.0.0 -l 1,2 -r /tmp/ms0.sock
     networks:
       mayastor_net:
-        ipv4_address: 10.0.0.2
+        ipv4_address: 10.1.0.2
     cap_add:
       # NUMA related
       - SYS_ADMIN
@@ -38,4 +38,4 @@ networks:
     ipam:
       driver: default
       config:
-        - subnet: "10.0.0.0/16"
+        - subnet: "10.1.0.0/16"

--- a/test/python/cross-grpc-version/replica/docker-compose.yml
+++ b/test/python/cross-grpc-version/replica/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: "ms0"
     image: rust:latest
     environment:
-      - MY_POD_IP=10.0.0.2
+      - MY_POD_IP=10.1.0.2
       - NEXUS_NVMF_ANA_ENABLE=1
       - NEXUS_NVMF_RESV_ENABLE=1
       - PATH=${LLVM_SYMBOLIZER_DIR:-}
@@ -16,7 +16,7 @@ services:
     command: ${SRCDIR}/${IO_ENGINE_DIR}/io-engine -g 0.0.0.0 -l 0,1 -r /tmp/ms0.sock
     networks:
       mayastor_net:
-        ipv4_address: 10.0.0.2
+        ipv4_address: 10.1.0.2
     cap_add:
       # NUMA related
       - SYS_ADMIN
@@ -38,4 +38,4 @@ networks:
     ipam:
       driver: default
       config:
-        - subnet: "10.0.0.0/16"
+        - subnet: "10.1.0.0/16"

--- a/test/python/pool/docker-compose.yml
+++ b/test/python/pool/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     container_name: "ms0"
     image: rust:latest
     environment:
-        - MY_POD_IP=10.0.0.2
+        - MY_POD_IP=10.1.0.2
         - NEXUS_NVMF_RESV_ENABLE=1
         - RUST_LOG=mayastor=trace
         - PATH=${LLVM_SYMBOLIZER_DIR:-}
@@ -12,7 +12,7 @@ services:
     command: ${SRCDIR}/${IO_ENGINE_DIR}/io-engine -g 0.0.0.0 -l 1,2 -r /tmp/ms0.sock
     networks:
       mayastor_net:
-        ipv4_address: 10.0.0.2
+        ipv4_address: 10.1.0.2
     privileged: true
     volumes:
       - ${SRCDIR}:${SRCDIR}
@@ -27,4 +27,4 @@ networks:
     ipam:
       driver: default
       config:
-        - subnet: "10.0.0.0/16"
+        - subnet: "10.1.0.0/16"

--- a/test/python/tests/ana_client/docker-compose.yml
+++ b/test/python/tests/ana_client/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: "ms0"
     image: rust:latest
     environment:
-        - MY_POD_IP=10.0.0.2
+        - MY_POD_IP=10.1.0.2
         - NEXUS_NVMF_ANA_ENABLE=1
         - NEXUS_NVMF_RESV_ENABLE=1
         - PATH=${LLVM_SYMBOLIZER_DIR:-}
@@ -16,7 +16,7 @@ services:
     command: ${SRCDIR}/${IO_ENGINE_DIR}/io-engine -g 0.0.0.0 -l 1,2 -r /tmp/ms0.sock
     networks:
       mayastor_net:
-        ipv4_address: 10.0.0.2
+        ipv4_address: 10.1.0.2
     cap_add:
       # NUMA related
       - SYS_ADMIN
@@ -36,7 +36,7 @@ services:
     container_name: "ms1"
     image: rust:latest
     environment:
-        - MY_POD_IP=10.0.0.3
+        - MY_POD_IP=10.1.0.3
         - NEXUS_NVMF_ANA_ENABLE=1
         - NEXUS_NVMF_RESV_ENABLE=1
         - PATH=${LLVM_SYMBOLIZER_DIR:-}
@@ -44,7 +44,7 @@ services:
     command: ${SRCDIR}/${IO_ENGINE_DIR}/io-engine -g 0.0.0.0 -l 3,4 -r /tmp/ms1.sock
     networks:
       mayastor_net:
-        ipv4_address: 10.0.0.3
+        ipv4_address: 10.1.0.3
     cap_add:
       # NUMA related
       - SYS_ADMIN
@@ -64,7 +64,7 @@ services:
     container_name: "ms2"
     image: rust:latest
     environment:
-        - MY_POD_IP=10.0.0.4
+        - MY_POD_IP=10.1.0.4
         - NEXUS_NVMF_ANA_ENABLE=1
         - NEXUS_NVMF_RESV_ENABLE=1
         - PATH=${LLVM_SYMBOLIZER_DIR:-}
@@ -72,7 +72,7 @@ services:
     command: ${SRCDIR}/${IO_ENGINE_DIR}/io-engine -g 0.0.0.0 -l 5,6 -r /tmp/ms2.sock
     networks:
       mayastor_net:
-        ipv4_address: 10.0.0.4
+        ipv4_address: 10.1.0.4
     cap_add:
       # NUMA related
       - SYS_ADMIN
@@ -92,7 +92,7 @@ services:
     container_name: "ms3"
     image: rust:latest
     environment:
-        - MY_POD_IP=10.0.0.5
+        - MY_POD_IP=10.1.0.5
         - NVME_KATO_MS=1000
         - NEXUS_NVMF_ANA_ENABLE=1
         - NEXUS_NVMF_RESV_ENABLE=1
@@ -101,7 +101,7 @@ services:
     command: ${SRCDIR}/${IO_ENGINE_DIR}/io-engine -g 0.0.0.0 -l 0,7 -r /tmp/ms3.sock
     networks:
       mayastor_net:
-        ipv4_address: 10.0.0.5
+        ipv4_address: 10.1.0.5
     cap_add:
       # NUMA related
       - SYS_ADMIN
@@ -123,4 +123,4 @@ networks:
     ipam:
       driver: default
       config:
-        - subnet: "10.0.0.0/16"
+        - subnet: "10.1.0.0/16"

--- a/test/python/tests/cli_controller/docker-compose.yml
+++ b/test/python/tests/cli_controller/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: "ms1"
     image: rust:latest
     environment:
-        - MY_POD_IP=10.0.0.3
+        - MY_POD_IP=10.1.0.3
         - NEXUS_NVMF_ANA_ENABLE=1
         - NEXUS_NVMF_RESV_ENABLE=1
         - PATH=${LLVM_SYMBOLIZER_DIR:-}
@@ -16,7 +16,7 @@ services:
     command: ${SRCDIR}/${IO_ENGINE_DIR}/io-engine -g 0.0.0.0 -l 3,4 -r /tmp/ms1.sock
     networks:
       mayastor_net:
-        ipv4_address: 10.0.0.3
+        ipv4_address: 10.1.0.3
     cap_add:
       # NUMA related
       - SYS_ADMIN
@@ -36,7 +36,7 @@ services:
     container_name: "ms2"
     image: rust:latest
     environment:
-        - MY_POD_IP=10.0.0.4
+        - MY_POD_IP=10.1.0.4
         - NEXUS_NVMF_ANA_ENABLE=1
         - NEXUS_NVMF_RESV_ENABLE=1
         - PATH=${LLVM_SYMBOLIZER_DIR:-}
@@ -44,7 +44,7 @@ services:
     command: ${SRCDIR}/${IO_ENGINE_DIR}/io-engine -g 0.0.0.0 -l 5,6 -r /tmp/ms2.sock
     networks:
       mayastor_net:
-        ipv4_address: 10.0.0.4
+        ipv4_address: 10.1.0.4
     cap_add:
       # NUMA related
       - SYS_ADMIN
@@ -64,7 +64,7 @@ services:
     container_name: "ms3"
     image: rust:latest
     environment:
-        - MY_POD_IP=10.0.0.5
+        - MY_POD_IP=10.1.0.5
         - NVME_KATO_MS=1000
         - NEXUS_NVMF_ANA_ENABLE=1
         - NEXUS_NVMF_RESV_ENABLE=1
@@ -73,7 +73,7 @@ services:
     command: ${SRCDIR}/${IO_ENGINE_DIR}/io-engine -g 0.0.0.0 -l 0,7 -r /tmp/ms3.sock
     networks:
       mayastor_net:
-        ipv4_address: 10.0.0.5
+        ipv4_address: 10.1.0.5
     cap_add:
       # NUMA related
       - SYS_ADMIN
@@ -95,4 +95,4 @@ networks:
     ipam:
       driver: default
       config:
-        - subnet: "10.0.0.0/16"
+        - subnet: "10.1.0.0/16"

--- a/test/python/tests/nexus/docker-compose.yml
+++ b/test/python/tests/nexus/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: "ms0"
     image: rust:latest
     environment:
-        - MY_POD_IP=10.0.0.2
+        - MY_POD_IP=10.1.0.2
         - NEXUS_NVMF_ANA_ENABLE=1
         - NEXUS_NVMF_RESV_ENABLE=1
         - PATH=${LLVM_SYMBOLIZER_DIR:-}
@@ -16,7 +16,7 @@ services:
     command: ${SRCDIR}/${IO_ENGINE_DIR}/io-engine -g 0.0.0.0 -l 1 -r /tmp/ms0.sock
     networks:
       mayastor_net:
-        ipv4_address: 10.0.0.2
+        ipv4_address: 10.1.0.2
     cap_add:
       # NUMA related
       - SYS_ADMIN
@@ -36,7 +36,7 @@ services:
     container_name: "ms1"
     image: rust:latest
     environment:
-        - MY_POD_IP=10.0.0.3
+        - MY_POD_IP=10.1.0.3
         - NEXUS_NVMF_ANA_ENABLE=1
         - NEXUS_NVMF_RESV_ENABLE=1
         - PATH=${LLVM_SYMBOLIZER_DIR:-}
@@ -44,7 +44,7 @@ services:
     command: ${SRCDIR}/${IO_ENGINE_DIR}/io-engine -g 0.0.0.0 -l 2 -r /tmp/ms1.sock
     networks:
       mayastor_net:
-        ipv4_address: 10.0.0.3
+        ipv4_address: 10.1.0.3
     cap_add:
       # NUMA related
       - SYS_ADMIN
@@ -64,7 +64,7 @@ services:
     container_name: "ms2"
     image: rust:latest
     environment:
-        - MY_POD_IP=10.0.0.4
+        - MY_POD_IP=10.1.0.4
         - NEXUS_NVMF_ANA_ENABLE=1
         - NEXUS_NVMF_RESV_ENABLE=1
         - PATH=${LLVM_SYMBOLIZER_DIR:-}
@@ -72,7 +72,7 @@ services:
     command: ${SRCDIR}/${IO_ENGINE_DIR}/io-engine -g 0.0.0.0 -l 3 -r /tmp/ms2.sock
     networks:
       mayastor_net:
-        ipv4_address: 10.0.0.4
+        ipv4_address: 10.1.0.4
     cap_add:
       # NUMA related
       - SYS_ADMIN
@@ -92,7 +92,7 @@ services:
     container_name: "ms3"
     image: rust:latest
     environment:
-        - MY_POD_IP=10.0.0.5
+        - MY_POD_IP=10.1.0.5
         - NVME_KATO_MS=1000
         - NEXUS_NVMF_ANA_ENABLE=1
         - NEXUS_NVMF_RESV_ENABLE=1
@@ -103,7 +103,7 @@ services:
     command: ${SRCDIR}/${IO_ENGINE_DIR}/io-engine -g 0.0.0.0 -l 4 -r /tmp/ms3.sock
     networks:
       mayastor_net:
-        ipv4_address: 10.0.0.5
+        ipv4_address: 10.1.0.5
     cap_add:
       # NUMA related
       - SYS_ADMIN
@@ -125,4 +125,4 @@ networks:
     ipam:
       driver: default
       config:
-        - subnet: "10.0.0.0/16"
+        - subnet: "10.1.0.0/16"

--- a/test/python/tests/nexus/test_nexus_rebuild.py
+++ b/test/python/tests/nexus/test_nexus_rebuild.py
@@ -24,7 +24,12 @@ def local_files(mayastors):
         path = f"/tmp/disk-{name}.img"
         pool_size_mb = int(POOL_SIZE / 1024 / 1024)
         subprocess.run(
-            ["sudo", "sh", "-c", f"rm -f '{path}'; truncate -s {pool_size_mb}M '{path}'"],
+            [
+                "sudo",
+                "sh",
+                "-c",
+                f"rm -f '{path}'; truncate -s {pool_size_mb}M '{path}'",
+            ],
             check=True,
         )
         files.append(path)
@@ -63,7 +68,7 @@ def create_nexuses(mayastors, create_replicas_on_all_nodes):
         [replica.uri for replica in mayastors.get(node).replica_list().replicas]
         for node in ["ms1", "ms2", "ms3"]
     ]
-    
+
     ms = mayastors.get("ms0")
     for children in zip(*uris):
         uuid = guid.uuid4()
@@ -91,8 +96,10 @@ def test_rebuild_failure(containers, mayastors, times, create_nexuses):
     time.sleep(1)
 
     # Add the replicas to the nexuses for rebuild.
-    for (idx, nexus) in enumerate(ms0.nexus_list()):
-        child = list(filter(lambda child: child.state == pb.CHILD_FAULTED, list(nexus.children)))[0]
+    for idx, nexus in enumerate(ms0.nexus_list()):
+        child = list(
+            filter(lambda child: child.state == pb.CHILD_FAULTED, list(nexus.children))
+        )[0]
         if nexus.state != pb.NEXUS_FAULTED:
             try:
                 ms0.nexus_remove_replica(nexus.uuid, child.uri)
@@ -107,7 +114,13 @@ def test_rebuild_failure(containers, mayastors, times, create_nexuses):
         for child in nexus.children:
             if child.rebuild_progress > -1:
                 rebuilds += 1
-                print("nexus", nexus.uuid, "rebuilding", child.uri, f"{child.rebuild_progress}")
+                print(
+                    "nexus",
+                    nexus.uuid,
+                    "rebuilding",
+                    child.uri,
+                    f"{child.rebuild_progress}",
+                )
 
     assert rebuilds > 0
 

--- a/test/python/tests/nexus/test_nexus_shutdown.py
+++ b/test/python/tests/nexus/test_nexus_shutdown.py
@@ -137,7 +137,7 @@ def check_second_nexus_shutdown_succeeded(get_a_shutdown_nexus, mayastor_mod):
 
 @pytest.fixture(scope="module")
 def create_published_nexus(mayastor_mod, create_replica):
-    """ Create and publish a nexus on ms3 with 2 replicas """
+    """Create and publish a nexus on ms3 with 2 replicas"""
     hdls = mayastor_mod
     replicas = create_replica
     replicas = [k.uri for k in replicas]
@@ -170,7 +170,7 @@ def create_published_nexus(mayastor_mod, create_replica):
 
 @pytest.fixture(scope="module")
 def create_connected_nexus(mayastor_mod, create_published_nexus):
-    """ Create a nexus on ms3 with 2 replicas """
+    """Create a nexus on ms3 with 2 replicas"""
     uri = create_published_nexus[0]
 
     dev = nvme_connect(uri)

--- a/test/python/tests/nexus_fault/docker-compose.yml
+++ b/test/python/tests/nexus_fault/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: "ms0"
     image: rust:latest
     environment:
-      - MY_POD_IP=10.0.0.2
+      - MY_POD_IP=10.1.0.2
       - NEXUS_NVMF_ANA_ENABLE=1
       - NEXUS_NVMF_RESV_ENABLE=1
       - PATH=${LLVM_SYMBOLIZER_DIR:-}
@@ -16,7 +16,7 @@ services:
     command: ${SRCDIR}/${IO_ENGINE_DIR}/io-engine -g 0.0.0.0 -l 1 -r /tmp/ms0.sock
     networks:
       mayastor_net:
-        ipv4_address: 10.0.0.2
+        ipv4_address: 10.1.0.2
     cap_add:
       # NUMA related
       - SYS_ADMIN
@@ -36,7 +36,7 @@ services:
     container_name: "ms1"
     image: rust:latest
     environment:
-      - MY_POD_IP=10.0.0.3
+      - MY_POD_IP=10.1.0.3
       - NEXUS_NVMF_ANA_ENABLE=1
       - NEXUS_NVMF_RESV_ENABLE=1
       - PATH=${LLVM_SYMBOLIZER_DIR:-}
@@ -44,7 +44,7 @@ services:
     command: ${SRCDIR}/${IO_ENGINE_DIR}/io-engine -g 0.0.0.0 -l 2 -r /tmp/ms1.sock
     networks:
       mayastor_net:
-        ipv4_address: 10.0.0.3
+        ipv4_address: 10.1.0.3
     cap_add:
       # NUMA related
       - SYS_ADMIN
@@ -67,4 +67,4 @@ networks:
     ipam:
       driver: default
       config:
-        - subnet: "10.0.0.0/16"
+        - subnet: "10.1.0.0/16"

--- a/test/python/tests/nexus_multipath/docker-compose.yml
+++ b/test/python/tests/nexus_multipath/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: "ms0"
     image: rust:latest
     environment:
-        - MY_POD_IP=10.0.0.2
+        - MY_POD_IP=10.1.0.2
         - NEXUS_NVMF_ANA_ENABLE=1
         - NEXUS_NVMF_RESV_ENABLE=1
         - PATH=${LLVM_SYMBOLIZER_DIR:-}
@@ -16,7 +16,7 @@ services:
     command: ${SRCDIR}/${IO_ENGINE_DIR}/io-engine -g 0.0.0.0 -l 1,2 -r /tmp/ms0.sock
     networks:
       mayastor_net:
-        ipv4_address: 10.0.0.2
+        ipv4_address: 10.1.0.2
     cap_add:
       # NUMA related
       - SYS_ADMIN
@@ -36,7 +36,7 @@ services:
     container_name: "ms1"
     image: rust:latest
     environment:
-        - MY_POD_IP=10.0.0.3
+        - MY_POD_IP=10.1.0.3
         - NEXUS_NVMF_ANA_ENABLE=1
         - NEXUS_NVMF_RESV_ENABLE=1
         - PATH=${LLVM_SYMBOLIZER_DIR:-}
@@ -44,7 +44,7 @@ services:
     command: ${SRCDIR}/${IO_ENGINE_DIR}/io-engine -g 0.0.0.0 -l 3,4 -r /tmp/ms1.sock
     networks:
       mayastor_net:
-        ipv4_address: 10.0.0.3
+        ipv4_address: 10.1.0.3
     cap_add:
       # NUMA related
       - SYS_ADMIN
@@ -64,7 +64,7 @@ services:
     container_name: "ms2"
     image: rust:latest
     environment:
-        - MY_POD_IP=10.0.0.4
+        - MY_POD_IP=10.1.0.4
         - NEXUS_NVMF_ANA_ENABLE=1
         - NEXUS_NVMF_RESV_ENABLE=1
         - PATH=${LLVM_SYMBOLIZER_DIR:-}
@@ -72,7 +72,7 @@ services:
     command: ${SRCDIR}/${IO_ENGINE_DIR}/io-engine -g 0.0.0.0 -l 5,6 -r /tmp/ms2.sock
     networks:
       mayastor_net:
-        ipv4_address: 10.0.0.4
+        ipv4_address: 10.1.0.4
     cap_add:
       # NUMA related
       - SYS_ADMIN
@@ -92,7 +92,7 @@ services:
     container_name: "ms3"
     image: rust:latest
     environment:
-        - MY_POD_IP=10.0.0.5
+        - MY_POD_IP=10.1.0.5
         - NVME_KATO_MS=1000
         - NEXUS_NVMF_ANA_ENABLE=1
         - NEXUS_NVMF_RESV_ENABLE=1
@@ -101,7 +101,7 @@ services:
     command: ${SRCDIR}/${IO_ENGINE_DIR}/io-engine -g 0.0.0.0 -l 0,7 -r /tmp/ms3.sock
     networks:
       mayastor_net:
-        ipv4_address: 10.0.0.5
+        ipv4_address: 10.1.0.5
     cap_add:
       # NUMA related
       - SYS_ADMIN
@@ -123,4 +123,4 @@ networks:
     ipam:
       driver: default
       config:
-        - subnet: "10.0.0.0/16"
+        - subnet: "10.1.0.0/16"

--- a/test/python/tests/nexus_multipath/test_bdd_nexus_multipath.py
+++ b/test/python/tests/nexus_multipath/test_bdd_nexus_multipath.py
@@ -48,7 +48,7 @@ def test_replace_failed_io_path_on_demand(setup):
 def create_nexus(
     mayastor_mod, nexus_name, nexus_uuid, create_replica, min_cntlid, resv_key
 ):
-    """ Create a nexus on ms3 with 2 replicas """
+    """Create a nexus on ms3 with 2 replicas"""
     hdls = mayastor_mod
     replicas = create_replica
     replicas = [k.uri for k in replicas]
@@ -86,7 +86,7 @@ def create_nexus(
 
 @pytest.fixture(scope="module")
 def create_nexus_2(mayastor_mod, nexus_name, nexus_uuid, min_cntlid_2, resv_key_2):
-    """ Create a 2nd nexus on ms0 with the same 2 replicas but with resv_key_2 """
+    """Create a 2nd nexus on ms0 with the same 2 replicas but with resv_key_2"""
     hdls = mayastor_mod
     NEXUS_NAME = nexus_name
 
@@ -284,7 +284,7 @@ def nexus_instance():
 def create_1_replica_connected_nexus(
     mayastor_mod, nexus_name, nexus_uuid, create_replica, min_cntlid, resv_key
 ):
-    """ Create a nexus on ms3 with one replica on ms1 """
+    """Create a nexus on ms3 with one replica on ms1"""
     hdls = mayastor_mod
     replicas = [create_replica[0].uri]
 
@@ -316,7 +316,7 @@ def create_1_replica_connected_nexus(
 def create_1_replica_disconnected_nexus(
     mayastor_mod, nexus_name, nexus_uuid, create_replica, min_cntlid_2, resv_key
 ):
-    """ Create a nexus on ms2 with one replica on ms1 """
+    """Create a nexus on ms2 with one replica on ms1"""
     hdls = mayastor_mod
     replicas = [create_replica[0].uri]
 

--- a/test/python/tests/nexus_multipath/test_nexus_multipath.py
+++ b/test/python/tests/nexus_multipath/test_nexus_multipath.py
@@ -20,7 +20,7 @@ from common.nvme import (
 def create_nexus_no_destroy(
     mayastor_mod, nexus_name, nexus_uuid, create_replica, min_cntlid, resv_key
 ):
-    """ Create a nexus on ms3 with 2 replicas """
+    """Create a nexus on ms3 with 2 replicas"""
     hdls = mayastor_mod
     replicas = create_replica
     replicas = [k.uri for k in replicas]
@@ -62,7 +62,7 @@ def create_nexus(create_nexus_no_destroy, mayastor_mod, nexus_name):
 def create_nexus_2_no_destroy(
     mayastor_mod, nexus_name, nexus_uuid, min_cntlid_2, resv_key_2
 ):
-    """ Create a 2nd nexus on ms0 with the same 2 replicas but with resv_key_2 """
+    """Create a 2nd nexus on ms0 with the same 2 replicas but with resv_key_2"""
     hdls = mayastor_mod
     NEXUS_NAME = nexus_name
 
@@ -157,7 +157,7 @@ def publish_nexus(mayastor_mod, nexus_name):
 def create_nexus_3_dev(
     mayastor_mod, nexus_name, nexus_uuid, replica_uuid, min_cntlid_3, resv_key_3
 ):
-    """ Create a 3rd nexus on ms1 with the same 2 replicas but with resv_key_3 """
+    """Create a 3rd nexus on ms1 with the same 2 replicas but with resv_key_3"""
     hdls = mayastor_mod
     NEXUS_NAME = nexus_name
 

--- a/test/python/tests/publish/docker-compose.yml
+++ b/test/python/tests/publish/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: "ms0"
     image: rust:latest
     environment:
-        - MY_POD_IP=10.0.0.2
+        - MY_POD_IP=10.1.0.2
         - NEXUS_NVMF_ANA_ENABLE=1
         - NEXUS_NVMF_RESV_ENABLE=1
         - PATH=${LLVM_SYMBOLIZER_DIR:-}
@@ -16,7 +16,7 @@ services:
     command: ${SRCDIR}/${IO_ENGINE_DIR}/io-engine -g 0.0.0.0 -l 1,2 -r /tmp/ms0.sock
     networks:
       mayastor_net:
-        ipv4_address: 10.0.0.2
+        ipv4_address: 10.1.0.2
     cap_add:
       # NUMA related
       - SYS_ADMIN
@@ -36,7 +36,7 @@ services:
     container_name: "ms1"
     image: rust:latest
     environment:
-        - MY_POD_IP=10.0.0.3
+        - MY_POD_IP=10.1.0.3
         - NEXUS_NVMF_ANA_ENABLE=1
         - NEXUS_NVMF_RESV_ENABLE=1
         - PATH=${LLVM_SYMBOLIZER_DIR:-}
@@ -44,7 +44,7 @@ services:
     command: ${SRCDIR}/${IO_ENGINE_DIR}/io-engine -g 0.0.0.0 -l 3,4 -r /tmp/ms1.sock
     networks:
       mayastor_net:
-        ipv4_address: 10.0.0.3
+        ipv4_address: 10.1.0.3
     cap_add:
       # NUMA related
       - SYS_ADMIN
@@ -66,4 +66,4 @@ networks:
     ipam:
       driver: default
       config:
-        - subnet: "10.0.0.0/16"
+        - subnet: "10.1.0.0/16"

--- a/test/python/tests/publish/test_bdd_nexus.py
+++ b/test/python/tests/publish/test_bdd_nexus.py
@@ -319,7 +319,7 @@ def attempt_to_create_nexus_with_child_uri_that_does_not_exist(
         create_nexus(
             nexus_uuid,
             megabytes(64),
-            nexus_children + [f"nvmf://10.0.0.2:8420/{nvme_nqn_prefix}:missing"],
+            nexus_children + [f"nvmf://10.1.0.2:8420/{nvme_nqn_prefix}:missing"],
         )
     assert error.value.code() == grpc.StatusCode.INVALID_ARGUMENT
 

--- a/test/python/tests/rebuild/docker-compose.yml
+++ b/test/python/tests/rebuild/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: "ms0"
     image: rust:latest
     environment:
-        - MY_POD_IP=10.0.0.2
+        - MY_POD_IP=10.1.0.2
         - NEXUS_NVMF_ANA_ENABLE=1
         - NEXUS_NVMF_RESV_ENABLE=1
         - PATH=${LLVM_SYMBOLIZER_DIR:-}
@@ -16,7 +16,7 @@ services:
     command: ${SRCDIR}/${IO_ENGINE_DIR}/io-engine -g 0.0.0.0 -l 1,2 -r /tmp/ms0.sock
     networks:
       mayastor_net:
-        ipv4_address: 10.0.0.2
+        ipv4_address: 10.1.0.2
     cap_add:
       # NUMA related
       - SYS_ADMIN
@@ -38,4 +38,4 @@ networks:
     ipam:
       driver: default
       config:
-        - subnet: "10.0.0.0/16"
+        - subnet: "10.1.0.0/16"

--- a/test/python/tests/replica/docker-compose.yml
+++ b/test/python/tests/replica/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: "ms0"
     image: rust:latest
     environment:
-        - MY_POD_IP=10.0.0.2
+        - MY_POD_IP=10.1.0.2
         - NEXUS_NVMF_ANA_ENABLE=1
         - NEXUS_NVMF_RESV_ENABLE=1
         - PATH=${LLVM_SYMBOLIZER_DIR:-}
@@ -16,7 +16,7 @@ services:
     command: ${SRCDIR}/${IO_ENGINE_DIR}/io-engine -g 0.0.0.0 -l 1,2 -r /tmp/ms0.sock
     networks:
       mayastor_net:
-        ipv4_address: 10.0.0.2
+        ipv4_address: 10.1.0.2
     cap_add:
       # NUMA related
       - SYS_ADMIN
@@ -38,4 +38,4 @@ networks:
     ipam:
       driver: default
       config:
-        - subnet: "10.0.0.0/16"
+        - subnet: "10.1.0.0/16"

--- a/test/python/tests/replica_uuid/docker-compose.yml
+++ b/test/python/tests/replica_uuid/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: "ms0"
     image: rust:latest
     environment:
-        - MY_POD_IP=10.0.0.2
+        - MY_POD_IP=10.1.0.2
         - NEXUS_NVMF_ANA_ENABLE=1
         - NEXUS_NVMF_RESV_ENABLE=1
         - PATH=${LLVM_SYMBOLIZER_DIR:-}
@@ -16,7 +16,7 @@ services:
     command: ${SRCDIR}/${IO_ENGINE_DIR}/io-engine -g 0.0.0.0 -l 1,2 -r /tmp/ms0.sock
     networks:
       mayastor_net:
-        ipv4_address: 10.0.0.2
+        ipv4_address: 10.1.0.2
     cap_add:
       # NUMA related
       - SYS_ADMIN
@@ -38,4 +38,4 @@ networks:
     ipam:
       driver: default
       config:
-        - subnet: "10.0.0.0/16"
+        - subnet: "10.1.0.0/16"

--- a/test/python/tests/rpc/docker-compose.yml
+++ b/test/python/tests/rpc/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: "ms1"
     image: rust:latest
     environment:
-        - MY_POD_IP=10.0.0.3
+        - MY_POD_IP=10.1.0.3
         - NEXUS_NVMF_ANA_ENABLE=1
         - NEXUS_NVMF_RESV_ENABLE=1
         - PATH=${LLVM_SYMBOLIZER_DIR:-}
@@ -16,7 +16,7 @@ services:
     command: ${SRCDIR}/${IO_ENGINE_DIR}/io-engine -g 0.0.0.0 -l 3,4 -r /tmp/ms1.sock
     networks:
       mayastor_net:
-        ipv4_address: 10.0.0.3
+        ipv4_address: 10.1.0.3
     cap_add:
       # NUMA related
       - SYS_ADMIN
@@ -38,4 +38,4 @@ networks:
     ipam:
       driver: default
       config:
-        - subnet: "10.0.0.0/16"
+        - subnet: "10.1.0.0/16"

--- a/test/python/v1/hdl.py
+++ b/test/python/v1/hdl.py
@@ -1,4 +1,5 @@
 """Common code that represents a mayastor handle."""
+
 from os import name
 import grpc
 import bdev_pb2 as bdev_pb
@@ -203,7 +204,7 @@ class MayastorHandle(object):
         """Create nexus snapshot"""
         active_replicas = []
 
-        for (r_uuid, s_uuid) in replicas:
+        for r_uuid, s_uuid in replicas:
             active_replicas.append(
                 snapshot_pb.NexusCreateSnapshotReplicaDescriptor(
                     replica_uuid=r_uuid,

--- a/test/python/v1/nexus/docker-compose.yml
+++ b/test/python/v1/nexus/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: "ms0"
     image: rust:latest
     environment:
-        - MY_POD_IP=10.0.0.2
+        - MY_POD_IP=10.1.0.2
         - NEXUS_NVMF_ANA_ENABLE=1
         - NEXUS_NVMF_RESV_ENABLE=1
         - PATH=${LLVM_SYMBOLIZER_DIR:-}
@@ -16,7 +16,7 @@ services:
     command: ${SRCDIR}/${IO_ENGINE_DIR}/io-engine -g 0.0.0.0 -l 1,2 -r /tmp/ms0.sock
     networks:
       mayastor_net:
-        ipv4_address: 10.0.0.2
+        ipv4_address: 10.1.0.2
     cap_add:
       # NUMA related
       - SYS_ADMIN
@@ -36,7 +36,7 @@ services:
     container_name: "ms1"
     image: rust:latest
     environment:
-        - MY_POD_IP=10.0.0.3
+        - MY_POD_IP=10.1.0.3
         - NEXUS_NVMF_ANA_ENABLE=1
         - NEXUS_NVMF_RESV_ENABLE=1
         - PATH=${LLVM_SYMBOLIZER_DIR:-}
@@ -44,7 +44,7 @@ services:
     command: ${SRCDIR}/${IO_ENGINE_DIR}/io-engine -g 0.0.0.0 -l 2 -r /tmp/ms1.sock
     networks:
       mayastor_net:
-        ipv4_address: 10.0.0.3
+        ipv4_address: 10.1.0.3
     cap_add:
       # NUMA related
       - SYS_ADMIN
@@ -64,7 +64,7 @@ services:
     container_name: "ms2"
     image: rust:latest
     environment:
-        - MY_POD_IP=10.0.0.4
+        - MY_POD_IP=10.1.0.4
         - NEXUS_NVMF_ANA_ENABLE=1
         - NEXUS_NVMF_RESV_ENABLE=1
         - PATH=${LLVM_SYMBOLIZER_DIR:-}
@@ -72,7 +72,7 @@ services:
     command: ${SRCDIR}/${IO_ENGINE_DIR}/io-engine -g 0.0.0.0 -l 3 -r /tmp/ms2.sock
     networks:
       mayastor_net:
-        ipv4_address: 10.0.0.4
+        ipv4_address: 10.1.0.4
     cap_add:
       # NUMA related
       - SYS_ADMIN
@@ -92,7 +92,7 @@ services:
     container_name: "ms3"
     image: rust:latest
     environment:
-        - MY_POD_IP=10.0.0.5
+        - MY_POD_IP=10.1.0.5
         - NVME_KATO_MS=1000
         - NEXUS_NVMF_ANA_ENABLE=1
         - NEXUS_NVMF_RESV_ENABLE=1
@@ -103,7 +103,7 @@ services:
     command: ${SRCDIR}/${IO_ENGINE_DIR}/io-engine -g 0.0.0.0 -l 4 -r /tmp/ms3.sock
     networks:
       mayastor_net:
-        ipv4_address: 10.0.0.5
+        ipv4_address: 10.1.0.5
     cap_add:
       # NUMA related
       - SYS_ADMIN
@@ -125,4 +125,4 @@ networks:
     ipam:
       driver: default
       config:
-        - subnet: "10.0.0.0/16"
+        - subnet: "10.1.0.0/16"

--- a/test/python/v1/pool/docker-compose.yml
+++ b/test/python/v1/pool/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: "ms0"
     image: rust:latest
     environment:
-        - MY_POD_IP=10.0.0.2
+        - MY_POD_IP=10.1.0.2
         - NEXUS_NVMF_ANA_ENABLE=1
         - NEXUS_NVMF_RESV_ENABLE=1
         - PATH=${LLVM_SYMBOLIZER_DIR:-}:${LVM_BINS:-}
@@ -17,7 +17,7 @@ services:
     command: ${SRCDIR}/${IO_ENGINE_DIR}/io-engine -g 0.0.0.0 -l 1,2 -r /tmp/ms0.sock
     networks:
       mayastor_net:
-        ipv4_address: 10.0.0.2
+        ipv4_address: 10.1.0.2
     cap_add:
       # NUMA related
       - SYS_ADMIN
@@ -49,4 +49,4 @@ networks:
     ipam:
       driver: default
       config:
-        - subnet: "10.0.0.0/16"
+        - subnet: "10.1.0.0/16"

--- a/test/python/v1/rebuild/docker-compose.yml
+++ b/test/python/v1/rebuild/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: "ms0"
     image: rust:latest
     environment:
-        - MY_POD_IP=10.0.0.2
+        - MY_POD_IP=10.1.0.2
         - NEXUS_NVMF_ANA_ENABLE=1
         - NEXUS_NVMF_RESV_ENABLE=1
         - PATH=${LLVM_SYMBOLIZER_DIR:-}
@@ -16,7 +16,7 @@ services:
     command: ${SRCDIR}/${IO_ENGINE_DIR}/io-engine -g 0.0.0.0 -l 1,2 -r /tmp/ms0.sock
     networks:
       mayastor_net:
-        ipv4_address: 10.0.0.2
+        ipv4_address: 10.1.0.2
     cap_add:
       # NUMA related
       - SYS_ADMIN
@@ -38,4 +38,4 @@ networks:
     ipam:
       driver: default
       config:
-        - subnet: "10.0.0.0/16"
+        - subnet: "10.1.0.0/16"

--- a/test/python/v1/replica/docker-compose.yml
+++ b/test/python/v1/replica/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: "ms0"
     image: rust:latest
     environment:
-        - MY_POD_IP=10.0.0.2
+        - MY_POD_IP=10.1.0.2
         - NEXUS_NVMF_ANA_ENABLE=1
         - NEXUS_NVMF_RESV_ENABLE=1
         - PATH=${LLVM_SYMBOLIZER_DIR:-}:${LVM_BINS:-}
@@ -18,7 +18,7 @@ services:
     command: ${SRCDIR}/${IO_ENGINE_DIR}/io-engine -g 0.0.0.0 -l 1 -r /tmp/ms0.sock --reactor-freeze-detection
     networks:
       mayastor_net:
-        ipv4_address: 10.0.0.2
+        ipv4_address: 10.1.0.2
     cap_add:
       # NUMA related
       - SYS_ADMIN
@@ -48,4 +48,4 @@ networks:
     ipam:
       driver: default
       config:
-        - subnet: "10.0.0.0/16"
+        - subnet: "10.1.0.0/16"


### PR DESCRIPTION
    Jenkins has become troublesome to maintain and makes it harder for users
    to see and test output without adding new users.
    We could probably spend some time improving that, but the current Jenkins
    is also setup on systems managed by the sponsoring company so it makes
    sense to move away from that at least.
    In order to run the CI tests we need a relatively powerful CI system so
    we are making use of the ubuntu-latest-16-cores runners.

    The tests seem to run slower than on Jenkins. Part of it may be explained
    because the dependencies are not pre-cache and also the pre-requisites
    which take time to install.

    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>