### PR TITLE
Improve the io-engine cli and logging ux

### DIFF
--- a/io-engine-tests/src/lib.rs
+++ b/io-engine-tests/src/lib.rs
@@ -159,6 +159,7 @@ pub fn mayastor_test_init_ex(log_format: LogFormat, log_level: Option<&str>) {
         log_format,
         None,
         None,
+        Default::default(),
     );
 
     io_engine::CPS_INIT!();

--- a/io-engine/src/bin/io-engine.rs
+++ b/io-engine/src/bin/io-engine.rs
@@ -262,6 +262,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             log_format,
             args.events_url.clone(),
             args.events_replicas,
+            args.log_span_events,
         );
     } else {
         logger::init_ex(
@@ -269,6 +270,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             log_format,
             args.events_url.clone(),
             args.events_replicas,
+            args.log_span_events,
         );
     }
 

--- a/io-engine/src/core/env.rs
+++ b/io-engine/src/core/env.rs
@@ -303,10 +303,18 @@ pub struct MayastorCliArgs {
 #[derive(Debug, clap::Parser, Clone)]
 pub struct SpdkTracingArgs {
     /// Number of trace entries per lcore.
-    #[clap(long, env = "SPDK_TRACING_ENTRIES", default_value_t = 0)]
+    #[clap(
+        long = "spdk-tracing-entries",
+        env = "SPDK_TRACING_ENTRIES",
+        default_value_t = 0
+    )]
     pub entries: u64,
     /// Number of user created threads.
-    #[clap(long, env = "SPDK_TRACING_THREADS", default_value_t = 1)]
+    #[clap(
+        long = "spdk-tracing-threads",
+        env = "SPDK_TRACING_THREADS",
+        default_value_t = 1
+    )]
     pub threads: u32,
 }
 impl Default for SpdkTracingArgs {
@@ -320,7 +328,11 @@ impl Default for SpdkTracingArgs {
 pub struct PoolCliArgs {
     /// I/O error count threshold. {n}
     /// After this many errors a pool alert is raised as Warning.
-    #[clap(long, env, default_value_t = 8)]
+    #[clap(
+        long = "pool-io-error-threshold",
+        env = "POOL_IO_ERROR_THRESHOLD",
+        default_value_t = 8
+    )]
     pub io_error_threshold: u64,
 
     /// I/O stall deadline. {n}
@@ -328,18 +340,30 @@ pub struct PoolCliArgs {
     /// Critical alert is raised. {n}
     /// The pool disk will also be reset and the stall will be cleared once complete and
     /// I/O flows again.
-    #[clap(long, env, default_value = "30s")]
+    #[clap(
+        long = "pool-io-stall-deadline",
+        env = "POOL_IO_STALL_DEADLINE",
+        default_value = "30s"
+    )]
     pub io_stall_deadline: humantime::Duration,
 
     /// I/O stall transitions threshold. {n}
     /// After this many transitions within the window, a pool alert is raised as Warning.
-    #[clap(long, env, default_value_t = 3)]
+    #[clap(
+        long = "pool-io-stall-transition-threshold",
+        env = "POOL_IO_STALL_TRANSITION_THRESHOLD",
+        default_value_t = 3
+    )]
     pub io_stall_transition_threshold: u64,
 
     /// I/O stall transitions window. {n}
     /// Time window during which stall ↔ resume state transitions are tracked
     /// for flakiness detection.
