### PR TITLE
Nvmf - don't panic when subsystem pause races subsystem stop

### DIFF
--- a/io-engine-tests/src/compose/mod.rs
+++ b/io-engine-tests/src/compose/mod.rs
@@ -74,6 +74,7 @@ impl<'a> MayastorTest<'a> {
     }
 
     pub fn new_ex(args: MayastorCliArgs, log_level: Option<&str>) -> MayastorTest<'static> {
+        io_engine::coredump::enable(io_engine::coredump::DEFAULT_CORE_LIMIT).ok();
         let (tx, rx) = bounded(1);
         mayastor_test_init_ex(args.log_format.unwrap_or_default(), log_level);
         let thdl = std::thread::Builder::new()

--- a/io-engine/src/bdev/nexus/nexus_bdev_children.rs
+++ b/io-engine/src/bdev/nexus/nexus_bdev_children.rs
@@ -1143,7 +1143,7 @@ impl<'n> Nexus<'n> {
 
                 // Step 5: Mark nexus as shutdown.
                 // Note: we don't persist nexus's state in ETCd as nexus
-                // might be recreated on onother node.
+                // might be recreated on another node.
                 *nexus.state.lock() = NexusState::Shutdown;
             }
         });

--- a/io-engine/src/bdev/nexus/nexus_bdev_snapshot.rs
+++ b/io-engine/src/bdev/nexus/nexus_bdev_snapshot.rs
@@ -310,13 +310,12 @@ impl<'n> Nexus<'n> {
         self.check_nexus_state()?;
 
         // Step 1: Pause I/O subsystem for nexus.
-        self.as_mut().pause().await.map_err(|error| {
+        self.as_mut().pause().await.inspect_err(|error| {
             error!(
                 ?self,
                 ?error,
                 "Failed to pause I/O subsystem, nexus snapshot creation failed"
             );
-            error
         })?;
 
         // Step 2: Create snapshots on all replicas.

--- a/io-engine/src/bdev/nexus/nexus_io_subsystem.rs
+++ b/io-engine/src/bdev/nexus/nexus_io_subsystem.rs
@@ -26,17 +26,14 @@ pub enum NexusPauseState {
 
 impl Display for NexusPauseState {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{}",
-            match self {
-                Self::Unpaused => "unpaused",
-                Self::Pausing => "pausing",
-                Self::Paused => "paused",
-                Self::Frozen => "frozen",
-                Self::Unpausing => "unpausing",
-            }
-        )
+        let fmt = match self {
+            Self::Unpaused => "unpaused",
+            Self::Pausing => "pausing",
+            Self::Paused => "paused",
+            Self::Frozen => "frozen",
+            Self::Unpausing => "unpausing",
+        };
+        write!(f, "{fmt}")
     }
 }
 
@@ -99,7 +96,7 @@ impl<'n> NexusIoSubsystem<'n> {
             "NexusIoSubsystem::suspend() must called on the first core"
         );
 
-        trace!("{:?}: pausing I/O...", self);
+        trace!("{self:?}: pausing I/O...");
 
         loop {
             let state = self
@@ -118,13 +115,14 @@ impl<'n> NexusIoSubsystem<'n> {
 
                     if let Some(Protocol::Nvmf) = self.bdev.shared() {
                         if let Some(subsystem) = NvmfSubsystem::nqn_lookup(&self.name) {
-                            trace!("{:?}: pausing subsystem '{}'...", self, subsystem.get_nqn());
+                            let nqn = subsystem.get_nqn();
+                            trace!("{self:?}: pausing subsystem '{nqn}'...");
 
                             if let Err(e) = subsystem.pause().await {
                                 panic!("Failed to pause subsystem '{}: {}", subsystem.get_nqn(), e);
                             }
 
-                            trace!("{:?}: subsystem '{}' paused", self, subsystem.get_nqn());
+                            trace!("{self:?}: subsystem '{nqn}' paused");
                         }
                     }
 
@@ -136,22 +134,13 @@ impl<'n> NexusIoSubsystem<'n> {
                 }
                 // Subsystem is already paused, increment number of paused.
                 Err(NexusPauseState::Paused | NexusPauseState::Frozen) => {
-                    trace!(
-                        "{:?}: nexus is already paused, \
-                        incrementing pause count",
-                        self
-                    );
+                    trace!("{self:?}: nexus is already paused, incrementing pause count");
                     self.pause_cnt.fetch_add(1, Ordering::SeqCst);
                     break;
                 }
-                // Wait till the subsystem has completed transition and retry
-                // operation.
+                // Wait till the subsystem has completed transition and retry operation.
                 Err(NexusPauseState::Unpausing) | Err(NexusPauseState::Pausing) => {
-                    trace!(
-                        "{:?}: nexus is in intermediate state, \
-                            deferring pause operation",
-                        self
-                    );
+                    trace!("{self:?}: nexus is in intermediate state, deferring pause operation");
 
                     let nex = format!("{self:?}");
 
@@ -162,30 +151,27 @@ impl<'n> NexusIoSubsystem<'n> {
                         return Ok(());
                     }
 
-                    trace!(
-                        "{:?}: nexus completed state transition, \
-                        retrying pause operation",
-                        self
-                    );
+                    trace!("{self:?}: nexus completed state transition, retrying pause operation");
                 }
-                _ => {
-                    panic!("Corrupted I/O subsystem state");
+                state => {
+                    panic!("Corrupted I/O subsystem state: {:?}", state);
                 }
-            };
+            }
         }
 
         // Resume one waiter in case there are any.
         if let Some(w) = self.pause_waiters.pop_front() {
-            trace!("{:?}: resuming the first pause waiter", self);
+            trace!("{self:?}: resuming the first pause waiter");
             w.send(0).expect("I/O subsystem pause waiter disappeared");
         }
 
-        trace!("{:?}: I/O paused", self);
+        trace!("{self:?}: I/O paused");
         Ok(())
     }
 
     /// Resume IO to the bdev.
-    /// Note: in order to handle concurrent resumes properly, this function must
+    /// # NOTE
+    /// In order to handle concurrent resumes properly, this function must
     /// be called only from the master core.
     pub(super) async fn resume(&mut self, freeze: bool) -> Result<(), Error> {
         assert_eq!(
@@ -194,7 +180,7 @@ impl<'n> NexusIoSubsystem<'n> {
             "NexusIoSubsystem::resume() must called on the first core"
         );
 
-        trace!("{:?}: resuming I/O...", self);
+        trace!("{self:?}: resuming I/O...");
 
         loop {
             let state = self.pause_state.load();
@@ -206,13 +192,15 @@ impl<'n> NexusIoSubsystem<'n> {
                 // Simultaneous pausing/unpausing: wait till the subsystem has
                 // completed transition and retry operation.
                 NexusPauseState::Pausing | NexusPauseState::Unpausing => {
-                    trace!(
-                        "{:?}: nexus is in intermediate state, \
-                        deferring resume operation",
-                        self
-                    );
+                    trace!("{self:?}: nexus is in intermediate state, deferring resume operation");
 
                     let nex = format!("{self:?}");
+
+                    debug_assert_eq!(
+                        state,
+                        NexusPauseState::Unpausing,
+                        "{nex}: resuming whilst pausing ??"
+                    );
 
                     let (s, r) = oneshot::channel::<i32>();
                     self.pause_waiters.push_back(s);
@@ -221,46 +209,41 @@ impl<'n> NexusIoSubsystem<'n> {
                         return Ok(());
                     }
 
-                    trace!(
-                        "{:?}: completed state transition, \
-                        retrying resume operation",
-                        self
-                    );
+                    trace!("{self:?}: completed state transition, retrying resume operation");
                 }
                 // Unpause the subsystem, taking into account the overall number
                 // of pauses, or leave it frozen.
                 NexusPauseState::Paused | NexusPauseState::Frozen => {
                     let v = self.pause_cnt.fetch_sub(1, Ordering::SeqCst);
-                    // In case the last pause discarded, resume the subsystem.
-                    if v == 1 {
-                        if state == NexusPauseState::Frozen || freeze {
-                            if let Some(subsystem) = NvmfSubsystem::nqn_lookup(&self.name) {
-                                trace!(
-                                    "{:?}: subsystem '{}' not being resumed",
-                                    self,
-                                    subsystem.get_nqn()
-                                );
-                            }
-                            self.pause_state.store(NexusPauseState::Frozen);
-                        } else {
-                            if let Some(subsystem) = NvmfSubsystem::nqn_lookup(&self.name) {
-                                self.pause_state.store(NexusPauseState::Unpausing);
-                                trace!(
-                                    "{:?}: resuming subsystem '{}'...",
-                                    self,
-                                    subsystem.get_nqn()
-                                );
-                                if let Err(e) = subsystem.resume().await {
-                                    panic!(
-                                        "Failed to resume subsystem '{}: {}",
-                                        subsystem.get_nqn(),
-                                        e
-                                    );
-                                }
-                                trace!("{:?}: subsystem '{}' resumed", self, subsystem.get_nqn());
-                            }
-                            self.pause_state.store(NexusPauseState::Unpaused);
+
+                    if v != 1 {
+                        break;
+                    } // In case the last pause discarded, resume the subsystem.
+
+                    if state == NexusPauseState::Frozen || freeze {
+                        if let Some(subsystem) = NvmfSubsystem::nqn_lookup(&self.name) {
+                            trace!(
+                                "{self:?}: subsystem '{}' not being resumed",
+                                subsystem.get_nqn()
+                            );
                         }
+                        self.pause_state.store(NexusPauseState::Frozen);
+                    } else {
+                        if let Some(subsystem) = NvmfSubsystem::nqn_lookup(&self.name) {
+                            self.pause_state.store(NexusPauseState::Unpausing);
+                            trace!("{self:?}: resuming subsystem '{}'...", subsystem.get_nqn());
+                            if let Err(error) = subsystem.resume().await {
+                                panic!(
+                                    "Failed to resume subsystem '{}: {}",
+                                    subsystem.get_nqn(),
+                                    error
+                                );
+                            }
+
+                            trace!("{self:?}: subsystem '{}' resumed", subsystem.get_nqn());
+                        }
+                        // todo: we may have received a Stop request whilst resuming
+                        self.pause_state.store(NexusPauseState::Unpaused);
                     }
                     break;
                 }
@@ -269,12 +252,12 @@ impl<'n> NexusIoSubsystem<'n> {
 
         // Resume one waiter in case there are any.
         if !self.pause_waiters.is_empty() {
-            trace!("{:?}: resuming the first resume waiter", self);
+            trace!("{self:?}: resuming the first resume waiter");
             let w = self.pause_waiters.pop_front().unwrap();
             w.send(0).expect("I/O subsystem resume waiter disappeared");
         }
 
-        trace!("{:?}: I/O resumed", self);
+        trace!("{self:?}: I/O resumed");
         Ok(())
     }
 }

--- a/io-engine/src/bdev/nexus/nexus_io_subsystem.rs
+++ b/io-engine/src/bdev/nexus/nexus_io_subsystem.rs
@@ -17,8 +17,12 @@ use crate::{
 /// Nexus pause states.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum NexusPauseState {
+    /// When subsystem is stopping/stopped but not destroyed, there's a race where a resume will
+    /// restart the subsystem!
     Unpaused,
     Pausing,
+    /// When subsystem is stopping/stopped but not destroyed, there's a race where a pause will fail.
+    /// We'll still consider it as paused in this case.
     Paused,
     Frozen,
     Unpausing,
@@ -118,11 +122,22 @@ impl<'n> NexusIoSubsystem<'n> {
                             let nqn = subsystem.get_nqn();
                             trace!("{self:?}: pausing subsystem '{nqn}'...");
 
-                            if let Err(e) = subsystem.pause().await {
-                                panic!("Failed to pause subsystem '{}: {}", subsystem.get_nqn(), e);
+                            let result = subsystem.pause().await;
+                            if let Err(ref error) = result {
+                                // todo: handle error instead of panic, but in practice only ENOMEM can be seen here?
+                                if error.errno() != nix::Error::EPERM {
+                                    panic!("Failed to pause subsystem: {}", error);
+                                }
+                                // Can't pause a stopped subsystem, but we're essentially paused anyway.
+                                // However, there's a race here as, resume may resume a stopped subsystem.
+                                // We should prevent this on the spdk nvmf subsystem state mgmt.
                             }
 
-                            trace!("{self:?}: subsystem '{nqn}' paused");
+                            if result.is_ok() {
+                                trace!("{self:?}: subsystem '{nqn}' paused");
+                            } else {
+                                warn!("{self:?}: subsystem '{nqn}' stopped");
+                            }
                         }
                     }
 
@@ -173,6 +188,11 @@ impl<'n> NexusIoSubsystem<'n> {
     /// # NOTE
     /// In order to handle concurrent resumes properly, this function must
     /// be called only from the master core.
+    /// # Warning
+    /// This function may return whilst the subsystem is still paused if other requests for pause
+    /// have been accepted.
+    /// The subsystem is only truly resumed when the last pause is undone, which may happen after
+    /// this function completes.
     pub(super) async fn resume(&mut self, freeze: bool) -> Result<(), Error> {
         assert_eq!(
             Cores::current(),
@@ -233,6 +253,7 @@ impl<'n> NexusIoSubsystem<'n> {
                             self.pause_state.store(NexusPauseState::Unpausing);
                             trace!("{self:?}: resuming subsystem '{}'...", subsystem.get_nqn());
                             if let Err(error) = subsystem.resume().await {
+                                // todo: handle error instead of panic, but in practice only ENOMEM can be seen here?
                                 panic!(
                                     "Failed to resume subsystem '{}: {}",
                                     subsystem.get_nqn(),

--- a/io-engine/src/bin/io-engine.rs
+++ b/io-engine/src/bin/io-engine.rs
@@ -274,10 +274,23 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     info!("{}", fmt_package_info!());
 
-    if let Err(err) = Prctl::set_io_flusher() {
-        error!("Failed to set PR_SET_IO_FLUSHER, CAP_SYS_RESOURCE is required error: {err}");
+    if let Err(error) = Prctl::set_io_flusher() {
+        error!(%error, "Failed to set PR_SET_IO_FLUSHER (CAP_SYS_RESOURCE is required)");
     } else {
         info!("PR_SET_IO_FLUSHER is configured");
+    }
+
+    #[cfg(debug_assertions)]
+    let enable_coredump = Some(args.enable_coredump.unwrap_or(None));
+    #[cfg(not(debug_assertions))]
+    let enable_coredump = args.enable_coredump;
+    if let Some(limit) = enable_coredump {
+        let limit = limit.unwrap_or(io_engine::coredump::DEFAULT_CORE_LIMIT);
+        if let Err(error) = io_engine::coredump::enable(limit) {
+            error!(limit, ?error, "Failed to set coredump");
+        } else {
+            info!(limit, "Configured coredump");
+        }
     }
 
     // Handle diagnostics-related commands before initializing the agent.

--- a/io-engine/src/core/bdev.rs
+++ b/io-engine/src/core/bdev.rs
@@ -206,8 +206,7 @@ where
 
         let ptpl = props.ptpl().as_ref().map(|ptpl| ptpl.path());
 
-        // todo: add option to use uuid here, will allow for the replica uuid to
-        // be used!
+        // todo: add option to use uuid here, will allow for the replica uuid to be used!
         let subsystem = NvmfSubsystem::try_from_with(me, ptpl).context(ShareNvmf {})?;
 
         if let Some((cntlid_min, cntlid_max)) = props.cntlid_range() {

--- a/io-engine/src/core/env.rs
+++ b/io-engine/src/core/env.rs
@@ -280,6 +280,11 @@ pub struct MayastorCliArgs {
     /// Enables globally blob store cluster release on unmap.
     #[clap(long, env = "ENABLE_BS_CLUSTER_UNMAP", hide = true)]
     pub bs_cluster_unmap: bool,
+    /// Enable core dump by setting ulimit -c.
+    /// You may specify a limit value or otherwise [`io_engine::core_dump::DEFAULT_CORE_LIMIT`] is used.
+    /// Enabled by default on debug builds.
+    #[clap(long, env = "ENABLE_COREDUMP", num_args(0..=1))]
+    pub enable_coredump: Option<Option<u64>>,
 
     /// [`PoolCliArgs`].
     #[clap(flatten)]

--- a/io-engine/src/core/env.rs
+++ b/io-engine/src/core/env.rs
@@ -289,6 +289,21 @@ pub struct MayastorCliArgs {
     /// [`PoolCliArgs`].
     #[clap(flatten)]
     pub pool: PoolCliArgs,
+
+    /// [`SpdkTracingArgs`].
+    #[clap(flatten)]
+    pub traces: SpdkTracingArgs,
+}
+
+/// SPDK tracing related arguments.
+#[derive(Debug, clap::Parser, Clone)]
+pub struct SpdkTracingArgs {
+    /// Number of trace entries per lcore.
+    #[clap(long, default_value_t = 0)]
+    pub entries: u64,
+    /// Number of user created threads.
+    #[clap(long, default_value_t = 1)]
+    pub threads: u32,
 }
 
 /// DiskPool related arguments.
@@ -417,7 +432,7 @@ pub struct MayastorEnvironment {
     pub mem_size: i32,
     pub name: String,
     no_pci: bool,
-    num_entries: u64,
+    traces: SpdkTracingArgs,
     num_pci_addr: usize,
     pci_blocklist: Vec<spdk_pci_addr>,
     pci_allowlist: Vec<spdk_pci_addr>,
@@ -469,7 +484,6 @@ impl Default for MayastorEnvironment {
             mem_size: -1,
             name: "mayastor".into(),
             no_pci: false,
-            num_entries: 0,
             num_pci_addr: 0,
             pci_blocklist: vec![],
             pci_allowlist: vec![],
@@ -494,6 +508,7 @@ impl Default for MayastorEnvironment {
             rdma: false,
             bs_cluster_unmap: false,
             pool_args: PoolCliArgs::parse_from(Vec::<String>::new()),
+            traces: SpdkTracingArgs::parse_from(Vec::<String>::new()),
         }
     }
 }
@@ -636,6 +651,7 @@ impl MayastorEnvironment {
             bs_cluster_unmap: args.bs_cluster_unmap,
             enable_io_all_thrd_nexus_channels: args.enable_io_all_thrd_nexus_channels,
             pool_args: args.pool,
+            traces: args.traces,
             ..Default::default()
         }
         .setup_static()
@@ -1000,9 +1016,16 @@ impl MayastorEnvironment {
         None
     }
 
+    /// You can capture snapshot of the traces using the spdk utils and backtrace config, exampl:
+    /// sudo -E ./scripts/bpftrace.sh $(pidof io-engine) scripts/bpf/nvmf.bt
+    /// # NOTE
+    /// You may have to remove the top trace on scripts/bpf/nvmf.bt : nvmf_tgt_state
     fn init_spdk_tracing(&self) {
-        const MAX_GROUP_IDS: u32 = 16;
-        const NUM_THREADS: u32 = 1;
+        if self.traces.entries == 0 {
+            return;
+        }
+
+        tracing::info!(traces=?self.traces, "Enabling SPDK Tracing");
         let cshm_name = if self.shm_id >= 0 {
             CString::new(format!("/{}_trace.{}", self.name, self.shm_id).as_str()).unwrap()
         } else {
@@ -1010,7 +1033,7 @@ impl MayastorEnvironment {
                 .unwrap()
         };
         unsafe {
-            if spdk_trace_init(cshm_name.as_ptr(), self.num_entries, NUM_THREADS) != 0 {
+            if spdk_trace_init(cshm_name.as_ptr(), self.traces.entries, self.traces.threads) != 0 {
                 error!("SPDK tracing init error");
             }
         }
@@ -1018,7 +1041,7 @@ impl MayastorEnvironment {
         let tpoint_group_mask =
             unsafe { spdk_trace_create_tpoint_group_mask(tpoint_group_name.as_ptr()) };
 
-        for group_id in 0..MAX_GROUP_IDS {
+        for group_id in 0..spdk_rs::libspdk::SPDK_TRACE_MAX_GROUP_ID {
             if (tpoint_group_mask & (1 << group_id) as u64) > 0 {
                 unsafe {
                     spdk_trace_set_tpoints(group_id, u64::MAX);
@@ -1095,10 +1118,8 @@ impl MayastorEnvironment {
         // ensure we are within the context of a spdk thread from here
         Mthread::primary().set_current();
 
-        // To enable SPDK tracing set self.num_entries (eg. to 32768).
-        if self.num_entries > 0 {
-            self.init_spdk_tracing();
-        }
+        // To enable SPDK tracing set self.traces.entries (eg. to 32768).
+        self.init_spdk_tracing();
 
         Reactor::block_on(async {
             let (sender, receiver) = oneshot::channel::<bool>();

--- a/io-engine/src/coredump.rs
+++ b/io-engine/src/coredump.rs
@@ -1,0 +1,15 @@
+use libc::{rlimit, setrlimit, RLIMIT_CORE};
+
+// Same limit as the one spdk app uses.
+pub const DEFAULT_CORE_LIMIT: libc::rlim_t = 0x140000000; /* 5 GiB */
+
+/// Enable coredumps by setting limit to high value.
+pub fn enable(limit: libc::rlim_t) -> Result<(), nix::Error> {
+    let lim = rlimit {
+        rlim_cur: limit,
+        rlim_max: limit,
+    };
+
+    let rc = unsafe { setrlimit(RLIMIT_CORE, &lim) };
+    nix::Error::result(rc).map(drop)
+}

--- a/io-engine/src/lib.rs
+++ b/io-engine/src/lib.rs
@@ -21,6 +21,7 @@ pub mod delay;
 pub use spdk_rs::ffihelper;
 pub mod bdev_api;
 pub mod constants;
+pub mod coredump;
 pub mod eventing;
 pub mod grpc;
 pub mod host;

--- a/io-engine/src/subsys/nvmf/mod.rs
+++ b/io-engine/src/subsys/nvmf/mod.rs
@@ -74,6 +74,24 @@ pub enum Error {
     HostCstrNul { host: String },
 }
 
+impl Error {
+    /// Get the [`nix::Error`] or equivalent for this error.
+    pub(crate) fn errno(&self) -> nix::Error {
+        match self {
+            Error::CreateTarget { .. } => nix::Error::EXFULL,
+            Error::DestroyTarget { source, .. } => *source,
+            Error::PgError { .. } => nix::Error::EXFULL,
+            Error::Transport { source, .. } => *source,
+            Error::SubsystemBusy { .. } => nix::Error::EBUSY,
+            Error::Subsystem { source, .. } => *source,
+            Error::Share { .. } => nix::Error::EXFULL,
+            Error::Namespace { .. } => nix::Error::EXFULL,
+            Error::Listener { .. } => nix::Error::EXFULL,
+            Error::HostCstrNul { .. } => nix::Error::EXFULL,
+        }
+    }
+}
+
 thread_local! {
     pub (crate) static NVMF_PGS: RefCell<Vec<PollGroup>> = const { RefCell::new(Vec::new()) };
 }

--- a/io-engine/src/subsys/nvmf/subsystem.rs
+++ b/io-engine/src/subsys/nvmf/subsystem.rs
@@ -766,7 +766,7 @@ impl NvmfSubsystem {
             s.send(status).unwrap();
         }
 
-        info!(?self, "Subsystem {} in progress...", op);
+        info!(?self, "Subsystem {op} in progress...");
 
         let res = {
             let mut n = 0;
@@ -783,10 +783,8 @@ impl NvmfSubsystem {
                 n += 1;
 
                 warn!(
-                    "Failed to {} '{}': subsystem is busy, retrying {}...",
-                    op,
-                    self.get_nqn(),
-                    n
+                    "Failed to {op} '{}': subsystem is busy, retrying {n}...",
+                    self.get_nqn()
                 );
 
                 crate::sleep::mayastor_sleep(std::time::Duration::from_millis(100))
@@ -813,9 +811,9 @@ impl NvmfSubsystem {
         };
 
         if let Err(ref e) = res {
-            error!(?self, "Subsystem {} failed: {}", op, e.to_string());
+            error!(?self, "Subsystem {op} failed: {e}");
         } else {
-            info!(?self, "Subsystem {} completed: Ok", op);
+            info!(?self, "Subsystem {op} completed: Ok");
         }
 
         res

--- a/io-engine/src/subsys/nvmf/subsystem.rs
+++ b/io-engine/src/subsys/nvmf/subsystem.rs
@@ -798,6 +798,7 @@ impl NvmfSubsystem {
                     nqn: self.get_nqn(),
                     msg: format!("{op} failed"),
                 }),
+                // this can't happen anymore, SPDK handles transitions in a q
                 libc::EBUSY => Err(Error::SubsystemBusy {
                     nqn: self.get_nqn(),
                     op: op.to_owned(),

--- a/io-engine/tests/nexus_io.rs
+++ b/io-engine/tests/nexus_io.rs
@@ -6,7 +6,7 @@ use io_engine::{
         NexusPauseState, NvmeAnaState,
     },
     constants::NVME_NQN_PREFIX,
-    core::{MayastorCliArgs, Protocol},
+    core::{MayastorCliArgs, Protocol, Reactors},
     lvs::Lvs,
     pool_backend::PoolArgs,
 };
@@ -1073,6 +1073,91 @@ async fn nexus_io_write_zeroes() {
             bdev_io::read_some(&name, 0, 2, 0)
                 .await
                 .expect("read should return block of 0");
+        })
+        .await;
+}
+
+#[tokio::test]
+async fn nexus_subsystem_races() {
+    let mayastor = get_ms();
+    let nexus_name = format!("nexus-{NEXUS_UUID}");
+
+    let name = nexus_name.clone();
+    let children = vec!["malloc:///d?size_mb=64".into()];
+    mayastor
+        .spawn(async move {
+            // create nexus on local node with remote replica as child
+            nexus_create(&name, 32 * 1024 * 1024, Some(NEXUS_UUID), &children)
+                .await
+                .unwrap();
+            // publish nexus on local node over nvmf
+            nexus_lookup_mut(&name)
+                .unwrap()
+                .share(Protocol::Nvmf, None)
+                .await
+                .unwrap();
+            assert_eq!(nexus_pause_state(&name), Some(NexusPauseState::Unpaused));
+        })
+        .await;
+
+    let name = nexus_name.clone();
+    mayastor
+        .spawn(async move {
+            let share_uri = nexus_lookup_mut(&name).unwrap().get_share_uri();
+            assert!(share_uri.is_some());
+
+            nexus_lookup_mut(&name).unwrap().pause().await.unwrap();
+            assert_eq!(nexus_pause_state(&name), Some(NexusPauseState::Paused));
+
+            let name2 = name.clone();
+            Reactors::current().send_future(async move {
+                let nx = nexus_lookup_mut(&name2).unwrap();
+                nx.unshare_nexus().await.unwrap();
+            });
+
+            let (s, r) = futures::channel::oneshot::channel();
+            let name2 = name.clone();
+            Reactors::current().send_future(async move {
+                nexus_lookup_mut(&name2).unwrap().resume().await.unwrap();
+                s.send(()).unwrap();
+            });
+            r.await.unwrap();
+
+            assert_eq!(nexus_pause_state(&name), Some(NexusPauseState::Unpaused));
+            let share_uri = nexus_lookup_mut(&name).unwrap().get_share_uri();
+            // Since stop races with resume, we actually end up in a limbo state where the share
+            // uri is not returned because the nexus_target is cleared, but the subsystem is
+            // running nonetheless!
+            assert_eq!(share_uri, None);
+
+            let nx = nexus_lookup_mut(&name).unwrap();
+            nx.share(Protocol::Nvmf, None).await.unwrap();
+
+            // sharing again will work and the subsystem will be reported correctly...
+            let share_uri = nexus_lookup_mut(&name).unwrap().get_share_uri();
+            assert!(share_uri.is_some());
+        })
+        .await;
+
+    let name = nexus_name.clone();
+    mayastor
+        .spawn(async move {
+            let name2 = name.clone();
+            Reactors::current().send_future(async move {
+                let nx = nexus_lookup_mut(&name2).unwrap();
+                nx.unshare_nexus().await.unwrap();
+            });
+
+            let name2 = name.clone();
+            let (s, r) = futures::channel::oneshot::channel();
+            Reactors::current().send_future(async move {
+                let _result = nexus_lookup_mut(&name2).unwrap().pause().await;
+                s.send(()).unwrap();
+            });
+
+            r.await.unwrap();
+
+            assert_eq!(nexus_pause_state(&name), Some(NexusPauseState::Paused));
         })
         .await;
 }


### PR DESCRIPTION
    test(nvmf): race stop with resume and pause

    There should be no crashes now when racing those.
    However, resume after stop will leave the subsystem active even
    though no share uri will be reported.
    This is a minor issue, though we should still address this.

---

    fix(nvmf): don't panic when pause races stop

    Pausing and/or stopping a subsystem may take some time if I/Os
    are stuck or haven't timed out.
    This may widen a race between between stop and pause where pause
    completes with an error if the subsystem is stopped but not yet
    deactivated.

    We now handle this by simply considering pause complete in this
    case since the subsystem is essentially paused.
    However this opens up a race where a resume may start a subsystem
    which was previously stopped but not yet deactivated!!
    I'm proposing that we handle this within SPDK and reject resumes
    when the subsystem is inactive/stopped.

---

    refactor(nvmf): use implicitly named arguments

    Also slightly simplify the pause handling with early break

---

    feat(tracing): enable dtracing and spdk tracing

    Pulls spdk-rs which allows us to configure spdk with dtracing and also
    parse cli args to enable spdk tracing.

    This can be very useful to debug spdk, ie subsystem state change events

---

    feat(io-engine): add coredump enablement

    Enables coredump by default in debug builds.
    Using spdk value of 5GiB limit if specific limit is not specified.
