### PR TITLE
feat(raid): proto changes for raid

### DIFF
--- a/io-engine-tests/src/pool.rs
+++ b/io-engine-tests/src/pool.rs
@@ -207,6 +207,7 @@ impl PoolBuilderRpc {
                 cluster_size: self.cluster_size,
                 md_args: None,
                 encryption: None,
+                raid_config: None,
             })
             .await
             .map(|r| r.into_inner())
@@ -282,6 +283,7 @@ impl PoolBuilderLocal {
             backend: Default::default(),
             enc_key: None,
             crypto_vbdev_name: None,
+            raid_config: None,
         })
         .await?;
         Ok(lvs)

--- a/io-engine/examples/lvs-eval/main.rs
+++ b/io-engine/examples/lvs-eval/main.rs
@@ -138,6 +138,7 @@ async fn create_lvs(args: &CliArgs) -> Lvs {
         backend: Default::default(),
         enc_key: None,
         crypto_vbdev_name: None,
+        raid_config: None,
     };
 
     Lvs::create_or_import(lvs_args.clone()).await.unwrap()

--- a/io-engine/src/bdev/lvs.rs
+++ b/io-engine/src/bdev/lvs.rs
@@ -217,6 +217,7 @@ impl Lvs {
             enc_key: self.key.clone(),
             // XXX: Is this path ever exercised apart from test, or casperf perhaps?
             crypto_vbdev_name: self.key.as_ref().map(|_| format!("crypto_{}", self.name)),
+            raid_config: None,
         };
         match &self.mode {
             LvsMode::Create => match crate::lvs::Lvs::import_from_args(args.clone()).await {

--- a/io-engine/src/bin/io-engine-client/v1/pool_cli.rs
+++ b/io-engine/src/bin/io-engine-client/v1/pool_cli.rs
@@ -77,6 +77,20 @@ pub fn subcommands() -> Command {
                 .help("encryption key2 required for AES_XTS")
                 .required(false)
                 .required_if_eq("cipher", "AES_XTS"),
+        )
+        .arg(
+            Arg::new("raid0")
+                .long("raid0")
+                .help("Enable RAID0 configuration for LVS pools")
+                .required(false)
+                .action(clap::ArgAction::SetTrue),
+        )
+        .arg(
+            Arg::new("strip-size")
+                .long("strip-size")
+                .help("RAID0 strip size in KB (default: 64)")
+                .required(false)
+                .requires("raid0"),
         );
 
     let import = Command::new("import")
@@ -132,6 +146,20 @@ pub fn subcommands() -> Command {
                 .help("encryption key2 required for AES_XTS")
                 .required_if_eq("cipher", "AES_XTS")
                 .required(false),
+        )
+        .arg(
+            Arg::new("raid0")
+                .long("raid0")
+                .help("Enable RAID0 configuration for LVS pools")
+                .required(false)
+                .action(clap::ArgAction::SetTrue),
+        )
+        .arg(
+            Arg::new("strip-size")
+                .long("strip-size")
+                .help("RAID0 strip size in KB (default: 64)")
+                .required(false)
+                .requires("raid0"),
         );
 
     let destroy = Command::new("destroy")
@@ -327,6 +355,8 @@ async fn create(mut ctx: Context, matches: &ArgMatches) -> crate::Result<()> {
         })
     });
 
+    let raid_config = parse_raid_config(matches, &pooltype).context(GrpcStatus)?;
+
     let response = ctx
         .v1
         .pool
@@ -341,6 +371,7 @@ async fn create(mut ctx: Context, matches: &ArgMatches) -> crate::Result<()> {
                 max_expansion,
             }),
             encryption: enc_msg,
+            raid_config,
         })
         .await
         .context(GrpcStatus)?;
@@ -451,6 +482,8 @@ async fn import(mut ctx: Context, matches: &ArgMatches) -> crate::Result<()> {
         })
     });
 
+    let raid_config = parse_raid_config(matches, &pooltype).context(GrpcStatus)?;
+
     let response = ctx
         .v1
         .pool
@@ -460,6 +493,7 @@ async fn import(mut ctx: Context, matches: &ArgMatches) -> crate::Result<()> {
             disks: disks_list,
             pooltype: v1rpc::pool::PoolType::from(pooltype) as i32,
             encryption: enc_msg,
+            raid_config,
         })
         .await
         .context(GrpcStatus)?;
