### PR TITLE
Fix IPv6 support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -683,9 +683,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.1"
+version = "1.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd9de9f2205d5ef3fd67e685b0df337994ddd4495e2a28d185500d0e1edfea47"
+checksum = "1fcb57c740ae1daf453ae85f16e37396f672b039e00d9d866e07ddb24e328e3a"
 dependencies = [
  "jobserver",
  "libc",
@@ -2613,7 +2613,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -3462,15 +3462,14 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.8"
+version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
  "getrandom",
  "libc",
- "spin",
  "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
@@ -4036,12 +4035,6 @@ dependencies = [
  "tracing",
  "uuid",
 ]
-
-[[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "spki"

--- a/io-engine/src/bin/io-engine-client/context.rs
+++ b/io-engine/src/bin/io-engine-client/context.rs
@@ -135,7 +135,10 @@ impl Context {
             .unwrap_or('b');
         // Ensure the provided host is defaulted & normalized to what we expect.
         let host = if let Some(host) = matches.get_one::<String>("bind") {
-            let uri = host.parse::<Uri>().context(InvalidUri)?;
+            let uri = match host.parse::<Uri>().context(InvalidUri) {
+                Ok(uri) => Ok(uri),
+                Err(error) => format!("[{host}]").parse::<Uri>().map_err(|_| error),
+            }?;
             let mut parts = uri.into_parts();
             if parts.scheme.is_none() {
                 parts.scheme = Scheme::from_str("http").ok();

--- a/io-engine/src/bin/io-engine-client/v1/mod.rs
+++ b/io-engine/src/bin/io-engine-client/v1/mod.rs
@@ -29,7 +29,7 @@ pub(super) async fn main_() -> crate::Result<()> {
                 .short('b')
                 .long("bind")
                 .env("MY_POD_IP")
-                .default_value("http://127.0.0.1:10124")
+                .default_value("http://127.0.0.1")
                 .value_name("HOST")
                 .help("The URI of mayastor instance")
                 .global(true),

--- a/io-engine/src/bin/io-engine.rs
+++ b/io-engine/src/bin/io-engine.rs
@@ -159,6 +159,7 @@ fn start_tokio_runtime(args: &MayastorCliArgs) {
                 Registration::init(
                     &node_name,
                     &node_nqn,
+                    // todo: handle scope ids?
                     &grpc_socket_addr.to_string(),
                     registration_addr,
                     api_versions,

--- a/io-engine/src/core/env.rs
+++ b/io-engine/src/core/env.rs
@@ -817,38 +817,52 @@ impl MayastorEnvironment {
             None => ("name", iface),
         };
 
-        let pred: Box<dyn Fn(&nic::Interface) -> bool> = match cls {
-            "name" => Box::new(|n| n.name == name),
+        let map_ok = |filter: bool, n: nic::Interface| -> Option<nic::Interface> {
+            if filter {
+                Some(n)
+            } else {
+                None
+            }
+        };
+
+        let pred: Box<dyn FnMut(nic::Interface) -> Option<nic::Interface>> = match cls {
+            "name" => Box::new(|n| map_ok(n.name == name, n)),
             "mac" => {
                 let mac = Some(name.parse::<nic::MacAddr>()?);
-                Box::new(move |n| n.mac == mac)
+                Box::new(move |n| map_ok(n.mac == mac, n))
             }
             "ip" => {
                 let addr = nic::parse_ip(name)?;
-                Box::new(move |n| n.ip_match(addr))
+                Box::new(move |n| n.matched_ip_kind(addr))
             }
             "subnet" => {
                 let (subnet, mask) = nic::parse_ip_subnet(name)?;
-                Box::new(move |n| n.ip_subnet_eq(subnet, mask))
+                Box::new(move |n| n.matched_subnet_kind(subnet, mask))
             }
             _ => {
                 return Err(format!("Invalid NVMF target interface: '{iface}'"));
             }
         };
 
-        let mut nics: Vec<_> = nic::find_all_nics().into_iter().filter(pred).collect();
+        let mut nics: Vec<_> = nic::find_all_nics().into_iter().filter_map(pred).collect();
 
-        let res = match nics.pop() {
+        // In case of matching by name, mac or subnet, the adapter may have multiple ips, and
+        // in this case how to prioritize them?
+        // For now, we can at least match ipv4 or ipv6 to match the grpc.
+        let env = MayastorEnvironment::global_or_default();
+        let grpc = env.grpc_endpoint.expect("Should always be set");
+        nics.sort_by(|a, b| a.sort(b, grpc.is_ipv4()));
+
+        let res: nic::Interface = match nics.pop() {
             None => Err(format!("Network interface matching '{iface}' not found")),
-            Some(_) if !nics.is_empty() => Err(format!(
-                "Multiple network interfaces that match '{iface}' are found"
-            )),
             Some(nic) => Ok(nic),
         }?;
 
         info!("NVMF target network interface '{iface}' matches to {res}");
 
-        match res.ip() {
+        // let ip = res.ip(grpc.is_ipv4());
+
+        match res.ip(grpc.is_ipv4()) {
             Some(ip) => Ok(ip),
             None => Err(format!(
                 "Network interface '{}' has no IP address configured",

--- a/io-engine/src/core/env.rs
+++ b/io-engine/src/core/env.rs
@@ -18,7 +18,6 @@ use futures::{channel::oneshot, future};
 use http::Uri;
 use once_cell::sync::{Lazy, OnceCell};
 use snafu::Snafu;
-use std::net::Ipv6Addr;
 use tokio::runtime::Builder;
 use version_info::{package_description, version_info_str};
 
@@ -39,6 +38,7 @@ use crate::{
     constants::NVME_NQN_PREFIX,
     core::{
         nic,
+        nic::SIpAddr,
         reactor::{Reactor, ReactorState, Reactors},
         Cores, MayastorFeatures, Mthread,
     },
@@ -101,6 +101,30 @@ fn parse_crdt(src: &str) -> Result<[u16; TARGET_CRDT_LEN], String> {
     }
 }
 
+/// Parses a grpc ip as a socket address.
+/// The port is ignored but we use the socket to keep the scope ip, which can be specified
+/// like so: `fe80::779c:c5ea:e9c5:2cc4%2`.
+/// # Warning
+/// Scope Ids are disabled for now as spdk posix sock seems to not format the traddr correctly
+/// when the endpoint has a scope id.
+fn parse_grpc_ip(src: &str) -> Result<SIpAddr, String> {
+    let (ip, scope_ip) = match src.split_once('%') {
+        Some(p) => p,
+        None => (src, ""),
+    };
+
+    match ip.parse::<std::net::IpAddr>() {
+        Ok(ip) => match ip {
+            std::net::IpAddr::V4(ip) => Ok(SIpAddr::from(ip)),
+            std::net::IpAddr::V6(ip) if scope_ip.is_empty() => Ok(SIpAddr::from(ip)),
+            std::net::IpAddr::V6(_) => Err(format!(
+                "Ip '{src}' has a scope_id '{scope_ip}' which is not currently supported"
+            )),
+        },
+        Err(error) => Err(format!("Invalid ip '{src}': {error}")),
+    }
+}
+
 #[derive(Debug, Clone, Parser)]
 #[clap(
     name = package_description!(),
@@ -112,9 +136,9 @@ pub struct MayastorCliArgs {
     #[deprecated = "Use grpc_ip and grpc_port instead"]
     /// IP address and port (optional) for the gRPC server to listen on.
     pub deprecated_grpc_endpoint: Option<String>,
-    #[clap(long, default_value_t = std::net::IpAddr::V6(std::net::Ipv6Addr::UNSPECIFIED))]
+    #[clap(long, value_parser = parse_grpc_ip, default_value_t = std::net::Ipv6Addr::UNSPECIFIED.into())]
     /// IP address for the gRPC server to listen on.
-    pub grpc_ip: std::net::IpAddr,
+    pub grpc_ip: SIpAddr,
     #[clap(long, default_value_t = 10124)]
     /// Port for the gRPC server to listen on.
     pub grpc_port: u16,
@@ -291,7 +315,7 @@ impl Default for MayastorCliArgs {
         #[allow(deprecated)]
         Self {
             deprecated_grpc_endpoint: None,
-            grpc_ip: std::net::IpAddr::V6(std::net::Ipv6Addr::UNSPECIFIED),
+            grpc_ip: std::net::Ipv6Addr::UNSPECIFIED.into(),
             grpc_port: 10124,
             ps_endpoint: None,
             ps_timeout: Duration::from_secs(10),
@@ -342,7 +366,8 @@ impl MayastorCliArgs {
         if let Some(deprecated_endpoint) = &self.deprecated_grpc_endpoint {
             grpc::endpoint_from_str(deprecated_endpoint, self.grpc_port)
         } else {
-            std::net::SocketAddr::new(self.grpc_ip, self.grpc_port)
+            // todo: scope ids are not properly supported on SPDK
+            std::net::SocketAddr::new(self.grpc_ip.ip(), self.grpc_port)
         }
     }
 }
@@ -792,8 +817,8 @@ impl MayastorEnvironment {
     }
 
     /// Returns NVMF target's IP address.
-    pub(crate) fn get_nvmf_tgt_ip() -> Result<std::net::IpAddr, String> {
-        static TGT_IP: OnceCell<std::net::IpAddr> = OnceCell::new();
+    pub(crate) fn get_nvmf_tgt_ip() -> Result<SIpAddr, String> {
+        static TGT_IP: OnceCell<SIpAddr> = OnceCell::new();
         TGT_IP
             .get_or_try_init(|| match Self::global_or_default().nvmf_tgt_interface {
                 Some(ref iface) => Self::detect_nvmf_tgt_iface_ip(iface),
@@ -809,8 +834,13 @@ impl MayastorEnvironment {
 
     /// Detects IP address for NVMF target by the interface specified in CLI
     /// arguments.
-    fn detect_nvmf_tgt_iface_ip(iface: &str) -> Result<std::net::IpAddr, String> {
-        info!("Detecting IP address for NVMF target network interface specified as '{iface}' ...");
+    fn detect_nvmf_tgt_iface_ip(iface: &str) -> Result<SIpAddr, String> {
+        // In case of matching by name, mac or subnet, the adapter may have multiple ips, and
+        // in this case how to prioritize them?
+        // For now, we can at least match ipv4 or ipv6 to match the grpc.
+        let env = MayastorEnvironment::global_or_default();
+        let prefer_ipv4 = Self::prefer_ipv4(env.grpc_endpoint.expect("Should always be set"));
+        info!("Detecting IP address (prefer ipv4: {prefer_ipv4}) for NVMF target network interface specified as '{iface}' ...");
 
         let (cls, name) = match iface.split_once(':') {
             Some(p) => p,
@@ -845,13 +875,7 @@ impl MayastorEnvironment {
         };
 
         let mut nics: Vec<_> = nic::find_all_nics().into_iter().filter_map(pred).collect();
-
-        // In case of matching by name, mac or subnet, the adapter may have multiple ips, and
-        // in this case how to prioritize them?
-        // For now, we can at least match ipv4 or ipv6 to match the grpc.
-        let env = MayastorEnvironment::global_or_default();
-        let grpc = env.grpc_endpoint.expect("Should always be set");
-        nics.sort_by(|a, b| a.sort(b, grpc.is_ipv4()));
+        nics.sort_by(|a, b| a.sort(b, prefer_ipv4));
 
         let res: nic::Interface = match nics.pop() {
             None => Err(format!("Network interface matching '{iface}' not found")),
@@ -860,9 +884,7 @@ impl MayastorEnvironment {
 
         info!("NVMF target network interface '{iface}' matches to {res}");
 
-        // let ip = res.ip(grpc.is_ipv4());
-
-        match res.ip(grpc.is_ipv4()) {
+        match res.ip(prefer_ipv4) {
             Some(ip) => Ok(ip),
             None => Err(format!(
                 "Network interface '{}' has no IP address configured",
@@ -871,24 +893,31 @@ impl MayastorEnvironment {
         }
     }
 
+    fn prefer_ipv4(grpc: std::net::SocketAddr) -> bool {
+        match grpc {
+            std::net::SocketAddr::V4(_) => true,
+            std::net::SocketAddr::V6(socket) if socket.ip().is_unspecified() => true,
+            std::net::SocketAddr::V6(_) => false,
+        }
+    }
+
     /// Detects pod IP address.
-    fn detect_pod_ip() -> Result<std::net::IpAddr, String> {
+    fn detect_pod_ip() -> Result<SIpAddr, String> {
         match env::var("MY_POD_IP") {
             Ok(val) => {
                 info!(
                     "Using 'MY_POD_IP' environment variable for IP address \
                         for NVMF target network interface"
                 );
-
-                match val.parse::<std::net::IpAddr>() {
-                    Ok(ip) => Ok(ip),
-                    Err(error) => Err(format!(
-                        "MY_POD_IP environment variable is set to an \
-                            invalid IPvX address: '{val}': {error}"
-                    )),
+                Ok(parse_grpc_ip(&val)?)
+            }
+            Err(_) => {
+                if Self::prefer_ipv4(Self::global_or_default().grpc_endpoint.unwrap()) {
+                    Ok(std::net::Ipv4Addr::LOCALHOST.into())
+                } else {
+                    Ok(std::net::Ipv6Addr::LOCALHOST.into())
                 }
             }
-            Err(_) => Ok(std::net::IpAddr::V6(Ipv6Addr::LOCALHOST)),
         }
     }
 

--- a/io-engine/src/core/env.rs
+++ b/io-engine/src/core/env.rs
@@ -1,7 +1,6 @@
 use std::{
     env,
     ffi::CString,
-    net::Ipv4Addr,
     os::raw::{c_char, c_void},
     pin::Pin,
     str::FromStr,
@@ -19,6 +18,7 @@ use futures::{channel::oneshot, future};
 use http::Uri;
 use once_cell::sync::{Lazy, OnceCell};
 use snafu::Snafu;
+use std::net::Ipv6Addr;
 use tokio::runtime::Builder;
 use version_info::{package_description, version_info_str};
 
@@ -792,8 +792,8 @@ impl MayastorEnvironment {
     }
 
     /// Returns NVMF target's IP address.
-    pub(crate) fn get_nvmf_tgt_ip() -> Result<String, String> {
-        static TGT_IP: OnceCell<String> = OnceCell::new();
+    pub(crate) fn get_nvmf_tgt_ip() -> Result<std::net::IpAddr, String> {
+        static TGT_IP: OnceCell<std::net::IpAddr> = OnceCell::new();
         TGT_IP
             .get_or_try_init(|| match Self::global_or_default().nvmf_tgt_interface {
                 Some(ref iface) => Self::detect_nvmf_tgt_iface_ip(iface),
@@ -809,12 +809,8 @@ impl MayastorEnvironment {
 
     /// Detects IP address for NVMF target by the interface specified in CLI
     /// arguments.
-    fn detect_nvmf_tgt_iface_ip(iface: &str) -> Result<String, String> {
-        info!(
-            "Detecting IP address for NVMF target network interface \
-                specified as '{}' ...",
-            iface
-        );
+    fn detect_nvmf_tgt_iface_ip(iface: &str) -> Result<std::net::IpAddr, String> {
+        info!("Detecting IP address for NVMF target network interface specified as '{iface}' ...");
 
         let (cls, name) = match iface.split_once(':') {
             Some(p) => p,
@@ -860,18 +856,17 @@ impl MayastorEnvironment {
             iface, res
         );
 
-        if res.inet.addr.is_none() {
-            return Err(format!(
-                "Network interface '{}' has no IPv4 address configured",
+        match res.ip() {
+            Some(ip) => Ok(ip),
+            None => Err(format!(
+                "Network interface '{}' has no IP address configured",
                 res.name
-            ));
+            )),
         }
-
-        Ok(res.inet.addr.unwrap().to_string())
     }
 
     /// Detects pod IP address.
-    fn detect_pod_ip() -> Result<String, String> {
+    fn detect_pod_ip() -> Result<std::net::IpAddr, String> {
         match env::var("MY_POD_IP") {
             Ok(val) => {
                 info!(
@@ -879,16 +874,15 @@ impl MayastorEnvironment {
                         for NVMF target network interface"
                 );
 
-                if val.parse::<Ipv4Addr>().is_ok() {
-                    Ok(val)
-                } else {
-                    Err(format!(
+                match val.parse::<std::net::IpAddr>() {
+                    Ok(ip) => Ok(ip),
+                    Err(error) => Err(format!(
                         "MY_POD_IP environment variable is set to an \
-                            invalid IPv4 address: '{val}'"
-                    ))
+                            invalid IPvX address: '{val}': {error}"
+                    )),
                 }
             }
-            Err(_) => Ok("127.0.0.1".to_owned()),
+            Err(_) => Ok(std::net::IpAddr::V6(Ipv6Addr::LOCALHOST)),
         }
     }
 

--- a/io-engine/src/core/env.rs
+++ b/io-engine/src/core/env.rs
@@ -824,37 +824,29 @@ impl MayastorEnvironment {
                 Box::new(move |n| n.mac == mac)
             }
             "ip" => {
-                let addr = Some(nic::parse_ipv4(name)?);
-                Box::new(move |n| n.inet.addr == addr)
+                let addr = nic::parse_ip(name)?;
+                Box::new(move |n| n.ip_match(addr))
             }
             "subnet" => {
-                let (subnet, mask) = nic::parse_ipv4_subnet(name)?;
-                Box::new(move |n| n.ipv4_subnet_eq(subnet, mask))
+                let (subnet, mask) = nic::parse_ip_subnet(name)?;
+                Box::new(move |n| n.ip_subnet_eq(subnet, mask))
             }
             _ => {
-                return Err(format!("Invalid NVMF target interface: '{iface}'",));
+                return Err(format!("Invalid NVMF target interface: '{iface}'"));
             }
         };
 
         let mut nics: Vec<_> = nic::find_all_nics().into_iter().filter(pred).collect();
 
-        if nics.is_empty() {
-            return Err(format!("Network interface matching '{iface}' not found",));
-        }
+        let res = match nics.pop() {
+            None => Err(format!("Network interface matching '{iface}' not found")),
+            Some(_) if !nics.is_empty() => Err(format!(
+                "Multiple network interfaces that match '{iface}' are found"
+            )),
+            Some(nic) => Ok(nic),
+        }?;
 
-        if nics.len() > 1 {
-            return Err(format!(
-                "Multiple network interfaces that \
-                match '{iface}' are found",
-            ));
-        }
-
-        let res = nics.pop().unwrap();
-
-        info!(
-            "NVMF target network interface '{}' matches to {}",
-            iface, res
-        );
+        info!("NVMF target network interface '{iface}' matches to {res}");
 
         match res.ip() {
             Some(ip) => Ok(ip),

--- a/io-engine/src/core/mod.rs
+++ b/io-engine/src/core/mod.rs
@@ -24,6 +24,7 @@ pub use env::{mayastor_env_stop, MayastorCliArgs, MayastorEnvironment, GLOBAL_RC
 pub use handle::{BdevHandle, UntypedBdevHandle};
 pub use io_device::IoDevice;
 pub use logical_volume::LogicalVolume;
+pub use nic::SIpAddr;
 pub use reactor::{reactor_monitor_loop, Reactor, ReactorState, Reactors, REACTOR_LIST};
 
 pub use lock::{

--- a/io-engine/src/core/nic.rs
+++ b/io-engine/src/core/nic.rs
@@ -2,7 +2,6 @@ use core::default::Default;
 use nix::ifaddrs::getifaddrs;
 
 use std::{
-    collections::BTreeMap,
     fmt,
     fmt::{Display, Formatter},
     net::{Ipv4Addr, Ipv6Addr},
@@ -130,61 +129,128 @@ impl Interface {
     }
 
     /// Get the available ip address.
-    pub(crate) fn ip(&self) -> Option<std::net::IpAddr> {
-        if let Some(ipv4) = self.inet.addr {
-            return Some(std::net::IpAddr::V4(ipv4));
+    pub(crate) fn ip(&self, prefer_ipv4: bool) -> Option<std::net::IpAddr> {
+        if prefer_ipv4 {
+            if let Some(ipv4) = self.inet.addr {
+                return Some(std::net::IpAddr::V4(ipv4));
+            }
+            if let Some(ipv6) = self.inet6.addr {
+                return Some(std::net::IpAddr::V6(ipv6));
+            }
+        } else {
+            if let Some(ipv6) = self.inet6.addr {
+                return Some(std::net::IpAddr::V6(ipv6));
+            }
+            if let Some(ipv4) = self.inet.addr {
+                return Some(std::net::IpAddr::V4(ipv4));
+            }
         }
-        if let Some(ipv6) = self.inet6.addr {
-            return Some(std::net::IpAddr::V6(ipv6));
-        }
+
         None
     }
 
-    /// Check if the given ip matches ours.
-    pub(crate) fn ip_match(&self, ip: std::net::IpAddr) -> bool {
-        match ip {
-            std::net::IpAddr::V4(ip) => Some(ip) == self.inet.addr,
-            std::net::IpAddr::V6(ip) => Some(ip) == self.inet6.addr,
+    /// Check if the given ip matches ours and if so dispose of the other kind of ip.
+    pub(crate) fn matched_ip_kind(mut self, ip: std::net::IpAddr) -> Option<Self> {
+        if match ip {
+            std::net::IpAddr::V4(ip) => {
+                self.inet6.addr = None;
+                self.inet6.netmask = None;
+                Some(ip) == self.inet.addr
+            }
+            std::net::IpAddr::V6(ip) => {
+                self.inet.addr = None;
+                self.inet.netmask = None;
+                Some(ip) == self.inet6.addr
+            }
+        } {
+            Some(self)
+        } else {
+            None
         }
     }
 
-    /// Tests if the interface belongs to the given subnet.
-    pub fn ip_subnet_eq(&self, net_addr: std::net::IpAddr, net_mask: u128) -> bool {
+    /// Sort interfaces depending on ip v4/v6 preference and ipv6 types
+    pub(crate) fn sort(&self, other: &Self, prefer_ipv4: bool) -> std::cmp::Ordering {
+        if prefer_ipv4 {
+            return self.inet.addr.is_some().cmp(&other.inet.addr.is_some());
+        }
+        if self.inet6.addr.is_some() != other.inet6.addr.is_some() {
+            // prefer ipv6
+            return self.inet6.addr.is_some().cmp(&other.inet6.addr.is_some());
+        }
+        fn is_unique_local(ip: &Ipv6Addr) -> bool {
+            (ip.segments()[0] & 0xfe00) == 0xfc00
+        }
+        fn is_unicast_link_local(ip: &Ipv6Addr) -> bool {
+            (ip.segments()[0] & 0xffc0) == 0xfe80
+        }
+        match (self.inet6.addr, other.inet6.addr) {
+            (Some(_), None) => std::cmp::Ordering::Greater,
+            (None, Some(_)) => std::cmp::Ordering::Less,
+            (Some(a), Some(b)) => {
+                // prefer unique local addresses
+                if is_unique_local(&a) != is_unique_local(&b) {
+                    return is_unique_local(&a).cmp(&is_unique_local(&b));
+                }
+                // prefer link local
+                if is_unicast_link_local(&a) != is_unicast_link_local(&b) {
+                    return is_unicast_link_local(&a).cmp(&is_unicast_link_local(&b));
+                }
+                // prefer not multicast
+                if a.is_multicast() != b.is_multicast() {
+                    return b.is_multicast().cmp(&a.is_multicast());
+                }
+                std::cmp::Ordering::Equal
+            }
+            (None, None) => std::cmp::Ordering::Equal,
+        }
+    }
+
+    /// Check if the given interface matches ours and if so dispose of the other kind of ip.
+    pub fn matched_subnet_kind(
+        mut self,
+        net_addr: std::net::IpAddr,
+        net_mask: u128,
+    ) -> Option<Self> {
         if let Some((addr, mask)) = match (self.inet.addr, self.inet.netmask) {
-            (Some(addr), Some(mask)) => Some((addr, mask)),
+            (Some(addr), Some(mask)) if net_addr.is_ipv4() => Some((addr, mask)),
             _ => None,
         } {
             let mask = mask.to_bits();
             if mask as u128 != net_mask {
-                return false;
+                return None;
             }
 
             let addr = addr.to_bits();
             let subnet = addr & mask;
 
             if Ipv4Addr::from(subnet) == net_addr {
-                return true;
+                self.inet6.addr = None;
+                self.inet6.netmask = None;
+                return Some(self);
             }
         }
 
         if let Some((addr, mask)) = match (self.inet6.addr, self.inet6.netmask) {
-            (Some(addr), Some(mask)) => Some((addr, mask)),
+            (Some(addr), Some(mask)) if net_addr.is_ipv6() => Some((addr, mask)),
             _ => None,
         } {
             let mask = mask.to_bits();
             if mask != net_mask {
-                return false;
+                return None;
             }
 
             let addr = addr.to_bits();
             let subnet = addr & mask;
 
             if Ipv6Addr::from(subnet) == net_addr {
-                return true;
+                self.inet.addr = None;
+                self.inet.netmask = None;
+                return Some(self);
             }
         }
 
-        false
+        None
     }
 }
 
@@ -210,12 +276,10 @@ impl fmt::Display for Interface {
 
 /// Lists all network interfaces found on the system.
 pub fn find_all_nics() -> Vec<Interface> {
-    let mut nics = BTreeMap::<String, Interface>::new();
+    let mut nics = vec![];
 
     for addr in getifaddrs().unwrap() {
-        let nic = nics
-            .entry(addr.interface_name)
-            .or_insert_with_key(|k| Interface::new(k));
+        let mut nic = Interface::new(&addr.interface_name);
         if let Some(sock) = addr.address {
             if let Some(sock) = sock.as_sockaddr_in() {
                 nic.inet.addr = Some(sock.ip());
@@ -236,9 +300,13 @@ pub fn find_all_nics() -> Vec<Interface> {
                 nic.inet6.netmask = Some(sock.ip());
             }
         }
+        // Skip interfaces without ip's.
+        if nic.inet.addr.is_some() || nic.inet6.addr.is_some() {
+            nics.push(nic);
+        }
     }
 
-    nics.into_values().collect()
+    nics
 }
 
 /// Utility to parse an IPv4 address string into a nix's Ipv4Addr.

--- a/io-engine/src/core/nic.rs
+++ b/io-engine/src/core/nic.rs
@@ -1,5 +1,6 @@
 use core::default::Default;
 use nix::ifaddrs::getifaddrs;
+
 use std::{
     collections::BTreeMap,
     fmt,
@@ -139,33 +140,51 @@ impl Interface {
         None
     }
 
-    /// Tests if the interface belongs to the given subnet.
-    pub fn ipv4_subnet_eq(&self, net_addr: Ipv4Addr, net_mask: u32) -> bool {
-        let (addr, mask) = match (self.inet.addr, self.inet.netmask) {
-            (Some(addr), Some(mask)) => (addr, mask),
-            _ => return false,
-        };
+    /// Check if the given ip matches ours.
+    pub(crate) fn ip_match(&self, ip: std::net::IpAddr) -> bool {
+        match ip {
+            std::net::IpAddr::V4(ip) => Some(ip) == self.inet.addr,
+            std::net::IpAddr::V6(ip) => Some(ip) == self.inet6.addr,
+        }
+    }
 
-        let mask = u32::from_be(ipv4addr_to_libc(mask).s_addr);
-        if mask != net_mask {
-            return false;
+    /// Tests if the interface belongs to the given subnet.
+    pub fn ip_subnet_eq(&self, net_addr: std::net::IpAddr, net_mask: u128) -> bool {
+        if let Some((addr, mask)) = match (self.inet.addr, self.inet.netmask) {
+            (Some(addr), Some(mask)) => Some((addr, mask)),
+            _ => None,
+        } {
+            let mask = mask.to_bits();
+            if mask as u128 != net_mask {
+                return false;
+            }
+
+            let addr = addr.to_bits();
+            let subnet = addr & mask;
+
+            if Ipv4Addr::from(subnet) == net_addr {
+                return true;
+            }
         }
 
-        let addr = u32::from_be(ipv4addr_to_libc(addr).s_addr);
-        let subnet = addr & mask;
+        if let Some((addr, mask)) = match (self.inet6.addr, self.inet6.netmask) {
+            (Some(addr), Some(mask)) => Some((addr, mask)),
+            _ => None,
+        } {
+            let mask = mask.to_bits();
+            if mask != net_mask {
+                return false;
+            }
 
-        Ipv4Addr::from(subnet) == net_addr
-    }
-}
-fn ipv4addr_to_libc(addr: Ipv4Addr) -> libc::in_addr {
-    let octets = addr.octets();
-    libc::in_addr {
-        s_addr: u32::to_be(
-            ((octets[0] as u32) << 24)
-                | ((octets[1] as u32) << 16)
-                | ((octets[2] as u32) << 8)
-                | (octets[3] as u32),
-        ),
+            let addr = addr.to_bits();
+            let subnet = addr & mask;
+
+            if Ipv6Addr::from(subnet) == net_addr {
+                return true;
+            }
+        }
+
+        false
     }
 }
 
@@ -223,30 +242,42 @@ pub fn find_all_nics() -> Vec<Interface> {
 }
 
 /// Utility to parse an IPv4 address string into a nix's Ipv4Addr.
-pub fn parse_ipv4(addr: &str) -> Result<Ipv4Addr, String> {
-    addr.parse::<Ipv4Addr>().map_err(|e| e.to_string())
+pub fn parse_ip(addr: &str) -> Result<std::net::IpAddr, String> {
+    addr.parse::<std::net::IpAddr>().map_err(|e| e.to_string())
 }
 
-/// Utility to parse an IPv4 subnet string into a nix's Ipv4Addr.
-pub fn parse_ipv4_subnet(addr_str: &str) -> Result<(Ipv4Addr, u32), String> {
+/// Utility to parse an IPvX subnet string into a nix's IpvXAddr.
+pub fn parse_ip_subnet(addr_str: &str) -> Result<(std::net::IpAddr, u128), String> {
     let (addr, bits) = match addr_str.split_once('/') {
         Some(p) => p,
         None => return Err(format!("Invalid subnet: '{addr_str}'")),
     };
 
-    let addr = parse_ipv4(addr)?;
-    let addr = u32::from_be(ipv4addr_to_libc(addr).s_addr);
-
     let bits = bits
         .parse::<u32>()
         .map_err(|e| format!("Invalid subnet '{addr_str}': {e}"))?;
 
-    if bits > 32 {
-        return Err(format!("Invalid subnet '{addr_str}': suffix too large"));
+    match parse_ip(addr)? {
+        std::net::IpAddr::V4(v4) => {
+            if bits > 32 {
+                return Err(format!("Invalid subnet '{addr_str}': suffix too large"));
+            }
+            let addr = v4.to_bits();
+            let mask = !0 << (32 - bits);
+            let subnet = addr & mask;
+
+            Ok((std::net::IpAddr::V4(Ipv4Addr::from(subnet)), mask as u128))
+        }
+        std::net::IpAddr::V6(v6) => {
+            if bits > 128 {
+                return Err(format!("Invalid subnet '{addr_str}': suffix too large"));
+            }
+
+            let addr = v6.to_bits();
+            let mask = !0 << (128 - bits);
+            let subnet = addr & mask;
+
+            Ok((std::net::IpAddr::V6(Ipv6Addr::from(subnet)), mask))
+        }
     }
-
-    let mask = !0 << (32 - bits);
-
-    let subnet = addr & mask;
-    Ok((Ipv4Addr::from(subnet), mask))
 }

--- a/io-engine/src/core/nic.rs
+++ b/io-engine/src/core/nic.rs
@@ -3,10 +3,68 @@ use nix::ifaddrs::getifaddrs;
 
 use std::{
     fmt,
-    fmt::{Display, Formatter},
+    fmt::{Debug, Display, Formatter},
     net::{Ipv4Addr, Ipv6Addr},
     str::FromStr,
 };
+
+/// An IpAddr wrapper which provides handy convertion methods as well as starting to
+/// support exposing the scope id out of the ipv6 address.
+#[derive(Copy, Clone, Debug)]
+pub enum SIpAddr {
+    V4(Ipv4Addr),
+    V6(Ipv6Addr, u32),
+}
+impl Display for SIpAddr {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            SIpAddr::V4(ip) => write!(f, "{ip}"),
+            SIpAddr::V6(ip, scope_id) if scope_id != &0 => {
+                write!(f, "{ip}%{scope_id}")
+            }
+            SIpAddr::V6(ip, _) => write!(f, "{ip}"),
+        }
+    }
+}
+
+impl SIpAddr {
+    /// Get the [`std::net::IpAddr`] of `Self`.
+    pub(crate) fn ip(&self) -> std::net::IpAddr {
+        match self {
+            SIpAddr::V4(ip) => (*ip).into(),
+            SIpAddr::V6(ip, _) => (*ip).into(),
+        }
+    }
+}
+
+impl From<std::net::SocketAddr> for SIpAddr {
+    fn from(value: std::net::SocketAddr) -> Self {
+        match value {
+            std::net::SocketAddr::V4(socket) => socket.into(),
+            std::net::SocketAddr::V6(socket) => socket.into(),
+        }
+    }
+}
+impl From<std::net::SocketAddrV4> for SIpAddr {
+    fn from(socket: std::net::SocketAddrV4) -> Self {
+        Self::V4(*socket.ip())
+    }
+}
+impl From<std::net::SocketAddrV6> for SIpAddr {
+    fn from(socket: std::net::SocketAddrV6) -> Self {
+        Self::V6(*socket.ip(), socket.scope_id())
+    }
+}
+impl From<Ipv6Addr> for SIpAddr {
+    fn from(ip: Ipv6Addr) -> Self {
+        Self::V6(ip, 0)
+    }
+}
+impl From<Ipv4Addr> for SIpAddr {
+    fn from(ip: Ipv4Addr) -> Self {
+        Self::V4(ip)
+    }
+}
 
 /// Formats an option value.
 fn fmt_opt<T: ToString>(addr: &Option<T>) -> String {
@@ -112,9 +170,9 @@ pub struct Interface {
     /// Name of the network interface.
     pub name: String,
     /// IPv4 network address and netmask of this interface.
-    pub inet: InetConfig<Ipv4Addr>,
+    pub inet: InetConfig<std::net::SocketAddrV4>,
     /// IPv6 network address and netmask of this interface.
-    pub inet6: InetConfig<Ipv6Addr>,
+    pub inet6: InetConfig<std::net::SocketAddrV6>,
     /// MAC address of this interface.
     pub mac: Option<MacAddr>,
 }
@@ -129,24 +187,20 @@ impl Interface {
     }
 
     /// Get the available ip address.
-    pub(crate) fn ip(&self, prefer_ipv4: bool) -> Option<std::net::IpAddr> {
-        if prefer_ipv4 {
-            if let Some(ipv4) = self.inet.addr {
-                return Some(std::net::IpAddr::V4(ipv4));
-            }
-            if let Some(ipv6) = self.inet6.addr {
-                return Some(std::net::IpAddr::V6(ipv6));
-            }
+    pub(crate) fn ip(&self, prefer_ipv4: bool) -> Option<SIpAddr> {
+        let (first, second) = if prefer_ipv4 {
+            (
+                self.inet.addr.map(Into::into),
+                self.inet6.addr.map(Into::into),
+            )
         } else {
-            if let Some(ipv6) = self.inet6.addr {
-                return Some(std::net::IpAddr::V6(ipv6));
-            }
-            if let Some(ipv4) = self.inet.addr {
-                return Some(std::net::IpAddr::V4(ipv4));
-            }
-        }
+            (
+                self.inet6.addr.map(Into::into),
+                self.inet.addr.map(Into::into),
+            )
+        };
 
-        None
+        first.or(second)
     }
 
     /// Check if the given ip matches ours and if so dispose of the other kind of ip.
@@ -155,12 +209,12 @@ impl Interface {
             std::net::IpAddr::V4(ip) => {
                 self.inet6.addr = None;
                 self.inet6.netmask = None;
-                Some(ip) == self.inet.addr
+                Some(&ip) == self.inet.addr.as_ref().map(|a| a.ip())
             }
             std::net::IpAddr::V6(ip) => {
                 self.inet.addr = None;
                 self.inet.netmask = None;
-                Some(ip) == self.inet6.addr
+                Some(&ip) == self.inet6.addr.as_ref().map(|a| a.ip())
             }
         } {
             Some(self)
@@ -188,13 +242,19 @@ impl Interface {
             (Some(_), None) => std::cmp::Ordering::Greater,
             (None, Some(_)) => std::cmp::Ordering::Less,
             (Some(a), Some(b)) => {
+                let a = a.ip();
+                let b = b.ip();
                 // prefer unique local addresses
-                if is_unique_local(&a) != is_unique_local(&b) {
-                    return is_unique_local(&a).cmp(&is_unique_local(&b));
+                if is_unique_local(a) != is_unique_local(b) {
+                    return is_unique_local(a).cmp(&is_unique_local(b));
                 }
                 // prefer link local
-                if is_unicast_link_local(&a) != is_unicast_link_local(&b) {
-                    return is_unicast_link_local(&a).cmp(&is_unicast_link_local(&b));
+                if is_unicast_link_local(a) != is_unicast_link_local(b) {
+                    return is_unicast_link_local(a).cmp(&is_unicast_link_local(b));
+                }
+                // prefer not unspecified
+                if a.is_unspecified() != b.is_unspecified() {
+                    return b.is_unspecified().cmp(&a.is_unspecified());
                 }
                 // prefer not multicast
                 if a.is_multicast() != b.is_multicast() {
@@ -216,12 +276,12 @@ impl Interface {
             (Some(addr), Some(mask)) if net_addr.is_ipv4() => Some((addr, mask)),
             _ => None,
         } {
-            let mask = mask.to_bits();
+            let mask = mask.ip().to_bits();
             if mask as u128 != net_mask {
                 return None;
             }
 
-            let addr = addr.to_bits();
+            let addr = addr.ip().to_bits();
             let subnet = addr & mask;
 
             if Ipv4Addr::from(subnet) == net_addr {
@@ -235,12 +295,12 @@ impl Interface {
             (Some(addr), Some(mask)) if net_addr.is_ipv6() => Some((addr, mask)),
             _ => None,
         } {
-            let mask = mask.to_bits();
+            let mask = mask.ip().to_bits();
             if mask != net_mask {
                 return None;
             }
 
-            let addr = addr.to_bits();
+            let addr = addr.ip().to_bits();
             let subnet = addr & mask;
 
             if Ipv6Addr::from(subnet) == net_addr {
@@ -282,10 +342,14 @@ pub fn find_all_nics() -> Vec<Interface> {
         let mut nic = Interface::new(&addr.interface_name);
         if let Some(sock) = addr.address {
             if let Some(sock) = sock.as_sockaddr_in() {
-                nic.inet.addr = Some(sock.ip());
+                nic.inet.addr = Some((*sock).into());
             }
             if let Some(sock) = sock.as_sockaddr_in6() {
-                nic.inet6.addr = Some(sock.ip());
+                // Not supported for now!
+                if sock.scope_id() > 0 {
+                    continue;
+                }
+                nic.inet6.addr = Some((*sock).into());
             }
             if let Some(link) = sock.as_link_addr() {
                 nic.mac = link.addr().map(MacAddr::new);
@@ -294,10 +358,10 @@ pub fn find_all_nics() -> Vec<Interface> {
 
         if let Some(sock) = addr.netmask {
             if let Some(sock) = sock.as_sockaddr_in() {
-                nic.inet.netmask = Some(sock.ip());
+                nic.inet.netmask = Some((*sock).into());
             }
             if let Some(sock) = sock.as_sockaddr_in6() {
-                nic.inet6.netmask = Some(sock.ip());
+                nic.inet6.netmask = Some((*sock).into());
             }
         }
         // Skip interfaces without ip's.

--- a/io-engine/src/core/nic.rs
+++ b/io-engine/src/core/nic.rs
@@ -128,6 +128,17 @@ impl Interface {
         }
     }
 
+    /// Get the available ip address.
+    pub(crate) fn ip(&self) -> Option<std::net::IpAddr> {
+        if let Some(ipv4) = self.inet.addr {
+            return Some(std::net::IpAddr::V4(ipv4));
+        }
+        if let Some(ipv6) = self.inet6.addr {
+            return Some(std::net::IpAddr::V6(ipv6));
+        }
+        None
+    }
+
     /// Tests if the interface belongs to the given subnet.
     pub fn ipv4_subnet_eq(&self, net_addr: Ipv4Addr, net_mask: u32) -> bool {
         let (addr, mask) = match (self.inet.addr, self.inet.netmask) {

--- a/io-engine/src/subsys/nvmf/target.rs
+++ b/io-engine/src/subsys/nvmf/target.rs
@@ -24,7 +24,7 @@ use crate::{
         nvmf::{
             poll_groups::PollGroup,
             subsystem::NvmfSubsystem,
-            transport::{self, get_ipv4_address, TransportId},
+            transport::{self, get_ip_address, TransportId},
             Error, NVMF_PGS,
         },
         Config,
@@ -251,7 +251,7 @@ impl Target {
         }
         info!(
             "nvmf target listening(tcp) on {}:({},{})",
-            get_ipv4_address().unwrap(),
+            get_ip_address().unwrap(),
             trid_nexus.trsvcid.as_str(),
             trid_replica.trsvcid.as_str(),
         );
@@ -316,7 +316,7 @@ impl Target {
         }
         info!(
             "nvmf target listening(rdma) on {}:({},{})",
-            get_ipv4_address().unwrap(),
+            get_ip_address().unwrap(),
             trid_nexus.trsvcid.as_str(),
             trid_replica.trsvcid.as_str(),
         );

--- a/io-engine/src/subsys/nvmf/transport.rs
+++ b/io-engine/src/subsys/nvmf/transport.rs
@@ -1,6 +1,7 @@
 use std::{
     ffi::CString,
     fmt::{Debug, Display, Formatter},
+    net::IpAddr,
     ops::{Deref, DerefMut},
 };
 
@@ -13,7 +14,7 @@ use spdk_rs::{
     libspdk::{
         spdk_nvme_transport_id, spdk_nvmf_tgt_add_transport, spdk_nvmf_transport_create,
         SPDK_NVME_TRANSPORT_RDMA, SPDK_NVME_TRANSPORT_TCP, SPDK_NVMF_ADRFAM_IPV4,
-        SPDK_NVMF_TRSVCID_MAX_LEN,
+        SPDK_NVMF_ADRFAM_IPV6, SPDK_NVMF_TRSVCID_MAX_LEN,
     },
 };
 
@@ -112,7 +113,7 @@ impl DerefMut for TransportId {
 
 impl TransportId {
     pub fn new(port: u16, transport: NvmfTgtTransport) -> Self {
-        let address = get_ipv4_address().unwrap();
+        let address = get_ip_address().unwrap();
         let (xprt_type, xprt_cstr) = match transport {
             NvmfTgtTransport::Tcp => (SPDK_NVME_TRANSPORT_TCP, &TCP_TRANSPORT),
             NvmfTgtTransport::Rdma => (SPDK_NVME_TRANSPORT_RDMA, &RDMA_TRANSPORT),
@@ -120,7 +121,10 @@ impl TransportId {
 
         let mut trid = spdk_nvme_transport_id {
             trtype: xprt_type,
-            adrfam: SPDK_NVMF_ADRFAM_IPV4,
+            adrfam: match address {
+                IpAddr::V4(_) => SPDK_NVMF_ADRFAM_IPV4,
+                IpAddr::V6(_) => SPDK_NVMF_ADRFAM_IPV6,
+            },
             ..Default::default()
         };
 
@@ -128,7 +132,7 @@ impl TransportId {
         assert!(port.len() < SPDK_NVMF_TRSVCID_MAX_LEN as usize);
 
         copy_cstr_with_null(xprt_cstr, &mut trid.trstring);
-        copy_str_with_null(&address, &mut trid.traddr);
+        copy_str_with_null(&address.to_string(), &mut trid.traddr);
         copy_str_with_null(&port, &mut trid.trsvcid);
 
         Self(trid)
@@ -170,7 +174,7 @@ impl Debug for TransportId {
     }
 }
 
-pub(crate) fn get_ipv4_address() -> Result<String, Error> {
+pub(crate) fn get_ip_address() -> Result<std::net::IpAddr, Error> {
     match MayastorEnvironment::get_nvmf_tgt_ip() {
         Ok(val) => Ok(val),
         Err(msg) => Err(Error::CreateTarget { msg }),

--- a/io-engine/src/subsys/nvmf/transport.rs
+++ b/io-engine/src/subsys/nvmf/transport.rs
@@ -1,7 +1,6 @@
 use std::{
     ffi::CString,
     fmt::{Debug, Display, Formatter},
-    net::IpAddr,
     ops::{Deref, DerefMut},
 };
 
@@ -19,7 +18,7 @@ use spdk_rs::{
 };
 
 use crate::{
-    core::MayastorEnvironment,
+    core::{MayastorEnvironment, SIpAddr},
     ffihelper::{cb_arg, done_errno_cb, AsStr, ErrnoResult, FfiResult},
     subsys::{
         config::opts::NvmfTgtTransport,
@@ -122,8 +121,8 @@ impl TransportId {
         let mut trid = spdk_nvme_transport_id {
             trtype: xprt_type,
             adrfam: match address {
-                IpAddr::V4(_) => SPDK_NVMF_ADRFAM_IPV4,
-                IpAddr::V6(_) => SPDK_NVMF_ADRFAM_IPV6,
+                SIpAddr::V4(_) => SPDK_NVMF_ADRFAM_IPV4,
+                SIpAddr::V6(_, _) => SPDK_NVMF_ADRFAM_IPV6,
             },
             ..Default::default()
         };
@@ -131,8 +130,12 @@ impl TransportId {
         let port = format!("{port}");
         assert!(port.len() < SPDK_NVMF_TRSVCID_MAX_LEN as usize);
 
+        // todo: handle scope_id when supported by posix socket where currently
+        //  get_addr_str returns ip without the %scope_id.
+        let address = address.ip().to_string();
+
         copy_cstr_with_null(xprt_cstr, &mut trid.trstring);
-        copy_str_with_null(&address.to_string(), &mut trid.traddr);
+        copy_str_with_null(&address, &mut trid.traddr);
         copy_str_with_null(&port, &mut trid.trsvcid);
 
         Self(trid)
@@ -152,14 +155,16 @@ impl Display for TransportId {
             "RDMA" => "+rdma+tcp".to_string(),
             _else => "".to_string(),
         };
-
-        write!(
-            f,
-            "nvmf{}://{}:{}",
-            trstring,
-            self.0.traddr.as_str(),
-            self.0.trsvcid.as_str()
-        )
+        let traddr = self.0.traddr.as_str();
+        let trsvcid = self.0.trsvcid.as_str();
+        match self.0.adrfam {
+            SPDK_NVMF_ADRFAM_IPV6 => {
+                write!(f, "nvmf{trstring}://[{traddr}]:{trsvcid}")
+            }
+            _ => {
+                write!(f, "nvmf{trstring}://{traddr}:{trsvcid}")
+            }
+        }
     }
 }
 
@@ -174,7 +179,7 @@ impl Debug for TransportId {
     }
 }
 
-pub(crate) fn get_ip_address() -> Result<std::net::IpAddr, Error> {
+pub(crate) fn get_ip_address() -> Result<crate::core::SIpAddr, Error> {
     match MayastorEnvironment::get_nvmf_tgt_ip() {
         Ok(val) => Ok(val),
         Err(msg) => Err(Error::CreateTarget { msg }),


### PR DESCRIPTION
    fix(tgt-iface): reject scope ids on ipv6
    
    Start to add support for scope ids on ipv6.
    This is not yet supported on the nvmf target, I suspect because there's
    a bug on the socket interface which doesn't return the scope id as part
    of the traddr, though this is mostly a guess so far.
    As such, for the moment we detect but reject scope ids.
    
---

    fix(tgt-iface): support multiple ips per adapter
    
    In case adapter has multiple ipv6 ips, then the libc function
    getifaddrs returns multiple elements with the same name and so
    putting them on a map was actually erasing some ips!
    
    However, this now means we need to handle trying to pick one
    of the ips!
    For now we prioritize ipv4 vs 6 IF the grpc is also ipv4.
    Also we prefer ipv6 unique local, link local and !multicast.
    
---

    fix(tgt-iface): support ipv6 on tgt-iface
    
    The tgt-iface allows us a different way of specifying which interface,
    subnet or ip to bind the nvmf target to.
    This was also hardcoded to work with ipv4 mostly.
    
---

    fix(ipv6): support ipv6 for grpc and nvmf target
    
    In a few places ipv4 was still pretty much expected, leading into a
    few different crashes.
    Now we try to parse always as std::net::IpAddr which is an enum variant
    that can be either ipv4 or ipv6.
