### PR TITLE
fix(nvmf/stuck): disconnect when target is in bad state

### DIFF
--- a/io-engine/src/bdev/nexus/nexus_bdev_children.rs
+++ b/io-engine/src/bdev/nexus/nexus_bdev_children.rs
@@ -710,6 +710,14 @@ impl DeviceEventListener for Nexus<'_> {
                 Reactors::master().send_future(Nexus::disconnect_failed_child(
                     self.name.clone(),
                     dev_name.to_owned(),
+                    true,
+                ));
+            }
+            DeviceEventType::AdminQBroken => {
+                Reactors::master().send_future(Nexus::disconnect_failed_child(
+                    self.name.clone(),
+                    dev_name.to_owned(),
+                    false,
                 ));
             }
 
@@ -838,25 +846,34 @@ impl<'n> Nexus<'n> {
     }
 
     /// Disconnect a failed child from the given nexus.
-    async fn disconnect_failed_child(nexus_name: String, dev: String) {
-        let Some(nex) = nexus_lookup_mut(&nexus_name) else {
-            warn!(
-                "Nexus '{nexus_name}': retiring failed device '{dev}': \
-                nexus already gone"
-            );
+    async fn disconnect_failed_child(nexus_name: String, dev: String, ctrl_failed: bool) {
+        let Some(nexus) = nexus_lookup_mut(&nexus_name) else {
+            warn!("Nexus '{nexus_name}': retiring failed device '{dev}': nexus already gone");
             return;
         };
 
-        info!("Nexus '{nexus_name}': disconnect handlers for controller failed device: '{dev}'");
+        info!("Nexus '{nexus_name}': disconnect handlers for controller failed device: '{dev}', failed: {ctrl_failed}");
 
-        if nex.io_subsystem_state() == Some(NexusPauseState::Pausing) {
-            nex.traverse_io_channels_async((), |channel, _| {
+        let Ok(child) = nexus.child_by_device(&dev) else {
+            warn!("Nexus '{nexus_name}': retiring failed device '{dev}': child already gone");
+            return;
+        };
+        if !child.is_faulted() {
+            error!("Nexus '{nexus_name}': retiring failed device '{dev}': child not faulted");
+            return;
+        }
+
+        if nexus.io_subsystem_state() != Some(NexusPauseState::Pausing) {
+            error!("Nexus '{nexus_name}': retiring failed device '{dev}': nexus not pausing");
+            return;
+        }
+        nexus
+            .traverse_io_channels_async((), |channel, _| {
                 channel.disconnect_detached_devices(|h| {
-                    h.get_device().device_name() == dev && h.is_ctrlr_failed()
+                    h.get_device().device_name() == dev && (h.is_ctrlr_failed() || !ctrl_failed)
                 });
             })
             .await;
-        }
     }
 
     /// Retires a child device for the given nexus.

--- a/io-engine/src/bdev/nexus/nexus_child.rs
+++ b/io-engine/src/bdev/nexus/nexus_child.rs
@@ -498,6 +498,11 @@ impl<'c> NexusChild<'c> {
         self.state() == ChildState::Open && self.sync_state() == ChildSyncState::Synced
     }
 
+    /// Determines if the child is faulted.
+    pub fn is_faulted(&self) -> bool {
+        matches!(self.state(), ChildState::Faulted(..))
+    }
+
     /// Determines if the child is being rebuilt.
     #[inline]
     pub(crate) fn is_rebuilding(&self) -> bool {

--- a/io-engine/src/bdev/nvmx/controller.rs
+++ b/io-engine/src/bdev/nvmx/controller.rs
@@ -788,32 +788,38 @@ pub extern "C" fn nvme_poll_adminq(ctx: *mut c_void) -> i32 {
     let result = context.process_adminq();
 
     if result < 0 {
+        let error = Errno::from_raw(result.abs());
+        let dev_name = context.name.as_str();
+
         if context.start_device_destroy() {
             error!(
-                "process adminq: {}: ctrl failed: {}, error: {}",
-                context.name,
+                "Process adminq: {dev_name}: ctrl failed: {}, error: {error}",
                 context.is_failed(),
-                Errno::from_raw(result.abs())
             );
-            info!("dispatching nexus fault and retire: {}", context.name);
-            let dev_name = context.name.as_str();
+            info!(
+                dev_name,
+                "Dispatching nexus fault and retire via AdminCommandCompletionFailed"
+            );
             let carc = NVME_CONTROLLERS.lookup_by_name(dev_name).unwrap();
-            debug!(
-                ?dev_name,
-                "notifying listeners of admin command completion failure"
-            );
             let controller = carc.lock();
             let num_listeners =
                 controller.notify_listeners(DeviceEventType::AdminCommandCompletionFailed);
             debug!(
-                ?dev_name,
-                ?num_listeners,
-                "listeners notified of admin command completion failure"
+                dev_name,
+                num_listeners, "Listeners notified of admin command completion failure"
             );
         } else if context.report_failed() {
+            error!(
+                "Reported process adminq: {dev_name}: ctrl failed: {}, error: {error}",
+                context.is_failed(),
+            );
             if let Some(carc) = NVME_CONTROLLERS.lookup_by_name(&context.name) {
                 carc.lock()
                     .notify_listeners(DeviceEventType::AdminQNoticeCtrlFailed);
+            }
+        } else if context.adminq_broken_tmo(error) {
+            if let Some(carc) = NVME_CONTROLLERS.lookup_by_name(&context.name) {
+                carc.lock().notify_listeners(DeviceEventType::AdminQBroken);
             }
         }
         return 1;

--- a/io-engine/src/bdev/nvmx/controller_inner.rs
+++ b/io-engine/src/bdev/nvmx/controller_inner.rs
@@ -21,6 +21,7 @@ use crate::{
         nvme_bdev_running_config, utils::nvme_cpl_succeeded, NvmeController, NVME_CONTROLLERS,
     },
     core::{CoreError, DeviceIoController, DeviceTimeoutAction},
+    subsys::Config,
 };
 
 impl TryFrom<u32> for DeviceTimeoutAction {
@@ -63,6 +64,11 @@ pub(crate) struct TimeoutConfig {
     next_reset_time: Instant,
     destroy_in_progress: AtomicCell<bool>,
     report_failed: AtomicCell<bool>,
+    /// Sometimes the target might misbehave, leading into us failing to send keep alives,
+    /// and leaving the controller in a non-failed state.
+    adminq_broken_report: AtomicCell<bool>,
+    adminq_broken_ts: AtomicCell<Option<Instant>>,
+    adminq_broken_tmo: Duration,
 }
 
 impl Drop for TimeoutConfig {
@@ -84,6 +90,9 @@ impl TimeoutConfig {
             next_reset_time: Instant::now(),
             destroy_in_progress: AtomicCell::new(false),
             report_failed: AtomicCell::new(true),
+            adminq_broken_ts: AtomicCell::new(None),
+            adminq_broken_tmo: Duration::from_micros(Config::get().nvme_bdev_opts.timeout_admin_us),
+            adminq_broken_report: AtomicCell::new(true),
         }
     }
 
@@ -91,7 +100,7 @@ impl TimeoutConfig {
         self as *const _ as *mut _
     }
 
-    pub fn start_device_destroy(&mut self) -> bool {
+    pub fn start_device_destroy(&self) -> bool {
         self.destroy_in_progress
             .compare_exchange(false, true)
             .is_ok()
@@ -104,13 +113,34 @@ impl TimeoutConfig {
         unsafe { spdk_nvme_ctrlr_process_admin_completions(self.ctrlr.as_ptr()) }
     }
 
+    /// Yields true when the adminq is receiving ENXIO for longer than the adminq timeout.
+    pub fn adminq_broken_tmo(&self, error: nix::Error) -> bool {
+        if error != nix::Error::ENXIO {
+            return false;
+        }
+        let Err(Some(start_ts)) = self
+            .adminq_broken_ts
+            .compare_exchange(None, Some(Instant::now()))
+        else {
+            return false;
+        };
+
+        if start_ts.elapsed() <= self.adminq_broken_tmo {
+            return false;
+        }
+
+        self.adminq_broken_report
+            .compare_exchange(true, false)
+            .is_ok()
+    }
+
     /// Check if the SPDK's nvme controller is failed.
     pub fn is_failed(&self) -> bool {
         self.ctrlr.is_failed
     }
     /// Check if we need to report the controller failure.
     /// We only report this failure once.
-    pub fn report_failed(&mut self) -> bool {
+    pub fn report_failed(&self) -> bool {
         if !self.is_failed() {
             return false;
         }

--- a/io-engine/src/core/device_events.rs
+++ b/io-engine/src/core/device_events.rs
@@ -27,6 +27,11 @@ pub enum DeviceEventType {
     /// failed for the first time, this event is sent, allowing further
     /// clean up to be performed.
     AdminQNoticeCtrlFailed,
+    /// Sometimes KeepAlives are failed to be sent, and the adminq keeps failing
+    /// to be polled, but never transitions into controller failed!
+    /// In this case IOs might get stuck, and lead to subsystem pause hang.
+    /// This event is sent after the q has been failing to pool for more than adminq timeout.
+    AdminQBroken,
 }
 
 /// TODO

--- a/io-engine/tests/block_device_nvmf.rs
+++ b/io-engine/tests/block_device_nvmf.rs
@@ -1756,7 +1756,10 @@ async fn nvmf_device_hot_remove() {
 
     impl DeviceEventListener for TestEventListener {
         fn handle_device_event(&self, event: DeviceEventType, device: &str) {
-            if event == DeviceEventType::AdminQNoticeCtrlFailed {
+            if matches!(
+                event,
+                DeviceEventType::AdminQNoticeCtrlFailed | DeviceEventType::AdminQBroken
+            ) {
                 return; // Not interested in this one
             }
             // Check event type and device name.

--- a/test/python/tests/nexus/test_nexus_rebuild.py
+++ b/test/python/tests/nexus/test_nexus_rebuild.py
@@ -107,8 +107,29 @@ def test_rebuild_failure(containers, mayastors, times, create_nexuses):
             except:
                 print(f"Failed to remove child {child.uri} from {nexus}")
 
-    time.sleep(5)
+    time.sleep(3)
+    rebuilds = 0
+    for i in range(3):
+        time.sleep(1)
+        rebuilds += collect_rebuilds(ms0)
+        if rebuilds > 0:
+            break
 
+    assert rebuilds > 0, f"{ms0.nexus_list()}"
+
+    # Stop ms3 again. Rebuild jobs in progress must terminate.
+    node3.stop()
+
+    time.sleep(10)
+
+    # All rebuild jobs must finish.
+    for nexus in ms0.nexus_list():
+        for child in nexus.children:
+            assert child.rebuild_progress == -1
+        ms0.nexus_destroy(nexus.uuid)
+
+
+def collect_rebuilds(ms0):
     rebuilds = 0
     for nexus in ms0.nexus_list():
         for child in nexus.children:
@@ -121,16 +142,4 @@ def test_rebuild_failure(containers, mayastors, times, create_nexuses):
                     child.uri,
                     f"{child.rebuild_progress}",
                 )
-
-    assert rebuilds > 0
-
-    # Stop ms3 again. Rebuild jobs in progress must terminate.
-    node3.stop()
-
-    time.sleep(10)
-
-    # All rebuild jobs must finish.
-    for nexus in ms0.nexus_list():
-        for child in nexus.children:
-            assert child.rebuild_progress == -1
-        ms0.nexus_destroy(nexus.uuid)
+    return rebuilds


### PR DESCRIPTION
It was seen that sometimes the connection to the replica is in an odd state where adminq keeps failing to send the keep alive, and the nexus subsystem pause is hung.

The theory is that there are stuck IOs somehow. Prior to 2.11 the timing out of replica IOs was not always correct so this could somehow be playing a part here.

To attempt to unstuck the hang, we now wait up to the adminq keep alive timeout and then in case the nexus is pausing we now force disconnect the bad replica.