### PR TITLE
Populate disk info for encrypted pools

### DIFF
--- a/io-engine/src/bin/io-engine-client/v1/pool_cli.rs
+++ b/io-engine/src/bin/io-engine-client/v1/pool_cli.rs
@@ -664,6 +664,7 @@ async fn list(mut ctx: Context, matches: &ArgMatches) -> crate::Result<()> {
                         md_usage,
                         p.disks.join(" "),
                         ctx.units(disk_cap),
+                        p.encrypted.unwrap_or_default().to_string(),
                     ]
                 })
                 .collect();
@@ -683,6 +684,7 @@ async fn list(mut ctx: Context, matches: &ArgMatches) -> crate::Result<()> {
                     "MD_USED%",
                     "DISKS",
                     "DISK_CAPACITY",
+                    "ENCRYPTED",
                 ],
                 table,
             );

--- a/io-engine/src/lvs/mod.rs
+++ b/io-engine/src/lvs/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     bdev::PtplFileOps,
     core::{
-        snapshot::SnapshotDescriptor, CloneParams, LogicalVolume, Protocol, PtplProps, Share,
+        snapshot::SnapshotDescriptor, Bdev, CloneParams, LogicalVolume, Protocol, PtplProps, Share,
         SnapshotParams, UpdateProps,
     },
     pool_backend::{
@@ -186,7 +186,14 @@ impl IPoolProps for Lvs {
     }
 
     fn disks(&self) -> Vec<String> {
-        vec![self.base_bdev().bdev_uri_str().unwrap_or_else(|| "".into())]
+        // Calling crypto_base_bdev() on non crypto bdev returns None.
+        let disk_bdev = self
+            .base_bdev()
+            .crypto_base_bdev()
+            .map(Bdev::new)
+            .unwrap_or_else(|| self.base_bdev());
+
+        vec![disk_bdev.bdev_uri_str().unwrap_or_else(|| "".into())]
     }
 
     fn disk_capacity(&self) -> u64 {


### PR DESCRIPTION
The `DISKS` field is now populated for an encrypted pool also. 

```
./io-engine-client pool list 
NAME   UUID                                 STATE  CAPACITY   USED USED% CLUSTER_SIZE PAGE_SIZE MD_PAGE_SIZE MD_PAGES MD_USED_PAGES MD_USED% DISKS                                                      DISK_CAPACITY ENCRYPTED
pool-2 f74d6a27-0ed6-4331-9760-29ab2fd76193 online 310378496  0    0.00% 4194304      4096      4096         75       1             1.33%    aio:///dev/loop1?uuid=9cc90df3-828d-4b4a-a357-424f31332604 314572800     false    
pool-1 49c29a9f-bc2e-4c7d-9fd5-12972899c4ec online 5360320512 0    0.00% 4194304      4096      4096         1280     1             0.08%    aio:///dev/loop0?uuid=7870a4dc-fb82-4a57-b3e5-a32b37782fbc 5368709120    true   
```