### PR TITLE
feat(encryption): add crypto vbdev

### DIFF
--- a/io-engine-tests/src/pool.rs
+++ b/io-engine-tests/src/pool.rs
@@ -272,6 +272,8 @@ impl PoolBuilderLocal {
             cluster_size: None,
             md_args: None,
             backend: Default::default(),
+            enc_key: None,
+            crypto_vbdev_name: None,
         })
         .await?;
         Ok(lvs)

--- a/io-engine/examples/lvs-eval/main.rs
+++ b/io-engine/examples/lvs-eval/main.rs
@@ -136,6 +136,8 @@ async fn create_lvs(args: &CliArgs) -> Lvs {
             md_resv_ratio: args.md_resv_ratio,
         }),
         backend: Default::default(),
+        enc_key: None,
+        crypto_vbdev_name: None,
     };
 
     Lvs::create_or_import(lvs_args.clone()).await.unwrap()

--- a/io-engine/src/bdev/crypto.rs
+++ b/io-engine/src/bdev/crypto.rs
@@ -1,0 +1,266 @@
+//!
+//! This modules deals with managing crypto vbdev. The crypto vbdev is
+//! a virtual bdev that needs a base bdev for it to be created. The crypto vbdev
+//! concept can be applied to encrypt the complete lvolstore or a particular lvol.
+//! For encrypting lvolstore(Mayastor diskpool), the crypto vbdev is created on top
+//! of base bdev of the disk pool e.g. aio bdev. For lvol level encryption, the
+//! crypto vbdev is to be created on top of the lvol vbdev.
+//!
+//! A general workflow example for creating a spdk crypto vbdev for encrypted lvolstore is as below:
+//!
+//! sudo $SPDK_SCRIPT_PATH/rpc.py accel_crypto_key_create -c AES_CBC -k 01234567891234560123456789deadc0 -n dskey_aes128_cbc_1
+//! sudo $SPDK_SCRIPT_PATH/rpc.py bdev_aio_create /dev/loop0 MyBaseBdev 512
+//! sudo $SPDK_SCRIPT_PATH/rpc.py bdev_crypto_create MyBaseBdev MyCryptoVbdev -n key_aes128_cbc
+//!
+//! The vbdev MyCryptoVbdev can now be used to create lvolstore on it.
+//!
+
+use futures::channel::oneshot;
+use io_engine_api::v1 as v1rpc;
+use nix::errno::Errno;
+use spdk_rs::{
+    ffihelper::IntoCString,
+    libspdk::{
+        accel_dpdk_cryptodev_enable, accel_dpdk_cryptodev_set_driver, create_crypto_disk,
+        create_crypto_opts_by_name, delete_crypto_disk, spdk_accel_assign_opc,
+        spdk_accel_crypto_key, spdk_accel_crypto_key_create, spdk_accel_crypto_key_create_param,
+        spdk_accel_crypto_key_get,
+    },
+};
+use std::{
+    fmt::{Debug, Display, Formatter},
+    os::raw::c_char,
+};
+
+use crate::{
+    bdev_api::BdevError,
+    core::CoreError,
+    ffihelper::{cb_arg, pair, FfiResult},
+};
+
+/// Representation of a crypto vbdev to be created in SPDK.
+/// TODO: Currently we don't fit crypto vbdev into the uri based bdev management
+/// as the information required to completely setup the crypto vbdev isn't part of the uri,
+/// and also the crypto uri isn't provided by user rather we'll have to do some masking
+/// using crypto:// scheme.
+#[allow(dead_code)]
+#[derive(Default)]
+pub(crate) struct Crypto {
+    // Name of the crypto vbdev.
+    pub name: String,
+    // Name of the base bdev.
+    pub base_bdev_name: String,
+    // Encryption key params.
+    pub key: EncryptionKey,
+}
+
+#[derive(Copy, Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+/// Cipher mode for the encryption enablement. The default is kept as AES_XTS here
+/// because operations are default assigned to software module, which only supports
+/// AES_XTS. We don't expect to use default though.
+pub enum Cipher {
+    AesCbc,
+    #[default]
+    AesXts,
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+/// A struct that represents the parameters required to create a key.
+pub struct EncryptionKey {
+    pub cipher: Cipher,
+    pub key_name: String,
+    pub key: String,
+    pub key_len: u32,
+    pub key2: Option<String>,
+    pub key2_len: Option<u32>,
+}
+
+impl Debug for Crypto {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "crypto vbdev '{}', 'base_bdev: {}', keyname '{}', cipher: '{:?}'",
+            self.name, self.base_bdev_name, self.key.key_name, self.key.cipher
+        )
+    }
+}
+
+impl Display for Cipher {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let c = match self {
+            Self::AesCbc => "AES_CBC",
+            Self::AesXts => "AES_XTS",
+        };
+        write!(f, "{c}")
+    }
+}
+
+impl From<v1rpc::common::Cipher> for Cipher {
+    fn from(value: v1rpc::common::Cipher) -> Self {
+        match value {
+            v1rpc::common::Cipher::AesCbc => Self::AesCbc,
+            v1rpc::common::Cipher::AesXts => Self::AesXts,
+        }
+    }
+}
+
+/// Driver types for dpdk_cryptodev module. We won't be using any other
+/// than aesni-mb.
+#[derive(Debug, Default)]
+enum AccelDpdkCryptodevDriverType {
+    #[default]
+    AccelDpdkCryptodevAesniMb,
+    _AccelDpdkCryptodevQat,
+    _AccelDpdkCryptodevMlx5Pci,
+    _AccelDpdkCryptodevUadk,
+    _AccelDpdkCryptodevLast,
+}
+
+impl Display for AccelDpdkCryptodevDriverType {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let drv = match self {
+            Self::AccelDpdkCryptodevAesniMb => "crypto_aesni_mb",
+            Self::_AccelDpdkCryptodevQat => "crypto_qat",
+            Self::_AccelDpdkCryptodevMlx5Pci => "mlx5_pci",
+            Self::_AccelDpdkCryptodevUadk => "crypto_uadk",
+            Self::_AccelDpdkCryptodevLast => "crypto_driver_invalid",
+        };
+        write!(f, "{drv}")
+    }
+}
+
+// This function enables the dpdk_cryptodev module with aesni_mb driver in spdk,
+// and assigns the encrypt and decrypt operation to it, which by default are assigned to
+// software module initially.
+#[allow(dead_code)]
+pub fn enable_dpdk_cryptodev_accel_module() -> Result<(), CoreError> {
+    info!("Enabling accel dpdk_cryptodev module");
+    unsafe {
+        accel_dpdk_cryptodev_enable();
+        let setdrv_ret = accel_dpdk_cryptodev_set_driver(
+            AccelDpdkCryptodevDriverType::AccelDpdkCryptodevAesniMb
+                .to_string()
+                .into_cstring()
+                .as_ptr(),
+        );
+        if setdrv_ret != 0 {
+            return Err(CoreError::InitCryptoModule {
+                reason: format!("Unsupported driver: {setdrv_ret:?}"),
+            });
+        }
+        let err_enc = spdk_accel_assign_opc(8, "dpdk_cryptodev".into_cstring().as_ptr());
+        let err_dec = spdk_accel_assign_opc(9, "dpdk_cryptodev".into_cstring().as_ptr());
+        trace!("assign opc err_enc: {err_enc}, err_dec: {err_dec}");
+        if err_enc != 0 || err_dec != 0 {
+            return Err(CoreError::InitCryptoModule {
+                reason: format!(
+                    "opcode assignment failed. err_enc {err_enc:?}, err_dec {err_dec:?}"
+                ),
+            });
+        }
+        Ok(())
+    }
+}
+
+/// A simple wrapper around `spdk_accel_crypto_key_create`. The keys' strings here are
+/// in hexlified format.
+fn create_crypto_key(key_params: &EncryptionKey) -> Result<*mut spdk_accel_crypto_key, BdevError> {
+    let cipher = key_params.cipher.to_string().into_cstring();
+    let key = key_params.key.as_str().into_cstring();
+    let key_name = key_params.key_name.as_str().into_cstring();
+    let hex_key2_str = key_params.key2.as_deref().map(|k2| k2.into_cstring());
+    let key2 = if let Some(ref k2) = hex_key2_str {
+        k2.as_ptr()
+    } else {
+        std::ptr::null_mut()
+    };
+
+    debug!(
+        "Creating {:?} key of size {}",
+        key_params.cipher.to_string(),
+        key_params.key_len,
+    );
+
+    let create_key_params = spdk_accel_crypto_key_create_param {
+        cipher: cipher.as_ptr() as *mut c_char,
+        hex_key: key.as_ptr() as *mut c_char,
+        hex_key2: key2 as *mut c_char,
+        key_name: key_name.as_ptr() as *mut c_char,
+        tweak_mode: std::ptr::null_mut(),
+    };
+
+    unsafe {
+        let ret = spdk_accel_crypto_key_create(&create_key_params);
+        if ret != 0 {
+            Err(BdevError::CreateBdevFailed {
+                source: Errno::from_raw(ret.abs()),
+                name: format!("Key create failed: {:?}", create_key_params.key_name),
+            })
+        } else {
+            let key_ptr = spdk_accel_crypto_key_get(create_key_params.key_name);
+            trace!("Key '{:?}' created", key_params.key_name);
+            Ok(key_ptr)
+        }
+    }
+}
+
+/// callback when operation has been performed on crypto vbdev
+extern "C" fn crypto_vbdev_op_cb(arg: *mut std::os::raw::c_void, errno: i32) {
+    let sender = unsafe { Box::from_raw(arg as *mut oneshot::Sender<i32>) };
+    trace!("crypto_vbdev_op_cb: errno {errno}");
+    sender.send(errno).unwrap();
+}
+
+/// Destroy a crypto vbdev.
+pub async fn destroy_crypto_vbdev(vbdev_name: String) -> Result<(), BdevError> {
+    let (s, r) = pair::<i32>();
+    unsafe {
+        delete_crypto_disk(
+            vbdev_name.as_ptr() as *mut std::os::raw::c_char,
+            Some(crypto_vbdev_op_cb),
+            cb_arg(s),
+        );
+    }
+
+    r.await
+        .expect("callback gone while deleting crypto disk")
+        .to_result(|e| BdevError::DestroyBdevFailed {
+            source: Errno::from_raw(e),
+            name: vbdev_name.to_string(),
+        })?;
+
+    info!("crypto vbdev {vbdev_name} destroyed successfully");
+    Ok(())
+}
+/// The primary function to create a crypto vbdev in spdk.
+pub fn create_crypto_vbdev_on_base_bdev(
+    crypto_vbdev_name: &str,
+    base_bdev_name: &str,
+    key_params: &EncryptionKey,
+) -> Result<(), BdevError> {
+    // Create the key.
+    let key = create_crypto_key(key_params)?;
+
+    // Setup the crypto opts using the key now.
+    let crypto_opts_ptr = unsafe {
+        create_crypto_opts_by_name(
+            crypto_vbdev_name.into_cstring().as_ptr() as *mut c_char,
+            base_bdev_name.into_cstring().as_ptr() as *mut c_char,
+            key,
+            true,
+        )
+    };
+
+    // Now create the crypto vbdev.
+    let ret = unsafe { create_crypto_disk(crypto_opts_ptr) };
+
+    if ret != 0 {
+        Err(BdevError::CreateBdevFailed {
+            source: Errno::from_raw(ret),
+            name: crypto_vbdev_name.to_string(),
+        })
+    } else {
+        info!("crypto vbdev {crypto_vbdev_name} created on base bdev {base_bdev_name}");
+        Ok(())
+    }
+}

