### PR TITLE
fix(ipv6): set correct adrfam and ip for nvmx

### DIFF
--- a/io-engine/src/bdev/nvmx/controller.rs
+++ b/io-engine/src/bdev/nvmx/controller.rs
@@ -1102,7 +1102,7 @@ pub(crate) mod options {
 }
 
 pub(crate) mod transport {
-    use std::{ffi::CStr, fmt::Debug};
+    use std::{ffi::CStr, fmt::Debug, str::FromStr};
 
     use spdk_rs::{ffihelper::copy_str_with_null, libspdk::spdk_nvme_transport_id};
 
@@ -1213,6 +1213,9 @@ pub(crate) mod transport {
 
         /// the address to connect to
         pub fn with_traddr(mut self, traddr: &str) -> Self {
+            if std::net::Ipv6Addr::from_str(traddr).is_ok() {
+                self.adrfam = AdressFamily::NvmfAdrfamIpv6;
+            }
             self.traddr = traddr.to_string();
             self
         }
@@ -1232,7 +1235,7 @@ pub(crate) mod transport {
         pub fn build(self) -> NvmeTransportId {
             let trtype = String::from(TransportId::TCP);
             let mut trid = spdk_nvme_transport_id {
-                adrfam: AdressFamily::NvmfAdrfamIpv4 as u32,
+                adrfam: self.adrfam as u32,
                 trtype: TransportId::TCP as u32,
                 ..Default::default()
             };

--- a/io-engine/src/bdev/nvmx/uri.rs
+++ b/io-engine/src/bdev/nvmx/uri.rs
@@ -161,10 +161,14 @@ impl TryFrom<&Url> for NvmfDeviceTemplate {
 
         let hostnqn = parameters.remove("hostnqn");
 
+        let host = host
+            .trim_start_matches("[")
+            .trim_end_matches("]")
+            .to_string();
         Ok(NvmfDeviceTemplate {
             name: url[url::Position::BeforeHost..url::Position::AfterPath].to_string(),
             alias: url.to_string(),
-            host: host.to_string(),
+            host,
             port: url.port().unwrap_or(DEFAULT_NVMF_PORT),
             subnqn: segments[0].to_string(),
             prchk_flags,


### PR DESCRIPTION
Removes the [ ] from the ip address for nvmx.
Sets the correct address family.

todo: probably we should refactor the builders to use proper types rather than just strings...