### PR TITLE
Don't let 1 bad nexus lockup the entire nexus subsystem

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,26 +1,38 @@
-module.exports = {
-  extends: ['@commitlint/config-conventional'],
-  rules: {
-    'type-enum': [2, 'always', ['build', 'chore', 'ci', 'docs', 'feat', 'fix', 'perf', 'refactor', 'revert', 'style', 'test', 'example', 'security']],
-    'code-review-rule': [0, 'always'],
-  },
-  defaultIgnores: false,
-  ignores: [
-      (message) => message.startsWith('chore(bors): merge pull request #'),
-      (message) => message.startsWith('Merge #')
-  ],
-  plugins: [
-    {
-      rules: {
-        'code-review-rule': ({subject}) => {
-          const REVIEW_COMMENTS = `Please don't merge code-review commits, instead squash them in the parent commit`;
-          if (subject.includes('code-review')) return [ false, REVIEW_COMMENTS ];
-          if (subject.includes('review comment')) return [ false, REVIEW_COMMENTS ];
-          if (subject.includes('address comment')) return [ false, REVIEW_COMMENTS ];
-          if (subject.includes('addressed comment')) return [ false, REVIEW_COMMENTS ];
-          return [ true ];
-        },
-      },
+export default {
+    rules: {
+        'type-enum': [2, 'always', ['build', 'chore', 'ci', 'docs', 'feat', 'fix', 'perf', 'refactor', 'revert', 'style', 'test', 'example', 'security']],
+        'code-review-rule': [2, 'always'],
+        "body-max-line-length": [2, "always", 100],
+        "footer-leading-blank": [1, "always"],
+        "footer-max-line-length": [1, "always", 100],
+        "header-max-length": [1, "always", 100],
+        "header-trim": [1, "always"],
+        "subject-case": [1, "never", ["sentence-case", "start-case", "pascal-case", "upper-case"]],
+        'subject-empty': [2, 'never'],
+        'subject-full-stop': [2, 'never', '.'],
+        'subject-max-length': [2, 'always', 80],
+        'subject-min-length': [2, 'always', 5],
+        'scope-case': [2, 'always', 'lower-case'],
+        'body-leading-blank': [2, 'always'],
     },
-  ],
+    defaultIgnores: false,
+    ignores: [
+        (message) => message.startsWith('chore(bors): merge pull request #'),
+        (message) => message.startsWith('Merge pull request #'),
+        (message) => message.startsWith('Merge #')
+    ],
+    plugins: [
+        {
+            rules: {
+                'code-review-rule': ({subject}) => {
+                    const REVIEW_COMMENTS = `Please don't merge code-review commits, instead squash them in the parent commit`;
+                    if (subject.includes('code-review')) return [false, REVIEW_COMMENTS];
+                    if (subject.includes('review comment')) return [false, REVIEW_COMMENTS];
+                    if (subject.includes('address comment')) return [false, REVIEW_COMMENTS];
+                    if (subject.includes('addressed comment')) return [false, REVIEW_COMMENTS];
+                    return [true];
+                },
+            },
+        },
+    ],
 }

--- a/io-engine/src/grpc/v1/nexus.rs
+++ b/io-engine/src/grpc/v1/nexus.rs
@@ -75,7 +75,8 @@ impl NexusService {
                     Some(g) => Some(g),
                     None => {
                         return Err(Status::deadline_exceeded(
-                            "Failed to acquire access to object within given timeout".to_string(),
+                            "Failed to acquire access to subsystem within given timeout"
+                                .to_string(),
                         ))
                     }
                 }
@@ -373,7 +374,7 @@ impl NexusRpc for NexusService {
         let ctx = GrpcClientContext::new(&request, function_name!());
         let args = request.into_inner();
 
-        self.serialized(ctx, args.uuid.clone(), true, async move {
+        self.serialized(ctx, args.uuid.clone(), false, async move {
             trace!("{:?}", args);
             let resv_type = NvmeReservationConv(args.resv_type).try_into()?;
             let preempt_policy = NvmePreemptionConv(args.preempt_policy).try_into()?;
@@ -436,7 +437,7 @@ impl NexusRpc for NexusService {
         let ctx = GrpcClientContext::new(&request, function_name!());
         let args = request.into_inner();
 
-        self.serialized(ctx, args.uuid.clone(), true, async move {
+        self.serialized(ctx, args.uuid.clone(), false, async move {
             let rx = rpc_submit::<_, _, nexus::Error>(async move {
                 trace!("{:?}", args);
                 nexus_destroy(&args.uuid).await?;

--- a/test/python/pytest.ini
+++ b/test/python/pytest.ini
@@ -2,3 +2,4 @@
 log_cli = true
 log_level = warn
 console_output_style = classic
+asyncio_default_fixture_loop_scope = function

--- a/test/python/requirements.txt
+++ b/test/python/requirements.txt
@@ -11,3 +11,4 @@ retrying==1.4.1
 requests==2.32.4
 docker==7.1.0
 pyyaml==6.0.2
+typing-extensions==4.13.2


### PR DESCRIPTION
    refactor(grpc/nexus): don't take subsystem lock on create/destroy
    
    A nexus gets sometimes locked up during unshare, and we're not yet sure of
    how this happens (ie IO stuck)
    This change loosens the sequential creation and destruction of nexuses,
    allowing us to interact with other nexuses when another is locked up.
    
    We could also enforce sequential during the happy path, for the subsystem
    itself?
    
    We should also start reporting the stuck nexuses in some way?
    
---

    chore: update commitlint config file
    
    This should have been modified since I lasted updated the packages, but
    somehow I must have missed this!
