### PR TITLE
modify DISKS output to have only uri scheme and disk path

### DIFF
--- a/io-engine/src/lvs/mod.rs
+++ b/io-engine/src/lvs/mod.rs
@@ -193,7 +193,7 @@ impl IPoolProps for Lvs {
             .map(Bdev::new)
             .unwrap_or_else(|| self.base_bdev());
 
-        vec![disk_bdev.bdev_uri_str().unwrap_or_else(|| "".into())]
+        vec![disk_bdev.bdev_uri_original_str().unwrap_or_default()]
     }
 
     fn disk_capacity(&self) -> u64 {


### PR DESCRIPTION
We were returning bdev uri for disk field. We want to trim it to have only driver and path.

Before:

```
./target/debug/io-engine-client pool list
NAME     UUID                                 STATE  CAPACITY    USED USED% CLUSTER_SIZE PAGE_SIZE MD_PAGE_SIZE MD_PAGES MD_USED_PAGES MD_USED% DISKS                                                                DISK_CAPACITY ENCRYPTED
pool-543 70acf8a4-cbd5-4b8f-b506-6663f0e7a9da online 53632565248 0    0.00% 4194304      4096      4096         12800    1             0.01%    aio:///tmp/diskwq.img?uuid=7c709e15-aced-4956-aeeb-df4487748e88      53687091200   false    
pool-578 6bde266c-f3fc-49da-9318-179fff3e45ef online 100663296   0    0.00% 4194304      4096      4096         25       1             4.00%    malloc:///disk?size_mb=100&uuid=22829bf0-72d2-44ad-b62e-1513f02a11fa 104857600     false 
```   


After:

```
./target/debug/io-engine-client pool list
NAME     UUID                                 STATE  CAPACITY    USED USED% CLUSTER_SIZE PAGE_SIZE MD_PAGE_SIZE MD_PAGES MD_USED_PAGES MD_USED% DISKS                      DISK_CAPACITY ENCRYPTED
pool-578 70a48b5b-5a25-4798-911f-019657725629 online 100663296   0    0.00% 4194304      4096      4096         25       1             4.00%    malloc:///disk?size_mb=100 104857600     false    
pool-551 909d1d46-3837-4c7c-b988-242b82458620 online 64357400576 0    0.00% 4194304      4096      4096         15360    1             0.01%    aio:///tmp/gyt.img         64424509440   false 
```