--- a/io-engine/src/bdev/lvs.rs
+++ b/io-engine/src/bdev/lvs.rs
@@ -34,6 +34,8 @@ use crate::{
     pool_backend::{PoolArgs, PoolBackend},
 };
 
+use super::crypto::EncryptionKey;
+
 /// An lvol specified via URI.
 pub(super) struct Lvol {
     /// Name of the lvol.
@@ -50,6 +52,8 @@ struct Lvs {
     disk: String,
     /// The lvs creation mode.
     mode: LvsMode,
+    // Encryption key - if the lvs is encrypted.
+    key: Option<EncryptionKey>,
 }
 
 impl Debug for Lvol {
@@ -144,6 +148,7 @@ impl TryFrom<String> for Lvs {
             name: uri.path()[1..].into(),
             disk,
             mode,
+            key: None,
         })
     }
 }
@@ -209,6 +214,9 @@ impl Lvs {
             cluster_size: None,
             md_args: None,
             backend: PoolBackend::Lvs,
+            enc_key: self.key.clone(),
+            // XXX: Is this path ever exercised apart from test, or casperf perhaps?
+            crypto_vbdev_name: self.key.as_ref().map(|_| format!("crypto_{}", self.name)),
         };
         match &self.mode {
             LvsMode::Create => match crate::lvs::Lvs::import_from_args(args.clone()).await {

--- a/io-engine/src/bdev/mod.rs
+++ b/io-engine/src/bdev/mod.rs
@@ -10,6 +10,7 @@ pub(crate) mod dev;
 use crate::core::{MayastorEnvironment, PtplProps};
 pub(crate) use dev::uri;
 
+pub mod crypto;
 pub(crate) mod device;
 mod ftl;
 mod loopback;

--- a/io-engine/src/bin/io-engine-client/v1/pool_cli.rs
+++ b/io-engine/src/bin/io-engine-client/v1/pool_cli.rs
@@ -54,6 +54,29 @@ pub fn subcommands() -> Command {
                 .required(false)
                 .value_parser(PoolType::types().to_vec())
                 .default_value(PoolType::Lvs.as_ref()),
+        )
+        .arg(
+            Arg::new("cipher")
+                .short('c')
+                .long("cipher")
+                .help("The cipher to use for encryption")
+                .required(false)
+                .requires("encryption-key"),
+        )
+        .arg(
+            Arg::new("encryption-key")
+                .short('k')
+                .long("encryption-key")
+                .help("The encryption key of the pool in hexlified format")
+                .required(false),
+        )
+        .arg(
+            Arg::new("xts-key")
+                .short('e')
+                .long("xts-key")
+                .help("encryption key2 required for AES_XTS")
+                .required(false)
+                .required_if_eq("cipher", "AES_XTS"),
         );
 
     let import = Command::new("import")
@@ -86,6 +109,28 @@ pub fn subcommands() -> Command {
                 .required(false)
                 .value_parser(PoolType::types().to_vec())
                 .default_value(PoolType::Lvs.as_ref()),
+        )
+        .arg(
+            Arg::new("cipher")
+                .short('c')
+                .long("cipher")
+                .help("The cipher to use for encryption")
+                .required(false)
+                .requires("encryption-key"),
+        )
+        .arg(
+            Arg::new("encryption-key")
+                .short('k')
+                .long("encryption-key")
+                .help("The encryption key of the pool in hexlified format")
+                .required(false),
+        )
+        .arg(
+            Arg::new("xts-key")
+                .short('e')
+                .long("xts-key")
+                .help("encryption key2 required for AES_XTS")
+                .required_if_eq("cipher", "AES_XTS"),
         );
 
     let destroy = Command::new("destroy")
@@ -211,6 +256,19 @@ async fn create(mut ctx: Context, matches: &ArgMatches) -> crate::Result<()> {
         .to_owned();
 
     let uuid = matches.get_one::<String>("uuid");
+    let cipher = matches.get_one::<String>("cipher");
+
+    if let Some(c) = cipher {
+        if !c.eq_ignore_ascii_case("AES_XTS") && !c.eq_ignore_ascii_case("AES_CBC") {
+            return Err(Status::invalid_argument(
+                "Need valid cipher(AES_XTS or AES_CBC)",
+            ))
+            .context(GrpcStatus);
+        }
+    }
+
+    let enc_key = matches.get_one::<String>("encryption-key");
+    let xts_key = matches.get_one::<String>("xts-key");
 
     let disks_list = matches
         .get_many::<String>("disk")
@@ -251,6 +309,23 @@ async fn create(mut ctx: Context, matches: &ArgMatches) -> crate::Result<()> {
         None => None,
     };
 
+    let enc_key_msg = enc_key.map(|k| v1rpc::common::EncryptionKey {
+        key_name: "key_".to_owned() + k.as_str(),
+        key: k.clone().into(),
+        key_length: (k.len() * 4) as u32,
+        key2: xts_key.map(|k2| k2.clone().into()),
+        key2_length: xts_key.map(|x| { x.len() * 4 } as u32),
+    });
+
+    let enc_msg = enc_key_msg.map(|e| {
+        v1rpc::common::create_pool_request::Encryption::Data(v1rpc::common::EncryptionData {
+            cipher: v1rpc::common::Cipher::from_str_name(cipher.unwrap())
+                .unwrap()
+                .into(),
+            key: Some(e),
+        })
+    });
+
     let response = ctx
         .v1
         .pool
@@ -261,7 +336,7 @@ async fn create(mut ctx: Context, matches: &ArgMatches) -> crate::Result<()> {
             pooltype: v1rpc::pool::PoolType::from(pooltype) as i32,
             cluster_size,
             md_args: Some(v1rpc::pool::PoolMetadataArgs { md_resv_ratio }),
-            encryption: None,
+            encryption: enc_msg,
         })
         .await
         .context(GrpcStatus)?;
@@ -282,6 +357,21 @@ async fn create(mut ctx: Context, matches: &ArgMatches) -> crate::Result<()> {
     };
 
     Ok(())
+}
+
+#[derive(EnumString, VariantNames, AsRefStr)]
+#[strum(serialize_all = "UPPERCASE")]
+pub(super) enum Cipher {
+    AesCbc,
+    AesXts,
+}
+impl From<Cipher> for v1rpc::common::Cipher {
+    fn from(value: Cipher) -> Self {
+        match value {
+            Cipher::AesCbc => Self::AesCbc,
+            Cipher::AesXts => Self::AesXts,
+        }
+    }
 }
 
 #[derive(EnumString, VariantNames, AsRefStr)]
@@ -312,6 +402,20 @@ async fn import(mut ctx: Context, matches: &ArgMatches) -> crate::Result<()> {
         })?
         .to_owned();
     let uuid = matches.get_one::<String>("uuid");
