### PR TITLE
chore(ci): inject github token post nix installation

### DIFF
--- a/.github/workflows/bdd.yml
+++ b/.github/workflows/bdd.yml
@@ -10,22 +10,44 @@ env:
 jobs:
   bdd-tests:
     runs-on: ubuntu-latest-16-cores
+    permissions:
+      contents: read
+      id-token: write
+
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: 'recursive'
+
       - uses: DeterminateSystems/nix-installer-action@v14
+        with:
+          github-token: ''      ## Override the default the token
+
+      - name: Inject github token to nix config
+        run: |
+          cat <<EOF | sudo tee -a /etc/nix/nix.conf
+          access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+          trusted-users = root runner
+          EOF
+
+      - name: Restart Nix daemon
+        run: sudo systemctl restart nix-daemon
+
       - uses: DeterminateSystems/magic-nix-cache-action@v8
+
       - name: Pre-populate nix-shell
         run: |
           export NIX_PATH=nixpkgs=$(jq '.nixpkgs.url' nix/sources.json -r)
           echo "NIX_PATH=$NIX_PATH" >> $GITHUB_ENV
           nix-shell --run "echo" shell.nix
+
       - name: Handle Rust dependencies caching
         uses: Swatinem/rust-cache@v2
+
       - name: Build binaries
         run: nix-shell --run "cargo build --bins --features=io-engine-testing"
+
       - name: Setup Test Pre-Requisites
         run: |
           sudo sysctl -w vm.nr_hugepages=2560
@@ -39,12 +61,15 @@ jobs:
           done
           # for the coredump check
           sudo apt-get install gdb
+
       - name: Setup VENV
         run: nix-shell --run "./test/python/setup.sh"
+
       - name: Run BDD Tests
         run: |
           echo "TEST_START_DATE=$(date +"%Y-%m-%d %H:%M:%S")" >> $GITHUB_ENV
           nix-shell --run "./scripts/pytest-tests.sh"
+
       - name: Pytest BDD Report
         if: always()
         uses: pmeier/pytest-results-action@main
@@ -61,13 +86,16 @@ jobs:
           fi
           nix-shell --run "./scripts/ci-report.sh"
         if: failure()
+
       - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: ci-report-bdd
           path: ./ci-report/ci-report.tar.gz
+
       - name: Check Coredumps
         run: sudo ./scripts/check-coredumps.sh --since "${TEST_START_DATE}"
+
       - name: Cleanup
         if: always()
         run: nix-shell --run "./scripts/pytest-tests.sh --clean-all-exit"

--- a/.github/workflows/unit-int.yml
+++ b/.github/workflows/unit-int.yml
@@ -10,24 +10,46 @@ env:
 jobs:
   int-tests:
     runs-on: ubuntu-latest-16-cores
+    permissions:
+      contents: read
+      id-token: write
+
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: 'recursive'
+
       - uses: DeterminateSystems/nix-installer-action@v14
+        with:
+          github-token: ''      ## Override the default the token
+
+      - name: Inject github token to nix config
+        run: |
+          cat <<EOF | sudo tee -a /etc/nix/nix.conf
+          access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+          trusted-users = root runner
+          EOF
+
+      - name: Restart Nix daemon
+        run: sudo systemctl restart nix-daemon
+
       - uses: DeterminateSystems/magic-nix-cache-action@v8
+
       - name: Pre-populate nix-shell
         run: |
           export NIX_PATH=nixpkgs=$(jq '.nixpkgs.url' nix/sources.json -r)
           echo "NIX_PATH=$NIX_PATH" >> $GITHUB_ENV
           nix-shell --run "echo" shell.nix
+
       - name: Handle Rust dependencies caching
         uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ startsWith(github.ref_name, 'release/') || github.ref_name == 'develop' }}
+
       - name: Build binaries
         run: nix-shell --run "cargo build --bins --features=io-engine-testing"
+
       - name: Setup Test Pre-Requisites
         run: |
           sudo sysctl -w vm.nr_hugepages=3584
@@ -40,15 +62,19 @@ jobs:
             sudo modprobe $module
           done
           sudo apt-get install gdb
+
       - name: Run Rust Tests
         run: |
           echo "TEST_START_DATE=$(date +"%Y-%m-%d %H:%M:%S")" >> $GITHUB_ENV
           nix-shell --run "./scripts/cargo-test.sh"
+
       - name: Check Coredumps
         run: sudo ./scripts/check-coredumps.sh --since "${TEST_START_DATE}"
+
       - name: Cleanup
         if: always()
         run: nix-shell --run "./scripts/clean-cargo-tests.sh"
+
       - name: Run JS Grpc Tests
         run: |
           echo "TEST_START_DATE=$(date +"%Y-%m-%d %H:%M:%S")" >> $GITHUB_ENV
@@ -59,6 +85,7 @@ jobs:
             cat $file >> "ci-report/js/$file"
             echo "</testsuites>" >> "ci-report/js/$file"
           done
+
       - name: Test Report
         if: always()
         uses: pmeier/pytest-results-action@main
@@ -70,13 +97,16 @@ jobs:
           title: Test results
       - run: nix-shell --run "./scripts/ci-report.sh"
         if: failure()
+
       - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: ci-report-int
           path: ./ci-report/ci-report.tar.gz
+
       - name: Check Coredumps
         run: sudo ./scripts/check-coredumps.sh --since "${TEST_START_DATE}"
+
       - name: Cleanup
         if: always()
         run: nix-shell --run "./scripts/clean-cargo-tests.sh"

--- a/scripts/ci-report.sh
+++ b/scripts/ci-report.sh
@@ -10,8 +10,7 @@ set -eu
 mkdir -p "$ROOT_DIR/ci-report"
 cd "$ROOT_DIR/ci-report"
 
-# Disable until we find how some CI envs are being included
-# journalctl --since="$CI_REPORT_START_DATE" -o short-precise > journalctl.txt
+journalctl --since="$CI_REPORT_START_DATE" -o short-precise | sed -E 's/ghs_[^[:space:]]+/ghs_***/g' > journalctl.txt
 journalctl -k -b0 -o short-precise > dmesg.txt
 lsblk -tfa > lsblk.txt
 $SUDO nvme list -v > nvme.txt


### PR DESCRIPTION
Tested here : https://github.com/openebs/mayastor/actions/runs/14969447595/job/42046846759

This PR address the security advisory where the github token was being exposed.
As a solution:
We are first installing nix (without gh token) and then injecting the token in a seperate step.
Also, as a safety measure we are making if a token is present.


