### PR TITLE
CherryPick PR1945

### DIFF
--- a/io-engine/src/bdev/nexus/nexus_bdev_children.rs
+++ b/io-engine/src/bdev/nexus/nexus_bdev_children.rs
@@ -1145,7 +1145,7 @@ impl<'n> Nexus<'n> {
 
                 // Step 5: Mark nexus as shutdown.
                 // Note: we don't persist nexus's state in ETCd as nexus
-                // might be recreated on onother node.
+                // might be recreated on another node.
                 *nexus.state.lock() = NexusState::Shutdown;
             }
         });

--- a/io-engine/src/bdev/nexus/nexus_bdev_snapshot.rs
+++ b/io-engine/src/bdev/nexus/nexus_bdev_snapshot.rs
@@ -310,13 +310,12 @@ impl<'n> Nexus<'n> {
         self.check_nexus_state()?;
 
         // Step 1: Pause I/O subsystem for nexus.
-        self.as_mut().pause().await.map_err(|error| {
+        self.as_mut().pause().await.inspect_err(|error| {
             error!(
                 ?self,
                 ?error,
                 "Failed to pause I/O subsystem, nexus snapshot creation failed"
             );
-            error
         })?;
 
         // Step 2: Create snapshots on all replicas.

--- a/io-engine/src/bdev/nexus/nexus_io_subsystem.rs
+++ b/io-engine/src/bdev/nexus/nexus_io_subsystem.rs
@@ -26,17 +26,14 @@ pub enum NexusPauseState {
 
 impl Display for NexusPauseState {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{}",
-            match self {
-                Self::Unpaused => "unpaused",
-                Self::Pausing => "pausing",
-                Self::Paused => "paused",
-                Self::Frozen => "frozen",
-                Self::Unpausing => "unpausing",
-            }
-        )
+        let fmt = match self {
+            Self::Unpaused => "unpaused",
+            Self::Pausing => "pausing",
+            Self::Paused => "paused",
+            Self::Frozen => "frozen",
+            Self::Unpausing => "unpausing",
+        };
+        write!(f, "{fmt}")
     }
 }
 
@@ -99,7 +96,7 @@ impl<'n> NexusIoSubsystem<'n> {
             "NexusIoSubsystem::suspend() must called on the first core"
         );
 
-        trace!("{:?}: pausing I/O...", self);
+        trace!("{self:?}: pausing I/O...");
 
         loop {
             let state = self
@@ -118,13 +115,14 @@ impl<'n> NexusIoSubsystem<'n> {
 
                     if let Some(Protocol::Nvmf) = self.bdev.shared() {
                         if let Some(subsystem) = NvmfSubsystem::nqn_lookup(&self.name) {
-                            trace!("{:?}: pausing subsystem '{}'...", self, subsystem.get_nqn());
+                            let nqn = subsystem.get_nqn();
+                            trace!("{self:?}: pausing subsystem '{nqn}'...");
 
                             if let Err(e) = subsystem.pause().await {
                                 panic!("Failed to pause subsystem '{}: {}", subsystem.get_nqn(), e);
                             }
 
-                            trace!("{:?}: subsystem '{}' paused", self, subsystem.get_nqn());
+                            trace!("{self:?}: subsystem '{nqn}' paused");
                         }
                     }
 
@@ -136,22 +134,13 @@ impl<'n> NexusIoSubsystem<'n> {
                 }
                 // Subsystem is already paused, increment number of paused.
                 Err(NexusPauseState::Paused | NexusPauseState::Frozen) => {
-                    trace!(
-                        "{:?}: nexus is already paused, \
-                        incrementing pause count",
-                        self
-                    );
+                    trace!("{self:?}: nexus is already paused, incrementing pause count");
                     self.pause_cnt.fetch_add(1, Ordering::SeqCst);
                     break;
                 }
-                // Wait till the subsystem has completed transition and retry
-                // operation.
+                // Wait till the subsystem has completed transition and retry operation.
                 Err(NexusPauseState::Unpausing) | Err(NexusPauseState::Pausing) => {
-                    trace!(
-                        "{:?}: nexus is in intermediate state, \
-                            deferring pause operation",
-                        self
-                    );
+                    trace!("{self:?}: nexus is in intermediate state, deferring pause operation");
 
                     let nex = format!("{self:?}");
 
@@ -162,30 +151,27 @@ impl<'n> NexusIoSubsystem<'n> {
                         return Ok(());
                     }
 
-                    trace!(
-                        "{:?}: nexus completed state transition, \
-                        retrying pause operation",
-                        self
-                    );
+                    trace!("{self:?}: nexus completed state transition, retrying pause operation");
                 }
-                _ => {
-                    panic!("Corrupted I/O subsystem state");
+                state => {
+                    panic!("Corrupted I/O subsystem state: {:?}", state);
                 }
-            };
+            }
         }
 
         // Resume one waiter in case there are any.
         if let Some(w) = self.pause_waiters.pop_front() {
-            trace!("{:?}: resuming the first pause waiter", self);
+            trace!("{self:?}: resuming the first pause waiter");
             w.send(0).expect("I/O subsystem pause waiter disappeared");
         }
 
-        trace!("{:?}: I/O paused", self);
+        trace!("{self:?}: I/O paused");
         Ok(())
     }
 
     /// Resume IO to the bdev.
-    /// Note: in order to handle concurrent resumes properly, this function must
+    /// # NOTE
+    /// In order to handle concurrent resumes properly, this function must
     /// be called only from the master core.
     pub(super) async fn resume(&mut self, freeze: bool) -> Result<(), Error> {
         assert_eq!(
@@ -194,7 +180,7 @@ impl<'n> NexusIoSubsystem<'n> {
             "NexusIoSubsystem::resume() must called on the first core"
         );
 
-        trace!("{:?}: resuming I/O...", self);
+        trace!("{self:?}: resuming I/O...");
 
         loop {
             let state = self.pause_state.load();
@@ -206,13 +192,15 @@ impl<'n> NexusIoSubsystem<'n> {
                 // Simultaneous pausing/unpausing: wait till the subsystem has
                 // completed transition and retry operation.
                 NexusPauseState::Pausing | NexusPauseState::Unpausing => {
-                    trace!(
-                        "{:?}: nexus is in intermediate state, \
-                        deferring resume operation",
-                        self
-                    );
+                    trace!("{self:?}: nexus is in intermediate state, deferring resume operation");
 
                     let nex = format!("{self:?}");
+
+                    debug_assert_eq!(
+                        state,
+                        NexusPauseState::Unpausing,
+                        "{nex}: resuming whilst pausing ??"
+                    );
 
                     let (s, r) = oneshot::channel::<i32>();
                     self.pause_waiters.push_back(s);
@@ -221,46 +209,41 @@ impl<'n> NexusIoSubsystem<'n> {
                         return Ok(());
                     }
 
-                    trace!(
-                        "{:?}: completed state transition, \
-                        retrying resume operation",
-                        self
-                    );
+                    trace!("{self:?}: completed state transition, retrying resume operation");
                 }
                 // Unpause the subsystem, taking into account the overall number
                 // of pauses, or leave it frozen.
                 NexusPauseState::Paused | NexusPauseState::Frozen => {
                     let v = self.pause_cnt.fetch_sub(1, Ordering::SeqCst);
-                    // In case the last pause discarded, resume the subsystem.
-                    if v == 1 {
-                        if state == NexusPauseState::Frozen || freeze {
-                            if let Some(subsystem) = NvmfSubsystem::nqn_lookup(&self.name) {
-                                trace!(
-                                    "{:?}: subsystem '{}' not being resumed",
-                                    self,
-                                    subsystem.get_nqn()
-                                );
-                            }
-                            self.pause_state.store(NexusPauseState::Frozen);
-                        } else {
-                            if let Some(subsystem) = NvmfSubsystem::nqn_lookup(&self.name) {
-                                self.pause_state.store(NexusPauseState::Unpausing);
-                                trace!(
-                                    "{:?}: resuming subsystem '{}'...",
-                                    self,
-                                    subsystem.get_nqn()
-                                );
-                                if let Err(e) = subsystem.resume().await {
-                                    panic!(
-                                        "Failed to resume subsystem '{}: {}",
-                                        subsystem.get_nqn(),
-                                        e
-                                    );
-                                }
-                                trace!("{:?}: subsystem '{}' resumed", self, subsystem.get_nqn());
-                            }
-                            self.pause_state.store(NexusPauseState::Unpaused);
+
+                    if v != 1 {
+                        break;
+                    } // In case the last pause discarded, resume the subsystem.
+
+                    if state == NexusPauseState::Frozen || freeze {
+                        if let Some(subsystem) = NvmfSubsystem::nqn_lookup(&self.name) {
+                            trace!(
+                                "{self:?}: subsystem '{}' not being resumed",
+                                subsystem.get_nqn()
+                            );
                         }
+                        self.pause_state.store(NexusPauseState::Frozen);
+                    } else {
+                        if let Some(subsystem) = NvmfSubsystem::nqn_lookup(&self.name) {
+                            self.pause_state.store(NexusPauseState::Unpausing);
+                            trace!("{self:?}: resuming subsystem '{}'...", subsystem.get_nqn());
+                            if let Err(error) = subsystem.resume().await {
+                                panic!(
+                                    "Failed to resume subsystem '{}: {}",
+                                    subsystem.get_nqn(),
+                                    error
+                                );
+                            }
+
+                            trace!("{self:?}: subsystem '{}' resumed", subsystem.get_nqn());
+                        }
+                        // todo: we may have received a Stop request whilst resuming
+                        self.pause_state.store(NexusPauseState::Unpaused);
                     }
                     break;
                 }
@@ -269,12 +252,12 @@ impl<'n> NexusIoSubsystem<'n> {
 
         // Resume one waiter in case there are any.
         if !self.pause_waiters.is_empty() {
-            trace!("{:?}: resuming the first resume waiter", self);
+            trace!("{self:?}: resuming the first resume waiter");
             let w = self.pause_waiters.pop_front().unwrap();
             w.send(0).expect("I/O subsystem resume waiter disappeared");
         }
 
-        trace!("{:?}: I/O resumed", self);
+        trace!("{self:?}: I/O resumed");
         Ok(())
     }
 }

--- a/io-engine/src/bdev/nexus/nexus_io_subsystem.rs
+++ b/io-engine/src/bdev/nexus/nexus_io_subsystem.rs
@@ -17,8 +17,12 @@ use crate::{
 /// Nexus pause states.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum NexusPauseState {
+    /// When subsystem is stopping/stopped but not destroyed, there's a race where a resume will
+    /// restart the subsystem!
     Unpaused,
     Pausing,
+    /// When subsystem is stopping/stopped but not destroyed, there's a race where a pause will fail.
+    /// We'll still consider it as paused in this case.
     Paused,
     Frozen,
     Unpausing,
@@ -118,11 +122,22 @@ impl<'n> NexusIoSubsystem<'n> {
                             let nqn = subsystem.get_nqn();
                             trace!("{self:?}: pausing subsystem '{nqn}'...");
 
-                            if let Err(e) = subsystem.pause().await {
-                                panic!("Failed to pause subsystem '{}: {}", subsystem.get_nqn(), e);
+                            let result = subsystem.pause().await;
+                            if let Err(ref error) = result {
+                                // todo: handle error instead of panic, but in practice only ENOMEM can be seen here?
+                                if error.errno() != nix::Error::EPERM {
+                                    panic!("Failed to pause subsystem: {}", error);
+                                }
+                                // Can't pause a stopped subsystem, but we're essentially paused anyway.
+                                // However, there's a race here as, resume may resume a stopped subsystem.
+                                // We should prevent this on the spdk nvmf subsystem state mgmt.
                             }
 
-                            trace!("{self:?}: subsystem '{nqn}' paused");
+                            if result.is_ok() {
+                                trace!("{self:?}: subsystem '{nqn}' paused");
+                            } else {
+                                warn!("{self:?}: subsystem '{nqn}' stopped");
+                            }
                         }
                     }
 
@@ -173,6 +188,11 @@ impl<'n> NexusIoSubsystem<'n> {
     /// # NOTE
     /// In order to handle concurrent resumes properly, this function must
     /// be called only from the master core.
+    /// # Warning
+    /// This function may return whilst the subsystem is still paused if other requests for pause
+    /// have been accepted.
+    /// The subsystem is only truly resumed when the last pause is undone, which may happen after
+    /// this function completes.
     pub(super) async fn resume(&mut self, freeze: bool) -> Result<(), Error> {
         assert_eq!(
             Cores::current(),
@@ -233,6 +253,7 @@ impl<'n> NexusIoSubsystem<'n> {
                             self.pause_state.store(NexusPauseState::Unpausing);
                             trace!("{self:?}: resuming subsystem '{}'...", subsystem.get_nqn());
                             if let Err(error) = subsystem.resume().await {
+                                // todo: handle error instead of panic, but in practice only ENOMEM can be seen here?
                                 panic!(
                                     "Failed to resume subsystem '{}: {}",
                                     subsystem.get_nqn(),

--- a/io-engine/src/core/bdev.rs
+++ b/io-engine/src/core/bdev.rs
@@ -190,8 +190,7 @@ where
 
         let ptpl = props.ptpl().as_ref().map(|ptpl| ptpl.path());
 
-        // todo: add option to use uuid here, will allow for the replica uuid to
-        // be used!
+        // todo: add option to use uuid here, will allow for the replica uuid to be used!
         let subsystem = NvmfSubsystem::try_from_with(me, ptpl).context(ShareNvmf {})?;
 
         if let Some((cntlid_min, cntlid_max)) = props.cntlid_range() {

--- a/io-engine/src/subsys/nvmf/mod.rs
+++ b/io-engine/src/subsys/nvmf/mod.rs
@@ -74,6 +74,24 @@ pub enum Error {
     HostCstrNul { host: String },
 }
 
+impl Error {
+    /// Get the [`nix::Error`] or equivalent for this error.
+    pub(crate) fn errno(&self) -> nix::Error {
+        match self {
+            Error::CreateTarget { .. } => nix::Error::EXFULL,
+            Error::DestroyTarget { source, .. } => *source,
+            Error::PgError { .. } => nix::Error::EXFULL,
+            Error::Transport { source, .. } => *source,
+            Error::SubsystemBusy { .. } => nix::Error::EBUSY,
+            Error::Subsystem { source, .. } => *source,
+            Error::Share { .. } => nix::Error::EXFULL,
+            Error::Namespace { .. } => nix::Error::EXFULL,
+            Error::Listener { .. } => nix::Error::EXFULL,
+            Error::HostCstrNul { .. } => nix::Error::EXFULL,
+        }
+    }
+}
+
 thread_local! {
     pub (crate) static NVMF_PGS: RefCell<Vec<PollGroup>> = const { RefCell::new(Vec::new()) };
 }

--- a/io-engine/src/subsys/nvmf/subsystem.rs
+++ b/io-engine/src/subsys/nvmf/subsystem.rs
@@ -806,6 +806,7 @@ impl NvmfSubsystem {
                     nqn: self.get_nqn(),
                     msg: format!("{op} failed"),
                 }),
+                // this can't happen anymore, SPDK handles transitions in a q
                 libc::EBUSY => Err(Error::SubsystemBusy {
                     nqn: self.get_nqn(),
                     op: op.to_owned(),

--- a/io-engine/src/subsys/nvmf/subsystem.rs
+++ b/io-engine/src/subsys/nvmf/subsystem.rs
@@ -774,7 +774,7 @@ impl NvmfSubsystem {
             s.send(status).unwrap();
         }
 
-        info!(?self, "Subsystem {} in progress...", op);
+        info!(?self, "Subsystem {op} in progress...");
 
         let res = {
             let mut n = 0;
@@ -791,10 +791,8 @@ impl NvmfSubsystem {
                 n += 1;
 
                 warn!(
-                    "Failed to {} '{}': subsystem is busy, retrying {}...",
-                    op,
-                    self.get_nqn(),
-                    n
+                    "Failed to {op} '{}': subsystem is busy, retrying {n}...",
+                    self.get_nqn()
                 );
 
                 crate::sleep::mayastor_sleep(std::time::Duration::from_millis(100))
@@ -821,9 +819,9 @@ impl NvmfSubsystem {
         };
 
         if let Err(ref e) = res {
-            error!(?self, "Subsystem {} failed: {}", op, e.to_string());
+            error!(?self, "Subsystem {op} failed: {e}");
         } else {
-            info!(?self, "Subsystem {} completed: Ok", op);
+            info!(?self, "Subsystem {op} completed: Ok");
         }
 
         res


### PR DESCRIPTION
    fix(nvmf): don't panic when pause races stop

    Pausing and/or stopping a subsystem may take some time if I/Os
    are stuck or haven't timed out.
    This may widen a race between between stop and pause where pause
    completes with an error if the subsystem is stopped but not yet
    deactivated.

    We now handle this by simply considering pause complete in this
    case since the subsystem is essentially paused.
    However this opens up a race where a resume may start a subsystem
    which was previously stopped but not yet deactivated!!
    I'm proposing that we handle this within SPDK and reject resumes
    when the subsystem is inactive/stopped.

---

    refactor(nvmf): use implicitly named arguments

    Also slightly simplify the pause handling with early break
