### PR TITLE
build(nix): set clang path env var

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -62,6 +62,9 @@ let
         export PATH="$PATH:$(pwd)/scripts/nix-sudo"
 
         export IO_ENGINE_DIR="$RUST_TARGET_DEBUG"
+
+        # Prevent Rust tooling to fallback to potentially incompatible host clang compiler
+        export CLANG_PATH="$NIX_CC_FOR_TARGET/bin/clang"
       '';
 
       shellInfoHook = ''


### PR DESCRIPTION
Sets CLANG_PATH environment variable in shell.nix to use Nix-provided clang compiler, preventing Rust tooling from falling back to potentially incompatible host system clang compiler.

When clang is installed cargo might fallback to /usr/bin/clang instead of using the one setup by the shell.nix environment. Unfortunately, if the clang versions are incompatible, this might lead to errors when linking DPDK/SPDK crypto support with the io-engine. Explicitely setting CLANG_PATH ensure that the correct clang instance will be used.

Note: I also did run into this problem even though PATH was set correctly and `which clang` did give me the correct path.