### PR TITLE
build: use shared workspace dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,12 +148,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
-name = "assert_matches"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
-
-[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -232,7 +226,7 @@ dependencies = [
  "serde_json",
  "serde_nanos",
  "serde_repr",
- "thiserror 1.0.69",
+ "thiserror",
  "time",
  "tokio",
  "tokio-rustls",
@@ -578,7 +572,7 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "serde_urlencoded",
- "thiserror 1.0.69",
+ "thiserror",
  "tokio",
  "tokio-util",
  "tower-service",
@@ -1264,9 +1258,9 @@ dependencies = [
 
 [[package]]
 name = "env_filter"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2c92ceda6ceec50f43169f9ee8424fe2db276791afde7b2cd8bc084cb376ab"
+checksum = "1bf3c259d255ca70051b30e2e95b5446cdb8949ac4cd22c0d7fd634d89f568e2"
 dependencies = [
  "log",
  "regex",
@@ -1274,9 +1268,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13fa619b91fb2381732789fc5de83b45675e882f66623b7d8cb4f643017018d"
+checksum = "dcaee3d8e3cfc3fd92428d477bc97fc29ec8716d180c0d74c643bb26166660e0"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1303,9 +1297,9 @@ dependencies = [
 
 [[package]]
 name = "etcd-client"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39bde3ce50a626efeb1caa9ab1083972d178bebb55ca627639c8ded507dfcbde"
+checksum = "fc0452bcc559431b16f472b7ab86e2f9ccd5f3c2da3795afbd6b773665e047fe"
 dependencies = [
  "http",
  "prost",
@@ -1358,7 +1352,6 @@ dependencies = [
  "bytes",
  "chrono",
  "futures",
- "once_cell",
  "prost",
  "prost-extend",
  "serde",
@@ -2116,7 +2109,6 @@ name = "io-engine"
 version = "1.0.0"
 dependencies = [
  "ansi_term",
- "assert_matches",
  "async-channel",
  "async-process",
  "async-task",
@@ -2160,12 +2152,10 @@ dependencies = [
  "pin-utils",
  "prettytable-rs",
  "prost",
- "prost-derive",
  "rand",
  "regex",
  "rstack",
  "run_script",
- "rustls",
  "secret-provider",
  "serde",
  "serde_json",
@@ -2180,7 +2170,6 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tonic",
- "tower 0.5.1",
  "tracing",
  "tracing-core",
  "tracing-filter",
@@ -2203,7 +2192,6 @@ dependencies = [
  "prost-extend",
  "prost-types",
  "serde",
- "serde_derive",
  "serde_json",
  "tonic",
  "tonic-build",
@@ -2213,26 +2201,10 @@ dependencies = [
 name = "io-engine-bench"
 version = "0.1.0"
 dependencies = [
- "chrono",
- "composer",
  "criterion",
- "crossbeam",
- "env_logger",
- "futures",
  "io-engine",
- "io-engine-api",
  "io-engine-tests",
- "libnvme-rs",
- "once_cell",
- "run_script",
- "spdk-rs",
  "tokio",
- "tonic",
- "tracing",
- "tracing-core",
- "tracing-futures",
- "tracing-subscriber",
- "url",
  "uuid",
 ]
 
@@ -2240,64 +2212,32 @@ dependencies = [
 name = "io-engine-tests"
 version = "0.1.0"
 dependencies = [
- "ansi_term",
- "async-channel",
- "async-task",
  "async-trait",
- "bincode",
- "byte-unit",
- "bytes",
  "chrono",
  "colored_json",
  "composer",
  "crossbeam",
  "derive_builder",
- "etcd-client",
- "function_name",
- "futures",
  "hex",
- "http",
  "io-engine",
  "io-engine-api",
  "io-engine-tests-macros",
- "io-uring",
- "ioctl-gen",
- "jsonrpc",
- "lazy_static",
- "libc",
  "libnvme-rs",
- "log",
  "md5",
- "merge",
  "nix",
  "once_cell",
- "parking_lot",
- "pin-utils",
- "prost",
- "prost-derive",
  "rand",
  "rand_chacha",
  "regex",
  "run_script",
  "serde",
  "serde_json",
- "serde_yaml",
- "sha2",
- "signal-hook",
- "snafu",
  "spdk-rs",
- "sysfs",
  "tokio",
  "tonic",
- "tower 0.5.1",
  "tracing",
- "tracing-core",
- "tracing-log",
- "tracing-subscriber",
- "udev",
  "url",
  "uuid",
- "version-info",
 ]
 
 [[package]]
@@ -2322,9 +2262,9 @@ dependencies = [
 
 [[package]]
 name = "io-uring"
-version = "0.7.1"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9c844e08c94e8558389fb9b8944cb99fc697e231c975e4274b42bc99e0625b"
+checksum = "fdd7bddefd0a8833b88a4b68f90dae22c7450d11b354198baee3874fd811b344"
 dependencies = [
  "bitflags 2.6.0",
  "cfg-if",
@@ -2423,7 +2363,7 @@ dependencies = [
  "jsonptr",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror",
 ]
 
 [[package]]
@@ -2438,7 +2378,7 @@ dependencies = [
  "pest_derive",
  "regex",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror",
 ]
 
 [[package]]
@@ -2458,7 +2398,6 @@ version = "1.0.0"
 dependencies = [
  "nix",
  "serde",
- "serde_derive",
  "serde_json",
  "tokio",
  "tonic",
@@ -2521,7 +2460,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "thiserror 1.0.69",
+ "thiserror",
  "tokio",
  "tokio-util",
  "tower 0.4.13",
@@ -2544,7 +2483,7 @@ dependencies = [
  "serde",
  "serde-value",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror",
 ]
 
 [[package]]
@@ -2582,7 +2521,7 @@ dependencies = [
  "pin-project",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror",
  "tokio",
  "tokio-util",
  "tracing",
@@ -2613,7 +2552,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2986,12 +2925,11 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.7.15"
+version = "2.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b7cafe60d6cf8e62e1b9b2ea516a089c008945bb5a275416789e7db0bc199dc"
+checksum = "cbcfd20a6d4eeba40179f05735784ad32bdaef05ce8e8af05f180d45bb3e7e22"
 dependencies = [
  "memchr",
- "thiserror 2.0.12",
  "ucd-trie",
 ]
 
@@ -3153,9 +3091,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.9.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
 
 [[package]]
 name = "powerfmt"
@@ -3231,9 +3169,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.92"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
+checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
 dependencies = [
  "unicode-ident",
 ]
@@ -3323,9 +3261,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.37"
+version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
 dependencies = [
  "proc-macro2",
 ]
@@ -3405,7 +3343,7 @@ checksum = "bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891"
 dependencies = [
  "getrandom",
  "libredox",
- "thiserror 1.0.69",
+ "thiserror",
 ]
 
 [[package]]
@@ -3929,9 +3867,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -4177,38 +4115,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+checksum = "5d11abd9594d9b38965ef50805c5e469ca9cc6f197f883f717e0269a3057b3d5"
 dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
-version = "2.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
-dependencies = [
- "thiserror-impl 2.0.12",
+ "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.69"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.89",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "2.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+checksum = "ae71770322cbd277e69d762a16c444af02aa0575ac0d174f0b9562d3b37f8602"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4520,16 +4438,6 @@ name = "tracing-filter"
 version = "0.1.0"
 dependencies = [
  "tracing-subscriber",
-]
-
-[[package]]
-name = "tracing-futures"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
-dependencies = [
- "pin-project",
- "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,19 +2,77 @@
 panic = "abort"
 
 [workspace]
-resolver="1"
+resolver = "1"
 members = [
-	"jsonrpc",
-	"libnvme-rs",
-	"io-engine",
-	"io-engine-bench",
-	"io-engine-tests",
-	"sysfs",
-	"spdk-rs",
-	"utils/dependencies/apis/io-engine",
-	"utils/dependencies/prost-extend",
-	"utils/dependencies/version-info",
-	"utils/dependencies/composer",
-	"utils/dependencies/devinfo",
-	"utils/dependencies/nvmeadm",
+    "jsonrpc",
+    "libnvme-rs",
+    "io-engine",
+    "io-engine-bench",
+    "io-engine-tests",
+    "sysfs",
+    "spdk-rs",
+    "utils/dependencies/apis/io-engine",
+    "utils/dependencies/prost-extend",
+    "utils/dependencies/version-info",
+    "utils/dependencies/composer",
+    "utils/dependencies/devinfo",
+    "utils/dependencies/nvmeadm",
 ]
+
+[workspace.dependencies]
+prost-extend = { path = "./utils/dependencies/prost-extend" }
+
+tokio = "1.45.1"
+futures = "0.3.31"
+
+tracing = "0.1.40"
+tracing-core = "0.1.32"
+tracing-log = "0.2.0"
+tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
+
+once_cell = "1.20.2"
+async-trait = "0.1.83"
+crossbeam = "0.8.4"
+ioctl-gen = "0.1.1"
+libc = "0.2.161"
+parking_lot = "0.12.3"
+
+serde = { version = "1.0.214", features = ["derive"] }
+serde_json = "1.0.132"
+serde_yaml = "0.9.34"
+
+snafu = "0.8.5"
+url = "2.5.4"
+uuid = { version = "1.4.1", features = ["v4"] }
+chrono = "0.4.38"
+glob = "0.3.1"
+md5 = "0.7.0"
+rand = "0.8.5"
+rand_chacha = "0.3.1"
+colored_json = "5.0.0"
+
+strum = "0.26.3"
+strum_macros = "0.26.4"
+hex = "0.4.3"
+
+tonic = "0.12.3"
+tonic-build = "0.12.3"
+prost-types = "0.13.3"
+prost = "0.13.2"
+prost-derive = "0.13.3"
+bytes = "1.8.0"
+prost-build = "0.13.3"
+
+udev = "0.9.1"
+bindgen = "0.70.1"
+cc = "1.1.31"
+nix = { version = "0.29.0", default-features = false }
+ipnetwork = "0.20.0"
+bollard = "0.17.1"
+semver = "1.0.23"
+run_script = "0.11.0"
+derive_builder = "0.20.2"
+regex = "1.11.1"
+
+async-nats = { version = "0.37.0", default-features = false }
+

--- a/io-engine-bench/Cargo.toml
+++ b/io-engine-bench/Cargo.toml
@@ -6,27 +6,11 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dev-dependencies]
-tokio = { version = "1.41.0", features = [ "full" ] }
-chrono = "0.4.38"
-env_logger = "0.11.5"
-futures = "0.3.31"
-once_cell = "1.20.2"
-tonic = "0.12.3"
-tracing = "0.1.40"
-tracing-core = "0.1.32"
-tracing-futures = "0.2.5"
-tracing-subscriber = "0.3.18"
-url = "2.5.4"
-crossbeam = "0.8.4"
-uuid = { version = "1.11.0", features = ["v4"] }
-run_script = "0.11.0"
-io-engine-api = { path = "../utils/dependencies/apis/io-engine" }
+tokio = { workspace = true, features = ["full"] }
+uuid = { workspace = true, features = ["v4"] }
 io-engine = { path = "../io-engine" }
-composer = { path = "../utils/dependencies/composer" }
-spdk-rs = { path = "../spdk-rs" }
 io-engine-tests = { path = "../io-engine-tests" }
-libnvme-rs = { path = "../libnvme-rs", version = "0.1.0" }
-criterion = { version = "0.5.1", features = [ "async_tokio" ] }
+criterion = { version = "0.5.1", features = ["async_tokio"] }
 
 [[bench]]
 name = "nexus"

--- a/io-engine-tests/Cargo.toml
+++ b/io-engine-tests/Cargo.toml
@@ -5,75 +5,41 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-ansi_term = "0.12.1"
-async-channel = "2.3.1"
-async-task = "4.7.1"
-async-trait = "0.1.83"
-bincode = "1.3.3"
-byte-unit = "5.1.4"
-bytes = "1.8.0"
-chrono = "0.4.38"
-colored_json = "5.0.0"
-crossbeam = "0.8.4"
-derive_builder = "0.20.2"
-etcd-client = "0.14.0"
-function_name = "0.3.0"
-futures = "0.3.31"
-hex = "0.4.3"
-http = "1.1.0"
-io-uring = "0.7.1"
-ioctl-gen = "0.1.1"
-jsonrpc = { path = "../jsonrpc"}
-lazy_static = "1.5.0"
-libc = "0.2.161"
-log = "0.4.22"
-md5 = "0.7.0"
-merge = "0.1.0"
-nix = "0.29.0"
-once_cell = "1.20.2"
-parking_lot = "0.12.3"
-pin-utils = "0.1.0"
-prost = "0.13.3"
-prost-derive = "0.13.3"
-rand = "0.8.5"
-rand_chacha = "0.3.1"
-regex = "1.11.1"
-run_script = "0.11.0"
-serde_json = "1.0.132"
-serde_yaml = "0.9.34"
-sha2 = "0.10.8"
-signal-hook = "0.3.17"
-snafu = "0.8.5"
-tonic = "0.12.3"
-tower = "0.5.1"
-tracing = "0.1.40"
-tracing-core = "0.1.32"
-tracing-log = "0.2.0"
-tracing-subscriber = "0.3.18"
-udev = "0.9.1"
-url = "2.5.4"
+async-trait = { workspace = true }
+chrono = { workspace = true }
+colored_json = { workspace = true }
+crossbeam = { workspace = true }
+derive_builder = { workspace = true }
+hex = { workspace = true }
+md5 = { workspace = true }
+nix = { workspace = true }
+once_cell = { workspace = true }
+rand = { workspace = true }
+rand_chacha = { workspace = true }
+regex = { workspace = true }
+run_script = { workspace = true }
+serde_json = { workspace = true }
+tonic = { workspace = true }
+tracing = { workspace = true }
+url = { workspace = true }
 
 composer = { path = "../utils/dependencies/composer" }
 libnvme-rs = { path = "../libnvme-rs" }
 io-engine-api = { path = "../utils/dependencies/apis/io-engine" }
-version-info = { path = "../utils/dependencies/version-info", features = ["deps-logs-head"] }
 io-engine = { path = "../io-engine" }
 io-engine-tests-macros = { path = "./io-engine-tests-macros" }
 
 [dependencies.serde]
 features = ["derive"]
-version = "1.0.214"
+workspace = true
 
 [dependencies.spdk-rs]
 path = "../spdk-rs"
 
-[dependencies.sysfs]
-path = "../sysfs"
-
 [dependencies.tokio]
 features = ["full"]
-version = "1.41.0"
+workspace = true
 
 [dependencies.uuid]
 features = ["v4"]
-version = "1.11.0"
+workspace = true

--- a/io-engine/Cargo.toml
+++ b/io-engine/Cargo.toml
@@ -48,6 +48,19 @@ name = "lvs-eval"
 path = "examples/lvs-eval/main.rs"
 
 [dependencies]
+clap = { version = "4.5.20", features = ["color", "derive", "string", "env"] }
+env_logger = "0.11.5"
+etcd-client = "0.14.0"
+function_name = "0.3.0"
+http = "1.1.0"
+humantime = "2.1.0"
+io-uring = "0.7.1"
+ioctl-gen = "0.1.1"
+lazy_static = "1.5.0"
+log = "0.4.22"
+merge = "0.1.0"
+percent-encoding = "2.3.1"
+pin-utils = "0.1.0"
 ansi_term = "0.12.1"
 async-channel = "2.3.1"
 async-task = "4.7.1"
@@ -56,55 +69,39 @@ bit-vec = "0.8.0"
 bincode = "1.3.3"
 byte-unit = "5.1.4"
 bytes = "1.8.0"
-chrono = "0.4.38"
-clap = { version = "4.5.20", features = ["color", "derive", "string", "env"] }
-colored_json = "5.0.0"
-crossbeam = "0.8.4"
-derive_builder = "0.20.2"
-env_logger = "0.11.5"
-etcd-client = "0.14.0"
-function_name = "0.3.0"
-futures = "0.3.31"
-hex = "0.4.3"
-http = "1.1.0"
-humantime = "2.1.0"
-io-uring = "0.7.1"
-ioctl-gen = "0.1.1"
-lazy_static = "1.5.0"
-libc = "0.2.161"
-log = "0.4.22"
-md5 = "0.7.0"
-merge = "0.1.0"
-nix = { version = "0.29.0", default-features = false, features = ["hostname", "net", "socket", "ioctl"] }
-once_cell = "1.20.2"
-parking_lot = "0.12.3"
-percent-encoding = "2.3.1"
-pin-utils = "0.1.0"
-prost = "0.13.3"
-prost-derive = "0.13.3"
-rand = "0.8.5"
-regex = "1.11.1"
-serde_json = "1.0.132"
-serde_yaml = "0.9.34"
-sha2 = "0.10.8"
-signal-hook = "0.3.17"
-snafu = "0.8.5"
-strum = "0.26"
-strum_macros = "0.26"
-tonic = "0.12.3"
-tower = "0.5.1"
-tracing = "0.1.40"
-tracing-core = "0.1.32"
-tracing-log = "0.2.0"
-tracing-subscriber = "0.3.18"
-udev = "0.9.1"
-url = "2.5.4"
 gettid = "0.1.3"
 async-process = { version = "2.3.0" }
 rstack = { version = "0.3.3" }
 tokio-stream = "0.1.16"
-rustls = { version = "0.23.19", default-features = false, features = ["ring"] }
 either = "1.13.0"
+sha2 = "0.10.8"
+signal-hook = "0.3.17"
+
+chrono = { workspace = true }
+colored_json = { workspace = true }
+crossbeam = { workspace = true }
+derive_builder = { workspace = true }
+futures = { workspace = true }
+hex = { workspace = true }
+libc = { workspace = true }
+nix = { workspace = true, default-features = false, features = ["hostname", "net", "socket", "ioctl"] }
+once_cell = { workspace = true }
+parking_lot = { workspace = true }
+prost = { workspace = true }
+rand = { workspace = true }
+regex = { workspace = true }
+serde_json = { workspace = true }
+serde_yaml = { workspace = true }
+snafu = { workspace = true }
+strum = { workspace = true }
+strum_macros = { workspace = true }
+tonic = { workspace = true }
+tracing = { workspace = true }
+tracing-core = { workspace = true }
+tracing-log = { workspace = true }
+tracing-subscriber = { workspace = true }
+udev = { workspace = true }
+url = { workspace = true }
 
 devinfo = { path = "../utils/dependencies/devinfo" }
 jsonrpc = { path = "../jsonrpc" }
@@ -119,19 +116,19 @@ tracing-filter = { path = "../utils/dependencies/tracing-filter" }
 
 [dependencies.serde]
 features = ["derive"]
-version = "1.0.214"
+workspace = true
 
 [dependencies.tokio]
 features = ["full"]
-version = "1.41.0"
+workspace = true
 
 [dependencies.uuid]
 features = ["v4"]
-version = "1.11.0"
+workspace = true
 
 [dev-dependencies]
-assert_matches = "1.5.0"
 io-engine-tests = { path = "../io-engine-tests" }
 libnvme-rs = { path = "../libnvme-rs", version = "0.1.0" }
 prettytable-rs = "0.10.0"
-run_script = "0.11.0"
+md5 = "0.7.0"
+run_script = { workspace = true }

--- a/jsonrpc/Cargo.toml
+++ b/jsonrpc/Cargo.toml
@@ -5,11 +5,10 @@ name = "jsonrpc"
 version = "1.0.0"
 
 [dependencies]
-nix = "0.29.0"
-serde = "1.0.214"
-serde_derive = "1.0.214"
-serde_json = "1.0.132"
-tonic = "0.12.3"
-tokio = { version = "1.41.0", features = ["full"] }
-tracing = "0.1.40"
+nix = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tonic = { workspace = true }
+tokio = { workspace = true, features = ["full"] }
+tracing = { workspace = true }
 

--- a/jsonrpc/src/lib.rs
+++ b/jsonrpc/src/lib.rs
@@ -3,8 +3,6 @@
 
 extern crate nix;
 extern crate serde;
-#[macro_use]
-extern crate serde_derive;
 extern crate serde_json;
 #[macro_use]
 extern crate tracing;
@@ -15,6 +13,7 @@ mod test;
 
 use self::error::{Error, RpcCode};
 use nix::errno::Errno;
+use serde::{Deserialize, Serialize};
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
     net::UnixStream,

--- a/libnvme-rs/Cargo.toml
+++ b/libnvme-rs/Cargo.toml
@@ -11,14 +11,14 @@ authors = [
 ]
 
 [build-dependencies]
-bindgen = "0.70.1"
-cc = "1.1.31"
+bindgen = { workspace = true }
+cc = { workspace = true }
 
 [dependencies]
-glob = "0.3.1"
-libc = "0.2"
-snafu = "0.8.5"
-url = "2.5.4"
+glob = { workspace = true }
+libc = { workspace = true }
+snafu = { workspace = true }
+url = { workspace = true }
 
 [dependencies.mio]
 package = "mio"
@@ -27,8 +27,8 @@ version = "1.0"
 
 [dependencies.udev]
 features = ["hwdb", "mio"]
-version = "^0.9.1"
+workspace = true
 
 [dependencies.uuid]
 features = ["v4"]
-version = "1.11.0"
+workspace = true

--- a/test/python/tests/nexus/test_nexus_rebuild.py
+++ b/test/python/tests/nexus/test_nexus_rebuild.py
@@ -4,6 +4,7 @@ from common.nvme import nvme_connect, nvme_disconnect
 from common.fio import Fio
 from common.fio_spdk import FioSpdk
 from common.mayastor import containers, mayastors, create_temp_files, check_size
+from retrying import retry
 import pytest
 import asyncio
 import uuid as guid
@@ -107,7 +108,9 @@ def test_rebuild_failure(containers, mayastors, times, create_nexuses):
             except:
                 print(f"Failed to remove child {child.uri} from {nexus}")
 
-    time.sleep(5)
+    # I'm not sure what this sleep was acomplishing, but if we wait too long we might
+    # miss the rebuilds... changing from 5 to 3 though this should probably be refactored.
+    time.sleep(3)
 
     rebuilds = 0
     for nexus in ms0.nexus_list():
@@ -127,10 +130,24 @@ def test_rebuild_failure(containers, mayastors, times, create_nexuses):
     # Stop ms3 again. Rebuild jobs in progress must terminate.
     node3.stop()
 
-    time.sleep(10)
-
     # All rebuild jobs must finish.
+    wait_no_rebuilds(ms0)
+
     for nexus in ms0.nexus_list():
         for child in nexus.children:
             assert child.rebuild_progress == -1
         ms0.nexus_destroy(nexus.uuid)
+
+
+@retry(wait_fixed=250, stop_max_attempt_number=50)
+def wait_no_rebuilds(ms0):
+    for nexus in ms0.nexus_list():
+        # Not here that the nexus may be degraded because the rebuilds above are started before the removed child is
+        # cleanly removed.
+        # I'm not sure if this was the intent or not?
+        assert nexus.state in [
+            pb.NEXUS_ONLINE,
+            pb.NEXUS_DEGRADED,
+        ], f"Nexus: {nexus}, {nexus.state}, {nexus.children}"
+        for child in nexus.children:
+            assert child.rebuild_progress == -1


### PR DESCRIPTION
This will make crate upgrades easier to maintain.