### PR TITLE
ci(gha/bdd): coredump before cleanup

### DIFF
--- a/.github/workflows/bdd.yml
+++ b/.github/workflows/bdd.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Setup Test Pre-Requisites
         run: |
           sudo sysctl -w vm.nr_hugepages=2560
+          sudo debconf-communicate <<< "set man-db/auto-update false" || true
+          sudo dpkg-reconfigure man-db || true
+          ulimit -c unlimited
           sudo apt-get update
           sudo apt-get install linux-modules-extra-$(uname -r)
           for module in nvme_tcp nbd nvme_rdma; do
@@ -63,11 +66,11 @@ jobs:
         with:
           name: ci-report-bdd
           path: ./ci-report/ci-report.tar.gz
+      - name: Check Coredumps
+        run: sudo ./scripts/check-coredumps.sh --since "${TEST_START_DATE}"
       - name: Cleanup
         if: always()
         run: nix-shell --run "./scripts/pytest-tests.sh --clean-all-exit"
-      - name: Check Coredumps
-        run: sudo ./scripts/check-coredumps.sh --since "${TEST_START_DATE}"
 # debugging
       # - name: Setup tmate session
       #   if: ${{ failure() }}


### PR DESCRIPTION
Ensure unlimited coredump.
Run coredump check before cleaning the workspace. This is helpful in case there was a coredump from our own binaries.
Also disable the man-pages auto-update.