+    let cipher = matches.get_one::<String>("cipher");
+
+    if let Some(c) = cipher {
+        if !c.eq_ignore_ascii_case("AES_XTS") && !c.eq_ignore_ascii_case("AES_CBC") {
+            return Err(Status::invalid_argument(
+                "Need valid cipher(AES_XTS or AES_CBC)",
+            ))
+            .context(GrpcStatus);
+        }
+    }
+
+    let enc_key = matches.get_one::<String>("encryption-key");
+    let xts_key = matches.get_one::<String>("xts-key");
+
     let disks_list = matches
         .get_many::<String>("disk")
         .ok_or_else(|| ClientError::MissingValue {
@@ -326,6 +430,23 @@ async fn import(mut ctx: Context, matches: &ArgMatches) -> crate::Result<()> {
         .map_err(|e| Status::invalid_argument(e.to_string()))
         .context(GrpcStatus)?;
 
+    let enc_key_msg = enc_key.map(|k| v1rpc::common::EncryptionKey {
+        key_name: "key_".to_owned() + k,
+        key: k.clone().into(),
+        key_length: k.len() as u32,
+        key2: xts_key.map(|k2| k2.clone().into()),
+        key2_length: xts_key.map(|x| x.len() as u32),
+    });
+
+    let enc_msg = enc_key_msg.map(|e| {
+        v1rpc::common::import_pool_request::Encryption::Data(v1rpc::common::EncryptionData {
+            cipher: v1rpc::common::Cipher::from_str_name(cipher.unwrap())
+                .unwrap()
+                .into(),
+            key: Some(e),
+        })
+    });
+
     let response = ctx
         .v1
         .pool
@@ -334,7 +455,7 @@ async fn import(mut ctx: Context, matches: &ArgMatches) -> crate::Result<()> {
             uuid: uuid.map(ToString::to_string),
             disks: disks_list,
             pooltype: v1rpc::pool::PoolType::from(pooltype) as i32,
-            encryption: None,
+            encryption: enc_msg,
         })
         .await
         .context(GrpcStatus)?;

--- a/io-engine/src/core/mod.rs
+++ b/io-engine/src/core/mod.rs
@@ -273,6 +273,10 @@ pub enum CoreError {
     WipeFailed {
         source: wiper::Error,
     },
+    #[snafu(display("Failed to init crypto module: {reason}"))]
+    InitCryptoModule {
+        reason: String,
+    },
 }
 
 /// Represent error as Errno value.
@@ -318,6 +322,7 @@ impl ToErrno for CoreError {
             Self::Ptpl { .. } => Errno::EIO,
             Self::SnapshotCreate { source, .. } => source,
             Self::WipeFailed { .. } => Errno::EIO,
+            Self::InitCryptoModule { .. } => Errno::EINVAL,
         }
     }
 }

