### PR TITLE
test: ignore the undesired event for failing ctlr

### DIFF
--- a/io-engine/tests/block_device_nvmf.rs
+++ b/io-engine/tests/block_device_nvmf.rs
@@ -191,6 +191,9 @@ async fn nvmf_device_events() {
 
     impl DeviceEventListener for TestEventListener {
         fn handle_device_event(&self, event: DeviceEventType, device: &str) {
+            if event == DeviceEventType::AdminQNoticeCtrlFailed {
+                return; // Not interested in this one
+            }
             // Check event type and device name.
             assert_eq!(event, DeviceEventType::DeviceRemoved);
             assert_eq!(


### PR DESCRIPTION
It might happen that AdminQNoticeCtrlFailed event gets reported first as a result of admin queue poll failures, and DeviceRemoved event comes afterwards from device destroy path.