### PR TITLE
fix: proper to_ptr type cast to c_char

### DIFF
--- a/io-engine/src/bdev/ftl.rs
+++ b/io-engine/src/bdev/ftl.rs
@@ -42,6 +42,7 @@ use std::{
     collections::HashMap,
     convert::TryFrom,
     fmt::{Debug, Formatter},
+    os::raw::c_char,
 };
 
 use core::ffi::c_void;
@@ -210,9 +211,9 @@ impl CreateDestroy for Ftl {
             ..unsafe { mem::zeroed() }
         };
         unsafe { spdk_ftl_get_default_conf(&mut ftl_conf, spdk_ftl_conf_size) };
-        ftl_conf.name = ftl_dev_name.as_ptr() as *mut i8;
-        ftl_conf.base_bdev = base_dev_name.as_ptr() as *mut i8;
-        ftl_conf.cache_bdev = cache_dev_name.as_ptr() as *mut i8;
+        ftl_conf.name = ftl_dev_name.as_ptr() as *mut c_char;
+        ftl_conf.base_bdev = base_dev_name.as_ptr() as *mut c_char;
+        ftl_conf.cache_bdev = cache_dev_name.as_ptr() as *mut c_char;
         ftl_conf.fast_shutdown = true;
         ftl_conf.verbose_mode = true;
         ftl_conf.mode = spdk_ftl_mode::SPDK_FTL_MODE_CREATE as u32;

--- a/io-engine/tests/memory_pool.rs
+++ b/io-engine/tests/memory_pool.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, ffi::CString, ptr::null_mut};
+use std::{collections::HashMap, ffi::CString, os::raw::c_char, ptr::null_mut};
 
 use once_cell::sync::OnceCell;
 
@@ -16,7 +16,7 @@ fn get_ms() -> &'static MayastorTest<'static> {
 struct TestCtx {
     id: u64,
     pos: u32,
-    ctx: *const i8,
+    ctx: *const c_char,
 }
 
 const POOL_SIZE: u64 = 128 * 1024 - 1;

--- a/libnvme-rs/src/nvme_uri.rs
+++ b/libnvme-rs/src/nvme_uri.rs
@@ -1,4 +1,4 @@
-use std::{convert::TryFrom, io, time::Duration};
+use std::{convert::TryFrom, io, os::raw::c_char, time::Duration};
 
 use url::{ParseError, Url};
 
@@ -15,14 +15,14 @@ use crate::{
 
 /// Wrapper for caller-owned C-strings from libnvme
 pub struct NvmeStringWrapper {
-    s: *mut i8,
+    s: *mut c_char,
 }
 
 impl NvmeStringWrapper {
-    pub fn new(s: *mut i8) -> Self {
+    pub fn new(s: *mut c_char) -> Self {
         NvmeStringWrapper { s }
     }
-    pub fn as_ptr(&self) -> *const i8 {
+    pub fn as_ptr(&self) -> *const c_char {
         self.s
     }
 }


### PR DESCRIPTION
## Platform agnostic `c_char` type casting

Instead of hard-casting to `i8` or `u8` we can just cast to the built in `std::os::raw::c_char`. This change allows for full `arm64` compilation of mayastor.

### Related

- Fixes #1795 
- Part of the fix to #1751 (not including `spdk-rs` changes)