--- a/io-engine/src/grpc/v1/pool.rs
+++ b/io-engine/src/grpc/v1/pool.rs
@@ -1,5 +1,6 @@
 pub use crate::pool_backend::FindPoolArgs as PoolIdProbe;
 use crate::{
+    bdev::crypto::{Cipher, EncryptionKey as PoolEncKey},
     core::{NvmfShareProps, ProtectedSubsystems, Protocol, ResourceLockGuard, ResourceLockManager},
     grpc::{acquire_subsystem_lock, GrpcClientContext, GrpcResult, RWLock, RWSerializer},
     lvs::{BsError, LvsError},
@@ -11,9 +12,17 @@ use crate::{
 use ::function_name::named;
 use futures::FutureExt;
 use io_engine_api::v1::{
-    pool::*, replica::destroy_replica_request, snapshot::destroy_snapshot_request,
+    common::{create_pool_request, import_pool_request, Cipher as GrpcCipher, EncryptionData},
+    pool::*,
+    replica::destroy_replica_request,
+    snapshot::destroy_snapshot_request,
 };
-use std::{convert::TryFrom, fmt::Debug, ops::Deref, panic::AssertUnwindSafe};
+use std::{
+    convert::{TryFrom, TryInto},
+    fmt::Debug,
+    ops::Deref,
+    panic::AssertUnwindSafe,
+};
 use tonic::{Request, Status};
 
 impl From<DestroyPoolRequest> for FindPoolArgs {
@@ -126,6 +135,37 @@ impl RWLock for PoolService {
     }
 }
 
+impl TryFrom<EncryptionData> for PoolEncKey {
+    type Error = LvsError;
+    fn try_from(msg: EncryptionData) -> Result<Self, Self::Error> {
+        let key = if let Some(k) = msg.key {
+            k
+        } else {
+            return Err(LvsError::Invalid {
+                source: BsError::InvalidArgument {},
+                msg: "invalid argument, missing key".to_string(),
+            });
+        };
+
+        let arg_cipher = msg.cipher;
+        let ctype: Cipher = GrpcCipher::try_from(arg_cipher)
+            .map_err(|_| LvsError::Invalid {
+                source: BsError::InvalidArgument {},
+                msg: format!("invalid cipher provided: {}", arg_cipher),
+            })?
+            .into();
+
+        Ok(Self {
+            cipher: ctype,
+            key_name: key.key_name,
+            key: String::from_utf8_lossy(&key.key).to_string(),
+            key_len: key.key_length,
+            key2: key.key2.map(|k2| String::from_utf8_lossy(&k2).to_string()),
+            key2_len: key.key2_length,
+        })
+    }
+}
+
 impl TryFrom<CreatePoolRequest> for PoolArgs {
     type Error = LvsError;
     fn try_from(args: CreatePoolRequest) -> Result<Self, Self::Error> {
@@ -149,13 +189,24 @@ impl TryFrom<CreatePoolRequest> for PoolArgs {
             }
         }
 
+        let enc_key = match args.encryption.clone() {
+            Some(create_pool_request::Encryption::Data(kd)) => kd.try_into().ok(),
+            Some(create_pool_request::Encryption::Secret(_ks)) => None,
+            _ => None,
+        };
+
         Ok(Self {
-            name: args.name,
-            disks: args.disks,
-            uuid: args.uuid,
+            name: args.name.clone(),
+            disks: args.disks.clone(),
+            uuid: args.uuid.clone(),
             cluster_size: args.cluster_size,
             md_args: args.md_args.map(|md| md.into()),
             backend: backend.into(),
+            enc_key,
+            crypto_vbdev_name: args
+                .encryption
+                .as_ref()
+                .map(|_| format!("crypto_{}", args.name)),
         })
     }
 }
@@ -226,13 +277,24 @@ impl TryFrom<ImportPoolRequest> for PoolArgs {
             }
         }
 
