### PR TITLE
SPDK DiskError and Hot-removal patches

### DIFF
--- a/io-engine-tests/src/compose/mod.rs
+++ b/io-engine-tests/src/compose/mod.rs
@@ -139,6 +139,9 @@ impl Drop for MayastorTest<'_> {
         self.reactor.send_future(async { mayastor_env_stop(0) });
         // wait for mayastor to stop
         let hdl = self.thdl.take().unwrap();
-        hdl.join().unwrap()
+        let result = hdl.join();
+        if !std::thread::panicking() {
+            result.unwrap();
+        }
     }
 }

--- a/io-engine-tests/src/lib.rs
+++ b/io-engine-tests/src/lib.rs
@@ -176,7 +176,7 @@ pub fn dd_random_file(path: &str, bs: u32, size: u64) {
         .output()
         .expect("failed exec dd");
 
-    assert!(output.status.success());
+    assert!(output.status.success(), "{:#?}", output);
 }
 
 pub fn truncate_file(path: &str, size: u64) {
@@ -185,7 +185,7 @@ pub fn truncate_file(path: &str, size: u64) {
         .output()
         .expect("failed exec truncate");
 
-    assert!(output.status.success());
+    assert!(output.status.success(), "{:#?}", output);
 }
 
 pub fn truncate_file_bytes(path: &str, size: u64) {
@@ -193,7 +193,7 @@ pub fn truncate_file_bytes(path: &str, size: u64) {
         .args(["-s", &format!("{size}"), path])
         .output()
         .expect("failed exec truncate");
-    assert!(output.status.success());
+    assert!(output.status.success(), "{:#?}", output);
 }
 
 pub fn expand_tempfs_file_bytes(path: &str, size: u64) {
@@ -201,7 +201,7 @@ pub fn expand_tempfs_file_bytes(path: &str, size: u64) {
         .args(["-s", &format!("+{size}"), path])
         .output()
         .expect("failed exec truncate");
-    assert!(output.status.success());
+    assert!(output.status.success(), "{:#?}", output);
 }
 
 /// Automatically assign a loopdev to path
@@ -212,7 +212,7 @@ pub fn setup_loopdev_file(path: &str, sector_size: Option<u64>) -> String {
         .args(["-f", "--show", "-b", &format!("{log_sec}"), path])
         .output()
         .expect("failed exec losetup");
-    assert!(output.status.success());
+    assert!(output.status.success(), "{:#?}", output);
     // return the assigned loop device
     String::from_utf8(output.stdout).unwrap().trim().to_string()
 }
@@ -223,7 +223,7 @@ pub fn detach_loopdev(dev: &str) {
         .args(["-d", dev])
         .output()
         .expect("failed exec losetup");
-    assert!(output.status.success());
+    assert!(output.status.success(), "{:#?}", output);
 }
 
 pub fn fscheck(device: &str) {
@@ -235,7 +235,7 @@ pub fn fscheck(device: &str) {
     io::stdout().write_all(&output.stderr).unwrap();
     io::stdout().write_all(&output.stdout).unwrap();
 
-    assert!(output.status.success());
+    assert!(output.status.success(), "{:#?}", output);
 }
 
 pub fn mkfs(path: &str, fstype: &str) -> bool {
@@ -279,7 +279,7 @@ pub fn compare_files(a: &str, b: &str) {
 
     io::stdout().write_all(&output.stderr).unwrap();
     io::stdout().write_all(&output.stdout).unwrap();
-    assert!(output.status.success());
+    assert!(output.status.success(), "{:#?}", output);
 }
 
 pub fn mount_umount(device: &str) -> Result<String, String> {

--- a/io-engine-tests/src/pool.rs
+++ b/io-engine-tests/src/pool.rs
@@ -282,6 +282,7 @@ impl PoolBuilderLocal {
             backend: Default::default(),
             enc_key: None,
             crypto_vbdev_name: None,
+            no_spdk: false,
         })
         .await?;
         Ok(lvs)

--- a/io-engine/examples/lvs-eval/main.rs
+++ b/io-engine/examples/lvs-eval/main.rs
@@ -135,9 +135,7 @@ async fn create_lvs(args: &CliArgs) -> Lvs {
         md_args: Some(PoolMetadataArgs {
             max_expansion: args.max_expansion.clone(),
         }),
-        backend: Default::default(),
-        enc_key: None,
-        crypto_vbdev_name: None,
+        ..Default::default()
     };
 
     Lvs::create_or_import(lvs_args.clone()).await.unwrap()

--- a/io-engine/src/bdev/lvs.rs
+++ b/io-engine/src/bdev/lvs.rs
@@ -217,6 +217,7 @@ impl Lvs {
             enc_key: self.key.clone(),
             // XXX: Is this path ever exercised apart from test, or casperf perhaps?
             crypto_vbdev_name: self.key.as_ref().map(|_| format!("crypto_{}", self.name)),
+            no_spdk: false,
         };
         match &self.mode {
             LvsMode::Create => match crate::lvs::Lvs::import_from_args(args.clone()).await {

--- a/io-engine/src/core/env.rs
+++ b/io-engine/src/core/env.rs
@@ -305,6 +305,11 @@ pub struct SpdkTracingArgs {
     #[clap(long, default_value_t = 1)]
     pub threads: u32,
 }
+impl Default for SpdkTracingArgs {
+    fn default() -> Self {
+        Self::parse_from(Vec::<String>::new())
+    }
+}
 
 /// DiskPool related arguments.
 #[derive(Debug, clap::Parser, Clone)]
@@ -332,6 +337,11 @@ pub struct PoolCliArgs {
     /// for flakiness detection.
     #[clap(long, default_value = "3h")]
     pub io_stall_transition_window: humantime::Duration,
+}
+impl Default for PoolCliArgs {
+    fn default() -> Self {
+        Self::parse_from(Vec::<String>::new())
+    }
 }
 
 fn delay_compat(s: &str) -> Result<bool, String> {
@@ -507,8 +517,8 @@ impl Default for MayastorEnvironment {
             developer_delay: false,
             rdma: false,
             bs_cluster_unmap: false,
-            pool_args: PoolCliArgs::parse_from(Vec::<String>::new()),
-            traces: SpdkTracingArgs::parse_from(Vec::<String>::new()),
+            pool_args: PoolCliArgs::default(),
+            traces: SpdkTracingArgs::default(),
         }
     }
 }

--- a/io-engine/src/core/env.rs
+++ b/io-engine/src/core/env.rs
@@ -299,10 +299,10 @@ pub struct MayastorCliArgs {
 #[derive(Debug, clap::Parser, Clone)]
 pub struct SpdkTracingArgs {
     /// Number of trace entries per lcore.
-    #[clap(long, default_value_t = 0)]
+    #[clap(long, env = "SPDK_TRACING_ENTRIES", default_value_t = 0)]
     pub entries: u64,
     /// Number of user created threads.
-    #[clap(long, default_value_t = 1)]
+    #[clap(long, env = "SPDK_TRACING_THREADS", default_value_t = 1)]
     pub threads: u32,
 }
 impl Default for SpdkTracingArgs {
@@ -316,7 +316,7 @@ impl Default for SpdkTracingArgs {
 pub struct PoolCliArgs {
     /// I/O error count threshold.
     /// After this many errors a pool alert is raised as Warning.
-    #[clap(long, default_value_t = 64)]
+    #[clap(long, env, default_value_t = 8)]
     pub io_error_threshold: u64,
 
     /// I/O stall deadline.
@@ -324,18 +324,18 @@ pub struct PoolCliArgs {
     /// Critical alert is raised.
     /// The pool disk will also be reset and the stall will be cleared once complete and
     /// I/O flows again.
-    #[clap(long, default_value = "30s")]
+    #[clap(long, env, default_value = "30s")]
     pub io_stall_deadline: humantime::Duration,
 
     /// I/O stall transitions threshold.
     /// After this many transitions within the window, a pool alert is raised as Warning.
-    #[clap(long, default_value_t = 3)]
+    #[clap(long, env, default_value_t = 3)]
     pub io_stall_transition_threshold: u64,
 
     /// I/O stall transitions window.
     /// Time window during which stall ↔ resume state transitions are tracked
     /// for flakiness detection.
-    #[clap(long, default_value = "3h")]
+    #[clap(long, env, default_value = "3h")]
     pub io_stall_transition_window: humantime::Duration,
 }
 impl Default for PoolCliArgs {

--- a/io-engine/src/grpc/v1/pool.rs
+++ b/io-engine/src/grpc/v1/pool.rs
@@ -278,6 +278,7 @@ impl TryFrom<CreatePoolRequest> for PoolArgs {
             backend: backend.into(),
             enc_key: None,
             crypto_vbdev_name: None,
+            no_spdk: false,
         })
     }
 }
@@ -366,6 +367,7 @@ impl TryFrom<ImportPoolRequest> for PoolArgs {
                 .encryption
                 .as_ref()
                 .map(|_| format!("crypto_{}", args.name)),
+            no_spdk: false,
         })
     }
 }

--- a/io-engine/src/grpc/v1/pool.rs
+++ b/io-engine/src/grpc/v1/pool.rs
@@ -580,6 +580,11 @@ impl PoolErrorsNt {
     }
 }
 
+/// Convert something which implements [`PoolOps`] to the proto `Pool` type.
+pub async fn pool_to_proto(pool: &dyn PoolOps) -> Pool {
+    pool.async_into().await
+}
+
 impl AsyncFrom<Box<dyn PoolOps>> for Pool {
     async fn async_from(value: Box<dyn PoolOps>) -> Self {
         let value = value.deref();

--- a/io-engine/src/lvm/cli.rs
+++ b/io-engine/src/lvm/cli.rs
@@ -121,6 +121,12 @@ enum LvmSubCmd {
     /// Display information about logical volumes.
     #[strum(serialize = "lvs")]
     LVList,
+    /// DeviceMapper commands.
+    #[strum(serialize = "dmsetup")]
+    DMSetup,
+    /// BlockDevice commands.
+    #[strum(serialize = "blockdev")]
+    BlkDev,
 }
 
 /// LVM wrapper over `Command` with added qol such as error mapping and
@@ -199,6 +205,14 @@ impl LvmCmd {
     /// Prepare a `Command` for `LvmSubCmd::LVList`.
     pub(super) fn lv_list() -> Self {
         Self::new(LvmSubCmd::LVList.as_ref())
+    }
+    /// Prepare a `Command` for `LvmSubCmd::DMSuspend`.
+    pub(super) fn dm_setup() -> Self {
+        Self::new(LvmSubCmd::DMSetup.as_ref())
+    }
+    /// Prepare a `Command` for `LvmSubCmd::BlkDev`.
+    pub(super) fn blk_dev() -> Self {
+        Self::new(LvmSubCmd::BlkDev.as_ref())
     }
     /// Runs the LVM command with the provided `Command` arguments et all and
     /// returns an LVM specific report containing an output type `T`.

--- a/io-engine/src/lvm/cli.rs
+++ b/io-engine/src/lvm/cli.rs
@@ -1,5 +1,6 @@
 use crate::lvm::{error, error::Error, property::Property};
 
+use nix::errno::Errno;
 use serde::de::Deserialize;
 use snafu::ResultExt;
 use std::ffi::OsStr;
@@ -296,13 +297,9 @@ impl LvmCmd {
 
         let in_spdk = spdk_rs::Thread::is_spdk_thread();
         let fut = async move {
-            let output = self
-                .cmder
-                .output()
-                .await
-                .context(error::LvmBinSpawnErrSnafu {
-                    command: self.cmd.to_string(),
-                })?;
+            let output = self.cmder().await.context(error::LvmBinSpawnErrSnafu {
+                command: self.cmd.to_string(),
+            })?;
             if !output.status.success() {
                 let error = String::from_utf8_lossy(&output.stderr).to_string();
                 return Err(Error::LvmBinErr {
@@ -317,6 +314,25 @@ impl LvmCmd {
         } else {
             fut.await
         }
+    }
+
+    async fn cmder(&mut self) -> std::io::Result<std::process::Output> {
+        unsafe {
+            self.cmder.pre_exec(|| {
+                Self::close_range().ok();
+                Ok(())
+            });
+        }
+
+        self.cmder.output().await
+    }
+
+    /// The close_range system call closes all open file descriptors from first to last (included).
+    /// Here close from 3 to 1024.
+    /// todo: find a better way such as querying /proc/self/fd ?.
+    fn close_range() -> nix::Result<()> {
+        let res = unsafe { libc::close_range(3, 1024, libc::CLOSE_RANGE_CLOEXEC as i32) };
+        Errno::result(res).map(drop)
     }
 }
 

--- a/io-engine/src/lvm/cli.rs
+++ b/io-engine/src/lvm/cli.rs
@@ -30,6 +30,15 @@ impl CmnQueryArgs {
             ..Default::default()
         }
     }
+    /// Find only our entries (ie, with our tag).
+    pub(crate) fn ours_if(spdk: bool) -> Self {
+        if spdk {
+            Self::ours()
+        } else {
+            Self::any()
+        }
+    }
+
     /// Find entries with the given name.
     pub(crate) fn named_opt(self, name: &Option<String>) -> Self {
         let Some(name) = name else {
@@ -241,7 +250,7 @@ impl LvmCmd {
     /// Tag the given `Property`.
     pub(super) fn tag_if(self, tag: bool, property: Property) -> Self {
         if tag {
-            self.arg(property.add())
+            self.tag(property)
         } else {
             self
         }
@@ -285,7 +294,8 @@ impl LvmCmd {
     pub(super) async fn output(mut self) -> Result<std::process::Output, Error> {
         tracing::trace!("{:?}", self.cmder);
 
-        crate::tokio_run!(async move {
+        let in_spdk = spdk_rs::Thread::is_spdk_thread();
+        let fut = async move {
             let output = self
                 .cmder
                 .output()
@@ -301,7 +311,12 @@ impl LvmCmd {
                 });
             }
             Ok(output)
-        })
+        };
+        if in_spdk {
+            crate::tokio_run!(fut)
+        } else {
+            fut.await
+        }
     }
 }
 

--- a/io-engine/src/lvm/cli.rs
+++ b/io-engine/src/lvm/cli.rs
@@ -5,7 +5,7 @@ use serde::de::Deserialize;
 use snafu::ResultExt;
 use std::ffi::OsStr;
 use strum_macros::{AsRefStr, Display, EnumString};
-use tokio::process::Command;
+use tokio::{io::AsyncWriteExt, process::Command};
 
 /// Common set of query options for a volume group or logical volume.
 /// If the name is present then the name will be used to query.
@@ -127,6 +127,7 @@ enum LvmSubCmd {
 /// decoding of json output reports.
 pub(super) struct LvmCmd {
     cmd: &'static str,
+    input: Option<String>,
     cmder: Command,
 }
 
@@ -152,6 +153,7 @@ impl LvmCmd {
         Self {
             cmd,
             cmder: Command::new(cmd),
+            input: None,
         }
     }
     /// Prepare a `Command` for `LvmSubCmd::PVCreate`.
@@ -274,6 +276,11 @@ impl LvmCmd {
         self.cmder.args(args);
         self
     }
+    /// Run the command with the given input.
+    pub fn input(mut self, input: String) -> Self {
+        self.input = Some(input);
+        self
+    }
     /// Runs the LVM command with the provided `Command` arguments et al.
     ///
     /// # Errors
@@ -324,7 +331,18 @@ impl LvmCmd {
             });
         }
 
-        self.cmder.output().await
+        let Some(input) = self.input.take() else {
+            return self.cmder.output().await;
+        };
+
+        let mut child = self.cmder.stdin(std::process::Stdio::piped()).spawn()?;
+
+        if let Some(mut stdin) = child.stdin.take() {
+            stdin.write_all(input.as_bytes()).await?;
+            stdin.shutdown().await?;
+        }
+
+        child.wait_with_output().await
     }
 
     /// The close_range system call closes all open file descriptors from first to last (included).

--- a/io-engine/src/lvm/dm_setup.rs
+++ b/io-engine/src/lvm/dm_setup.rs
@@ -1,0 +1,127 @@
+/// Possible device states are SUSPENDED, ACTIVE, and READ-ONLY.
+/// The dmsetup suspend command sets a device state to SUSPENDED.
+/// When a device is suspended, all I/O operations to that device stop.
+/// The dmsetup resume command restores a device state to ACTIVE.
+#[derive(Eq, PartialEq)]
+pub enum DmState {
+    Suspended,
+    Active,
+    ReadOnly,
+    Unknown(String),
+}
+impl From<String> for DmState {
+    fn from(value: String) -> Self {
+        let state = value.to_uppercase();
+        match state.as_str() {
+            "SUSPENDED" => Self::Suspended,
+            "ACTIVE" => Self::Active,
+            "READ-ONLY" => Self::ReadOnly,
+            _ => Self::Unknown(state),
+        }
+    }
+}
+impl std::fmt::Display for DmState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let state = match self {
+            DmState::Suspended => "Suspended",
+            DmState::Active => "Active",
+            DmState::ReadOnly => "Read-Only",
+            DmState::Unknown(state) => state.as_str(),
+        };
+        write!(f, "{state}")
+    }
+}
+
+/// A device-mapper setup table.
+#[derive(Debug)]
+pub struct DmTable(pub String);
+
+impl std::fmt::Display for DmTable {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// Helper methods for running dmsetup commands.
+pub struct DmSetup;
+
+impl DmSetup {
+    /// Suspends the device.
+    ///
+    /// # NOTES
+    ///
+    /// Any I/O that has already been mapped by the device but has not yet completed will be flushed. \
+    /// Any further I/O to that device will be postponed for as long as the device is suspended. \
+    /// If there's a filesystem on the device which supports the operation, an attempt will be made
+    /// to sync it first unless --nolockfs is specified. \
+    /// Some targets such as recent (October 2006) versions of multipath may support the --noflush option.
+    /// This lets outstanding I/O that has not yet reached the device to remain unflushed.
+    pub async fn suspend(path: &str) -> Result<(), super::Error> {
+        super::cli::LvmCmd::dm_setup()
+            .arg("suspend")
+            .arg(path)
+            .run()
+            .await?;
+        Ok(())
+    }
+    /// Resumes/Un-suspends the device.
+    ///
+    /// # NOTES
+    ///
+    /// If an inactive table has been loaded, it becomes live. \
+    /// Postponed I/O then gets re-queued for processing.
+    pub async fn resume(path: &str) -> Result<(), super::Error> {
+        super::cli::LvmCmd::dm_setup()
+            .arg("resume")
+            .arg(path)
+            .run()
+            .await?;
+        Ok(())
+    }
+
+    /// Retrieve the currently applied [`DmTable`] of the device.
+    ///
+    /// Outputs the current table for the device in a format that can be fed back in using the create or load commands. \
+    /// With --target, only information relating to the specified target type is displayed. \
+    /// Real encryption keys are suppressed in the table output for crypt and integrity targets unless the --showkeys parameter is supplied. \
+    /// Kernel key references prefixed with : are not affected  by  the parameter  and get displayed always (crypt target only).
+    /// With --concise, the output is presented concisely on a single line. \
+    /// Commas then separate the name, uuid, minor device number, flags ('ro' or 'rw') and the table (if present).
+    /// Semi-colons separate devices.  \
+    /// Backslashes escape any commas, semi-colons or backslashes.
+    pub async fn table(path: &str) -> Result<DmTable, super::Error> {
+        let output = super::cli::LvmCmd::dm_setup()
+            .arg("table")
+            .arg(path)
+            .output()
+            .await?;
+        let output_str = String::from_utf8_lossy(&output.stdout).to_string();
+        let table_str = output_str.trim_end();
+        Ok(DmTable(table_str.to_string()))
+    }
+
+    /// Loads a [`DmTable`].
+    pub async fn load(path: &str, table: DmTable) -> Result<(), super::Error> {
+        let _output = super::cli::LvmCmd::dm_setup()
+            .arg("load")
+            .arg(path)
+            .input(table.to_string())
+            .output()
+            .await?;
+        Ok(())
+    }
+
+    /// Get the [`DmState`] of the given device-mapper device path.
+    pub async fn state(path: &str) -> Result<DmState, super::Error> {
+        let output = super::cli::LvmCmd::dm_setup()
+            .arg("info")
+            .arg("-C")
+            .arg("-osuspended")
+            .arg("--noheadings")
+            .arg(path)
+            .output()
+            .await?;
+        let state = String::from_utf8_lossy(&output.stdout).to_string();
+        Ok(DmState::from(state.trim_end().to_string()))
+    }
+}

--- a/io-engine/src/lvm/dm_setup.rs
+++ b/io-engine/src/lvm/dm_setup.rs
@@ -111,6 +111,27 @@ impl DmSetup {
         Ok(())
     }
 
+    /// Removes a device-mapper device.
+    ///
+    /// # NOTES
+    ///
+    /// It will no longer be visible to dmsetup.
+    ///
+    /// Open devices cannot be removed, but:
+    /// - adding --force will replace the table with one that fails all I/O.
+    /// - --deferred will enable deferred removal of open devices - the device will be removed when
+    ///   the last user closes it.
+    ///
+    /// As is, this method will remove stale devices.
+    pub async fn remove(path: &str) -> Result<(), super::Error> {
+        let _output = super::cli::LvmCmd::dm_setup()
+            .arg("remove")
+            .arg(path)
+            .output()
+            .await?;
+        Ok(())
+    }
+
     /// Get the [`DmState`] of the given device-mapper device path.
     pub async fn state(path: &str) -> Result<DmState, super::Error> {
         let output = super::cli::LvmCmd::dm_setup()

--- a/io-engine/src/lvm/error.rs
+++ b/io-engine/src/lvm/error.rs
@@ -54,10 +54,19 @@ pub enum Error {
     },
     #[snafu(display("{error}"))]
     NoSpace { error: String },
+    #[snafu(display("{error}"))]
+    Exists { error: String },
     #[snafu(display("Snapshots are not currently supported for LVM volumes"))]
     SnapshotNotSup {},
     #[snafu(display("Pool expansion is not currently supported for LVM volumes"))]
     GrowNotSup {},
+}
+
+impl Error {
+    /// Fail method is required by the snafu::ensure! macro.
+    pub(crate) fn fail<T>(self) -> Result<T, Self> {
+        Err(self)
+    }
 }
 
 impl ToErrno for Error {
@@ -84,6 +93,7 @@ impl ToErrno for Error {
             Error::BdevMissing { .. } => Errno::ENODEV,
             Error::UpdateProps { .. } => Errno::EIO,
             Error::NoSpace { .. } => Errno::ENOSPC,
+            Error::Exists { .. } => Errno::EEXIST,
             Error::SnapshotNotSup { .. } => Errno::ENOTSUP,
             Error::GrowNotSup { .. } => Errno::ENOTSUP,
         }

--- a/io-engine/src/lvm/error.rs
+++ b/io-engine/src/lvm/error.rs
@@ -60,6 +60,8 @@ pub enum Error {
     SnapshotNotSup {},
     #[snafu(display("Pool expansion is not currently supported for LVM volumes"))]
     GrowNotSup {},
+    #[snafu(display("{error}"))]
+    Internal { error: String },
 }
 
 impl Error {
@@ -96,6 +98,7 @@ impl ToErrno for Error {
             Error::Exists { .. } => Errno::EEXIST,
             Error::SnapshotNotSup { .. } => Errno::ENOTSUP,
             Error::GrowNotSup { .. } => Errno::ENOTSUP,
+            Error::Internal { .. } => Errno::EPIPE,
         }
     }
 }

--- a/io-engine/src/lvm/lv_replica.rs
+++ b/io-engine/src/lvm/lv_replica.rs
@@ -194,6 +194,7 @@ struct LogicalVolumeList {
 
 impl LogicalVolume {
     /// Create a new logical volume for the given vg uuid.
+    #[allow(clippy::too_many_arguments)]
     pub(crate) async fn create(
         vg_uuid: &str,
         name: &str,
@@ -202,14 +203,15 @@ impl LogicalVolume {
         thin: bool,
         entity_id: &Option<String>,
         share: Protocol,
+        spdk: bool,
     ) -> Result<LogicalVolume, Error> {
-        let pool = VolumeGroup::lookup(CmnQueryArgs::ours().uuid(vg_uuid)).await?;
-        pool.create_lvol(name, size, uuid, thin, entity_id, share)
+        let pool = VolumeGroup::lookup(CmnQueryArgs::ours_if(spdk).uuid(vg_uuid)).await?;
+        pool.create_lvol(name, size, uuid, thin, entity_id, share, spdk)
             .await?;
         Self::lookup(
             &QueryArgs::new()
-                .with_lv(CmnQueryArgs::ours().uuid(uuid))
-                .with_vg(CmnQueryArgs::ours().uuid(vg_uuid)),
+                .with_lv(CmnQueryArgs::ours_if(spdk).uuid(uuid))
+                .with_vg(CmnQueryArgs::ours_if(spdk).uuid(vg_uuid)),
         )
         .await
     }

--- a/io-engine/src/lvm/lv_replica.rs
+++ b/io-engine/src/lvm/lv_replica.rs
@@ -194,30 +194,21 @@ struct LogicalVolumeList {
 
 impl LogicalVolume {
     /// Create a new logical volume for the given vg uuid.
-    #[allow(clippy::too_many_arguments)]
     pub(crate) async fn create(
-        vg_uuid: &str,
-        name: &str,
-        size: u64,
-        uuid: &str,
-        thin: bool,
-        entity_id: &Option<String>,
+        pool: &VolumeGroup,
+        args: crate::pool_backend::ReplicaArgs,
         share: Protocol,
         spdk: bool,
     ) -> Result<LogicalVolume, Error> {
-        let pool = VolumeGroup::lookup(CmnQueryArgs::ours_if(spdk).uuid(vg_uuid)).await?;
-        let error = match pool
-            .create_lvol(name, size, uuid, thin, entity_id, share, spdk)
-            .await
-        {
+        let error = match pool.create_lvoli(&args, share, spdk).await {
             Ok(_) => Ok(None),
             Err(error @ Error::Exists { .. }) => Ok(Some(error)),
             Err(error) => Err(error),
         }?;
         let lvol = Self::lookup(
             &QueryArgs::new()
-                .with_lv(CmnQueryArgs::ours_if(spdk).uuid(uuid))
-                .with_vg(CmnQueryArgs::ours_if(spdk).uuid(vg_uuid)),
+                .with_lv(CmnQueryArgs::ours_if(spdk).uuid(&args.uuid))
+                .with_vg(CmnQueryArgs::ours_if(spdk).uuid(pool.uuid())),
         )
         .await?;
 
@@ -225,15 +216,15 @@ impl LogicalVolume {
             return Ok(lvol);
         };
 
-        snafu::ensure!(lvol.name().as_deref() == Some(name), error);
-        snafu::ensure!(lvol.uuid() == uuid, error);
-        snafu::ensure!(lvol.size() == size, error);
-        snafu::ensure!(lvol.entity_id() == entity_id.as_ref(), error);
+        snafu::ensure!(lvol.name().as_deref() == Some(&args.name), error);
+        snafu::ensure!(lvol.uuid() == args.uuid, error);
+        snafu::ensure!(lvol.size() == args.size, error);
+        snafu::ensure!(lvol.entity_id() == args.entity_id.as_ref(), error);
         snafu::ensure!(lvol.share_proto().unwrap_or_default() == share, error);
 
         info!(
-            name,
-            uuid,
+            name = args.name,
+            uuid = args.uuid,
             vg_name = pool.name(),
             "LVM LogicalVolume imported successfully"
         );

--- a/io-engine/src/lvm/lv_replica.rs
+++ b/io-engine/src/lvm/lv_replica.rs
@@ -201,6 +201,13 @@ impl LogicalVolume {
         share: Protocol,
         spdk: bool,
     ) -> Result<LogicalVolume, Error> {
+        info!(
+            name = args.name,
+            uuid = args.uuid,
+            vg_name = pool.name(),
+            "Creating LVM Logical Volume"
+        );
+
         let error = match pool.create_lvoli(&args, share, spdk).await {
             Ok(_) => Ok(None),
             Err(error @ Error::Exists { .. }) => Ok(Some(error)),

--- a/io-engine/src/lvm/lv_replica.rs
+++ b/io-engine/src/lvm/lv_replica.rs
@@ -5,6 +5,7 @@ use crate::{
     core::{NvmfShareProps, Protocol, PtplProps, Share, UntypedBdev, UpdateProps},
     lvm::{
         cli::LvmCmd,
+        dm_setup::{DmSetup, DmState, DmTable},
         property::{Property, PropertyType},
     },
     pool_backend::PoolBackend,
@@ -260,6 +261,77 @@ impl LogicalVolume {
         }
         g_error?;
         Ok(lvs)
+    }
+
+    /// Suspends the [`LogicalVolume`].
+    ///
+    /// # NOTES
+    ///
+    /// See details from [`DmSetup::suspend`].
+    ///
+    /// # WARNING
+    ///
+    /// The device is only suspended once the open count reaches 0.
+    /// This means the device might not be suspended after the suspend call completes.
+    /// You should consider using awaiting till [`DmState`] is [`DmState::SUSPENDED`].
+    pub async fn dm_suspend(&mut self) -> Result<DmState, Error> {
+        DmSetup::suspend(&self.path).await?;
+        self.dm_state().await
+    }
+    /// Resumes/Un-suspends the [`LogicalVolume`].
+    ///
+    /// # NOTES
+    ///
+    /// See details from [`DmSetup::resume`].
+    pub async fn dm_resume(&mut self) -> Result<(), Error> {
+        DmSetup::resume(&self.path).await
+    }
+
+    /// Retrieve the [`DmState`] of the [`LogicalVolume`].
+    pub async fn dm_state(&self) -> Result<DmState, Error> {
+        DmSetup::state(&self.path).await
+    }
+
+    /// Retrieve the device-mapper table for the [`LogicalVolume`].
+    pub async fn table(&self) -> Result<DmTable, Error> {
+        DmSetup::table(self.path()).await
+    }
+
+    /// A very simple way of making the [`LogicalVolume`] return -EIO for all I/O.
+    ///
+    /// Returns the previous device-mapper table for restoring.
+    pub async fn bork(&mut self) -> Result<DmTable, Error> {
+        let current = DmSetup::table(self.path()).await?;
+
+        let sz = self.sz().await?;
+        let table = format!("0 {sz} error");
+        DmSetup::load(self.path(), DmTable(table)).await?;
+        self.dm_resume().await.ok();
+        Ok(current)
+    }
+
+    async fn sz(&self) -> Result<u64, Error> {
+        let output = LvmCmd::blk_dev()
+            .arg("--getsz")
+            .arg(self.path())
+            .output()
+            .await?;
+        let output_str = String::from_utf8_lossy(&output.stdout).to_string();
+        let sz_str = output_str.trim_end();
+        sz_str.parse::<u64>().map_err(|error| Error::Internal {
+            error: error.to_string(),
+        })
+    }
+
+    /// Undoes a borked [`LogicalVolume`] by re-applying the previous device-mapper table.
+    pub async fn unbork(&mut self, table: DmTable) -> Result<(), Error> {
+        DmSetup::load(self.path(), table).await?;
+        self.dm_resume().await
+    }
+
+    /// Retrieve the device path of the [`LogicalVolume`].
+    pub fn path(&self) -> &str {
+        &self.path
     }
 
     /// Fetch logical volumes using the provided options as query criteria.

--- a/io-engine/src/lvm/lv_replica.rs
+++ b/io-engine/src/lvm/lv_replica.rs
@@ -206,14 +206,39 @@ impl LogicalVolume {
         spdk: bool,
     ) -> Result<LogicalVolume, Error> {
         let pool = VolumeGroup::lookup(CmnQueryArgs::ours_if(spdk).uuid(vg_uuid)).await?;
-        pool.create_lvol(name, size, uuid, thin, entity_id, share, spdk)
-            .await?;
-        Self::lookup(
+        let error = match pool
+            .create_lvol(name, size, uuid, thin, entity_id, share, spdk)
+            .await
+        {
+            Ok(_) => Ok(None),
+            Err(error @ Error::Exists { .. }) => Ok(Some(error)),
+            Err(error) => Err(error),
+        }?;
+        let lvol = Self::lookup(
             &QueryArgs::new()
                 .with_lv(CmnQueryArgs::ours_if(spdk).uuid(uuid))
                 .with_vg(CmnQueryArgs::ours_if(spdk).uuid(vg_uuid)),
         )
-        .await
+        .await?;
+
+        let Some(error) = error else {
+            return Ok(lvol);
+        };
+
+        snafu::ensure!(lvol.name().as_deref() == Some(name), error);
+        snafu::ensure!(lvol.uuid() == uuid, error);
+        snafu::ensure!(lvol.size() == size, error);
+        snafu::ensure!(lvol.entity_id() == entity_id.as_ref(), error);
+        snafu::ensure!(lvol.share_proto().unwrap_or_default() == share, error);
+
+        info!(
+            name,
+            uuid,
+            vg_name = pool.name(),
+            "LVM LogicalVolume imported successfully"
+        );
+
+        Ok(lvol)
     }
 
     /// Lookup a single logical volume.

--- a/io-engine/src/lvm/mod.rs
+++ b/io-engine/src/lvm/mod.rs
@@ -115,17 +115,7 @@ impl PoolOps for VolumeGroup {
         &self,
         args: ReplicaArgs,
     ) -> Result<Box<dyn ReplicaOps>, crate::pool_backend::Error> {
-        let replica = LogicalVolume::create(
-            self.uuid(),
-            &args.name,
-            args.size,
-            &args.uuid,
-            args.thin,
-            &args.entity_id,
-            Protocol::Off,
-            self.ours(),
-        )
-        .await?;
+        let replica = self.create_lvol(args).await?;
         Ok(Box::new(replica))
     }
 

--- a/io-engine/src/lvm/mod.rs
+++ b/io-engine/src/lvm/mod.rs
@@ -123,6 +123,7 @@ impl PoolOps for VolumeGroup {
             args.thin,
             &args.entity_id,
             Protocol::Off,
+            self.ours(),
         )
         .await?;
         Ok(Box::new(replica))

--- a/io-engine/src/lvm/mod.rs
+++ b/io-engine/src/lvm/mod.rs
@@ -26,6 +26,8 @@
 
 /// Helps run LVM commands and decode their json output and reports.
 mod cli;
+/// Device Mapper setup and info.
+mod dm_setup;
 mod error;
 /// Logical Volume management.
 mod lv_replica;
@@ -40,7 +42,7 @@ pub(crate) use error::Error;
 pub(crate) use cli::CmnQueryArgs;
 
 /// A pool which is a Volume Group in LVM.
-pub(crate) use vg_pool::VolumeGroup;
+pub use vg_pool::VolumeGroup;
 
 /// Logical volume and its query arguments.
 pub(crate) use lv_replica::{LogicalVolume, QueryArgs};

--- a/io-engine/src/lvm/vg_pool.rs
+++ b/io-engine/src/lvm/vg_pool.rs
@@ -140,9 +140,13 @@ impl VolumeGroup {
     /// Import a volume group with the name provided or create one with the name
     /// and disks provided currently only import is supported.
     pub(crate) async fn create(args: PoolArgs) -> Result<VolumeGroup, Error> {
-        tracing::info!(?args, "Creating LVM VolumeGroup");
-        let vg = match VolumeGroup::lookup(CmnQueryArgs::any().named(&args.name)).await {
-            Ok(_) => Self::import_inner(args).await,
+        tracing::info!(?args, "Creating/Importing LVM Volume Group");
+        match VolumeGroup::lookup(CmnQueryArgs::any().named(&args.name)).await {
+            Ok(_) => {
+                let vg = Self::import_inner(args).await?;
+                info!(name = vg.name(), "LVM Volume Group imported successfully");
+                Ok(vg)
+            }
             Err(Error::NotFound { .. }) => {
                 LvmCmd::pv_create().args(&args.disks).run().await?;
 
@@ -152,16 +156,14 @@ impl VolumeGroup {
                     .args(args.disks)
                     .run()
                     .await?;
+                info!(name = args.name, "LVM VolumeGroup created successfully");
                 let lookup = CmnQueryArgs::ours_if(!args.no_spdk)
                     .named(&args.name)
                     .uuid_opt(&args.uuid);
                 VolumeGroup::lookup(lookup).await
             }
             Err(error) => Err(error),
-        }?;
-
-        info!("The lvm vg pool '{}' has been created", vg.name());
-        Ok(vg)
+        }
     }
 
     async fn import_lvols(&self) -> Result<(), Error> {
@@ -188,6 +190,7 @@ impl VolumeGroup {
     /// as a Pool.
     pub(crate) async fn import(args: PoolArgs) -> Result<VolumeGroup, Error> {
         let vg = Self::import_inner(args).await?;
+        info!(name = vg.name(), "LVM Volume Group imported successfully");
         vg.import_lvols().await?;
         Ok(vg)
     }
@@ -303,11 +306,11 @@ impl VolumeGroup {
     ) -> Result<(), Error> {
         let vg_name = self.name();
         let ins_space = format!("Volume group \"{vg_name}\" has insufficient free space");
+        let eexists =
+            format!("Logical Volume \"{uuid}\" already exists in volume group \"{vg_name}\"");
 
         if thin {
             return Err(Error::ThinProv {});
-        } else if size > self.free {
-            return Err(Error::NoSpace { error: ins_space });
         }
 
         let entity_id = entity_id.clone().unwrap_or_default();
@@ -326,10 +329,16 @@ impl VolumeGroup {
             Err(Error::LvmBinErr { error, .. }) if error.starts_with(&ins_space) => {
                 Err(Error::NoSpace { error })
             }
+            Err(Error::LvmBinErr { error, .. }) if error.starts_with(&eexists) => {
+                Err(Error::Exists { error })
+            }
             _else => _else,
         }?;
 
-        info!("lvm volume {name} created");
+        info!(
+            name,
+            uuid, vg_name, "LVM Logical Volume created successfully"
+        );
 
         Ok(())
     }

--- a/io-engine/src/lvm/vg_pool.rs
+++ b/io-engine/src/lvm/vg_pool.rs
@@ -1,15 +1,14 @@
-use crate::{
-    bdev::PtplFileOps,
-    core::Protocol,
-    lvm::{property::Property, LogicalVolume},
-    pool_backend::PoolArgs,
-};
-use serde::Deserialize;
-
 use super::{
     cli::{de, CmnQueryArgs, LvmCmd},
     error::Error,
 };
+use crate::{
+    bdev::PtplFileOps,
+    core::Protocol,
+    lvm::{dm_setup::DmSetup, property::Property, LogicalVolume},
+    pool_backend::PoolArgs,
+};
+use serde::Deserialize;
 
 /// VG query arguments, allowing filtering via --select.
 /// It's essentially a new-type wrapper over the common arguments
@@ -150,12 +149,28 @@ impl VolumeGroup {
             Err(Error::NotFound { .. }) => {
                 LvmCmd::pv_create().args(&args.disks).run().await?;
 
-                LvmCmd::vg_create()
-                    .arg(&args.name)
-                    .tag_if(!args.no_spdk, Property::Lvm)
-                    .args(args.disks)
-                    .run()
-                    .await?;
+                // A broken vg as a result of improper cleanup during tests
+                let edm_e = format!("/dev/{}: already exists in filesystem", args.name);
+                let cmd = || {
+                    LvmCmd::vg_create()
+                        .arg(&args.name)
+                        .tag_if(!args.no_spdk, Property::Lvm)
+                        .args(&args.disks)
+                };
+                match cmd().run().await {
+                    Err(Error::LvmBinErr { error, command }) if error.starts_with(&edm_e) => {
+                        // cleanup
+                        let name = &args.name;
+                        let Ok(dir) = std::fs::read_dir(format!("/dev/{name}")) else {
+                            return Err(Error::LvmBinErr { error, command });
+                        };
+                        for entry in dir.flatten() {
+                            DmSetup::remove(&entry.path().display().to_string()).await?;
+                        }
+                        cmd().run().await
+                    }
+                    _else => _else,
+                }?;
                 info!(name = args.name, "LVM VolumeGroup created successfully");
                 let lookup = CmnQueryArgs::ours_if(!args.no_spdk)
                     .named(&args.name)

--- a/io-engine/src/lvm/vg_pool.rs
+++ b/io-engine/src/lvm/vg_pool.rs
@@ -1,11 +1,10 @@
-use serde::Deserialize;
-
 use crate::{
     bdev::PtplFileOps,
     core::Protocol,
     lvm::{property::Property, LogicalVolume},
     pool_backend::PoolArgs,
 };
+use serde::Deserialize;
 
 use super::{
     cli::{de, CmnQueryArgs, LvmCmd},
@@ -141,6 +140,7 @@ impl VolumeGroup {
     /// Import a volume group with the name provided or create one with the name
     /// and disks provided currently only import is supported.
     pub(crate) async fn create(args: PoolArgs) -> Result<VolumeGroup, Error> {
+        tracing::info!(?args, "Creating LVM VolumeGroup");
         let vg = match VolumeGroup::lookup(CmnQueryArgs::any().named(&args.name)).await {
             Ok(_) => Self::import_inner(args).await,
             Err(Error::NotFound { .. }) => {
@@ -148,11 +148,13 @@ impl VolumeGroup {
 
                 LvmCmd::vg_create()
                     .arg(&args.name)
-                    .tag(Property::Lvm)
+                    .tag_if(!args.no_spdk, Property::Lvm)
                     .args(args.disks)
                     .run()
                     .await?;
-                let lookup = CmnQueryArgs::ours().named(&args.name).uuid_opt(&args.uuid);
+                let lookup = CmnQueryArgs::ours_if(!args.no_spdk)
+                    .named(&args.name)
+                    .uuid_opt(&args.uuid);
                 VolumeGroup::lookup(lookup).await
             }
             Err(error) => Err(error),
@@ -194,6 +196,7 @@ impl VolumeGroup {
     /// and if true add our tag to the volume group to make it available
     /// as a Pool.
     async fn import_inner(args: PoolArgs) -> Result<VolumeGroup, Error> {
+        tracing::info!(?args, "Importing LVM Volume Group");
         let name = &args.name;
         let mut vg = Self::lookup(CmnQueryArgs::any().named(name)).await?;
 
@@ -206,6 +209,15 @@ impl VolumeGroup {
                 args: args.disks,
                 vg: vg.disks,
             });
+        }
+
+        if args.no_spdk {
+            if !vg.tags.contains(&Property::Lvm) {
+                return Ok(vg);
+            }
+            LvmCmd::vg_change(name).untag(Property::Lvm).run().await?;
+            vg.tags.retain(|t| t != &Property::Lvm);
+            return Ok(vg);
         }
 
         if vg.tags.contains(&Property::Lvm) {
@@ -278,6 +290,7 @@ impl VolumeGroup {
     }
 
     /// Create a logical volume in this volume group.
+    #[allow(clippy::too_many_arguments)]
     pub(super) async fn create_lvol(
         &self,
         name: &str,
@@ -286,6 +299,7 @@ impl VolumeGroup {
         thin: bool,
         entity_id: &Option<String>,
         share: Protocol,
+        spdk: bool,
     ) -> Result<(), Error> {
         let vg_name = self.name();
         let ins_space = format!("Volume group \"{vg_name}\" has insufficient free space");
@@ -296,7 +310,6 @@ impl VolumeGroup {
             return Err(Error::NoSpace { error: ins_space });
         }
 
-        let ins_space = format!("Volume group \"{vg_name}\" has insufficient free space");
         let entity_id = entity_id.clone().unwrap_or_default();
         match LvmCmd::lv_create()
             .arg(format!("-L{size}b"))
@@ -304,7 +317,7 @@ impl VolumeGroup {
             .tag(Property::LvName(name.to_string()))
             .tag(Property::LvShare(share))
             .tag_if(!entity_id.is_empty(), Property::LvEntityId(entity_id))
-            .tag(Property::Lvm)
+            .tag_if(spdk, Property::Lvm)
             .arg(self.name())
             .run()
             .await
@@ -387,6 +400,11 @@ impl VolumeGroup {
         let eq = uuid.map(|uuid| &self.uuid == uuid).unwrap_or(true);
         tracing::trace!("{uuid:?} == {} ? {eq}", self.uuid);
         eq
+    }
+
+    /// Check if the volume group is owned by mayastor.
+    pub(crate) fn ours(&self) -> bool {
+        self.tags.iter().any(|t| t == &Property::Lvm)
     }
 
     /// Get a `PtplFileOps` from `&self`.

--- a/io-engine/src/lvm/vg_pool.rs
+++ b/io-engine/src/lvm/vg_pool.rs
@@ -139,7 +139,7 @@ impl VolumeGroup {
 
     /// Import a volume group with the name provided or create one with the name
     /// and disks provided currently only import is supported.
-    pub(crate) async fn create(args: PoolArgs) -> Result<VolumeGroup, Error> {
+    pub async fn create(args: PoolArgs) -> Result<VolumeGroup, Error> {
         tracing::info!(?args, "Creating/Importing LVM Volume Group");
         match VolumeGroup::lookup(CmnQueryArgs::any().named(&args.name)).await {
             Ok(_) => {
@@ -164,6 +164,14 @@ impl VolumeGroup {
             }
             Err(error) => Err(error),
         }
+    }
+
+    /// Creates a [`LogicalVolume`] from this [`VolumeGroup`].
+    pub async fn create_lvol(
+        &self,
+        args: crate::pool_backend::ReplicaArgs,
+    ) -> Result<LogicalVolume, Error> {
+        LogicalVolume::create(self, args, Protocol::Off, self.ours()).await
     }
 
     async fn import_lvols(&self) -> Result<(), Error> {
@@ -293,31 +301,28 @@ impl VolumeGroup {
     }
 
     /// Create a logical volume in this volume group.
-    #[allow(clippy::too_many_arguments)]
-    pub(super) async fn create_lvol(
+    /// This is an internal method that should not be used outside the LVM module.
+    pub(super) async fn create_lvoli(
         &self,
-        name: &str,
-        size: u64,
-        uuid: &str,
-        thin: bool,
-        entity_id: &Option<String>,
+        args: &crate::pool_backend::ReplicaArgs,
         share: Protocol,
         spdk: bool,
     ) -> Result<(), Error> {
         let vg_name = self.name();
+        let uuid = &args.uuid;
         let ins_space = format!("Volume group \"{vg_name}\" has insufficient free space");
         let eexists =
             format!("Logical Volume \"{uuid}\" already exists in volume group \"{vg_name}\"");
 
-        if thin {
+        if args.thin {
             return Err(Error::ThinProv {});
         }
 
-        let entity_id = entity_id.clone().unwrap_or_default();
+        let entity_id = args.entity_id.clone().unwrap_or_default();
         match LvmCmd::lv_create()
-            .arg(format!("-L{size}b"))
+            .arg(format!("-L{}b", args.size))
             .args(["-n", uuid])
-            .tag(Property::LvName(name.to_string()))
+            .tag(Property::LvName(args.name.to_string()))
             .tag(Property::LvShare(share))
             .tag_if(!entity_id.is_empty(), Property::LvEntityId(entity_id))
             .tag_if(spdk, Property::Lvm)
@@ -336,7 +341,7 @@ impl VolumeGroup {
         }?;
 
         info!(
-            name,
+            name = args.name,
             uuid, vg_name, "LVM Logical Volume created successfully"
         );
 
@@ -412,7 +417,7 @@ impl VolumeGroup {
     }
 
     /// Check if the volume group is owned by mayastor.
-    pub(crate) fn ours(&self) -> bool {
+    fn ours(&self) -> bool {
         self.tags.iter().any(|t| t == &Property::Lvm)
     }
 

--- a/io-engine/src/lvm/vg_pool.rs
+++ b/io-engine/src/lvm/vg_pool.rs
@@ -246,13 +246,27 @@ impl VolumeGroup {
 
     /// Delete the volume group.
     /// > Note: The Vg is first exported and then destroyed.
-    pub(crate) async fn destroy(mut self) -> Result<(), Error> {
+    /// > Note: The Vg is kept if it contains foreign LVs.
+    pub async fn destroy(self) -> Result<(), Error> {
+        self.destroy_(false).await
+    }
+
+    /// Delete the volume group.
+    /// > Note: The Vg is first exported and then destroyed.
+    /// > Warning: The Vg is destroyed even if containing foreign LVs.
+    pub async fn purge(self) -> Result<(), Error> {
+        self.destroy_(true).await
+    }
+
+    /// Delete the volume group.
+    /// > Note: The Vg is first exported and then destroyed.
+    pub async fn destroy_(mut self, purge_always: bool) -> Result<(), Error> {
         self.export().await?;
 
         let foreign_lvs = self.list_foreign_lvs().await?;
         let name = self.name().to_string();
 
-        if foreign_lvs.is_empty() {
+        if purge_always || foreign_lvs.is_empty() {
             LvmCmd::vg_remove()
                 .arg(format!("--select=vg_name={name}"))
                 .arg("-y")

--- a/io-engine/src/pool_backend.rs
+++ b/io-engine/src/pool_backend.rs
@@ -19,6 +19,9 @@ pub struct PoolArgs {
     pub backend: PoolBackend,
     pub enc_key: Option<EncryptionKey>,
     pub crypto_vbdev_name: Option<String>,
+    /// Set to false if you don't want the pool and its replicas to be managed by spdk.
+    /// Applicable for non LvsBlobstore pools, such as the LVM.
+    pub no_spdk: bool,
 }
 
 impl PoolArgs {
@@ -47,6 +50,7 @@ pub enum PoolBackend {
 }
 
 /// Arguments for replica creation.
+#[derive(Default)]
 pub struct ReplicaArgs {
     pub name: String,
     pub size: u64,

--- a/io-engine/src/subsys/config/pool.rs
+++ b/io-engine/src/subsys/config/pool.rs
@@ -175,6 +175,7 @@ impl From<&Pool> for PoolArgs {
             } else {
                 None
             },
+            no_spdk: false,
         }
     }
 }

--- a/io-engine/tests/lvs_grow.rs
+++ b/io-engine/tests/lvs_grow.rs
@@ -9,9 +9,8 @@ use spdk_rs::{ffihelper::IntoCString, libspdk::resize_malloc_disk, UntypedBdev};
 use io_engine::{
     core::MayastorCliArgs,
     lvs::Lvs,
-    pool_backend::{IPoolProps, PoolArgs},
+    pool_backend::{IPoolProps, PoolArgs, PoolBackend},
 };
-
 use io_engine_tests::{
     bdev::{create_bdev, find_bdev_by_name},
     compose::{
@@ -150,11 +149,8 @@ async fn lvs_grow_ms_malloc() {
                     name: POOL_NAME.to_string(),
                     disks: vec![BDEV_URI.to_string()],
                     uuid: Some(POOL_UUID.to_string()),
-                    cluster_size: None,
-                    md_args: None,
-                    backend: Default::default(),
-                    enc_key: None,
-                    crypto_vbdev_name: None,
+                    backend: PoolBackend::Lvs,
+                    ..Default::default()
                 };
 
                 // Create LVS.

--- a/io-engine/tests/lvs_import.rs
+++ b/io-engine/tests/lvs_import.rs
@@ -9,6 +9,7 @@ use io_engine::{
 
 use io_engine_tests::MayastorTest;
 
+use io_engine::pool_backend::PoolBackend;
 use once_cell::sync::OnceCell;
 use std::{collections::HashSet, time::Instant};
 
@@ -53,11 +54,8 @@ async fn lvs_import_many_volume() {
             name: POOL_NAME.to_string(),
             disks: vec![BDEV_NAME.to_string()],
             uuid: Some(POOL_UUID.to_string()),
-            cluster_size: None,
-            md_args: None,
-            backend: Default::default(),
-            enc_key: None,
-            crypto_vbdev_name: None,
+            backend: PoolBackend::Lvs,
+            ..Default::default()
         };
 
         // Create LVS.

--- a/io-engine/tests/lvs_limits.rs
+++ b/io-engine/tests/lvs_limits.rs
@@ -48,11 +48,7 @@ async fn lvs_metadata_limit() {
             name: POOL_NAME.to_string(),
             disks: vec![BDEV_NAME.to_string()],
             uuid: Some(POOL_UUID.to_string()),
-            cluster_size: None,
-            md_args: None,
-            backend: Default::default(),
-            enc_key: None,
-            crypto_vbdev_name: None,
+            ..Default::default()
         };
 
         // Create LVS.

--- a/io-engine/tests/lvs_pool.rs
+++ b/io-engine/tests/lvs_pool.rs
@@ -3,7 +3,8 @@ use io_engine::{
     bdev::crypto::{Cipher, EncryptionKey},
     bdev_api::bdev_create,
     core::{
-        logical_volume::LogicalVolume, MayastorCliArgs, PoolCliArgs, Protocol, Share, UntypedBdev,
+        logical_volume::LogicalVolume, MayastorCliArgs, PoolCliArgs, Protocol, Share, ToErrno,
+        UntypedBdev,
     },
     grpc::v1::pool::pool_to_proto,
     lvs::{Lvs, LvsLvol, PropName, PropValue},
@@ -13,6 +14,7 @@ use io_engine::{
 use io_engine_api::v1::pool::{
     Pool, PoolAlert, PoolAlertStatus, PoolAlerts, PoolErrors, PoolState,
 };
+use once_cell::sync::OnceCell;
 use std::pin::Pin;
 
 pub mod common;
@@ -24,6 +26,22 @@ static DISKNAME3: &str = "/tmp/io-engine-tests/disk3.img";
 static DISK_CRYPTO: &str = "/tmp/io-engine-tests/crypto_disk.img";
 static XTS_KEY: &str = "2b7e151628aed2a6abf7158809cf4f3c";
 static XTS_KEY2: &str = "2b7e151628aed2a6abf7158809cf4f3d";
+const IO_ERROR_THRESHOLD: u64 = 5;
+
+static MAYASTOR: OnceCell<MayastorTest> = OnceCell::new();
+
+fn ms() -> &'static MayastorTest<'static> {
+    MAYASTOR.get_or_init(|| {
+        MayastorTest::new(MayastorCliArgs {
+            reactor_mask: "0x3".into(),
+            pool: PoolCliArgs {
+                io_error_threshold: IO_ERROR_THRESHOLD,
+                ..Default::default()
+            },
+            ..Default::default()
+        })
+    })
+}
 
 #[tokio::test]
 async fn lvs_pool_test() {
@@ -49,11 +67,7 @@ async fn lvs_pool_test() {
     //setup disk3 via loop device using a sector size of 4096.
     let ldev = common::setup_loopdev_file(DISKNAME3, Some(4096));
 
-    let args = MayastorCliArgs {
-        reactor_mask: "0x3".into(),
-        ..Default::default()
-    };
-    let ms = MayastorTest::new(args);
+    let ms = ms();
 
     // should fail to import a pool that does not exist on disk
     ms.spawn(async {
@@ -542,17 +556,6 @@ async fn lvs_errors() {
     }
     let mut guard = TestGuard { loop_dev: None };
 
-    let io_error_threshold = 5;
-    let args = MayastorCliArgs {
-        reactor_mask: "0x2".into(),
-        pool: PoolCliArgs {
-            io_error_threshold,
-            ..Default::default()
-        },
-        ..Default::default()
-    };
-    let ms = MayastorTest::new(args);
-
     //setup disk1 via loop device using a sector size of 4096.
     let ldev = common::setup_loopdev_file(DISKNAME1, Some(4096));
     guard.loop_dev = Some(ldev.clone());
@@ -582,20 +585,22 @@ async fn lvs_errors() {
         ..Default::default()
     };
 
+    let ms = ms();
     ms.spawn(async move {
         let lvs_pool = Lvs::create_or_import(pool_args).await.unwrap();
 
         // We bork the device, making it return -EIO for all I/O
         let table = lvol.bork().await.unwrap();
 
-        for i in 1..=io_error_threshold {
+        for i in 1..=IO_ERROR_THRESHOLD {
             let error = lvs_pool
                 .create_lvol("fail", 8 * 1024 * 1024, None, true, None)
                 .await
                 .expect_err("error due to -EIO");
             println!("error: {error}");
+            assert_eq!(error.to_errno(), nix::Error::EIO);
 
-            if i < io_error_threshold {
+            if i < IO_ERROR_THRESHOLD {
                 let (pool, errors, alerts) = pool_info(&lvs_pool).await;
 
                 assert_eq!(pool.state(), PoolState::PoolOnline);
@@ -607,7 +612,7 @@ async fn lvs_errors() {
 
         let (pool, errors, alerts) = pool_info(&lvs_pool).await;
         assert_eq!(pool.state(), PoolState::PoolSuspected);
-        assert_eq!(errors.io_error_count, io_error_threshold);
+        assert_eq!(errors.io_error_count, IO_ERROR_THRESHOLD);
         assert_eq!(alerts.warning, vec![PoolAlert::IoErrorExc as i32]);
         assert_eq!(alerts.status(), PoolAlertStatus::Warning);
 
@@ -646,4 +651,90 @@ async fn pool_info(pool: &dyn PoolOps) -> (Pool, PoolErrors, PoolAlerts) {
     let errors = pool.errors.clone().unwrap();
     let alerts = errors.alerts.clone().unwrap_or_default();
     (pool, errors, alerts)
+}
+
+#[tokio::test]
+async fn lvs_hot_remove() {
+    let _ = std::process::Command::new("mkdir")
+        .args(["-p"])
+        .args([TESTDIR])
+        .output()
+        .expect("failed to execute mkdir");
+
+    common::delete_file(&[DISKNAME1.into()]);
+    common::truncate_file(DISKNAME1, 128 * 1024);
+
+    let script = r#"
+        set -euo pipefail
+        modprobe ublk_drv
+        o=$(ublk add -t loop -f $1)
+        echo $o | head -n 1 | awk '{print $3}' | tr -d ':'
+    "#;
+    let args = vec![DISKNAME1.into()];
+    let result = run_script::run_script!(script, args, run_script::ScriptOptions::new()).unwrap();
+    if result.0 == 1 && result.2.contains("ublk_drv not found") {
+        eprint!(" skipped because UBLK kernel module not found, not");
+        return;
+    }
+    assert_eq!(result.0, 0, "Failed to setup ublk device: {result:#?}");
+
+    let ublk_n: u64 = result.1.trim_end().parse().unwrap();
+    let ublk_dev = format!("/dev/ublkb{ublk_n}");
+
+    struct TestGuard {
+        ublk_n: u64,
+    }
+    impl Drop for TestGuard {
+        fn drop(&mut self) {
+            let script = r#"
+                if ! ublk del -n $1 --async; then
+                    echo "Ublk delete async not supported..."
+                    ublk del -n $1 &
+                    PID=$!
+                    sleep 1
+                    kill $PID || kill -9 $PID
+                fi
+            "#;
+            let args = vec![self.ublk_n.to_string()];
+            let out =
+                run_script::run_script!(script, args, run_script::ScriptOptions::new()).unwrap();
+            if out.0 != 0 {
+                eprintln!("TestGuard=>{out:#?}");
+            }
+            common::delete_file(&[DISKNAME1.into()]);
+        }
+    }
+    let guard = TestGuard { ublk_n };
+
+    let pool_args = PoolArgs {
+        name: "tpool".into(),
+        disks: vec![ublk_dev],
+        backend: PoolBackend::Lvs,
+        ..Default::default()
+    };
+
+    ms().start_grpc();
+
+    ms().spawn(async move {
+        let lvs_pool = Lvs::create_or_import(pool_args).await.unwrap();
+
+        let repl = lvs_pool
+            .create_lvol("ok", 8 * 1024 * 1024, None, true, None)
+            .await
+            .unwrap();
+
+        // We bork the device, leading to hot-removal
+        drop(guard);
+
+        let error = lvs_pool
+            .create_lvol("fail", 8 * 1024 * 1024, None, true, None)
+            .await
+            .expect_err("-EIO");
+        println!("repl: {error:#?}");
+        assert_eq!(error.to_errno(), nix::Error::EIO);
+
+        let error = repl.destroy().await.expect_err("-EIO");
+        assert_eq!(error.to_errno(), nix::Error::EIO);
+    })
+    .await;
 }

--- a/io-engine/tests/lvs_pool.rs
+++ b/io-engine/tests/lvs_pool.rs
@@ -60,12 +60,8 @@ async fn lvs_pool_test() {
     let pool_args = PoolArgs {
         name: "tpool".into(),
         disks: vec![format!("aio://{DISKNAME1}")],
-        uuid: None,
-        cluster_size: None,
-        md_args: None,
         backend: PoolBackend::Lvs,
-        enc_key: None,
-        crypto_vbdev_name: None,
+        ..Default::default()
     };
 
     // should succeed to create a pool we can not import
@@ -147,12 +143,8 @@ async fn lvs_pool_test() {
         assert!(Lvs::create_from_args_inner(PoolArgs {
             name: "tpool".to_string(),
             disks: vec![format!("aio://{DISKNAME1}")],
-            uuid: None,
-            cluster_size: None,
-            md_args: None,
             backend: PoolBackend::Lvs,
-            enc_key: None,
-            crypto_vbdev_name: None,
+            ..Default::default()
         })
         .await
         .is_ok());
@@ -181,12 +173,8 @@ async fn lvs_pool_test() {
         let pool2 = Lvs::create_or_import(PoolArgs {
             name: "tpool2".to_string(),
             disks: vec!["malloc:///malloc0?size_mb=64".to_string()],
-            uuid: None,
-            cluster_size: None,
-            md_args: None,
             backend: PoolBackend::Lvs,
-            enc_key: None,
-            crypto_vbdev_name: None,
+            ..Default::default()
         })
         .await
         .unwrap();
@@ -221,12 +209,8 @@ async fn lvs_pool_test() {
         let pool = Lvs::create_or_import(PoolArgs {
             name: "tpool".to_string(),
             disks: vec![format!("aio://{DISKNAME1}")],
-            uuid: None,
-            cluster_size: None,
-            md_args: None,
             backend: PoolBackend::Lvs,
-            enc_key: None,
-            crypto_vbdev_name: None,
+            ..Default::default()
         })
         .await
         .unwrap();
@@ -362,12 +346,8 @@ async fn lvs_pool_test() {
         let pool = Lvs::create_or_import(PoolArgs {
             name: "tpool".into(),
             disks: vec![format!("aio://{DISKNAME1}")],
-            uuid: None,
-            cluster_size: None,
-            md_args: None,
             backend: PoolBackend::Lvs,
-            enc_key: None,
-            crypto_vbdev_name: None,
+            ..Default::default()
         })
         .await
         .unwrap();
@@ -386,12 +366,8 @@ async fn lvs_pool_test() {
         Lvs::create_or_import(PoolArgs {
             name: "tpool_4k_aio".into(),
             disks: vec![format!("aio://{pool_dev_aio}")],
-            uuid: None,
-            cluster_size: None,
-            md_args: None,
             backend: PoolBackend::Lvs,
-            enc_key: None,
-            crypto_vbdev_name: None,
+            ..Default::default()
         })
         .await
         .unwrap();
@@ -416,12 +392,8 @@ async fn lvs_pool_test() {
         Lvs::create_or_import(PoolArgs {
             name: "tpool_4k_uring".into(),
             disks: vec![format!("uring://{pool_dev_uring}")],
-            uuid: None,
-            cluster_size: None,
-            md_args: None,
             backend: PoolBackend::Lvs,
-            enc_key: None,
-            crypto_vbdev_name: None,
+            ..Default::default()
         })
         .await
         .unwrap();
@@ -456,12 +428,8 @@ async fn lvs_pool_test() {
         Lvs::create_or_import(PoolArgs {
             name: "jpool".into(),
             disks: vec![format!("aio://{DISKNAME1}")],
-            uuid: None,
-            cluster_size: None,
-            md_args: None,
             backend: PoolBackend::Lvs,
-            enc_key: None,
-            crypto_vbdev_name: None,
+            ..Default::default()
         })
         .await
         .err()
@@ -476,12 +444,8 @@ async fn lvs_pool_test() {
         let pool = Lvs::create_or_import(PoolArgs {
             name: "tpool2".into(),
             disks: vec![format!("aio://{DISKNAME2}")],
-            uuid: None,
-            cluster_size: None,
-            md_args: None,
             backend: PoolBackend::Lvs,
-            enc_key: None,
-            crypto_vbdev_name: None,
+            ..Default::default()
         })
         .await
         .unwrap();
@@ -498,10 +462,6 @@ async fn lvs_pool_test() {
         let pool = Lvs::create_or_import(PoolArgs {
             name: "enc_pool".into(),
             disks: vec![format!("aio://{DISK_CRYPTO}")],
-            uuid: None,
-            cluster_size: None,
-            md_args: None,
-            backend: PoolBackend::Lvs,
             enc_key: Some(EncryptionKey {
                 cipher: Cipher::AesXts,
                 key_name: "test_key".into(),
@@ -511,6 +471,8 @@ async fn lvs_pool_test() {
                 key2_len: Some(128),
             }),
             crypto_vbdev_name: Some("crypto_enc_pool".into()),
+            backend: PoolBackend::Lvs,
+            ..Default::default()
         })
         .await
         .unwrap();

--- a/io-engine/tests/lvs_pool.rs
+++ b/io-engine/tests/lvs_pool.rs
@@ -2,10 +2,16 @@ use common::MayastorTest;
 use io_engine::{
     bdev::crypto::{Cipher, EncryptionKey},
     bdev_api::bdev_create,
-    core::{logical_volume::LogicalVolume, MayastorCliArgs, Protocol, Share, UntypedBdev},
+    core::{
+        logical_volume::LogicalVolume, MayastorCliArgs, PoolCliArgs, Protocol, Share, UntypedBdev,
+    },
+    grpc::v1::pool::pool_to_proto,
     lvs::{Lvs, LvsLvol, PropName, PropValue},
-    pool_backend::{PoolArgs, PoolBackend},
+    pool_backend::{PoolArgs, PoolBackend, PoolOps, ReplicaArgs},
     subsys::NvmfSubsystem,
+};
+use io_engine_api::v1::pool::{
+    Pool, PoolAlert, PoolAlertStatus, PoolAlerts, PoolErrors, PoolState,
 };
 use std::pin::Pin;
 
@@ -501,4 +507,143 @@ async fn lvs_pool_test() {
         common::delete_file(&[DISK_CRYPTO.into()]);
     })
     .await;
+}
+
+#[tokio::test]
+async fn lvs_errors() {
+    let _ = std::process::Command::new("mkdir")
+        .args(["-p"])
+        .args([TESTDIR])
+        .output()
+        .expect("failed to execute mkdir");
+
+    common::delete_file(&[DISKNAME1.into()]);
+    common::truncate_file(DISKNAME1, 128 * 1024);
+
+    const VG_NAME: &str = "vg-1";
+    const LV_NAME: &str = "lvol1";
+
+    struct TestGuard {
+        loop_dev: Option<String>,
+    }
+    impl Drop for TestGuard {
+        fn drop(&mut self) {
+            if let Some(loop_dev) = self.loop_dev.take() {
+                let script = r#"
+                    export LVM_SUPPRESS_FD_WARNINGS=1
+                    vgremove -f $2
+                    pvremove -f $3
+                "#;
+                let args = vec![DISKNAME1.into(), VG_NAME.into(), loop_dev.clone()];
+                run_script::run_script!(script, args, run_script::ScriptOptions::new()).ok();
+                common::detach_loopdev(&loop_dev);
+            }
+        }
+    }
+    let mut guard = TestGuard { loop_dev: None };
+
+    let io_error_threshold = 5;
+    let args = MayastorCliArgs {
+        reactor_mask: "0x2".into(),
+        pool: PoolCliArgs {
+            io_error_threshold,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let ms = MayastorTest::new(args);
+
+    //setup disk1 via loop device using a sector size of 4096.
+    let ldev = common::setup_loopdev_file(DISKNAME1, Some(4096));
+    guard.loop_dev = Some(ldev.clone());
+
+    let vg_pool = io_engine::lvm::VolumeGroup::create(PoolArgs {
+        name: VG_NAME.into(),
+        disks: vec![ldev.clone()],
+        no_spdk: true,
+        ..Default::default()
+    })
+    .await
+    .unwrap();
+
+    let mut lvol = vg_pool
+        .create_lvol(ReplicaArgs {
+            name: LV_NAME.into(),
+            uuid: LV_NAME.into(),
+            size: 64 * 1024 * 1024,
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+    let pool_args = PoolArgs {
+        name: "tpool".into(),
+        disks: vec![format!("aio://{}", lvol.path())],
+        backend: PoolBackend::Lvs,
+        ..Default::default()
+    };
+
+    ms.spawn(async move {
+        let lvs_pool = Lvs::create_or_import(pool_args).await.unwrap();
+
+        // We bork the device, making it return -EIO for all I/O
+        let table = lvol.bork().await.unwrap();
+
+        for i in 1..=io_error_threshold {
+            let error = lvs_pool
+                .create_lvol("fail", 8 * 1024 * 1024, None, true, None)
+                .await
+                .expect_err("error due to -EIO");
+            println!("error: {error}");
+
+            if i < io_error_threshold {
+                let (pool, errors, alerts) = pool_info(&lvs_pool).await;
+
+                assert_eq!(pool.state(), PoolState::PoolOnline);
+                assert_eq!(errors.io_error_count, i);
+                assert_eq!(alerts.attention, vec![PoolAlert::IoError as i32]);
+                assert_eq!(alerts.status(), PoolAlertStatus::Attention);
+            }
+        }
+
+        let (pool, errors, alerts) = pool_info(&lvs_pool).await;
+        assert_eq!(pool.state(), PoolState::PoolSuspected);
+        assert_eq!(errors.io_error_count, io_error_threshold);
+        assert_eq!(alerts.warning, vec![PoolAlert::IoErrorExc as i32]);
+        assert_eq!(alerts.status(), PoolAlertStatus::Warning);
+
+        lvol.unbork(table).await.unwrap();
+
+        let repl = lvs_pool
+            .create_lvol("ok", 8 * 1024 * 1024, None, true, None)
+            .await
+            .expect("now we can create it");
+
+        println!("repl: {}", repl.uuid());
+
+        lvs_pool.reset_errors().await.unwrap();
+
+        let (pool, errors, alerts) = pool_info(&lvs_pool).await;
+        assert_eq!(pool.state(), PoolState::PoolOnline);
+        assert_eq!(errors.io_error_count, 0);
+        assert_eq!(
+            alerts.notice.len()
+                + alerts.attention.len()
+                + alerts.warning.len()
+                + alerts.critical.len(),
+            0
+        );
+        assert_eq!(alerts.status(), PoolAlertStatus::Healthy);
+
+        lvs_pool.destroy().await.unwrap();
+    })
+    .await;
+
+    vg_pool.purge().await.unwrap();
+}
+
+async fn pool_info(pool: &dyn PoolOps) -> (Pool, PoolErrors, PoolAlerts) {
+    let pool = pool_to_proto(pool).await;
+    let errors = pool.errors.clone().unwrap();
+    let alerts = errors.alerts.clone().unwrap_or_default();
+    (pool, errors, alerts)
 }

--- a/io-engine/tests/replica_snapshot.rs
+++ b/io-engine/tests/replica_snapshot.rs
@@ -93,12 +93,8 @@ async fn replica_snapshot() {
             Lvs::create_or_import(PoolArgs {
                 name: POOL1_NAME.to_string(),
                 disks: vec![format!("aio://{DISKNAME1}")],
-                uuid: None,
-                cluster_size: None,
-                md_args: None,
                 backend: PoolBackend::Lvs,
-                enc_key: None,
-                crypto_vbdev_name: None,
+                ..Default::default()
             })
             .await
             .unwrap();

--- a/io-engine/tests/snapshot_lvol.rs
+++ b/io-engine/tests/snapshot_lvol.rs
@@ -55,12 +55,9 @@ async fn create_test_pool(pool_name: &str, disk: String, cluster_size: Option<u3
     Lvs::create_or_import(PoolArgs {
         name: pool_name.to_string(),
         disks: vec![disk],
-        uuid: None,
         cluster_size,
-        md_args: None,
         backend: PoolBackend::Lvs,
-        enc_key: None,
-        crypto_vbdev_name: None,
+        ..Default::default()
     })
     .await
     .expect("Failed to create test pool");

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -13,5 +13,6 @@ self: super: rec {
   ms-buildenv = super.callPackage ./pkgs/ms-buildenv { };
   nvmet-cli = super.callPackage ./pkgs/nvmet-cli { };
   units = (super.callPackage ./pkgs/io-engine/units.nix { inherit tag sourcer rustFlags; });
+  ublksrv = super.callPackage ./pkgs/ublksrv { };
 }
   // (import ../spdk-rs/nix/overlay.nix self super)

--- a/nix/pkgs/ublksrv/default.nix
+++ b/nix/pkgs/ublksrv/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, lib, fetchFromGitHub, pkgs }:
+
+stdenv.mkDerivation rec {
+  version = "v1.6";
+  pname = "ublksrv";
+
+  src = fetchFromGitHub {
+    owner = "ublk-org";
+    repo = "ublksrv";
+    rev = version;
+    sha256 = "sha256-bK+cf/qdlbyQ2gSObk8cqDkIWjaneNIpnlZDyywezf8=";
+    leaveDotGit = true;
+  };
+
+  nativeBuildInputs = with pkgs; [ pkg-config autoreconfHook git ];
+  buildInputs = with pkgs; [ liburing ];
+
+  meta = {
+    description = "The userspace part of the ublk framework";
+    longDescription = ''
+      This is the userspace daemon part(ublksrv) of the ublk framework, the other part is ublk driver which supports multiple queue.
+    '';
+    homepage = "https://github.com/ublk-org/ublksrv";
+  };
+}
+

--- a/scripts/clean-cargo-tests.sh
+++ b/scripts/clean-cargo-tests.sh
@@ -5,6 +5,16 @@ ROOT_DIR=$(realpath "$SCRIPT_DIR/..")
 
 nix-sudo nvme disconnect-all
 
+# Clean up ublk devices
+back_dir="/tmp/io-engine-tests/"
+nix-sudo ublk list -v | jq -r --arg dir "$back_dir" '
+  select(.target.backing_file? // "" | startswith($dir))
+  | .dev_info.dev_id
+' | while read -r id; do
+    echo "Deleting ublk device $id"
+    nix-sudo ublk del -n "$id" --async
+done
+
 # Detach any loop devices created for test purposes
 for back_file in "/tmp/io-engine-tests"/*; do
     # Find loop devices associated with the disk image

--- a/shell.nix
+++ b/shell.nix
@@ -41,6 +41,7 @@ let
         nvme-cli
         xfsprogs
         nixpkgs-fmt
+        ublksrv
       ];
 
       shellEnv = with pkgs; {


### PR DESCRIPTION
     test: add lvs hot-removal
    
    The bdev aio and uring modules now hot-remove the bdev when they
    detect the backing device is hot-removed.
    This happens when they complete an io with -ENODEV, -EIO or positive error.
    
    Add a test which leverages ublk to achieve this by removing the ublk device.
    
---

    feat(ublk): add ublksrv nix package

---

    test: add disk errors test
    
    Makes uses of an LVM lvol allowing us to set it up to yield errors
    without detaching the device.
    
    We "import" the gRPC pool types, allowing us to test we're returning
    the correct states, alerts and errors.

---

    fix(lvm): cleanup stable dm entries when creating a vg
    
---

    test: don't panic twice on environment drop
    
    Also improve some testing asserts to output more information.
    
---

    build: pulls latest spdk-rs to include hotremoval fixes
    
---

    feat(lvm): add device-mapper utilities
    
    Adds methods for suspending, resuming, retrieving the table and
    updating the table.
    This can be useful for testing for example.
    
---

    feat(lvm): support commands with inputs
    
---

    fix(lvm): close fd above stderr
    
    On invocation, lvm requires that only the standard file descriptors stdin,
    stdout and stderr are available. If others are found, they get closed
    and messages are issued warning about the leak.
    
    Previously we were silencing the errors only, now we close the range from
    3 to 1024.
    todo: pick higher range?

---

    refactor: implement default for cli args
    
    Makes it less awkward to use.
    Also we should consider modifying the MayastorEnvironment.
    
---

    refactor: expose lvm vg create lvol
    
    This will allow us to use concrete types for testing.
    
    As a bonus we also avoid looking up the VG twice.
    Though something seems slightly off, there's some indirection
    back and forth from vg to lv.
    
---

    fix(lvm): handle lvol already exists error
    
    If already exists, then validates the parameters.
    
---

    feat: allow running the lvm code outside of spdk context
    
    Adds a no_spdk variable to the PoolArgs, which is only usable
    for the LVM backend currently, though could extend to ZFS ex.
    
    As a simplistic impl for now we won't attach the mayastor tag
    in this case. Probably not ideal, but for now should be ok.
    
    Also the lvm commands were being trampolined to the spdk reactor.
    This is easily removed by simply checking if we're in and spdk
    thread, and if not then no need to trampoline anyway so this
    was an easy win.
