### PR TITLE
feat(io-engine): expose SPDK transport_tos for RDMA QoS/DSCP marking

### DIFF
--- a/io-engine/src/subsys/config/opts.rs
+++ b/io-engine/src/subsys/config/opts.rs
@@ -382,6 +382,10 @@ pub struct NvmeBdevOpts {
     /// These strings are based on device serial number and namespace ID and
     ///  will always be the same for that device.
     pub generate_uuids: bool,
+    /// Type of Service value for RDMA transport connections.
+    /// Used to set DSCP for QoS classification (e.g., 104 = DSCP 26/AF31
+    /// for lossless RoCE traffic with Priority Flow Control).
+    pub transport_tos: u8,
 }
 
 impl GetOpts for NvmeBdevOpts {
@@ -443,6 +447,7 @@ impl Default for NvmeBdevOpts {
             fast_io_fail_timeout_sec: 0,
             disable_auto_failback: false,
             generate_uuids: try_from_env("NVME_GENERATE_UUIDS", true),
+            transport_tos: try_from_env("NVME_TRANSPORT_TOS", 0),
         }
     }
 }
@@ -470,6 +475,7 @@ impl From<spdk_bdev_nvme_opts> for NvmeBdevOpts {
             fast_io_fail_timeout_sec: o.fast_io_fail_timeout_sec,
             disable_auto_failback: o.disable_auto_failback,
             generate_uuids: o.generate_uuids,
+            transport_tos: o.transport_tos,
         }
     }
 }
@@ -499,7 +505,7 @@ impl From<&NvmeBdevOpts> for spdk_bdev_nvme_opts {
             fast_io_fail_timeout_sec: o.fast_io_fail_timeout_sec,
             disable_auto_failback: o.disable_auto_failback,
             generate_uuids: o.generate_uuids,
-            transport_tos: 0,
+            transport_tos: o.transport_tos,
             nvme_error_stat: false,
             rdma_srq_size: 0,
             io_path_stat: false,


### PR DESCRIPTION
## Summary

  - Add `transport_tos` field to `NvmeBdevOpts` struct, replacing the hardcoded `0` value
  - Configurable via `NVME_TRANSPORT_TOS` environment variable (defaults to `0` for backwards compatibility)
  - Wire through both `From` impls (`spdk_bdev_nvme_opts ↔ NvmeBdevOpts`)

## Motivation

When using NVMe-oF over RDMA (RoCEv2), lossless transport requires end-to-end DSCP marking so that switches and NICs can classify storage traffic into a priority queue with Priority Flow Control (PFC) enabled.

SPDK already supports `transport_tos` on `spdk_bdev_nvme_opts`, but Mayastor hardcodes it to `0`. This means all RDMA packets are sent with default best-effort QoS, making it impossible to achieve lossless RoCE without kernel-level workarounds that only cover the target (responder) side.

With this change, operators can set `NVME_TRANSPORT_TOS=104` (DSCP 26 / AF31) on the io-engine container to mark initiator-side RDMA traffic, completing the end-to-end lossless path:

  - **Switch side**: DCB config trusts DSCP and maps AF31 → priority 3 with PFC
  - **NIC side**: `dcb app add dscp-prio 26:3` + `dcb pfc set prio-pfc 3:on`
  - **Target side**: `rdma_cm.cma_roce_tos=104` kernel parameter
  - **Initiator side**: `NVME_TRANSPORT_TOS=104` ← **this PR**