+        let enc_key = match args.encryption.clone() {
+            Some(import_pool_request::Encryption::Data(kd)) => PoolEncKey::try_from(kd).ok(),
+            Some(import_pool_request::Encryption::Secret(_ks)) => None,
+            _ => None,
+        };
+
         Ok(Self {
-            name: args.name,
-            disks: args.disks,
-            uuid: args.uuid,
+            name: args.name.clone(),
+            disks: args.disks.clone(),
+            uuid: args.uuid.clone(),
             cluster_size: None,
             md_args: None,
             backend: backend.into(),
+            enc_key,
+            crypto_vbdev_name: args
+                .encryption
+                .as_ref()
+                .map(|_| format!("crypto_{}", args.name)),
         })
     }
 }

--- a/io-engine/src/lvs/lvs_error.rs
+++ b/io-engine/src/lvs/lvs_error.rs
@@ -49,6 +49,8 @@ pub enum BsError {
     OutOfMetadata {},
     #[snafu(display(": capacity overflow"))]
     CapacityOverflow {},
+    #[snafu(display(": crypto vbdev error"))]
+    LvsCryptoVbdev {},
 }
 
 impl BsError {
@@ -101,6 +103,7 @@ impl ToErrno for BsError {
             Self::NoSpace {} => Errno::ENOSPC,
             Self::OutOfMetadata {} => Errno::EMFILE,
             Self::CapacityOverflow {} => Errno::EOVERFLOW,
+            Self::LvsCryptoVbdev {} => Errno::EINVAL,
         }
     }
 }

