### PR TITLE
fix(nvme): create nvme bdev with spdk_nvme_ctrlr_opts

### DIFF
--- a/io-engine/src/bdev/nvme.rs
+++ b/io-engine/src/bdev/nvme.rs
@@ -12,7 +12,7 @@ use url::Url;
 use spdk_rs::{
     bdevs::bdev_nvme_delete_async,
     ffihelper::copy_str_with_null,
-    libspdk::{spdk_bdev_nvme_create, spdk_nvme_transport_id},
+    libspdk::{self, spdk_bdev_nvme_create, spdk_nvme_transport_id},
 };
 
 use crate::{
@@ -79,6 +79,14 @@ impl CreateDestroy for NVMe {
 
         let (sender, receiver) = oneshot::channel::<ErrnoResult<()>>();
 
+        let mut drv_opts: libspdk::spdk_nvme_ctrlr_opts = unsafe { std::mem::zeroed() };
+        unsafe {
+            libspdk::spdk_nvme_ctrlr_get_default_ctrlr_opts(
+                &mut drv_opts,
+                size_of::<libspdk::spdk_nvme_ctrlr_opts>() as u64,
+            );
+        }
+
         let errno = unsafe {
             spdk_bdev_nvme_create(
                 &mut context.trid,
@@ -87,7 +95,7 @@ impl CreateDestroy for NVMe {
                 context.count,
                 Some(nvme_create_cb),
                 cb_arg(sender),
-                std::ptr::null_mut(),
+                &mut drv_opts,
                 std::ptr::null_mut(),
             )
         };

--- a/io-engine/src/bdev/nvmf.rs
+++ b/io-engine/src/bdev/nvmf.rs
@@ -14,7 +14,7 @@ use spdk_rs::{
     bdevs::bdev_nvme_delete_async,
     ffihelper::copy_str_with_null,
     libspdk::{
-        spdk_bdev_nvme_create, spdk_nvme_transport_id, SPDK_NVME_IO_FLAGS_PRCHK_GUARD,
+        self, spdk_bdev_nvme_create, spdk_nvme_transport_id, SPDK_NVME_IO_FLAGS_PRCHK_GUARD,
         SPDK_NVME_IO_FLAGS_PRCHK_REFTAG, SPDK_NVME_TRANSPORT_TCP, SPDK_NVMF_ADRFAM_IPV4,
     },
 };
@@ -149,6 +149,14 @@ impl CreateDestroy for Nvmf {
 
         let (sender, receiver) = oneshot::channel::<ErrnoResult<usize>>();
 
+        let mut drv_opts: libspdk::spdk_nvme_ctrlr_opts = unsafe { std::mem::zeroed() };
+        unsafe {
+            libspdk::spdk_nvme_ctrlr_get_default_ctrlr_opts(
+                &mut drv_opts,
+                size_of::<libspdk::spdk_nvme_ctrlr_opts>() as u64,
+            );
+        }
+
         let errno = unsafe {
             spdk_bdev_nvme_create(
                 &mut context.trid,
@@ -157,7 +165,7 @@ impl CreateDestroy for Nvmf {
                 context.count,
                 Some(done_nvme_create_cb),
                 cb_arg(sender),
-                std::ptr::null_mut(), // context.prchk_flags,
+                &mut drv_opts,
                 std::ptr::null_mut(),
             )
         };


### PR DESCRIPTION
Setup and pass spdk_nvme_ctrlr_opts as a parameter when creating the bdev. This is required because the nvme create bdev function no longer handles a nullptr parameter.