### PR TITLE
fix: nexus multipath test to retry on resetting

### DIFF
--- a/io-engine/tests/nexus_crd.rs
+++ b/io-engine/tests/nexus_crd.rs
@@ -215,7 +215,7 @@ async fn run_nexus_manage_task(r: Receiver<()>, cfg: NexusManageTask) {
     add_fault_injection(ms_nex.clone(), &inj_r).await.unwrap();
 
     // When nexus fails, I/O should be freezing due to CRD (if enabled).
-    tokio::time::sleep(Duration::from_secs(2)).await;
+    tokio::time::sleep(Duration::from_secs(3)).await;
 
     // Destroy the nexus, remove injectios and re-create and re-publish the
     // nexus with the same ID.

--- a/test/python/common/nvme.py
+++ b/test/python/common/nvme.py
@@ -70,7 +70,7 @@ def nvme_connect(uri, delay=10, tmo=600):
     )
     print(command)
     subprocess.run(command, check=True, shell=True, capture_output=False)
-    time.sleep(1)
+    time.sleep(3)
     command = "nix-sudo nvme list -v -o json"
     discover = json.loads(
         subprocess.run(

--- a/test/python/tests/nexus_multipath/test_bdd_nexus_multipath.py
+++ b/test/python/tests/nexus_multipath/test_bdd_nexus_multipath.py
@@ -1,6 +1,7 @@
 import pytest
 import logging
 from pytest_bdd import given, scenario, then, when, parsers
+from retrying import retry
 
 from common.command import run_cmd
 from common.fio import Fio
@@ -375,6 +376,7 @@ def degrade_single_io_path(container_mod, a_client_connected_to_one_path_nexus):
 @then(
     "it should be possible to create a second nexus and connect it as the second path"
 )
+@retry(wait_fixed=10, stop_max_attempt_number=200)
 def check_add_second_io_path(create_1_replica_disconnected_nexus):
     # Connect the second nexus and check the paths.
     nexus2_uri = create_1_replica_disconnected_nexus
@@ -397,6 +399,7 @@ def check_add_second_io_path(create_1_replica_disconnected_nexus):
 
 
 @then("it should be possible to remove the first failed I/O path")
+@retry(wait_fixed=10, stop_max_attempt_number=200)
 def check_remove_the_degraded_path(a_client_connected_to_one_path_nexus):
     dev = a_client_connected_to_one_path_nexus
     desc = nvme_list_subsystems(dev)

--- a/test/python/tests/nexus_multipath/test_nexus_multipath.py
+++ b/test/python/tests/nexus_multipath/test_nexus_multipath.py
@@ -14,6 +14,7 @@ from common.nvme import (
     nvme_list_subsystems,
     nvme_resv_report,
 )
+from retrying import retry
 
 
 @pytest.fixture
@@ -336,6 +337,7 @@ def delay2():
 
 
 @pytest.fixture
+@retry(wait_fixed=10, stop_max_attempt_number=200)
 def verify_paths(connect_nexus):
     dev = connect_nexus
     desc = nvme_list_subsystems(dev)
@@ -446,6 +448,7 @@ def test_nexus_multipath_remove_3rd_path(
 
 
 @pytest.mark.timeout(60)
+@retry(wait_fixed=10, stop_max_attempt_number=200)
 def test_nexus_multipath_remove_all_paths(
     create_nexus_no_destroy,
     create_nexus_2_no_destroy,


### PR DESCRIPTION
- It's seen due to kernel upgrade on github machines, there is an intermittent "resetting" state of subsys path, causing test failure on CI. This adds a retry on such state.