--- a/io-engine/src/pool_backend.rs
+++ b/io-engine/src/pool_backend.rs
@@ -1,4 +1,5 @@
 use crate::{
+    bdev::crypto::EncryptionKey,
     core::{BdevStater, BdevStats, ToErrno},
     replica_backend::ReplicaOps,
 };
@@ -16,6 +17,8 @@ pub struct PoolArgs {
     pub cluster_size: Option<u32>,
     pub md_args: Option<PoolMetadataArgs>,
     pub backend: PoolBackend,
+    pub enc_key: Option<EncryptionKey>,
+    pub crypto_vbdev_name: Option<String>,
 }
 
 /// Pool metadata args.

--- a/io-engine/src/subsys/config/pool.rs
+++ b/io-engine/src/subsys/config/pool.rs
@@ -159,9 +159,11 @@ struct Pool {
     #[serde(skip_serializing)]
     replicas: Option<Vec<Replica>>,
     backend: PoolBackend,
+    /// Is the pool enrypted.
+    encrypted: bool,
 }
 
-/// Convert a Pool into a gRPC request payload
+/// Convert a Pool into a gRPC request payload.
 impl From<&Pool> for PoolArgs {
     fn from(pool: &Pool) -> Self {
         Self {
@@ -171,6 +173,12 @@ impl From<&Pool> for PoolArgs {
             cluster_size: None,
             md_args: None,
             backend: pool.backend,
+            enc_key: None,
+            crypto_vbdev_name: if pool.encrypted {
+                Some(format!("crypto_{}", pool.name))
+            } else {
+                None
+            },
         }
     }
 }
@@ -186,6 +194,8 @@ impl From<LvsBdev> for Pool {
                 .unwrap_or_else(|| base.name().to_string())],
             replicas: None,
             backend: PoolBackend::Lvs,
+            // XXX: Check how we use this and set correctly.
+            encrypted: false,
         }
     }
 }

