### PR TITLE
ci: filter git scissor line in commit lint hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
         name: Commit Lint
         description: Runs commitlint against the commit message.
         language: system
-        entry: bash -c "npm install @commitlint/config-conventional @commitlint/cli; cat $1 | grep -v '^#' | npx commitlint"
+        entry: bash -c "npm install @commitlint/config-conventional @commitlint/cli; cat $1 | awk '/^# -+.*>8.*-+/{exit} 1' | grep -v '^#' | npx commitlint"
         args: [$1]
         stages: [commit-msg]
     -   id: python-check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
         name: Commit Lint
         description: Runs commitlint against the commit message.
         language: system
-        entry: bash -c "npm install @commitlint/config-conventional @commitlint/cli; cat $1 | awk '/^# -+.*>8.*-+/{exit} 1' | grep -v '^#' | npx commitlint"
+        entry: bash -c "cat $1 | awk '/^# -+.*>8.*-+/{exit} 1' | grep -v '^#' | commitlint"
         args: [$1]
         stages: [commit-msg]
     -   id: python-check


### PR DESCRIPTION
Updates pre-commit hook to exclude Git's scissor line when running commitlint, preventing the hook from processing contents intended to be excluded from the final commit message.

I have git configured to add a diff of all changes to my editor when writing the commit message. But unfortunately long lines and rust code tend to fail the commitlint. The filter will remove the diff before sending the commit message to commitlint.

For example for this PR git did append the following to the message:

```
#
# ------------------------ >8 ------------------------
# Do not modify or remove the line above.
# Everything below it will be ignored.
diff --git c/.pre-commit-config.yaml i/.pre-commit-config.yaml
index a81f5daa..32342d32 100644
--- c/.pre-commit-config.yaml
+++ i/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
         name: Commit Lint
         description: Runs commitlint against the commit message.
         language: system
-        entry: bash -c "npm install @commitlint/config-conventional @commitlint/cli; cat $1 | grep -v '^#' | npx commitlint"
+        entry: bash -c "npm install @commitlint/config-conventional @commitlint/cli; cat $1 | awk '/^# -+.*>8.*-+/{exit} 1' | grep -v '^#' | npx commitlint"
         args: [$1]
         stages: [commit-msg]
     -   id: python-check
```

We look for the `# ------------------------ >8 ------------------------` line and remove everything until the end.