@@ -683,6 +717,12 @@ async fn list(mut ctx: Context, matches: &ArgMatches) -> crate::Result<()> {
                             )
                         };
 
+                    let raid_level = p
+                        .raid_info
+                        .as_ref()
+                        .map(|r| format!("{} ({})", r.level, r.state))
+                        .unwrap_or_else(|| "none".to_string());
+
                     vec![
                         p.name.clone(),
                         p.uuid.clone(),
@@ -699,6 +739,7 @@ async fn list(mut ctx: Context, matches: &ArgMatches) -> crate::Result<()> {
                         p.disks.join(" "),
                         ctx.units(disk_cap),
                         p.encrypted.unwrap_or_default().to_string(),
+                        raid_level,
                     ]
                 })
                 .collect();
@@ -719,6 +760,7 @@ async fn list(mut ctx: Context, matches: &ArgMatches) -> crate::Result<()> {
                     "DISKS",
                     "DISK_CAPACITY",
                     "ENCRYPTED",
+                    "RAID",
                 ],
                 table,
             );
@@ -726,6 +768,37 @@ async fn list(mut ctx: Context, matches: &ArgMatches) -> crate::Result<()> {
     };
 
     Ok(())
+}
+
+/// Parse pool configuration from command line arguments
+fn parse_raid_config(
+    matches: &ArgMatches,
+    pooltype: &PoolType,
+) -> Result<Option<v1rpc::pool::RaidConfig>, Status> {
+    if !matches.get_flag("raid0") {
+        return Ok(None);
+    }
+
+    if !matches!(pooltype, PoolType::Lvs) {
+        return Err(Status::invalid_argument(
+            "RAID configuration is only supported for LVS pools",
+        ));
+    }
+
+    let strip_size_kb = matches
+        .get_one::<String>("strip-size")
+        .map(|s| {
+            s.parse::<u32>()
+                .map_err(|err| Status::invalid_argument(format!("Invalid strip size: {err}")))
+        })
+        .transpose()?
+        .unwrap_or(64);
+
+    Ok(Some(v1rpc::pool::RaidConfig {
+        config: Some(v1rpc::pool::raid_config::Config::Raid0(
+            v1rpc::pool::Raid0Config { strip_size_kb },
+        )),
+    }))
 }
 
 fn pool_state_to_str(idx: i32) -> &'static str {

--- a/io-engine/src/grpc/v1/pool.rs
+++ b/io-engine/src/grpc/v1/pool.rs
@@ -6,7 +6,7 @@ use crate::{
     lvs::{BsError, LvsError},
     pool_backend::{
         self, FindPoolArgs, IPoolFactory, ListPoolArgs, PoolArgs, PoolBackend, PoolFactory,
-        PoolOps, ReplicaArgs,
+        PoolOps, Raid0Config, ReplicaArgs,
     },
 };
 use ::function_name::named;
@@ -254,6 +254,7 @@ impl TryFrom<CreatePoolRequest> for PoolArgs {
             backend: backend.into(),
             enc_key: None,
             crypto_vbdev_name: None,
+            raid_config: args.raid_config.map(TryFrom::try_from).transpose()?,
         })
     }
 }
@@ -261,6 +262,24 @@ impl From<PoolMetadataArgs> for pool_backend::PoolMetadataArgs {
     fn from(params: PoolMetadataArgs) -> Self {
         Self {
             max_expansion: params.max_expansion,
+        }
+    }
+}
+
+impl TryFrom<RaidConfig> for pool_backend::RaidConfig {
+    type Error = LvsError;
+
+    fn try_from(config: RaidConfig) -> Result<Self, Self::Error> {
+        match config.config {
+            Some(raid_config::Config::Raid0(raid0_config)) => {
+                Ok(pool_backend::RaidConfig::Raid0(Raid0Config {
+                    strip_size_kb: raid0_config.strip_size_kb,
+                }))
+            }
+            None => Err(LvsError::Invalid {
+                source: BsError::InvalidArgument {},
+                msg: "Pool config specified but no configuration found".to_string(),
+            }),
         }
     }
 }
@@ -342,6 +361,7 @@ impl TryFrom<ImportPoolRequest> for PoolArgs {
                 .encryption
                 .as_ref()
                 .map(|_| format!("crypto_{}", args.name)),
+            raid_config: args.raid_config.map(TryFrom::try_from).transpose()?,
         })
     }
 }