--- a/io-engine/tests/lvs_grow.rs
+++ b/io-engine/tests/lvs_grow.rs
@@ -145,6 +145,8 @@ async fn lvs_grow_ms_malloc() {
                     cluster_size: None,
                     md_args: None,
                     backend: Default::default(),
+                    enc_key: None,
+                    crypto_vbdev_name: None,
                 };
 
                 // Create LVS.

--- a/io-engine/tests/lvs_import.rs
+++ b/io-engine/tests/lvs_import.rs
@@ -56,6 +56,8 @@ async fn lvs_import_many_volume() {
             cluster_size: None,
             md_args: None,
             backend: Default::default(),
+            enc_key: None,
+            crypto_vbdev_name: None,
         };
 
         // Create LVS.

--- a/io-engine/tests/lvs_limits.rs
+++ b/io-engine/tests/lvs_limits.rs
@@ -51,6 +51,8 @@ async fn lvs_metadata_limit() {
             cluster_size: None,
             md_args: None,
             backend: Default::default(),
+            enc_key: None,
+            crypto_vbdev_name: None,
         };
 
         // Create LVS.

--- a/io-engine/tests/lvs_pool.rs
+++ b/io-engine/tests/lvs_pool.rs
@@ -54,6 +54,8 @@ async fn lvs_pool_test() {
         cluster_size: None,
         md_args: None,
         backend: PoolBackend::Lvs,
+        enc_key: None,
+        crypto_vbdev_name: None,
     };
 
     // should succeed to create a pool we can not import
