### PR TITLE
fix(bdev/destroy): unload pool when disk is hotremoved

### DIFF
--- a/io-engine/src/bdev/aio.rs
+++ b/io-engine/src/bdev/aio.rs
@@ -160,8 +160,7 @@ impl CreateDestroy for Aio {
         debug!("{:?}: deleting", self);
 
         match UntypedBdev::lookup_by_name(&self.name) {
-            Some(mut bdev) => {
-                bdev.remove_alias(&self.alias);
+            Some(bdev) => {
                 let (sender, receiver) = oneshot::channel::<ErrnoResult<()>>();
                 unsafe {
                     bdev_aio_delete(

--- a/io-engine/src/bdev/ftl.rs
+++ b/io-engine/src/bdev/ftl.rs
@@ -267,11 +267,10 @@ impl CreateDestroy for Ftl {
     async fn destroy(self: Box<Self>) -> Result<(), Self::Error> {
         debug!("{:?}: deleting", self);
 
-        let Some(mut bdev) = UntypedBdev::lookup_by_name(&self.name) else {
+        let Some(bdev) = UntypedBdev::lookup_by_name(&self.name) else {
             return Err(BdevError::BdevNotFound { name: self.name });
         };
 
-        bdev.remove_alias(&self.alias);
         let (s, r) = oneshot::channel::<ErrnoResult<()>>();
 
         unsafe {

--- a/io-engine/src/bdev/malloc.rs
+++ b/io-engine/src/bdev/malloc.rs
@@ -244,8 +244,7 @@ impl CreateDestroy for Malloc {
     async fn destroy(self: Box<Self>) -> Result<(), Self::Error> {
         debug!("{:?}: deleting", self);
 
-        if let Some(mut bdev) = UntypedBdev::lookup_by_name(&self.name) {
-            bdev.remove_alias(&self.alias);
+        if let Some(bdev) = UntypedBdev::lookup_by_name(&self.name) {
             let (s, r) = oneshot::channel::<ErrnoResult<()>>();
 
             unsafe {

--- a/io-engine/src/bdev/null_bdev.rs
+++ b/io-engine/src/bdev/null_bdev.rs
@@ -202,8 +202,7 @@ impl CreateDestroy for Null {
     }
 
     async fn destroy(self: Box<Self>) -> Result<(), Self::Error> {
-        if let Some(mut bdev) = UntypedBdev::lookup_by_name(&self.name) {
-            bdev.remove_alias(&self.alias);
+        if let Some(bdev) = UntypedBdev::lookup_by_name(&self.name) {
             let (s, r) = oneshot::channel::<ErrnoResult<()>>();
             unsafe {
                 spdk_rs::libspdk::bdev_null_delete(

--- a/io-engine/src/bdev/nvme.rs
+++ b/io-engine/src/bdev/nvme.rs
@@ -128,9 +128,7 @@ impl CreateDestroy for NVMe {
     }
 
     async fn destroy(self: Box<Self>) -> Result<(), Self::Error> {
-        if let Some(mut bdev) = UntypedBdev::lookup_by_name(&self.get_name()) {
-            bdev.remove_alias(self.url.as_ref());
-
+        if UntypedBdev::lookup_by_name(&self.get_name()).is_some() {
             let res = bdev_nvme_delete_async(&self.name, None).await;
 
             // Restore the alias in the case the deletion failed.

--- a/io-engine/src/bdev/nvmf.rs
+++ b/io-engine/src/bdev/nvmf.rs
@@ -236,18 +236,14 @@ impl CreateDestroy for Nvmf {
     /// Destroy the given NVMF bdev
     async fn destroy(self: Box<Self>) -> Result<(), Self::Error> {
         match UntypedBdev::lookup_by_name(&self.get_name()) {
-            Some(mut bdev) => {
-                bdev.remove_alias(&self.alias);
-
-                bdev_nvme_delete_async(&self.name, None)
-                    .await
-                    .context(bdev_api::BdevCommandCanceled {
-                        name: self.name.clone(),
-                    })?
-                    .context(bdev_api::DestroyBdevFailed {
-                        name: self.name.clone(),
-                    })
-            }
+            Some(_) => bdev_nvme_delete_async(&self.name, None)
+                .await
+                .context(bdev_api::BdevCommandCanceled {
+                    name: self.name.clone(),
+                })?
+                .context(bdev_api::DestroyBdevFailed {
+                    name: self.name.clone(),
+                }),
             None => Err(BdevError::BdevNotFound {
                 name: self.get_name(),
             }),

--- a/io-engine/src/bdev/uring.rs
+++ b/io-engine/src/bdev/uring.rs
@@ -123,8 +123,7 @@ impl CreateDestroy for Uring {
     /// Destroy the given uring bdev
     async fn destroy(self: Box<Self>) -> Result<(), Self::Error> {
         match UntypedBdev::lookup_by_name(&self.name) {
-            Some(mut bdev) => {
-                bdev.remove_alias(&self.alias);
+            Some(bdev) => {
                 let (sender, receiver) = oneshot::channel::<ErrnoResult<()>>();
                 unsafe {
                     delete_uring_bdev(


### PR DESCRIPTION
When destroying a bdev as part of a hot-removal, the uri used to destroy the bdev may not match exactly the alias which was added on the creation.
In this case we'll leak a bdev alias which will cause issues if we attempt to re-create the bdev as it'll have a stale alias pointer.

We've modified spdk to automatically delete all aliases on unregister, and so we don't need to manually remove them, thus fixing this scenario.