@@ -449,6 +469,7 @@ impl From<&dyn PoolOps> for Pool {
             md_info: value.md_props().map(|md| md.into()),
             encrypted: Some(value.encrypted()),
             max_expandable_size: value.max_expandable_size(),
+            raid_info: value.raid_info().map(|raid| raid.into()),
         }
     }
 }
@@ -458,6 +479,15 @@ impl From<pool_backend::PoolMetadataInfo> for PoolMetadataInfo {
             md_page_size: value.md_page_size,
             md_pages: value.md_pages,
             md_used_pages: value.md_used_pages,
+        }
+    }
+}
+
+impl From<crate::pool_backend::RaidInfo> for RaidInfo {
+    fn from(value: crate::pool_backend::RaidInfo) -> Self {
+        Self {
+            level: value.level,
+            state: value.state,
         }
     }
 }

--- a/io-engine/src/lvm/mod.rs
+++ b/io-engine/src/lvm/mod.rs
@@ -329,6 +329,10 @@ impl IPoolProps for VolumeGroup {
     fn max_expandable_size(&self) -> Option<u64> {
         None
     }
+
+    fn raid_info(&self) -> Option<crate::pool_backend::RaidInfo> {
+        None // LVM pools do not support RAID
+    }
 }
 
 /// A factory instance which implements LVM specific `PoolFactory`.

--- a/io-engine/src/lvs/lvs_store.rs
+++ b/io-engine/src/lvs/lvs_store.rs
@@ -188,6 +188,10 @@ impl Lvs {
         b.driver() == "crypto"
     }
 