-    #[clap(long, env, default_value = "3h")]
+    #[clap(
+        long = "pool-io-stall-transition-window",
+        env = "POOL_IO_STALL_TRANSITION_WINDOW",
+        default_value = "3h"
+    )]
     pub io_stall_transition_window: humantime::Duration,
 }
 impl Default for PoolCliArgs {

--- a/io-engine/src/core/env.rs
+++ b/io-engine/src/core/env.rs
@@ -46,6 +46,7 @@ use crate::{
     grpc,
     grpc::MayastorGrpcServer,
     logger,
+    logger::FmtSpan,
     persistent_store::PersistentStoreBuilder,
     subsys::{
         self, config::opts::TARGET_CRDT_LEN, registration::registration_grpc::ApiVersion, Config,
@@ -145,12 +146,16 @@ pub struct MayastorCliArgs {
     #[clap(short = 'R')]
     /// Registration grpc endpoint
     pub registration_endpoint: Option<Uri>,
-    #[clap(short = 'L')]
-    /// Enable logging for sub components.
+    #[clap(long, short = 'L')]
+    /// Enable logging for SPDK sub-components.
     pub log_components: Vec<String>,
-    #[clap(short = 'F')]
-    /// Log format.
+    #[clap(long, short = 'F', default_value = "default")]
+    /// The logging format. {n}
+    /// Possible values: [ default compact, json, color, nocolor, date, nodate, host, nohost ]. {n}
+    /// You can combine multiple values with commas, e.g. "-F=compact,nocolor,date".
     pub log_format: Option<logger::LogFormat>,
+    #[clap(long, default_value = "none")]
+    pub log_span_events: FmtSpan,
     #[clap(short = 'm', default_value = "0x1")]
     /// The reactor mask to be used for starting up the instance
     pub reactor_mask: String,
@@ -158,7 +163,8 @@ pub struct MayastorCliArgs {
     /// Name of the node where mayastor is running (ID used by control plane)
     pub node_name: Option<String>,
     /// The maximum amount of hugepage memory we are allowed to allocate in
-    /// MiB. A value of 0 means no limit.
+    /// MiB. {n}
+    /// A value of 0 means no limit.
     #[clap(short = 's', value_parser = parse_mb, default_value = "0")]
     pub mem_size: i32,
     #[clap(short = 'u')]
@@ -183,8 +189,8 @@ pub struct MayastorCliArgs {
     /// Pass additional arguments to the EAL environment.
     pub env_context: Option<String>,
     #[clap(short = 'l')]
-    /// List of cores to run on instead of using the core mask. When specified
-    /// it supersedes the core mask (-m) argument.
+    /// List of cores to run on instead of using the core mask. {n}
+    /// When specified it supersedes the core mask (-m) argument.
     pub core_list: Option<String>,
     #[clap(short = 'p')]
     /// Endpoint of the persistent store.
@@ -203,16 +209,15 @@ pub struct MayastorCliArgs {
     /// Number of entries in memory pool for bdev I/O contexts
     pub bdev_io_ctx_pool_size: u64,
     #[clap(long = "nvme-ctl-pool-size", default_value = "65535")]
-    /// Number of entries in memory pool for NVMe controller I/O contexts
+    /// Number of entries in memory pool for NVMe controller I/O contexts.
     pub nvme_ctl_io_ctx_pool_size: u64,
     #[clap(short = 'T', long = "tgt-iface", env = "NVMF_TGT_IFACE")]
     /// NVMF target interface (ip, mac, name or subnet).
     pub nvmf_tgt_interface: Option<String>,
-    /// NVMF target Command Retry Delay in x100 ms (single integer or three
-    /// comma-separated integers). First value is used for errors on nexus
-    /// target except reservation conflict and no space; second
-    /// value is used for reservation conflict and no space on nexus target;
-    /// third value is used for all errors on replica target.
+    /// NVMF target Command Retry Delay in x100 ms (single integer or three comma-separated integers): {n}
+    /// - first value is used for errors on nexus target except reservation conflict and no space {n}
+    /// - second value is used for reservation conflict and no space on nexus target {n}
+    /// - third value is used for all errors on replica target
     #[clap(
         long = "tgt-crdt",
         env = "NVMF_TGT_CRDT",
@@ -228,8 +233,7 @@ pub struct MayastorCliArgs {
         env = "API_VERSIONS"
     )]
     pub api_versions: Vec<ApiVersion>,
-    /// Dump stack trace for all threads inside I/O agent process with target
-    /// PID.
+    /// Dump stack trace for all threads inside I/O agent process with target PID.
     #[clap(short = 'd', long = "diagnose-stack", env = "DIAGNOSE_STACK")]
     pub diagnose_stack: Option<u32>,
     /// Enable reactor freeze detection.
@@ -238,14 +242,14 @@ pub struct MayastorCliArgs {
     /// Timeout (in seconds) for reactor freeze detection.
     #[clap(long = "reactor-freeze-timeout", env = "REACTOR_FREEZE_TIMEOUT")]
     pub reactor_freeze_timeout: Option<u64>,
-    /// Skip install of the signal handler which will trigger process graceful
-    /// termination.
+    /// Skip install of the signal handler which will trigger process graceful termination.
     #[clap(long, hide = true)]
     pub skip_sig_handler: bool,
-    /// Whether the nexus channel should have readers/writers configured.
+    /// Whether the nexus channel should have readers/writers configured. {n}
     /// This must be set true ONLY from tests. This option can be removed once
     /// dynamic reconfiguration of nexus channels can handle async-qpair
-    /// connect. Details in NexusChannel::new
+    /// connect. {n}
+    /// Details in [`NexusChannel::new`].
     #[clap(long = "enable-io-all-thrd-nexus-channels", hide = true)]
     pub enable_io_all_thrd_nexus_channels: bool,
     /// Events message-bus endpoint url.
@@ -261,8 +265,8 @@ pub struct MayastorCliArgs {
         hide = true
     )]
     pub enable_nexus_channel_debug: bool,
-    /// Enables experimental LVM backend support.
-    /// LVM pools can then be created by specifying the LVM pool type.
+    /// Enables experimental LVM backend support. {n}
+    /// LVM pools can then be created by specifying the LVM pool type. {n}
     /// If LVM is enabled and LVM_SUPPRESS_FD_WARNINGS is not set then it will
     /// be set to 1.
     #[clap(long = "enable-lvm", env = "ENABLE_LVM", value_parser = delay_compat)]
@@ -280,8 +284,8 @@ pub struct MayastorCliArgs {
     /// Enables globally blob store cluster release on unmap.
     #[clap(long, env = "ENABLE_BS_CLUSTER_UNMAP", hide = true)]
     pub bs_cluster_unmap: bool,
-    /// Enable core dump by setting ulimit -c.
-    /// You may specify a limit value or otherwise [`io_engine::core_dump::DEFAULT_CORE_LIMIT`] is used.
+    /// Enable core dump by setting ulimit -c. {n}
+    /// You may specify a limit value or otherwise DEFAULT_CORE_LIMIT=5GiB is used. {n}
     /// Enabled by default on debug builds.
     #[clap(long, env = "ENABLE_COREDUMP", num_args(0..=1))]
     pub enable_coredump: Option<Option<u64>>,
@@ -314,25 +318,25 @@ impl Default for SpdkTracingArgs {
 /// DiskPool related arguments.
 #[derive(Debug, clap::Parser, Clone)]
 pub struct PoolCliArgs {
-    /// I/O error count threshold.
+    /// I/O error count threshold. {n}
     /// After this many errors a pool alert is raised as Warning.
     #[clap(long, env, default_value_t = 8)]
     pub io_error_threshold: u64,
 
-    /// I/O stall deadline.
+    /// I/O stall deadline. {n}
     /// If an I/O is stuck longer than this period, then the pool is considered stalled and a
-    /// Critical alert is raised.
+    /// Critical alert is raised. {n}
     /// The pool disk will also be reset and the stall will be cleared once complete and
     /// I/O flows again.
     #[clap(long, env, default_value = "30s")]
     pub io_stall_deadline: humantime::Duration,
 
-    /// I/O stall transitions threshold.
+    /// I/O stall transitions threshold. {n}
     /// After this many transitions within the window, a pool alert is raised as Warning.
     #[clap(long, env, default_value_t = 3)]
     pub io_stall_transition_threshold: u64,
 
-    /// I/O stall transitions window.
+    /// I/O stall transitions window. {n}
     /// Time window during which stall ↔ resume state transitions are tracked
     /// for flakiness detection.
     #[clap(long, env, default_value = "3h")]

--- a/io-engine/src/core/mod.rs
+++ b/io-engine/src/core/mod.rs
@@ -99,24 +99,15 @@ where
 #[snafu(visibility(pub(crate)), context(suffix(false)))]
 pub enum CoreError {
     #[snafu(display("bdev {name} not found"))]
-    BdevNotFound {
-        name: String,
-    },
+    BdevNotFound { name: String },
     #[snafu(display("failed to open bdev: {source}"))]
-    OpenBdev {
-        source: Errno,
-    },
+    OpenBdev { source: Errno },
     #[snafu(display("bdev {name} not found"))]
-    InvalidDescriptor {
-        name: String,
-    },
+    InvalidDescriptor { name: String },
     #[snafu(display("failed to get IO channel for {name}"))]
-    GetIoChannel {
-        name: String,
-    },
-    InvalidOffset {
-        offset: u64,
-    },
+    GetIoChannel { name: String },
+    #[snafu(display("invalid offset {offset}"))]
+    InvalidOffset { offset: u64 },
     #[snafu(display("Failed to dispatch write at offset {offset} length {len}: {source}"))]
     WriteDispatch {
         source: Errno,
@@ -136,18 +127,11 @@ pub enum CoreError {
         len: u64,
     },
     #[snafu(display("Failed to dispatch reset: {source}"))]
-    ResetDispatch {
-        source: Errno,
-    },
+    ResetDispatch { source: Errno },
     #[snafu(display("Failed to dispatch flush: {source}"))]
-    FlushDispatch {
-        source: Errno,
-    },
+    FlushDispatch { source: Errno },
     #[snafu(display("Failed to dispatch NVMe Admin command {opcode:x}h: {source}"))]
-    NvmeAdminDispatch {
-        source: Errno,
-        opcode: u16,
-    },
+    NvmeAdminDispatch { source: Errno, opcode: u16 },
     #[snafu(display("Failed to dispatch unmap at offset {offset} length {len}"))]
     UnmapDispatch {
         source: Errno,
@@ -161,10 +145,7 @@ pub enum CoreError {
         len: u64,
     },
     #[snafu(display("Failed to dispatch NVMe IO passthru command {opcode:x}h: {source}"))]
-    NvmeIoPassthruDispatch {
-        source: Errno,
-        opcode: u16,
-    },
+    NvmeIoPassthruDispatch { source: Errno, opcode: u16 },
     #[snafu(display("Write failed at offset {offset} length {len} with status {status:?}",))]
     WriteFailed {
         status: IoCompletionStatus,
@@ -184,78 +165,41 @@ pub enum CoreError {
         len: u64,
     },
     #[snafu(display("attempt to read unallocated block failed at offset {offset} length {len}",))]
-    ReadingUnallocatedBlock {
-        offset: u64,
-        len: u64,
-    },
+    ReadingUnallocatedBlock { offset: u64, len: u64 },
     #[snafu(display("reset failed"))]
     ResetFailed {},
     #[snafu(display("write zeroes failed at offset {offset} length {len}"))]
-    WriteZeroesFailed {
-        offset: u64,
-        len: u64,
-    },
+    WriteZeroesFailed { offset: u64, len: u64 },
     #[snafu(display("NVMe Admin command {opcode:x}h failed: {source}"))]
-    NvmeAdminFailed {
-        source: Errno,
-        opcode: u16,
-    },
+    NvmeAdminFailed { source: Errno, opcode: u16 },
     #[snafu(display("NVMe IO Passthru command {opcode:x}h failed"))]
-    NvmeIoPassthruFailed {
-        opcode: u16,
-    },
+    NvmeIoPassthruFailed { opcode: u16 },
     #[snafu(display("failed to share: {source}"))]
-    ShareNvmf {
-        source: NvmfError,
-    },
+    ShareNvmf { source: NvmfError },
     #[snafu(display("failed to unshare: {source}"))]
-    UnshareNvmf {
-        source: NvmfError,
-    },
+    UnshareNvmf { source: NvmfError },
     #[snafu(display("the operation is invalid for this bdev: {source}"))]
-    NotSupported {
-        source: Errno,
-    },
+    NotSupported { source: Errno },
     #[snafu(display("failed to configure reactor: {source}"))]
-    ReactorConfigureFailed {
-        source: Errno,
-    },
-    #[snafu(display("Failed to allocate DMA buffer of {} bytes", size))]
-    DmaAllocationFailed {
-        size: u64,
-    },
+    ReactorConfigureFailed { source: Errno },
+    #[snafu(display("Failed to allocate DMA buffer of {size} bytes"))]
+    DmaAllocationFailed { size: u64 },
     #[snafu(display("failed to get I/O satistics for device: {source}"))]
-    DeviceStatisticsFailed {
-        source: Errno,
-    },
+    DeviceStatisticsFailed { source: Errno },
     #[snafu(display("no devices available for I/O"))]
     NoDevicesAvailable {},
     #[snafu(display("invalid NVMe device hanele: {msg}"))]
-    InvalidNvmeDeviceHandle {
-        msg: String,
-    },
+    InvalidNvmeDeviceHandle { msg: String },
     #[snafu(display("failed to flush {name}: {source}"))]
-    DeviceFlush {
-        source: Errno,
-        name: String,
-    },
+    DeviceFlush { source: Errno, name: String },
     #[snafu(display("NVMe persistence through power-loss failure: {reason}"))]
-    Ptpl {
-        reason: String,
-    },
+    Ptpl { reason: String },
     #[snafu(display("failed to create device snapshot: {reason}"))]
-    SnapshotCreate {
-        reason: String,
-        source: Errno,
-    },
+    SnapshotCreate { reason: String, source: Errno },
     #[snafu(display("failed to wipe the device: {source}"))]
-    WipeFailed {
-        source: wiper::Error,
-    },
+    WipeFailed { source: wiper::Error },
     #[snafu(display("failed to init crypto module: {reason}"))]
-    InitCryptoModule {
-        reason: String,
-    },
+    InitCryptoModule { reason: String },
 }
 
 /// Represent error as Errno value.
@@ -288,8 +232,8 @@ impl ToErrno for CoreError {
             | Self::ResetFailed { .. }
             | Self::WriteZeroesFailed { .. }
             | Self::NvmeIoPassthruFailed { .. }
-            | Self::ShareNvmf { .. }
             | Self::UnshareNvmf { .. } => Errno::EIO,
+            Self::ShareNvmf { source } => source.to_errno(),
             Self::NvmeAdminFailed { source, .. } => *source,
             Self::NotSupported { source, .. } => *source,
             Self::ReactorConfigureFailed { source, .. } => *source,

--- a/io-engine/src/core/mod.rs
+++ b/io-engine/src/core/mod.rs
@@ -260,27 +260,27 @@ pub enum CoreError {
 
 /// Represent error as Errno value.
 pub trait ToErrno {
-    fn to_errno(self) -> Errno;
+    fn to_errno(&self) -> Errno;
 }
 
 /// Map CoreError to errno code.
 impl ToErrno for CoreError {
-    fn to_errno(self) -> Errno {
+    fn to_errno(&self) -> Errno {
         match self {
             Self::BdevNotFound { .. } => Errno::ENODEV,
-            Self::OpenBdev { source } => source,
+            Self::OpenBdev { source } => *source,
             Self::InvalidDescriptor { .. } => Errno::ENODEV,
             Self::GetIoChannel { .. } => Errno::ENXIO,
             Self::InvalidOffset { .. } => Errno::EINVAL,
-            Self::WriteDispatch { source, .. } => source,
-            Self::ReadDispatch { source, .. } => source,
-            Self::CompareDispatch { source, .. } => source,
-            Self::ResetDispatch { source, .. } => source,
-            Self::FlushDispatch { source, .. } => source,
-            Self::NvmeAdminDispatch { source, .. } => source,
-            Self::UnmapDispatch { source, .. } => source,
-            Self::WriteZeroesDispatch { source, .. } => source,
-            Self::NvmeIoPassthruDispatch { source, .. } => source,
+            Self::WriteDispatch { source, .. } => *source,
+            Self::ReadDispatch { source, .. } => *source,
+            Self::CompareDispatch { source, .. } => *source,
+            Self::ResetDispatch { source, .. } => *source,
+            Self::FlushDispatch { source, .. } => *source,
+            Self::NvmeAdminDispatch { source, .. } => *source,
+            Self::UnmapDispatch { source, .. } => *source,
+            Self::WriteZeroesDispatch { source, .. } => *source,
+            Self::NvmeIoPassthruDispatch { source, .. } => *source,
             Self::WriteFailed { .. }
             | Self::ReadFailed { .. }
             | Self::CompareFailed { .. }
@@ -290,16 +290,16 @@ impl ToErrno for CoreError {
             | Self::NvmeIoPassthruFailed { .. }
             | Self::ShareNvmf { .. }
             | Self::UnshareNvmf { .. } => Errno::EIO,
-            Self::NvmeAdminFailed { source, .. } => source,
-            Self::NotSupported { source, .. } => source,
-            Self::ReactorConfigureFailed { source, .. } => source,
+            Self::NvmeAdminFailed { source, .. } => *source,
+            Self::NotSupported { source, .. } => *source,
+            Self::ReactorConfigureFailed { source, .. } => *source,
             Self::DmaAllocationFailed { .. } => Errno::ENOMEM,
-            Self::DeviceStatisticsFailed { source, .. } => source,
+            Self::DeviceStatisticsFailed { source, .. } => *source,
             Self::NoDevicesAvailable { .. } => Errno::ENODEV,
             Self::InvalidNvmeDeviceHandle { .. } => Errno::EINVAL,
-            Self::DeviceFlush { source, .. } => source,
+            Self::DeviceFlush { source, .. } => *source,
             Self::Ptpl { .. } => Errno::EIO,
-            Self::SnapshotCreate { source, .. } => source,
+            Self::SnapshotCreate { source, .. } => *source,
             Self::WipeFailed { .. } => Errno::EIO,
             Self::InitCryptoModule { .. } => Errno::EINVAL,
         }

--- a/io-engine/src/core/mod.rs
+++ b/io-engine/src/core/mod.rs
@@ -98,132 +98,109 @@ where
 #[derive(Debug, Snafu, Clone)]
 #[snafu(visibility(pub(crate)), context(suffix(false)))]
 pub enum CoreError {
-    #[snafu(display("bdev {} not found", name))]
+    #[snafu(display("bdev {name} not found"))]
     BdevNotFound {
         name: String,
     },
-    #[snafu(display("failed to open bdev"))]
+    #[snafu(display("failed to open bdev: {source}"))]
     OpenBdev {
         source: Errno,
     },
-    #[snafu(display("bdev {} not found", name))]
+    #[snafu(display("bdev {name} not found"))]
     InvalidDescriptor {
         name: String,
     },
-    #[snafu(display("failed to get IO channel for {}", name))]
+    #[snafu(display("failed to get IO channel for {name}"))]
     GetIoChannel {
         name: String,
     },
     InvalidOffset {
         offset: u64,
     },
-    #[snafu(display("Failed to dispatch write at offset {} length {}", offset, len))]
+    #[snafu(display("Failed to dispatch write at offset {offset} length {len}: {source}"))]
     WriteDispatch {
         source: Errno,
         offset: u64,
         len: u64,
     },
-    #[snafu(display("Failed to dispatch compare at offset {} length {}", offset, len))]
+    #[snafu(display("Failed to dispatch compare at offset {offset} length {len}: {source}"))]
     CompareDispatch {
         source: Errno,
         offset: u64,
         len: u64,
     },
-    #[snafu(display("Failed to dispatch read at offset {} length {}", offset, len))]
+    #[snafu(display("Failed to dispatch read at offset {offset} length {len}: {source}"))]
     ReadDispatch {
         source: Errno,
         offset: u64,
         len: u64,
     },
-    #[snafu(display("Failed to dispatch reset: {}", source))]
+    #[snafu(display("Failed to dispatch reset: {source}"))]
     ResetDispatch {
         source: Errno,
     },
-    #[snafu(display("Failed to dispatch flush: {}", source))]
+    #[snafu(display("Failed to dispatch flush: {source}"))]
     FlushDispatch {
         source: Errno,
     },
-    #[snafu(display("Failed to dispatch NVMe Admin command {:x}h: {}", opcode, source))]
+    #[snafu(display("Failed to dispatch NVMe Admin command {opcode:x}h: {source}"))]
     NvmeAdminDispatch {
         source: Errno,
         opcode: u16,
     },
-    #[snafu(display("Failed to dispatch unmap at offset {} length {}", offset, len))]
+    #[snafu(display("Failed to dispatch unmap at offset {offset} length {len}"))]
     UnmapDispatch {
         source: Errno,
         offset: u64,
         len: u64,
     },
-    #[snafu(display("Failed to dispatch write-zeroes at offset {} length {}", offset, len))]
+    #[snafu(display("Failed to dispatch write-zeroes at offset {offset} length {len}"))]
     WriteZeroesDispatch {
         source: Errno,
         offset: u64,
         len: u64,
     },
-    #[snafu(display(
-        "Failed to dispatch NVMe IO passthru command {:x}h: {}",
-        opcode,
-        source
-    ))]
+    #[snafu(display("Failed to dispatch NVMe IO passthru command {opcode:x}h: {source}"))]
     NvmeIoPassthruDispatch {
         source: Errno,
         opcode: u16,
     },
-    #[snafu(display(
-        "Write failed at offset {} length {} with status {:?}",
-        offset,
-        len,
-        status
-    ))]
+    #[snafu(display("Write failed at offset {offset} length {len} with status {status:?}",))]
     WriteFailed {
         status: IoCompletionStatus,
         offset: u64,
         len: u64,
     },
-    #[snafu(display(
-        "Read failed at offset {} length {} with status {:?}",
-        offset,
-        len,
-        status
-    ))]
+    #[snafu(display("Read failed at offset {offset} length {len} with status {status:?}",))]
     ReadFailed {
         status: IoCompletionStatus,
         offset: u64,
         len: u64,
     },
-    #[snafu(display(
-        "Compare failed at offset {} length {} with status {:?}",
-        offset,
-        len,
-        status
-    ))]
+    #[snafu(display("Compare failed at offset {offset} length {len} with status {status:?}",))]
     CompareFailed {
         status: IoCompletionStatus,
         offset: u64,
         len: u64,
     },
-    #[snafu(display(
-        "Attempt to read unallocated block failed at offset {} length {}",
-        offset,
-        len
-    ))]
+    #[snafu(display("attempt to read unallocated block failed at offset {offset} length {len}",))]
     ReadingUnallocatedBlock {
         offset: u64,
         len: u64,
     },
-    #[snafu(display("Reset failed"))]
+    #[snafu(display("reset failed"))]
     ResetFailed {},
-    #[snafu(display("Write zeroes failed at offset {} length {}", offset, len))]
+    #[snafu(display("write zeroes failed at offset {offset} length {len}"))]
     WriteZeroesFailed {
         offset: u64,
         len: u64,
     },
-    #[snafu(display("NVMe Admin command {:x}h failed: {}", opcode, source))]
+    #[snafu(display("NVMe Admin command {opcode:x}h failed: {source}"))]
     NvmeAdminFailed {
         source: Errno,
         opcode: u16,
     },
-    #[snafu(display("NVMe IO Passthru command {:x}h failed", opcode))]
+    #[snafu(display("NVMe IO Passthru command {opcode:x}h failed"))]
     NvmeIoPassthruFailed {
         opcode: u16,
     },
@@ -231,15 +208,15 @@ pub enum CoreError {
     ShareNvmf {
         source: NvmfError,
     },
-    #[snafu(display("failed to unshare"))]
+    #[snafu(display("failed to unshare: {source}"))]
     UnshareNvmf {
         source: NvmfError,
     },
-    #[snafu(display("the operation is invalid for this bdev: {}", source))]
+    #[snafu(display("the operation is invalid for this bdev: {source}"))]
     NotSupported {
         source: Errno,
     },
-    #[snafu(display("failed to configure reactor: {}", source))]
+    #[snafu(display("failed to configure reactor: {source}"))]
     ReactorConfigureFailed {
         source: Errno,
     },
@@ -247,36 +224,35 @@ pub enum CoreError {
     DmaAllocationFailed {
         size: u64,
     },
-    #[snafu(display("Failed to get I/O satistics for device: {}", source))]
+    #[snafu(display("failed to get I/O satistics for device: {source}"))]
     DeviceStatisticsFailed {
         source: Errno,
     },
-    #[snafu(display("No devices available for I/O"))]
+    #[snafu(display("no devices available for I/O"))]
     NoDevicesAvailable {},
-    #[snafu(display("Invalid NVMe device hanele: {}", msg))]
+    #[snafu(display("invalid NVMe device hanele: {msg}"))]
     InvalidNvmeDeviceHandle {
         msg: String,
     },
-
-    #[snafu(display("errno: {} Device Flush {}", source, name))]
+    #[snafu(display("failed to flush {name}: {source}"))]
     DeviceFlush {
         source: Errno,
         name: String,
     },
-    #[snafu(display("NVMe persistence through power-loss failure: {}", reason))]
+    #[snafu(display("NVMe persistence through power-loss failure: {reason}"))]
     Ptpl {
         reason: String,
     },
-    #[snafu(display("Failed to create device snapshot: {}", reason))]
+    #[snafu(display("failed to create device snapshot: {reason}"))]
     SnapshotCreate {
         reason: String,
         source: Errno,
     },
-    #[snafu(display("Failed to wipe the device"))]
+    #[snafu(display("failed to wipe the device: {source}"))]
     WipeFailed {
         source: wiper::Error,
     },
-    #[snafu(display("Failed to init crypto module: {reason}"))]
+    #[snafu(display("failed to init crypto module: {reason}"))]
     InitCryptoModule {
         reason: String,
     },

--- a/io-engine/src/grpc/v0/mayastor_grpc.rs
+++ b/io-engine/src/grpc/v0/mayastor_grpc.rs
@@ -269,6 +269,9 @@ impl From<LvsError> for tonic::Status {
                 Errno::ENOSPC => Status::out_of_range(e.to_string()),
                 _ => Status::internal(e.to_string()),
             },
+            LvsError::LvolShare { .. } if errno == Errno::EMLINK => {
+                Status::out_of_range(e.to_string())
+            }
             _ => Status::internal(e.to_string()),
         };
         status

--- a/io-engine/src/grpc/v0/mayastor_grpc.rs
+++ b/io-engine/src/grpc/v0/mayastor_grpc.rs
@@ -19,7 +19,7 @@ use crate::{
         lock::{ProtectedSubsystems, ResourceLockManager},
         logical_volume::{LogicalVolume, LvolSpaceUsage},
         BlockDeviceIoStats, CoreError, MayastorFeatures, NvmfShareProps, Protocol, Share,
-        SnapshotParams, ToErrno, UntypedBdev,
+        SnapshotParams, ToErrno, UntypedBdev, UpdateProps,
     },
     grpc::{
         controller_grpc::{controller_stats, list_controllers, NvmeControllerInfo},
@@ -34,6 +34,7 @@ use crate::{
     subsys::PoolConfig,
 };
 
+use ::function_name::named;
 use chrono::Utc;
 use futures::FutureExt;
 use io_engine_api::v0::*;
@@ -42,13 +43,11 @@ use std::{
     convert::{TryFrom, TryInto},
     fmt::Debug,
     ops::Deref,
+    panic::AssertUnwindSafe,
+    pin::Pin,
     time::Duration,
 };
 use tonic::{Request, Response, Status};
-
-use crate::core::{UpdateProps, VerboseError};
-use ::function_name::named;
-use std::{panic::AssertUnwindSafe, pin::Pin};
 use uuid::Uuid;
 use version_info::raw_version_string;
 
@@ -196,6 +195,23 @@ impl TryFrom<CreatePoolRequest> for PoolArgs {
 impl From<LvsError> for tonic::Status {
     fn from(e: LvsError) -> Self {
         match e {
+            ref e @ LvsError::Import {
+                source: crate::lvs::BsError::InvalidArgument {},
+                ref reason,
+                ..
+            } => {
+                let mut status = Status::invalid_argument(e.to_string());
+                let error = match reason {
+                    crate::lvs::ImportErrorReason::None => Errno::EINVAL,
+                    crate::lvs::ImportErrorReason::NameMismatch { .. } => Errno::EMEDIUMTYPE,
+                    crate::lvs::ImportErrorReason::NameClash { .. } => Errno::ENOTUNIQ,
+                    crate::lvs::ImportErrorReason::UuidMismatch { .. } => Errno::EMEDIUMTYPE,
+                };
+                status
+                    .metadata_mut()
+                    .insert("errno", tonic::metadata::MetadataValue::from(error as i32));
+                status
+            }
             LvsError::Import { source, .. } => match source.to_errno() {
                 Errno::EINVAL => Status::invalid_argument(e.to_string()),
                 Errno::EEXIST => Status::already_exists(e.to_string()),
@@ -236,7 +252,6 @@ impl From<LvsError> for tonic::Status {
                 Errno::EEXIST => Status::already_exists(e.to_string()),
                 _ => Status::invalid_argument(e.to_string()),
             },
-            LvsError::PoolNotFound { .. } => Status::not_found(e.to_string()),
             LvsError::PoolCreate { source, .. } => {
                 if source.to_errno() == Errno::EEXIST {
                     Status::already_exists(e.to_string())
@@ -248,7 +263,7 @@ impl From<LvsError> for tonic::Status {
             }
             LvsError::InvalidBdev { source, .. } => source.into(),
             LvsError::SetProperty { .. } => Status::data_loss(e.to_string()),
-            LvsError::WipeFailed { source } => source.into(),
+            LvsError::WipeFailed { .. } => Status::data_loss(e.to_string()),
             LvsError::ResourceLockFailed { .. } => Status::aborted(e.to_string()),
             LvsError::MaxExpansionParse { .. } => Status::invalid_argument(e.to_string()),
             LvsError::BdevRescanFailed { .. } => {
@@ -271,7 +286,7 @@ impl From<LvsError> for tonic::Status {
                 Errno::ENOSPC => Status::out_of_range(e.to_string()),
                 _ => Status::internal(e.to_string()),
             },
-            _ => Status::internal(e.verbose()),
+            _ => Status::internal(e.to_string()),
         }
     }
 }

--- a/io-engine/src/grpc/v0/mayastor_grpc.rs
+++ b/io-engine/src/grpc/v0/mayastor_grpc.rs
@@ -194,10 +194,13 @@ impl TryFrom<CreatePoolRequest> for PoolArgs {
 
 impl From<LvsError> for tonic::Status {
     fn from(e: LvsError) -> Self {
-        match e {
+        let errno = e.to_errno();
+        let mut status = match e {
             LvsError::Import { source, .. } => match source.to_errno() {
                 Errno::EINVAL => Status::invalid_argument(e.to_string()),
                 Errno::EEXIST => Status::already_exists(e.to_string()),
+                Errno::EILSEQ => Status::data_loss(e.to_string()),
+                Errno::EIO => Status::data_loss(e.to_string()),
                 _ => Status::invalid_argument(e.to_string()),
             },
             LvsError::RepCreate { source, .. } => {
@@ -267,7 +270,11 @@ impl From<LvsError> for tonic::Status {
                 _ => Status::internal(e.to_string()),
             },
             _ => Status::internal(e.to_string()),
-        }
+        };
+        status
+            .metadata_mut()
+            .insert("errno", tonic::metadata::MetadataValue::from(errno as i32));
+        status
     }
 }
 

--- a/io-engine/src/grpc/v0/mayastor_grpc.rs
+++ b/io-engine/src/grpc/v0/mayastor_grpc.rs
@@ -195,23 +195,6 @@ impl TryFrom<CreatePoolRequest> for PoolArgs {
 impl From<LvsError> for tonic::Status {
     fn from(e: LvsError) -> Self {
         match e {
-            ref e @ LvsError::Import {
-                source: crate::lvs::BsError::InvalidArgument {},
-                ref reason,
-                ..
-            } => {
-                let mut status = Status::invalid_argument(e.to_string());
-                let error = match reason {
-                    crate::lvs::ImportErrorReason::None => Errno::EINVAL,
-                    crate::lvs::ImportErrorReason::NameMismatch { .. } => Errno::EMEDIUMTYPE,
-                    crate::lvs::ImportErrorReason::NameClash { .. } => Errno::ENOTUNIQ,
-                    crate::lvs::ImportErrorReason::UuidMismatch { .. } => Errno::EMEDIUMTYPE,
-                };
-                status
-                    .metadata_mut()
-                    .insert("errno", tonic::metadata::MetadataValue::from(error as i32));
-                status
-            }
             LvsError::Import { source, .. } => match source.to_errno() {
                 Errno::EINVAL => Status::invalid_argument(e.to_string()),
                 Errno::EEXIST => Status::already_exists(e.to_string()),
@@ -252,15 +235,12 @@ impl From<LvsError> for tonic::Status {
                 Errno::EEXIST => Status::already_exists(e.to_string()),
                 _ => Status::invalid_argument(e.to_string()),
             },
-            LvsError::PoolCreate { source, .. } => {
-                if source.to_errno() == Errno::EEXIST {
-                    Status::already_exists(e.to_string())
-                } else if source.to_errno() == Errno::EINVAL {
-                    Status::invalid_argument(e.to_string())
-                } else {
-                    Status::internal(e.to_string())
-                }
-            }
+            LvsError::PoolCreate { source, .. } => match source.to_errno() {
+                Errno::EEXIST => Status::already_exists(e.to_string()),
+                Errno::EINVAL => Status::invalid_argument(e.to_string()),
+                Errno::EIO => Status::data_loss(e.to_string()),
+                _ => Status::internal(e.to_string()),
+            },
             LvsError::InvalidBdev { source, .. } => source.into(),
             LvsError::SetProperty { .. } => Status::data_loss(e.to_string()),
             LvsError::WipeFailed { .. } => Status::data_loss(e.to_string()),

--- a/io-engine/src/grpc/v1/pool.rs
+++ b/io-engine/src/grpc/v1/pool.rs
@@ -223,7 +223,7 @@ impl TryFrom<EncryptionData> for PoolEncKey {
         } else {
             return Err(LvsError::Invalid {
                 source: BsError::InvalidArgument {},
-                msg: "invalid argument, missing key".to_string(),
+                msg: "missing key".to_string(),
             });
         };
 
@@ -252,7 +252,7 @@ impl TryFrom<CreatePoolRequest> for PoolArgs {
         if args.disks.is_empty() {
             return Err(LvsError::Invalid {
                 source: BsError::InvalidArgument {},
-                msg: "invalid argument, missing devices".to_string(),
+                msg: "missing devices".to_string(),
             });
         }
 
@@ -332,7 +332,7 @@ impl TryFrom<ImportPoolRequest> for PoolArgs {
         if args.disks.is_empty() {
             return Err(LvsError::Invalid {
                 source: BsError::InvalidArgument {},
-                msg: "invalid argument, missing devices".to_string(),
+                msg: "missing devices".to_string(),
             });
         }
 

--- a/io-engine/src/logger.rs
+++ b/io-engine/src/logger.rs
@@ -1,4 +1,9 @@
+use crate::{
+    constants::{EVENTING_TARGET, SERVICE_NAME},
+    core::spawn,
+};
 use ansi_term::{Colour, Style};
+use event_publisher::event_handler::EventHandle;
 use once_cell::sync::OnceCell;
 use std::{
     collections::HashMap,
@@ -10,19 +15,13 @@ use std::{
     path::Path,
     str::FromStr,
 };
-
-use crate::{
-    constants::{EVENTING_TARGET, SERVICE_NAME},
-    core::spawn,
-};
-use event_publisher::event_handler::EventHandle;
 use tracing::field::{Field, Visit};
 use tracing_core::{event::Event, Level, Metadata};
 use tracing_log::{LogTracer, NormalizeEvent};
 use tracing_subscriber::{
     filter::{filter_fn, Targets},
     fmt::{
-        format::{FmtSpan, FormatEvent, FormatFields, Writer},
+        format::{FormatEvent, FormatFields, Writer},
         FmtContext, FormattedFields,
     },
     layer::{Layer, SubscriberExt},
@@ -348,7 +347,8 @@ fn ellipsis(s: &str, w: usize) -> String {
 /// Input struct for json serializer.
 #[derive(Serialize)]
 struct JsonLogger {
-    hostname: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    hostname: Option<String>,
     level: String,
     timestamp: String,
     fields: HashMap<String, String>,
@@ -481,7 +481,7 @@ impl LogFormat {
         msg.insert(key, val.to_string());
 
         let json_log = JsonLogger {
-            hostname: self.hostname().to_string(),
+            hostname: self.hostname_json(),
             level: fmt.long(),
             timestamp: now.to_rfc2822(),
             fields: msg,
@@ -491,13 +491,71 @@ impl LogFormat {
         writeln!(writer)
     }
 
-    fn hostname(&self) -> &str {
+    fn hostname_json(&self) -> Option<String> {
         if self.show_host {
-            HOSTNAME_PREFIX
-                .get_or_init(|| format!("{} :: ", get_hostname()))
-                .as_str()
+            Some(Self::global_hostname().to_string())
         } else {
-            ""
+            None
+        }
+    }
+    fn global_hostname<'a>() -> &'a str {
+        HOSTNAME_PREFIX.get_or_init(get_hostname).as_str()
+    }
+    fn hostname(&self) -> LogHostname<'_> {
+        if self.show_host {
+            LogHostname(Some(Self::global_hostname()))
+        } else {
+            LogHostname(None)
+        }
+    }
+}
+
+struct LogHostname<'a>(Option<&'a str>);
+impl std::fmt::Display for LogHostname<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self.0 {
+            Some(hostname) => write!(f, "{hostname} :: "),
+            None => write!(f, ""),
+        }
+    }
+}
+
+/// Configures how synthesized events are emitted at points in the [span lifecycle][lifecycle].
+///
+/// [lifecycle]: https://docs.rs/tracing/latest/tracing/span/index.html#the-span-lifecycle
+// todo: support combinations.
+#[derive(clap::ValueEnum, Debug, Default, Clone, Copy)]
+pub enum FmtSpan {
+    /// One event when span is created.
+    New,
+    /// One event per enter of a span.
+    Enter,
+    /// One event per exit of a span.
+    Exit,
+    /// One event when the span is dropped.
+    Close,
+    /// Spans are ignored (this is the default).
+    #[default]
+    None,
+    /// One event per enter/exit of a span.
+    Active,
+    /// Events at all points (new, enter, exit, drop).
+    Full,
+    /// Events at all points (new, enter, exit, drop).
+    All,
+}
+
+impl From<FmtSpan> for tracing_subscriber::fmt::format::FmtSpan {
+    fn from(value: FmtSpan) -> Self {
+        match value {
+            FmtSpan::New => Self::NEW,
+            FmtSpan::Enter => Self::ENTER,
+            FmtSpan::Exit => Self::EXIT,
+            FmtSpan::Close => Self::CLOSE,
+            FmtSpan::None => Self::NONE,
+            FmtSpan::Active => Self::ACTIVE,
+            FmtSpan::Full => Self::FULL,
+            FmtSpan::All => Self::FULL,
         }
     }
 }
@@ -513,6 +571,7 @@ pub fn init_ex(
     format: LogFormat,
     events_url: Option<url::Url>,
     events_replicas: Option<usize>,
+    span: FmtSpan,
 ) {
     // Set up a "logger" that simply translates any "log" messages it receives
     // to trace events. This is for our custom spdk log messages, but also
@@ -522,7 +581,7 @@ pub fn init_ex(
 
     // Create a default subscriber.
     let builder = tracing_subscriber::fmt::layer()
-        .with_span_events(FmtSpan::FULL)
+        .with_span_events(span.into())
         .event_format(format)
         .with_filter(filter_fn(|metadata| {
             // Exclude spans or events that have the target
@@ -553,5 +612,5 @@ pub fn init_ex(
 }
 
 pub fn init(level: &str) {
-    init_ex(level, Default::default(), None, None)
+    init_ex(level, Default::default(), None, None, Default::default())
 }

--- a/io-engine/src/lvm/error.rs
+++ b/io-engine/src/lvm/error.rs
@@ -72,7 +72,7 @@ impl Error {
 }
 
 impl ToErrno for Error {
-    fn to_errno(self) -> Errno {
+    fn to_errno(&self) -> Errno {
         match self {
             Error::ReportMissing { .. } => Errno::EIO,
             Error::JsonParsing { .. } => Errno::EIO,

--- a/io-engine/src/lvs/lvs_error.rs
+++ b/io-engine/src/lvs/lvs_error.rs
@@ -200,6 +200,16 @@ pub enum LvsError {
 impl ToErrno for LvsError {
     fn to_errno(&self) -> Errno {
         match self {
+            Self::Import {
+                source: crate::lvs::BsError::InvalidArgument {},
+                reason,
+                ..
+            } => match reason {
+                crate::lvs::ImportErrorReason::None => Errno::EINVAL,
+                crate::lvs::ImportErrorReason::NameMismatch { .. } => Errno::EMEDIUMTYPE,
+                crate::lvs::ImportErrorReason::NameClash { .. } => Errno::ENOTUNIQ,
+                crate::lvs::ImportErrorReason::UuidMismatch { .. } => Errno::EMEDIUMTYPE,
+            },
             Self::Import { source, .. } => source.to_errno(),
             Self::PoolCreate { source, .. } => source.to_errno(),
             Self::Export { source, .. } => source.to_errno(),

--- a/io-engine/src/lvs/lvs_error.rs
+++ b/io-engine/src/lvs/lvs_error.rs
@@ -29,7 +29,7 @@ pub enum ImportErrorReason {
 pub enum BsError {
     #[snafu(display("{source}"))]
     Generic { source: Errno },
-    #[snafu(display(""))]
+    #[snafu(display("{}", Errno::EINVAL))]
     InvalidArgument {},
     #[snafu(display(": volume not found"))]
     LvolNotFound {},
@@ -37,7 +37,7 @@ pub enum BsError {
     VolAlreadyExists {},
     #[snafu(display(": volume is busy"))]
     VolBusy {},
-    #[snafu(display(": cannot import LVS"))]
+    #[snafu(display("{}: cannot import LVS", Errno::EILSEQ))]
     CannotImportLvs {},
     #[snafu(display(": LVS not found or was not loaded"))]
     LvsNotFound {},
@@ -49,7 +49,7 @@ pub enum BsError {
     OutOfMetadata {},
     #[snafu(display(": capacity overflow"))]
     CapacityOverflow {},
-    #[snafu(display(": crypto vbdev error. {source:?}"))]
+    #[snafu(display("{source}: crypto vbdev error"))]
     LvsCryptoVbdev { source: Errno },
 }
 
@@ -119,166 +119,81 @@ pub enum LvsError {
         reason: ImportErrorReason,
     },
     #[snafu(display("{source}, failed to create pool {name}"))]
-    PoolCreate {
-        source: BsError,
-        name: String,
-    },
+    PoolCreate { source: BsError, name: String },
     #[snafu(display("{source}, failed to export pool {name}"))]
-    Export {
-        source: BsError,
-        name: String,
-    },
+    Export { source: BsError, name: String },
     #[snafu(display("{source}, failed to destroy pool {name}"))]
-    Destroy {
-        source: BdevError,
-        name: String,
-    },
+    Destroy { source: BdevError, name: String },
     #[snafu(display("{source}, failed to grow pool {name}"))]
-    Grow {
-        source: BsError,
-        name: String,
-    },
-    #[snafu(display("{}", msg))]
-    PoolNotFound {
-        source: BsError,
-        msg: String,
-    },
-    InvalidBdev {
-        source: BdevError,
-        name: String,
-    },
-    #[snafu(display("errno {}: {}", source, msg))]
-    Invalid {
-        source: BsError,
-        msg: String,
-    },
-    #[snafu(display("errno {}: Invalid cluster-size {}, for pool {}", source, msg, name))]
-    InvalidClusterSize {
-        source: BsError,
-        name: String,
-        msg: String,
-    },
+    Grow { source: BsError, name: String },
+    #[snafu(display("{source}: {name}"))]
+    InvalidBdev { source: BdevError, name: String },
+    #[snafu(display("{source}: {msg}"))]
+    Invalid { source: BsError, msg: String },
+    #[snafu(display("invalid cluster-size {msg}, for pool {name}"))]
+    InvalidClusterSize { name: String, msg: String },
     #[snafu(display("pool {name}: invalid metadata parameter: {msg}"))]
-    InvalidMetadataParam {
-        name: String,
-        msg: String,
-    },
-    #[snafu(display("lvol exists {}", name))]
-    RepExists {
-        source: BsError,
-        name: String,
-    },
-    #[snafu(display("errno: {} failed to create lvol {}", source, name))]
-    RepCreate {
-        source: BsError,
-        name: String,
-    },
-    #[snafu(display("failed to destroy lvol {} {}", name, if msg.is_empty() { "" } else { msg.as_str() }))]
+    InvalidMetadataParam { name: String, msg: String },
+    #[snafu(display("{source}, lvol exists {name}"))]
+    RepExists { source: BsError, name: String },
+    #[snafu(display("{source}, failed to create lvol {name}"))]
+    RepCreate { source: BsError, name: String },
+    #[snafu(display("{source}, failed to destroy lvol {name}: {msg}"))]
     RepDestroy {
         source: BsError,
         name: String,
         msg: String,
     },
-    #[snafu(display("failed to resize lvol {}", name))]
-    RepResize {
-        source: BsError,
-        name: String,
-    },
-    #[snafu(display("bdev {} is not a lvol", name))]
-    NotALvol {
-        source: BsError,
-        name: String,
-    },
-    #[snafu(display("failed to share lvol {}", name))]
-    LvolShare {
-        source: CoreError,
-        name: String,
-    },
-    #[snafu(display("failed to update share properties lvol {}", name))]
-    UpdateShareProperties {
-        source: CoreError,
-        name: String,
-    },
-    #[snafu(display("failed to unshare lvol {}", name))]
-    LvolUnShare {
-        source: CoreError,
-        name: String,
-    },
-    #[snafu(display("failed to get property {} ({}) from {}", prop, source, name))]
+    #[snafu(display("failed to resize lvol {name}"))]
+    RepResize { source: BsError, name: String },
+    #[snafu(display("bdev {name} is not a lvol"))]
+    NotALvol { name: String },
+    #[snafu(display("{source}, failed to share lvol {name}"))]
+    LvolShare { source: CoreError, name: String },
+    #[snafu(display("{source}, failed to update share properties lvol {name}"))]
+    UpdateShareProperties { source: CoreError, name: String },
+    #[snafu(display("{source}, failed to unshare lvol {name}"))]
+    LvolUnShare { source: CoreError, name: String },
+    #[snafu(display("{source}, failed to get property {prop} from {name}"))]
     GetProperty {
         source: BsError,
         prop: PropName,
         name: String,
     },
-    #[snafu(display("failed to set property {} on {}", prop, name))]
+    #[snafu(display("{source}, failed to set property {prop} on {name}"))]
     SetProperty {
         source: BsError,
         prop: String,
         name: String,
     },
-    #[snafu(display("failed to sync properties {}", name))]
-    SyncProperty {
-        source: BsError,
-        name: String,
-    },
-    #[snafu(display("invalid property value: {}", name))]
-    Property {
-        source: BsError,
-        name: String,
-    },
-    #[snafu(display("invalid replica share protocol value: {}", value))]
-    ReplicaShareProtocol {
-        value: i32,
-    },
-    #[snafu(display("Snapshot {} creation failed", msg))]
-    SnapshotCreate {
-        source: BsError,
-        msg: String,
-    },
-    #[snafu(display("SnapshotClone {} creation failed", msg))]
-    SnapshotCloneCreate {
-        source: BsError,
-        msg: String,
-    },
-    #[snafu(display("Flush Failed for replica {}", name))]
-    FlushFailed {
-        name: String,
-    },
-    #[snafu(display("Snapshot parameters for replica {} is not correct: {}", name, msg))]
-    SnapshotConfigFailed {
-        name: String,
-        msg: String,
-    },
-    #[snafu(display("Clone parameters for replica {} are not correct: {}", name, msg))]
-    CloneConfigFailed {
-        name: String,
-        msg: String,
-    },
-    #[snafu(display("Failed to wipe the replica"))]
-    WipeFailed {
-        source: crate::core::wiper::Error,
-    },
-    #[snafu(display("Failed to acquire resource lock, {}", msg))]
-    ResourceLockFailed {
-        msg: String,
-    },
+    #[snafu(display("{source}, failed to sync properties {name}"))]
+    SyncProperty { source: BsError, name: String },
+    #[snafu(display("invalid property value: {name}"))]
+    Property { name: String },
+    #[snafu(display("invalid replica share protocol value: {value}"))]
+    ReplicaShareProtocol { value: i32 },
+    #[snafu(display("{source}, snapshot {msg} creation failed"))]
+    SnapshotCreate { source: BsError, msg: String },
+    #[snafu(display("{source}, snapshotClone {msg} creation failed"))]
+    SnapshotCloneCreate { source: BsError, msg: String },
+    #[snafu(display("flush Failed for replica {name}"))]
+    FlushFailed { name: String },
+    #[snafu(display("snapshot parameters for replica {name} is not correct: {msg}"))]
+    SnapshotConfigFailed { name: String, msg: String },
+    #[snafu(display("clone parameters for replica {name} are not correct: {msg}"))]
+    CloneConfigFailed { name: String, msg: String },
+    #[snafu(display("{source}, failed to wipe the replica {name}"))]
+    WipeFailed { source: CoreError, name: String },
+    #[snafu(display("failed to acquire resource lock, {msg}"))]
+    ResourceLockFailed { msg: String },
     #[snafu(display("{msg}"))]
-    MaxExpansionParse {
-        msg: String,
-    },
-    #[snafu(display("{source}, Failed to rescan bdev {name}"))]
-    BdevRescanFailed {
-        source: BsError,
-        name: String,
-    },
-    #[snafu(display("Pool Bdev not extended: {name}"))]
-    BdevNotExtended {
-        name: String,
-    },
-    #[snafu(display("Failed to resize crypto bdev: {name}"))]
-    CryptoBdevNotResized {
-        name: String,
-    },
+    MaxExpansionParse { msg: String },
+    #[snafu(display("{source}, failed to rescan bdev {name}"))]
+    BdevRescanFailed { source: BsError, name: String },
+    #[snafu(display("pool Bdev not extended: {name}"))]
+    BdevNotExtended { name: String },
+    #[snafu(display("failed to resize crypto bdev: {name}"))]
+    CryptoBdevNotResized { name: String },
 }
 
 /// Map CoreError to errno code.
@@ -290,16 +205,15 @@ impl ToErrno for LvsError {
             Self::Export { source, .. } => source.to_errno(),
             Self::Destroy { .. } => Errno::ENXIO,
             Self::Grow { source, .. } => source.to_errno(),
-            Self::PoolNotFound { source, .. } => source.to_errno(),
             Self::InvalidBdev { .. } => Errno::ENXIO,
             Self::Invalid { source, .. } => source.to_errno(),
-            Self::InvalidClusterSize { source, .. } => source.to_errno(),
+            Self::InvalidClusterSize { .. } => Errno::EINVAL,
             Self::InvalidMetadataParam { .. } => Errno::EINVAL,
             Self::RepExists { source, .. } => source.to_errno(),
             Self::RepCreate { source, .. } => source.to_errno(),
             Self::RepDestroy { source, .. } => source.to_errno(),
             Self::RepResize { source, .. } => source.to_errno(),
-            Self::NotALvol { source, .. } => source.to_errno(),
+            Self::NotALvol { .. } => Errno::EINVAL,
             Self::LvolShare { source, .. } => source.to_errno(),
             Self::UpdateShareProperties { source, .. } => source.to_errno(),
             Self::LvolUnShare { source, .. } => source.to_errno(),
@@ -308,7 +222,7 @@ impl ToErrno for LvsError {
             Self::SyncProperty { source, .. } => source.to_errno(),
             Self::SnapshotCreate { source, .. } => source.to_errno(),
             Self::FlushFailed { .. } => Errno::EIO,
-            Self::Property { source, .. } => source.to_errno(),
+            Self::Property { .. } => Errno::EINVAL,
             Self::SnapshotConfigFailed { .. } | Self::ReplicaShareProtocol { .. } => Errno::EINVAL,
             Self::SnapshotCloneCreate { source, .. } => source.to_errno(),
             Self::CloneConfigFailed { .. } => Errno::EINVAL,
@@ -319,11 +233,5 @@ impl ToErrno for LvsError {
             Self::BdevNotExtended { .. } => Errno::EOPNOTSUPP,
             Self::CryptoBdevNotResized { .. } => Errno::EBUSY,
         }
-    }
-}
-
-impl From<crate::core::wiper::Error> for LvsError {
-    fn from(source: crate::core::wiper::Error) -> Self {
-        Self::WipeFailed { source }
     }
 }

--- a/io-engine/src/lvs/lvs_error.rs
+++ b/io-engine/src/lvs/lvs_error.rs
@@ -27,7 +27,7 @@ pub enum ImportErrorReason {
 /// codes in high-level LVS code.
 #[derive(Debug, Snafu, Copy, Clone)]
 pub enum BsError {
-    #[snafu(display(""))]
+    #[snafu(display("{source}"))]
     Generic { source: Errno },
     #[snafu(display(""))]
     InvalidArgument {},

--- a/io-engine/src/lvs/lvs_error.rs
+++ b/io-engine/src/lvs/lvs_error.rs
@@ -90,9 +90,9 @@ impl BsError {
 }
 
 impl ToErrno for BsError {
-    fn to_errno(self) -> Errno {
+    fn to_errno(&self) -> Errno {
         match self {
-            Self::Generic { source } => source,
+            Self::Generic { source } => *source,
             Self::InvalidArgument {} => Errno::EINVAL,
             Self::LvolNotFound {} => Errno::ENOENT,
             Self::VolAlreadyExists {} => Errno::EEXIST,
@@ -103,7 +103,7 @@ impl ToErrno for BsError {
             Self::NoSpace {} => Errno::ENOSPC,
             Self::OutOfMetadata {} => Errno::EMFILE,
             Self::CapacityOverflow {} => Errno::EOVERFLOW,
-            Self::LvsCryptoVbdev { source } => source,
+            Self::LvsCryptoVbdev { source } => *source,
         }
     }
 }
@@ -198,7 +198,7 @@ pub enum LvsError {
 
 /// Map CoreError to errno code.
 impl ToErrno for LvsError {
-    fn to_errno(self) -> Errno {
+    fn to_errno(&self) -> Errno {
         match self {
             Self::Import { source, .. } => source.to_errno(),
             Self::PoolCreate { source, .. } => source.to_errno(),
@@ -226,7 +226,7 @@ impl ToErrno for LvsError {
             Self::SnapshotConfigFailed { .. } | Self::ReplicaShareProtocol { .. } => Errno::EINVAL,
             Self::SnapshotCloneCreate { source, .. } => source.to_errno(),
             Self::CloneConfigFailed { .. } => Errno::EINVAL,
-            Self::WipeFailed { .. } => Errno::EINVAL,
+            Self::WipeFailed { source, .. } => source.to_errno(),
             Self::ResourceLockFailed { .. } => Errno::EBUSY,
             Self::MaxExpansionParse { .. } => Errno::EINVAL,
             Self::BdevRescanFailed { source, .. } => source.to_errno(),

--- a/io-engine/src/lvs/lvs_lvol.rs
+++ b/io-engine/src/lvs/lvs_lvol.rs
@@ -2,7 +2,6 @@ use async_trait::async_trait;
 use byte_unit::Byte;
 use events_api::event::EventAction;
 use futures::channel::oneshot;
-use nix::errno::Errno;
 use pin_utils::core_reexport::fmt::Formatter;
 
 use std::{
@@ -121,7 +120,6 @@ impl TryFrom<UntypedBdev> for Lvol {
             }
         } else {
             Err(LvsError::NotALvol {
-                source: BsError::InvalidArgument {},
                 name: b.name().to_string(),
             })
         }
@@ -288,24 +286,22 @@ impl Lvol {
         if self.as_inner_ref().clear_method != LVS_CLEAR_WITH_UNMAP {
             let hdl = Bdev::open(&self.as_bdev(), true)
                 .and_then(|desc| desc.into_handle())
-                .map_err(|e| {
-                    error!(?self, ?e, "failed to wipe lvol");
-                    LvsError::RepDestroy {
-                        source: BsError::from_errno(Errno::ENXIO),
+                .map_err(|error| {
+                    error!(?self, %error, "failed to open lvol for wipe");
+                    LvsError::WipeFailed {
+                        source: error,
                         name: self.name(),
-                        msg: "failed to wipe lvol".into(),
                     }
                 })?;
 
             // write zero to the first 8MB which wipes the metadata and the
             // first 4MB of the data partition
             let wipe_size = std::cmp::min(self.as_bdev().size_in_bytes(), WIPE_SUPER_LEN);
-            hdl.write_zeroes_at(0, wipe_size).await.map_err(|e| {
-                error!(?self, ?e);
-                LvsError::RepDestroy {
-                    source: BsError::from_errno(Errno::EIO),
+            hdl.write_zeroes_at(0, wipe_size).await.map_err(|error| {
+                error!(?self, %error, "Failed to wipe/write-zeroes");
+                LvsError::WipeFailed {
+                    source: error,
                     name: self.name(),
-                    msg: "failed to write to lvol".into(),
                 }
             })?;
         }
@@ -781,12 +777,7 @@ impl LvsLvol for Lvol {
             prop,
             name: self.name(),
         })?;
-        let einval = || {
-            Err(LvsError::Property {
-                source: BsError::InvalidArgument {},
-                name: self.name(),
-            })
-        };
+        let einval = || Err(LvsError::Property { name: self.name() });
 
         match prop {
             PropName::Shared => match unsafe { CStr::from_ptr(value).to_str() } {

--- a/io-engine/src/lvs/lvs_store.rs
+++ b/io-engine/src/lvs/lvs_store.rs
@@ -1,13 +1,12 @@
-use core::f64;
-use parking_lot::RwLock;
-use std::{convert::TryFrom, fmt::Debug, os::raw::c_void, pin::Pin, ptr::NonNull, str::FromStr};
-
-use crate::sleep::mayastor_sleep;
 use byte_unit::Byte;
+use core::f64;
 use events_api::event::EventAction;
 use futures::channel::oneshot;
 use nix::errno::Errno;
+use parking_lot::RwLock;
 use pin_utils::core_reexport::fmt::Formatter;
+use std::{convert::TryFrom, fmt::Debug, os::raw::c_void, pin::Pin, ptr::NonNull, str::FromStr};
+use url::Url;
 
 use spdk_rs::libspdk::{
     bdev_aio_rescan, bdev_uring_rescan, spdk_bdev_update_bs_blockcnt, spdk_blob_store,
@@ -19,7 +18,6 @@ use spdk_rs::libspdk::{
     vbdev_lvs_create_ext, vbdev_lvs_create_with_uuid, vbdev_lvs_destruct, vbdev_lvs_import,
     vbdev_lvs_unload, LVOL_CLEAR_WITH_NONE, LVOL_CLEAR_WITH_UNMAP, LVS_CLEAR_WITH_NONE,
 };
-use url::Url;
 
 use super::{BsError, ImportErrorReason, Lvol, LvsError, LvsIter, PropName, PropValue};
 
@@ -41,6 +39,7 @@ use crate::{
     },
     pool_backend::{PoolArgs, ReplicaArgs},
     pool_information::{pool_info_write, PoolInfo},
+    sleep::mayastor_sleep,
 };
 
 static ROUND_TO_MB: u32 = 1024 * 1024;
@@ -333,9 +332,14 @@ impl Lvs {
         }
     }
 
-    /// imports a pool based on its name, uuid and base bdev name
+    /// Imports a pool based on its name, uuid and base bdev name.
     #[tracing::instrument(level = "debug", err)]
     pub async fn import_from_args(args: PoolArgs) -> Result<Lvs, LvsError> {
+        Self::import_from_args_(args).await
+    }
+
+    /// Imports a pool based on its name, uuid and base bdev name.
+    pub async fn import_from_args_(args: PoolArgs) -> Result<Lvs, LvsError> {
         let disk = Self::parse_disk(args.disks.clone())?;
 
         let parsed = uri::parse(&disk).map_err(|e| LvsError::InvalidBdev {
@@ -663,7 +667,7 @@ impl Lvs {
             }
         }
 
-        match Self::import_from_args(args.clone()).await {
+        match Self::import_from_args_(args.clone()).await {
             Ok(pool) => Ok(pool),
             // try to create the pool
             Err(LvsError::Import {

--- a/io-engine/src/lvs/lvs_store.rs
+++ b/io-engine/src/lvs/lvs_store.rs
@@ -351,8 +351,7 @@ impl Lvs {
             &parsed.get_name()
         };
 
-        // At any point two pools with the same name should
-        // not exists so returning error
+        // At any point two pools with the same name should not exists so returning error
         if let Some(pool) = Self::lookup(&args.name) {
             let pool_name = pool.base_bdev().name().to_string();
             return if pool_name.as_str() == pool_bdev_name {
@@ -417,8 +416,7 @@ impl Lvs {
 
         let bsdev_name = args.crypto_vbdev_name.as_ref().unwrap_or(&bdev);
         let pool = Self::import(&args.name, bsdev_name).await?;
-        // Try to destroy the pending snapshots without catching
-        // the error.
+        // Try to destroy the pending snapshots without catching the error.
         Lvol::destroy_pending_discarded_snapshot().await;
         // if the uuid is provided for the import request check
         // for the pool uuid to make sure it is the correct one
@@ -570,7 +568,7 @@ impl Lvs {
 
         match Self::lookup(&args.name) {
             Some(pool) => {
-                info!("{:?}: new lvs created successfully", pool);
+                info!("{pool:?}: new lvs created successfully");
                 pool.add_info();
                 Ok(pool)
             }
@@ -586,17 +584,14 @@ impl Lvs {
     #[tracing::instrument(level = "debug", err)]
     pub async fn create_or_import(args: PoolArgs) -> Result<Lvs, LvsError> {
         let disk = Self::parse_disk(args.disks.clone())?;
+        let name = &args.name;
+        let enc = if args.crypto_vbdev_name.is_some() {
+            "encrypted"
+        } else {
+            "non-encrypted"
+        };
 
-        info!(
-            "Creating or importing {enc} lvs '{}' from '{}'...",
-            args.name,
-            disk,
-            enc = if args.crypto_vbdev_name.is_some() {
-                "encrypted"
-            } else {
-                "non-encrypted"
-            }
-        );
+        info!("Creating or importing {enc} lvs '{name}' from '{disk}'...");
 
         let bdev_ops = uri::parse(&disk).map_err(|e| LvsError::InvalidBdev {
             source: e,

--- a/io-engine/src/lvs/lvs_store.rs
+++ b/io-engine/src/lvs/lvs_store.rs
@@ -346,7 +346,7 @@ impl Lvs {
             name: args.name.clone(),
         })?;
 
-        // If we are requesting for an encrypted pool, then we should match existing pool(if any)
+        // If we are requesting for an encrypted pool, then we should match existing pool (if any)
         // by pool's bdev name as crypto bdev name.
         let pool_bdev_name = if let Some(c) = args.crypto_vbdev_name.as_ref() {
             c

--- a/io-engine/src/lvs/lvs_store.rs
+++ b/io-engine/src/lvs/lvs_store.rs
@@ -260,7 +260,7 @@ impl Lvs {
     pub async fn import(name: &str, bdev: &str) -> Result<Lvs, LvsError> {
         let (sender, receiver) = pair::<ErrnoResult<Lvs>>();
 
-        debug!("Trying to import lvs '{}' from '{}'...", name, bdev);
+        debug!("Trying to import lvs '{name}' from '{bdev}'...");
 
         let mut bdev = UntypedBdev::lookup_by_name(bdev).ok_or(LvsError::InvalidBdev {
             source: BdevError::BdevNotFound {
@@ -291,6 +291,8 @@ impl Lvs {
         };
 
         if rc != 0 {
+            // as of now, vbdev_lvs_import fails only with -1, even when hitting enomem
+            debug_assert_eq!(rc, -1, "Unexpected error for vbdev_lvs_import");
             return Err(LvsError::Import {
                 source: BsError::InvalidArgument {},
                 name: name.to_string(),
@@ -311,10 +313,7 @@ impl Lvs {
 
         if name != lvs.name() {
             warn!(
-                "No lvs with name '{}' found on this device: '{}'; \
-                found lvs: '{}'",
-                name,
-                bdev,
+                "No lvs with name '{name}' found on this device: '{bdev}'; found lvs: '{}'",
                 lvs.name()
             );
             let pool_name = lvs.name().to_string();
@@ -493,7 +492,6 @@ impl Lvs {
                 cluster_size
             } else {
                 return Err(LvsError::InvalidClusterSize {
-                    source: BsError::InvalidArgument {},
                     name: args.name,
                     msg: format!("{cluster_size}, not multiple of 1MiB"),
                 });
@@ -504,7 +502,6 @@ impl Lvs {
 
         if cluster_size > MAX_CLUSTER_SIZE {
             return Err(LvsError::InvalidClusterSize {
-                source: BsError::InvalidArgument {},
                 name: args.name,
                 msg: format!("{cluster_size}, larger than max limit {MAX_CLUSTER_SIZE}"),
             });
@@ -718,7 +715,7 @@ impl Lvs {
     pub async fn export(self) -> Result<(), LvsError> {
         let self_str = format!("{self:?}");
 
-        info!("{}: exporting lvs...", self_str);
+        info!("{self_str}: exporting lvs...");
 
         let pool = self.name().to_string();
         let mut base_bdev = self.base_bdev();
@@ -740,11 +737,14 @@ impl Lvs {
             Lvs::remove_info(&pool);
         }
 
+        // todo: if result is EIO error, then delete the bdevs as well here?
+        //  note that in this case we'd have to re-lookup the bdevs again as
+        //  they may have been hot-removed!
+
         result?;
 
         info!(
-            "{}: lvs exported successfully. base bdev: {}",
-            self_str,
+            "{self_str}: lvs exported successfully. base bdev: {}",
             base_bdev.name()
         );
 

--- a/io-engine/src/pool_backend.rs
+++ b/io-engine/src/pool_backend.rs
@@ -79,10 +79,10 @@ impl From<GenericError> for tonic::Status {
     }
 }
 impl ToErrno for GenericError {
-    fn to_errno(self) -> Errno {
+    fn to_errno(&self) -> Errno {
         match self {
             GenericError::NotFound { .. } => Errno::ENODEV,
-            GenericError::StatsReset { errno } => errno,
+            GenericError::StatsReset { errno } => *errno,
         }
     }
 }
@@ -123,7 +123,7 @@ impl From<Error> for tonic::Status {
     }
 }
 impl ToErrno for Error {
-    fn to_errno(self) -> Errno {
+    fn to_errno(&self) -> Errno {
         match self {
             Error::Lvs { source } => source.to_errno(),
             Error::Lvm { source } => source.to_errno(),

--- a/io-engine/src/subsys/nvmf/mod.rs
+++ b/io-engine/src/subsys/nvmf/mod.rs
@@ -93,7 +93,7 @@ impl Error {
 }
 
 thread_local! {
-    pub (crate) static NVMF_PGS: RefCell<Vec<PollGroup>> = const { RefCell::new(Vec::new()) };
+    pub(crate) static NVMF_PGS: RefCell<Vec<PollGroup>> = const { RefCell::new(Vec::new()) };
 }
 
 impl Nvmf {
@@ -110,7 +110,7 @@ impl Nvmf {
         if Config::get().nexus_opts.nvmf_enable {
             NVMF_TGT.with(|tgt| tgt.borrow_mut().next_state());
         } else {
-            debug!("nvmf target disabled");
+            debug!("NVMF target disabled");
             unsafe { spdk_subsystem_init_next(0) }
         }
     }

--- a/io-engine/src/subsys/nvmf/mod.rs
+++ b/io-engine/src/subsys/nvmf/mod.rs
@@ -48,29 +48,29 @@ impl RpcErrorCode for Error {
 #[derive(Debug, Clone, Snafu)]
 #[snafu(visibility(pub(crate)), context(suffix(false)))]
 pub enum Error {
-    #[snafu(display("Failed to create nvmf target {}", msg))]
+    #[snafu(display("failed to create nvmf target {}", msg))]
     CreateTarget { msg: String },
-    #[snafu(display("Failed to destroy nvmf target {}: {}", endpoint, source))]
+    #[snafu(display("failed to destroy nvmf target {}: {}", endpoint, source))]
     DestroyTarget { source: Errno, endpoint: String },
-    #[snafu(display("Failed to create poll groups {}", msg))]
+    #[snafu(display("failed to create poll groups {}", msg))]
     PgError { msg: String },
-    #[snafu(display("Failed to create transport {}", msg))]
+    #[snafu(display("failed to create transport {}", msg))]
     Transport { source: Errno, msg: String },
-    #[snafu(display("Failed to {} subsystem '{}': subsystem is busy", op, nqn))]
+    #[snafu(display("failed to {} subsystem '{}': subsystem is busy", op, nqn))]
     SubsystemBusy { nqn: String, op: String },
-    #[snafu(display("Failed nvmf subsystem operation for {} {} error: {}", source.desc(), nqn, msg))]
+    #[snafu(display("failed nvmf subsystem operation for {nqn}, {} error: {msg}", source.desc()))]
     Subsystem {
         source: Errno,
         nqn: String,
         msg: String,
     },
-    #[snafu(display("Failed to create share for {} {}", bdev, msg))]
+    #[snafu(display("failed to create share for {} {}", bdev, msg))]
     Share { bdev: String, msg: String },
-    #[snafu(display("Failed to add namespace for {} {}", bdev, msg))]
+    #[snafu(display("failed to add namespace for {} {}", bdev, msg))]
     Namespace { bdev: String, msg: String },
-    #[snafu(display("Failed to find listener for {} {}", nqn, trid))]
+    #[snafu(display("failed to find listener for {} {}", nqn, trid))]
     Listener { nqn: String, trid: String },
-    #[snafu(display("Interior nul byte found for host {}", host))]
+    #[snafu(display("interior nul byte found for host {}", host))]
     HostCstrNul { host: String },
 }
 

--- a/io-engine/src/subsys/nvmf/mod.rs
+++ b/io-engine/src/subsys/nvmf/mod.rs
@@ -48,30 +48,38 @@ impl RpcErrorCode for Error {
 #[derive(Debug, Clone, Snafu)]
 #[snafu(visibility(pub(crate)), context(suffix(false)))]
 pub enum Error {
-    #[snafu(display("failed to create nvmf target {}", msg))]
+    #[snafu(display("failed to create nvmf target {msg}"))]
     CreateTarget { msg: String },
-    #[snafu(display("failed to destroy nvmf target {}: {}", endpoint, source))]
+    #[snafu(display("failed to destroy nvmf target {endpoint}: {source}"))]
     DestroyTarget { source: Errno, endpoint: String },
-    #[snafu(display("failed to create poll groups {}", msg))]
+    #[snafu(display("failed to create poll groups {msg}"))]
     PgError { msg: String },
-    #[snafu(display("failed to create transport {}", msg))]
+    #[snafu(display("failed to create transport {msg}: {source}"))]
     Transport { source: Errno, msg: String },
-    #[snafu(display("failed to {} subsystem '{}': subsystem is busy", op, nqn))]
+    #[snafu(display("failed to {op} subsystem {nqn}: subsystem is busy"))]
     SubsystemBusy { nqn: String, op: String },
-    #[snafu(display("failed nvmf subsystem operation for {nqn}, {} error: {msg}", source.desc()))]
+    #[snafu(display("{nqn}: {source}"))]
+    SubsystemExt { source: Errno, nqn: String },
+    #[snafu(display("failed nvmf subsystem operation for {nqn}, {source}: {msg}"))]
     Subsystem {
         source: Errno,
         nqn: String,
         msg: String,
     },
-    #[snafu(display("failed to create share for {} {}", bdev, msg))]
+    #[snafu(display("failed to create share for {bdev} {msg}"))]
     Share { bdev: String, msg: String },
-    #[snafu(display("failed to add namespace for {} {}", bdev, msg))]
+    #[snafu(display("failed to add namespace for {bdev} {msg}"))]
     Namespace { bdev: String, msg: String },
-    #[snafu(display("failed to find listener for {} {}", nqn, trid))]
+    #[snafu(display("failed to find listener for {nqn} {trid}"))]
     Listener { nqn: String, trid: String },
-    #[snafu(display("interior nul byte found for host {}", host))]
+    #[snafu(display("interior nul byte found for host {host}"))]
     HostCstrNul { host: String },
+}
+
+impl crate::core::ToErrno for Error {
+    fn to_errno(&self) -> Errno {
+        self.errno()
+    }
 }
 
 impl Error {
@@ -83,6 +91,7 @@ impl Error {
             Error::PgError { .. } => nix::Error::EXFULL,
             Error::Transport { source, .. } => *source,
             Error::SubsystemBusy { .. } => nix::Error::EBUSY,
+            Error::SubsystemExt { source, .. } => *source,
             Error::Subsystem { source, .. } => *source,
             Error::Share { .. } => nix::Error::EXFULL,
             Error::Namespace { .. } => nix::Error::EXFULL,

--- a/io-engine/src/subsys/nvmf/subsystem.rs
+++ b/io-engine/src/subsys/nvmf/subsystem.rs
@@ -11,8 +11,9 @@ use nix::errno::Errno;
 
 use spdk_rs::{
     libspdk::{
-        nvmf_subsystem_find_listener, spdk_nvmf_ctrlr_set_cpl_error_cb, spdk_nvmf_ns_get_bdev,
-        spdk_nvmf_ns_opts, spdk_nvmf_request, spdk_nvmf_subsystem, spdk_nvmf_subsystem_add_host,
+        nvmf_subsystem_find_listener, spdk_bit_array_find_first_clear,
+        spdk_nvmf_ctrlr_set_cpl_error_cb, spdk_nvmf_ns_get_bdev, spdk_nvmf_ns_opts,
+        spdk_nvmf_request, spdk_nvmf_subsystem, spdk_nvmf_subsystem_add_host,
         spdk_nvmf_subsystem_add_listener, spdk_nvmf_subsystem_add_ns_ext,
         spdk_nvmf_subsystem_create, spdk_nvmf_subsystem_destroy,
         spdk_nvmf_subsystem_disconnect_host, spdk_nvmf_subsystem_event,
@@ -26,8 +27,8 @@ use spdk_rs::{
         spdk_nvmf_subsystem_set_ana_state, spdk_nvmf_subsystem_set_cntlid_range,
         spdk_nvmf_subsystem_set_event_cb, spdk_nvmf_subsystem_set_mn, spdk_nvmf_subsystem_set_sn,
         spdk_nvmf_subsystem_start, spdk_nvmf_subsystem_state_change_done, spdk_nvmf_subsystem_stop,
-        spdk_nvmf_tgt, spdk_nvmf_tgt_get_transport, SPDK_NVME_SCT_GENERIC,
-        SPDK_NVME_SC_CAPACITY_EXCEEDED, SPDK_NVME_SC_RESERVATION_CONFLICT,
+        spdk_nvmf_tgt, spdk_nvmf_tgt_find_subsystem, spdk_nvmf_tgt_get_transport,
+        SPDK_NVME_SCT_GENERIC, SPDK_NVME_SC_CAPACITY_EXCEEDED, SPDK_NVME_SC_RESERVATION_CONFLICT,
         SPDK_NVMF_SUBTYPE_DISCOVERY, SPDK_NVMF_SUBTYPE_NVME,
     },
     struct_size_init, NvmeStatus, NvmfController, NvmfSubsystemEvent,
@@ -408,16 +409,35 @@ impl NvmfSubsystem {
     /// create a new subsystem where the NQN is based on the UUID
     pub fn new(uuid: &str) -> Result<Self, Error> {
         let nqn = make_nqn(uuid).into_cstring();
-        let ss = NVMF_TGT
-            .with(|t| {
-                let tgt = t.borrow().tgt.as_ptr();
-                unsafe { spdk_nvmf_subsystem_create(tgt, nqn.as_ptr(), SPDK_NVMF_SUBTYPE_NVME, 1) }
-            })
-            .to_result(|_| Error::Subsystem {
-                source: Errno::EEXIST,
-                nqn: uuid.into(),
-                msg: "ss ptr is null".into(),
-            })?;
+
+        let ss = match NVMF_TGT.with(|t| {
+            let tgt = t.borrow().tgt.as_ptr();
+
+            let ss =
+                unsafe { spdk_nvmf_subsystem_create(tgt, nqn.as_ptr(), SPDK_NVMF_SUBTYPE_NVME, 1) };
+            if !ss.is_null() {
+                return Ok(ss);
+            }
+
+            // try to decipher why it's failed (the spdk_nvmf_subsystem_create provides no help)
+            if !unsafe { spdk_nvmf_tgt_find_subsystem(tgt, nqn.as_ptr()) }.is_null() {
+                return Err(Errno::EEXIST);
+            }
+            // check if we've hit the max number of namespaces/targets (since we have 1n-1t)
+            if unsafe { spdk_bit_array_find_first_clear((*tgt).subsystem_ids, 0) } == u32::MAX {
+                return Err(Errno::EMLINK);
+            }
+            Ok(ss)
+        }) {
+            Err(source) => Err(Error::SubsystemExt {
+                source,
+                nqn: nqn.to_string_lossy().to_string(),
+            }),
+            Ok(x) => x.to_result(|_| Error::SubsystemExt {
+                source: Errno::ENOMEM,
+                nqn: nqn.to_string_lossy().to_string(),
+            }),
+        }?;
 
         // Register subsystem event handler.
         unsafe {

--- a/shell.nix
+++ b/shell.nix
@@ -1,6 +1,6 @@
-{ rust ? "stable"
-, spdk ? "develop"
-, spdk-path ? null
+{ rust ? (let v = builtins.getEnv "NIX_RUST"; in if v == "" then "stable" else v)
+, spdk ? (let v = builtins.getEnv "NIX_SPDK"; in if v == "" then "develop" else v)
+, spdk-path ? (let v = builtins.getEnv "NIX_SPDK_PATH"; in if v == "" then null else v)
 } @ args:
 let
   sources = import ./nix/sources.nix;
@@ -15,6 +15,8 @@ let
   # python environment for test/python
   pytest_inputs = with pkgs; python3.withPackages
     (ps: with ps; [ virtualenv grpcio grpcio-tools asyncssh black ]);
+
+  nix-file = "\\$" + "{workspaceFolder}/shell.nix";
 
   shellAttrs = import ./spdk-rs/nix/shell {
     inherit rust;
@@ -54,6 +56,11 @@ let
         # Dummy values in case environment does not have /etc/nvme
         NVME_HOSTID = "03f79caf-dc58-475a-a111-bf0b75214a51";
         NVME_HOSTNQN = "nqn.2014-08.org.nvmexpress:uuid:03f79caf-dc58-475a-a111-bf0b75214a51";
+
+        # Env vars to allow for better integration with code editors which use a nix environment selector
+        NIX_RUST = rust;
+        NIX_SPDK = spdk;
+        NIX_SPDK_PATH = toString spdk-path;
       };
 
       shellHook = ''
@@ -66,6 +73,13 @@ let
 
         # Prevent Rust tooling to fallback to potentially incompatible host clang compiler
         export CLANG_PATH="$NIX_CC_FOR_TARGET/bin/clang"
+
+        cat > "$SRCDIR/.vscode/settings.json" <<EOF
+        {
+            "nixEnvSelector.args": "--argstr rust ${rust} --argstr spdk ${spdk} --argstr spdk-path $(realpath ${toString spdk-path})",
+            "nixEnvSelector.nixFile": "${toString nix-file}"
+        }
+        EOF
       '';
 
       shellInfoHook = ''


### PR DESCRIPTION
    fix: set correct error code for max nvmf subsystem
    
    In this case we now return out_of_range status code with
    an errno of EMLINK.

---

    fix: expose errno in the grpc status metadata
    
    The grpc status codes are very limited, and makes it hard to determine
    what has actually happened.
    In the control-plane we've take a different approach where we return
    the status as a proto message.
    To avoid changing the entire api here, we're now exposing the errno
    as a metadata header.
    
    Also, create a better mapping from EIO/EILSEQ to data_loss code.
    
---

    refactor: change Errno trait to use reference
    
    This makes using it more flexible and allows us to consume the
    value in other paths whilst taking the errno a priori.
    
---

    style: tidy up error logging with display
    
    Some of the errors were still using the debug, and relying on
    the verbose error trait.
    This would in times generate very long error messages with repeated
    errors due to a mix of Display and Debug
    I tried to move everything to Display and not rely on the verbose
    trait at all.
    Also removed some unused errors fields and variants.

---

    style(pool/lvs): don't trace the pool args twice during create
    
    The pool create top method already sets the args in the span, so
    if we add it again we get a huge line with both which are the same!
    
---

    fix(pool/lvs): include generic errno error
    
    When an lvs pool operation fails with a gereric errno, that was
    not being displayed which is not helpful.
    
---

    build: use existing config from nix-shell and setup vscode
    
    Sometimes we override the nix-shell args, which leads to a different
    set of libs etc
    When we open an editor from inside this shell or when we run another
    nix-shell command, then we have to pick up the initial args, otherwise
    we may get incorrect or unexpected results.
    Also, setup the vscode env variables so when we're using an ssh connection
    for example, it'd pick up the correct variables as well.

---

    style: prefix cli flattened structs with prefix
    
    Adds prefix to spdk-tracing and pool error thresholds.
    This should help clarify what the values as for.
    
---

    style: improve cli help as well as default logging
    
    Improves the help menu to make it easier to use.
    Also de-clutters the default span logging when running in debug.
    Fixes the hostname being set in json logging.
