### PR TITLE
ci: ignore udisksd coredumps

### DIFF
--- a/scripts/check-coredumps.sh
+++ b/scripts/check-coredumps.sh
@@ -53,7 +53,7 @@ fi
 # Iterate over new coredumps and print a summary and stack for each
 echo "Looking for new coredumps ..."
 echo
-coredump_pids=$(coredumpctl list --quiet --no-legend --since="$since" | grep -v "sshd$" | awk '{ print $5 }')
+coredump_pids=$(coredumpctl list --json=short --since="$since" | jq '.[] | select(.exe | endswith("sshd") or endswith("udisksd") | not) | .pid')
 coredump_count=0
 for pid in $coredump_pids; do
   coredump_count=$((coredump_count + 1))


### PR DESCRIPTION
Otherwise we detect this as a failure.
todo: instead, we should only detect crashes on processes started by the test.