+    pub fn raid_info(&self) -> Option<crate::pool_backend::RaidInfo> {
+        None
+    }
+
     /// Returns blobstore cluster size.
     pub fn blob_cluster_size(&self) -> u64 {
         let blobs = self.blob_store();

--- a/io-engine/src/lvs/mod.rs
+++ b/io-engine/src/lvs/mod.rs
@@ -6,7 +6,7 @@ use crate::{
     },
     pool_backend::{
         Error, FindPoolArgs, IPoolFactory, IPoolProps, ListPoolArgs, PoolArgs, PoolBackend,
-        PoolMetadataInfo, PoolOps, ReplicaArgs,
+        PoolMetadataInfo, PoolOps, RaidInfo, ReplicaArgs,
     },
     replica_backend::{
         FindReplicaArgs, IReplicaFactory, ListCloneArgs, ListReplicaArgs, ListSnapshotArgs,
@@ -234,6 +234,10 @@ impl IPoolProps for Lvs {
 
     fn max_expandable_size(&self) -> Option<u64> {
         self.max_expandable_size()
+    }
+
+    fn raid_info(&self) -> Option<RaidInfo> {
+        self.raid_info()
     }
 }
 

--- a/io-engine/src/pool_backend.rs
+++ b/io-engine/src/pool_backend.rs
@@ -19,6 +19,7 @@ pub struct PoolArgs {
     pub backend: PoolBackend,
     pub enc_key: Option<EncryptionKey>,
     pub crypto_vbdev_name: Option<String>,
+    pub raid_config: Option<RaidConfig>,
 }
 
 impl PoolArgs {
@@ -36,6 +37,24 @@ impl PoolArgs {
 #[derive(Clone, Debug, Default)]
 pub struct PoolMetadataArgs {
     pub max_expansion: Option<String>,
+}
+
+/// Pool configuration for advanced features like RAID.
+#[derive(Clone, Debug, PartialEq)]
+pub enum RaidConfig {
+    /// RAID0 configuration
+    Raid0(Raid0Config),
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Raid0Config {
+    pub strip_size_kb: u32,
+}
+
+impl Default for Raid0Config {
+    fn default() -> Self {
+        Self { strip_size_kb: 64 }
+    }
 }
 
 /// PoolBackend is the type of pool underneath Lvs, Lvm, etc
@@ -220,6 +239,12 @@ pub struct PoolMetadataInfo {
     pub md_used_pages: u64,
 }
 
+/// Pool RAID information.
+pub struct RaidInfo {
+    pub level: String,
+    pub state: String,
+}
+
 /// Various properties from a pool.
 pub trait IPoolProps {
     fn pool_type(&self) -> PoolBackend;
@@ -235,6 +260,7 @@ pub trait IPoolProps {
     fn md_props(&self) -> Option<PoolMetadataInfo>;
     fn encrypted(&self) -> bool;
     fn max_expandable_size(&self) -> Option<u64>;
+    fn raid_info(&self) -> Option<RaidInfo>;
 }
 
 /// A pool factory helper.

--- a/io-engine/src/subsys/config/pool.rs
+++ b/io-engine/src/subsys/config/pool.rs
@@ -8,7 +8,7 @@ use crate::{
     core::{runtime, Cores, Reactor, Share, VerboseError},
     grpc::rpc_submit,
     lvs::{Lvs, LvsBdev, LvsError},
-    pool_backend::{PoolArgs, PoolBackend},
+    pool_backend::{PoolArgs, PoolBackend, Raid0Config},
 };
 
 static CONFIG_FILE: OnceCell<String> = OnceCell::new();
@@ -143,9 +143,23 @@ impl PoolConfig {
     }
 }
 
+/// Pool storage configuration for config files.
+#[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
+pub enum RaidConfig {
+    #[serde(rename = "raid0")]
+    Raid0 {
+        #[serde(default = "default_strip_size")]
+        strip_size_kb: u32,
+    },
+}
+
+fn default_strip_size() -> u32 {
+    64
+}
+
 #[derive(Debug, Default, PartialEq, Serialize, Deserialize, Clone)]
-/// Pools that we create. Future work will include the ability to create RAID0
-/// or RAID5.
+/// Pools that we create. Supports RAID0 configuration.
+/// Future work will include RAID5 support.
 struct Pool {
     /// name of the pool to be created or imported
     name: String,
@@ -157,6 +171,22 @@ struct Pool {
     backend: PoolBackend,
     /// Is the pool encrypted.
     encrypted: bool,
+    /// Pool storage configuration for RAID support.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    raid_config: Option<RaidConfig>,
+}
+
+/// Convert PoolStorageConfig to backend PoolConfig.
+impl From<&RaidConfig> for crate::pool_backend::RaidConfig {
+    fn from(config: &RaidConfig) -> Self {
+        match config {
+            RaidConfig::Raid0 { strip_size_kb } => {
+                crate::pool_backend::RaidConfig::Raid0(Raid0Config {
+                    strip_size_kb: *strip_size_kb,
+                })
+            }
+        }
+    }
 }
 
 /// Convert a Pool into a gRPC request payload.
@@ -175,6 +205,7 @@ impl From<&Pool> for PoolArgs {
             } else {
                 None
             },
+            raid_config: pool.raid_config.as_ref().map(Into::into),
         }
     }
 }
@@ -192,6 +223,7 @@ impl From<LvsBdev> for Pool {
             backend: PoolBackend::Lvs,
             // XXX: Check how we use this and set correctly.
             encrypted: false,
+            raid_config: None,
         }
     }
 }

--- a/io-engine/tests/lvs_grow.rs
+++ b/io-engine/tests/lvs_grow.rs
@@ -151,6 +151,7 @@ async fn lvs_grow_ms_malloc() {
                     backend: Default::default(),
                     enc_key: None,
                     crypto_vbdev_name: None,
+                    raid_config: None,
                 };
 
                 // Create LVS.

--- a/io-engine/tests/lvs_import.rs
+++ b/io-engine/tests/lvs_import.rs
@@ -58,6 +58,7 @@ async fn lvs_import_many_volume() {
             backend: Default::default(),
             enc_key: None,
             crypto_vbdev_name: None,
+            raid_config: None,
         };
 
         // Create LVS.

--- a/io-engine/tests/lvs_limits.rs
+++ b/io-engine/tests/lvs_limits.rs
@@ -53,6 +53,7 @@ async fn lvs_metadata_limit() {
             backend: Default::default(),
             enc_key: None,
             crypto_vbdev_name: None,
+            raid_config: None,
         };
 
         // Create LVS.

--- a/io-engine/tests/lvs_pool.rs
+++ b/io-engine/tests/lvs_pool.rs
@@ -66,6 +66,7 @@ async fn lvs_pool_test() {
         backend: PoolBackend::Lvs,
         enc_key: None,
         crypto_vbdev_name: None,
+        raid_config: None,
     };
 
     // should succeed to create a pool we can not import
@@ -153,6 +154,7 @@ async fn lvs_pool_test() {
             backend: PoolBackend::Lvs,
             enc_key: None,
             crypto_vbdev_name: None,
+            raid_config: None,
         })
         .await
         .is_ok());
