### PR TITLE
Update github runners to oci gh arc runners

### DIFF
--- a/.github/workflows/bdd.yml
+++ b/.github/workflows/bdd.yml
@@ -9,7 +9,7 @@ env:
 
 jobs:
   bdd-tests:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: oracle-vm-16cpu-64gb-x86-64
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/unit-int.yml
+++ b/.github/workflows/unit-int.yml
@@ -9,7 +9,7 @@ env:
 
 jobs:
   int-tests:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: oracle-vm-16cpu-64gb-x86-64
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
CNCF has hosted ephemeral GitHub runners on Oracle that we want projects to use instead of the GitHub-hosted ones, which now incur a cost to use.

Please direct any questions to me, @jeefy, @krook, and @RobertKielty. (or #cncf-ci-infra channel on the CNCF Slack)

(Similar to https://github.com/openebs/openebs/pull/3914)