@@ -139,6 +141,8 @@ async fn lvs_pool_test() {
             cluster_size: None,
             md_args: None,
             backend: PoolBackend::Lvs,
+            enc_key: None,
+            crypto_vbdev_name: None,
         })
         .await
         .is_ok());
@@ -171,6 +175,8 @@ async fn lvs_pool_test() {
             cluster_size: None,
             md_args: None,
             backend: PoolBackend::Lvs,
+            enc_key: None,
+            crypto_vbdev_name: None,
         })
         .await
         .unwrap();
@@ -209,6 +215,8 @@ async fn lvs_pool_test() {
             cluster_size: None,
             md_args: None,
             backend: PoolBackend::Lvs,
+            enc_key: None,
+            crypto_vbdev_name: None,
         })
         .await
         .unwrap();
@@ -348,6 +356,8 @@ async fn lvs_pool_test() {
             cluster_size: None,
             md_args: None,
             backend: PoolBackend::Lvs,
+            enc_key: None,
+            crypto_vbdev_name: None,
         })
         .await
         .unwrap();
@@ -370,6 +380,8 @@ async fn lvs_pool_test() {
             cluster_size: None,
             md_args: None,
             backend: PoolBackend::Lvs,
+            enc_key: None,
+            crypto_vbdev_name: None,
         })
         .await
         .unwrap();
@@ -398,6 +410,8 @@ async fn lvs_pool_test() {
             cluster_size: None,
             md_args: None,
             backend: PoolBackend::Lvs,
+            enc_key: None,
+            crypto_vbdev_name: None,
         })
         .await
         .unwrap();
@@ -436,6 +450,8 @@ async fn lvs_pool_test() {
             cluster_size: None,
             md_args: None,
             backend: PoolBackend::Lvs,
+            enc_key: None,
+            crypto_vbdev_name: None,
         })
         .await
         .err()
@@ -454,6 +470,8 @@ async fn lvs_pool_test() {
             cluster_size: None,
             md_args: None,
             backend: PoolBackend::Lvs,
+            enc_key: None,
+            crypto_vbdev_name: None,
         })
         .await
         .unwrap();

--- a/io-engine/tests/replica_snapshot.rs
+++ b/io-engine/tests/replica_snapshot.rs
@@ -97,6 +97,8 @@ async fn replica_snapshot() {
                 cluster_size: None,
                 md_args: None,
                 backend: PoolBackend::Lvs,
+                enc_key: None,
+                crypto_vbdev_name: None,
             })
             .await
             .unwrap();

--- a/io-engine/tests/snapshot_lvol.rs
+++ b/io-engine/tests/snapshot_lvol.rs
@@ -59,6 +59,8 @@ async fn create_test_pool(pool_name: &str, disk: String, cluster_size: Option<u3
         cluster_size,
         md_args: None,
         backend: PoolBackend::Lvs,
+        enc_key: None,
+        crypto_vbdev_name: None,
     })
     .await
     .expect("Failed to create test pool");

--- a/nix/pkgs/io-engine/cargo-package.nix
+++ b/nix/pkgs/io-engine/cargo-package.nix
@@ -28,6 +28,7 @@
 , versions
 , systemdMinimal
 , rdma-core
+, keyutils
 , cargoBuildFlags ? [ ]
 , pname ? "io-engine"
 , rustFlags
@@ -91,6 +92,7 @@ let
       systemdMinimal.dev
       utillinux.dev
       rdma-core
+      keyutils
     ];
     cargoLock = {
       lockFile = ../../../Cargo.lock;


### PR DESCRIPTION
This adds a crypto vbdev support in Mayastor. A crypto vbdev is always created with a base bdev underneath e.g an aio bdev. A crypto vbdev needs an associated key and crypto opts, that are attached to the vbdev for its lifetime.