### PR TITLE
Rename action and add ci-report

### DIFF
--- a/.github/workflows/bdd.yml
+++ b/.github/workflows/bdd.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           echo "TEST_START_DATE=$(date +"%Y-%m-%d %H:%M:%S")" >> $GITHUB_ENV
           nix-shell --run "./scripts/pytest-tests.sh"
-      - name: Test Report
+      - name: Pytest BDD Report
         if: always()
         uses: pmeier/pytest-results-action@main
         with:
@@ -50,6 +50,18 @@ jobs:
           display-options: a
           fail-on-empty: true
           title: Test results
+      - run: |
+          if [ -d test/python/reports ]; then
+            mkdir -p ci-report
+            mv test/python/reports ci-report/python
+          fi
+          nix-shell --run "./scripts/ci-report.sh"
+        if: failure()
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: ci-report-bdd
+          path: ./ci-report/ci-report.tar.gz
       - name: Cleanup
         if: always()
         run: nix-shell --run "./scripts/pytest-tests.sh --clean-all-exit"

--- a/.github/workflows/bdd.yml
+++ b/.github/workflows/bdd.yml
@@ -29,6 +29,7 @@ jobs:
       - name: Setup Test Pre-Requisites
         run: |
           sudo sysctl -w vm.nr_hugepages=2560
+          sudo apt-get update
           sudo apt-get install linux-modules-extra-$(uname -r)
           for module in nvme_tcp nbd nvme_rdma; do
             sudo modprobe $module

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -13,7 +13,7 @@ env:
   CI: 1
 
 jobs:
-  image-build-test:
+  image-build-push:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/unit-int.yml
+++ b/.github/workflows/unit-int.yml
@@ -49,21 +49,28 @@ jobs:
         run: |
           echo "TEST_START_DATE=$(date +"%Y-%m-%d %H:%M:%S")" >> $GITHUB_ENV
           nix-shell --run "./scripts/grpc-test.sh"
-          mkdir js-reports
+          mkdir -p ci-report/js
           for file in *-xunit-report.xml; do
-            echo "<testsuites>" > "js-reports/$file"
-            cat $file >> "js-reports/$file"
-            echo "</testsuites>" >> "js-reports/$file"
+            echo "<testsuites>" > "ci-report/js/$file"
+            cat $file >> "ci-report/js/$file"
+            echo "</testsuites>" >> "ci-report/js/$file"
           done
       - name: Test Report
         if: always()
         uses: pmeier/pytest-results-action@main
         with:
-          path: 'js-reports/*-xunit-report.xml'
+          path: 'ci-report/js/*-xunit-report.xml'
           summary: true
           display-options: a
           fail-on-empty: true
           title: Test results
+      - run: nix-shell --run "./scripts/ci-report.sh"
+        if: failure()
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: ci-report-int
+          path: ./ci-report/ci-report.tar.gz
       - name: Cleanup
         if: always()
         run: nix-shell --run "./scripts/clean-cargo-tests.sh"

--- a/.github/workflows/unit-int.yml
+++ b/.github/workflows/unit-int.yml
@@ -31,6 +31,7 @@ jobs:
       - name: Setup Test Pre-Requisites
         run: |
           sudo sysctl -w vm.nr_hugepages=3584
+          sudo apt-get update
           sudo apt-get install linux-modules-extra-$(uname -r)
           for module in nvme_tcp nbd nvme_rdma; do
             sudo modprobe $module

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ ansible-hosts
 /package.json
 /rust-toolchain.toml
 /test/python/reports
+/ci-report/

--- a/scripts/ci-report.sh
+++ b/scripts/ci-report.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+SCRIPT_DIR="$(dirname "$0")"
+export ROOT_DIR="$SCRIPT_DIR/.."
+SUDO=$(which sudo)
+CI_REPORT_START_DATE=${CI_REPORT_START_DATE:--3h}
+
+set -eu
+
+mkdir -p "$ROOT_DIR/ci-report"
+cd "$ROOT_DIR/ci-report"
+
+journalctl --since="$CI_REPORT_START_DATE" -o short-precise > journalctl.txt
+journalctl -k -b0 -o short-precise > dmesg.txt
+lsblk -tfa > lsblk.txt
+$SUDO nvme list -v > nvme.txt
+$SUDO nvme list-subsys -v >> nvme.txt
+cat /proc/meminfo > meminfo.txt
+
+find . -type f \( -name "*.txt" -o -name "*.xml" \) -print0 | xargs -0 tar -czvf ci-report.tar.gz


### PR DESCRIPTION
    ci(gha): upload test report
    
    Add test script which generates a report tar with useful
    information such as journalctl logs and nvme devices.
    Upload this tar on github actions.
    
---

    ci: rename push job
    
    The previous name was image-build-test which clashed with the image
    build test :)