@@ -187,6 +189,7 @@ async fn lvs_pool_test() {
             backend: PoolBackend::Lvs,
             enc_key: None,
             crypto_vbdev_name: None,
+            raid_config: None,
         })
         .await
         .unwrap();
@@ -227,6 +230,7 @@ async fn lvs_pool_test() {
             backend: PoolBackend::Lvs,
             enc_key: None,
             crypto_vbdev_name: None,
+            raid_config: None,
         })
         .await
         .unwrap();
@@ -368,6 +372,7 @@ async fn lvs_pool_test() {
             backend: PoolBackend::Lvs,
             enc_key: None,
             crypto_vbdev_name: None,
+            raid_config: None,
         })
         .await
         .unwrap();
@@ -392,6 +397,7 @@ async fn lvs_pool_test() {
             backend: PoolBackend::Lvs,
             enc_key: None,
             crypto_vbdev_name: None,
+            raid_config: None,
         })
         .await
         .unwrap();
@@ -422,6 +428,7 @@ async fn lvs_pool_test() {
             backend: PoolBackend::Lvs,
             enc_key: None,
             crypto_vbdev_name: None,
+            raid_config: None,
         })
         .await
         .unwrap();
@@ -462,6 +469,7 @@ async fn lvs_pool_test() {
             backend: PoolBackend::Lvs,
             enc_key: None,
             crypto_vbdev_name: None,
+            raid_config: None,
         })
         .await
         .err()
@@ -482,6 +490,7 @@ async fn lvs_pool_test() {
             backend: PoolBackend::Lvs,
             enc_key: None,
             crypto_vbdev_name: None,
+            raid_config: None,
         })
         .await
         .unwrap();
@@ -511,6 +520,7 @@ async fn lvs_pool_test() {
                 key2_len: Some(128),
             }),
             crypto_vbdev_name: Some("crypto_enc_pool".into()),
+            raid_config: None,
         })
         .await
         .unwrap();

--- a/io-engine/tests/nexus_with_local.rs
+++ b/io-engine/tests/nexus_with_local.rs
@@ -47,6 +47,7 @@ async fn create_replicas(h: &mut RpcHandle) {
             cluster_size: None,
             md_args: None,
             encryption: None,
+            raid_config: None,
         })
         .await
         .unwrap();

--- a/io-engine/tests/nvmf.rs
+++ b/io-engine/tests/nvmf.rs
@@ -261,6 +261,7 @@ async fn test_rdma_target() {
             cluster_size: None,
             md_args: None,
             encryption: None,
+            raid_config: None,
         })
         .await
         .unwrap();

--- a/io-engine/tests/replica_snapshot.rs
+++ b/io-engine/tests/replica_snapshot.rs
@@ -99,6 +99,7 @@ async fn replica_snapshot() {
                 backend: PoolBackend::Lvs,
                 enc_key: None,
                 crypto_vbdev_name: None,
+                raid_config: None,
             })
             .await
             .unwrap();

--- a/io-engine/tests/snapshot_lvol.rs
+++ b/io-engine/tests/snapshot_lvol.rs
@@ -61,6 +61,7 @@ async fn create_test_pool(pool_name: &str, disk: String, cluster_size: Option<u3
         backend: PoolBackend::Lvs,
         enc_key: None,
         crypto_vbdev_name: None,
+        raid_config: None,
     })
     .await
     .expect("Failed to create test pool");

--- a/io-engine/tests/snapshot_nexus.rs
+++ b/io-engine/tests/snapshot_nexus.rs
@@ -130,6 +130,7 @@ async fn launch_instance(create_replicas: bool) -> (ComposeTest, Vec<String>) {
             cluster_size: None,
             md_args: None,
             encryption: None,
+            raid_config: None,
         })
         .await
         .unwrap();


### PR DESCRIPTION
Related to oep 4011 (raid support). We add raid 0 configuration and status reporting to gRPC.

Note: I have a working Raid0 implementation (MVP) available in my feature-raid0 branch. For context how the changes in here fit in the full implementation see: https://github.com/openebs/mayastor/compare/develop...urso:mayastor:feature-raid0?expand=1