### PR TITLE
Cherry-Pick 1951 - Help prevent message pool exhaustion

### DIFF
--- a/io-engine/src/bdev/nvmx/controller.rs
+++ b/io-engine/src/bdev/nvmx/controller.rs
@@ -45,6 +45,7 @@ use crate::{
     },
     ffihelper::{cb_arg, done_cb},
     sleep::mayastor_sleep,
+    subsys::nvmx::NvmxSubsystem,
 };
 
 #[derive(Debug)]
@@ -85,13 +86,16 @@ impl NvmeControllerInner<'_> {
 
         info!("Running admin queue poller on core #{}", core);
 
-        let adminq_poller = PollerBuilder::new()
-            .with_name("nvme_poll_adminq")
+        let poller = match NvmxSubsystem::adminq_thread(core) {
+            Some(thread) => PollerBuilder::new().with_thread(thread),
+            // in case the poller threads were not registered
+            None => PollerBuilder::new(),
+        };
+        let adminq_poller = poller
             .with_interval(Duration::from_micros(
                 nvme_bdev_running_config().nvme_adminq_poll_period_us,
             ))
             .with_poll_fn(move |_| nvme_poll_adminq(cfg.as_ptr().cast()))
-            .with_core(core)
             .build();
 
         Self {

--- a/io-engine/src/core/reactor.rs
+++ b/io-engine/src/core/reactor.rs
@@ -58,6 +58,7 @@ use spdk_rs::libspdk::{
 use crate::{
     core::{CoreError, Cores},
     eventing::Event,
+    subsys::config::opts::try_from_env,
 };
 use gettid::gettid;
 use nix::errno::Errno;
@@ -132,13 +133,15 @@ impl Reactors {
     /// initialize the reactor subsystem for each core assigned to us
     pub fn init(developer_delay: bool) {
         REACTOR_LIST.get_or_init(|| {
+            let mempool_sz = try_from_env(
+                "SPDK_DEFAULT_MSG_MEMPOOL_SIZE",
+                SPDK_DEFAULT_MSG_MEMPOOL_SIZE as u64,
+            );
+            if !(mempool_sz+1).is_power_of_two() {
+                tracing::warn!("The provided SPDK_DEFAULT_MSG_MEMPOOL_SIZE ({SPDK_DEFAULT_MSG_MEMPOOL_SIZE}) is not a power of 2 - 1. This is not optimal for memory consumption");
+            }
             let rc = unsafe {
-                spdk_thread_lib_init_ext(
-                    Some(Self::do_op),
-                    Some(Self::can_op),
-                    0,
-                    SPDK_DEFAULT_MSG_MEMPOOL_SIZE as u64,
-                )
+                spdk_thread_lib_init_ext(Some(Self::do_op), Some(Self::can_op), 0, mempool_sz)
             };
             assert_eq!(rc, 0);
 

--- a/io-engine/src/subsys/config/opts.rs
+++ b/io-engine/src/subsys/config/opts.rs
@@ -138,7 +138,7 @@ impl Default for NvmfTgtConfig {
         let args = MayastorEnvironment::global_or_default();
         Self {
             name: "mayastor_target".to_string(),
-            max_namespaces: 2048,
+            max_namespaces: try_from_env("NVME_MAX_NAMESPACES", 4096),
             crdt: args.nvmf_tgt_crdt,
             opts_tcp: NvmfTransportOpts::default(),
             interface: None,

--- a/io-engine/src/subsys/mod.rs
+++ b/io-engine/src/subsys/mod.rs
@@ -19,6 +19,8 @@ use crate::subsys::nvmf::Nvmf;
 
 pub(super) mod config;
 mod nvmf;
+/// Module for managing of the nvmx admin queues.
+pub mod nvmx;
 /// Module for registration of the data-plane with control-plane
 pub mod registration;
 
@@ -35,6 +37,7 @@ pub(crate) fn register_subsystem() {
         spdk_add_subsystem_depend(Box::into_raw(Box::new(depend)));
     }
     RegistrationSubsystem::register();
+    nvmx::NvmxSubsystem::register();
 }
 
 /// Makes a subsystem serial number from a subsystem UUID or name.

--- a/io-engine/src/subsys/nvmx/mod.rs
+++ b/io-engine/src/subsys/nvmx/mod.rs
@@ -1,0 +1,72 @@
+//! A Registration subsystem is used to keep control-plane in the loop
+//! about the lifecycle of mayastor instances.
+
+use spdk_rs::libspdk::{
+    spdk_add_subsystem, spdk_subsystem, spdk_subsystem_fini_next, spdk_subsystem_init_next,
+};
+use std::mem::zeroed;
+
+// wrapper around our Registration subsystem used for registration
+pub struct NvmxSubsystem(*mut spdk_subsystem);
+
+use once_cell::sync::OnceCell;
+use std::collections::HashMap;
+
+static ADMINQ_POLL_THREADS: OnceCell<HashMap<u32, u64>> = OnceCell::new();
+
+impl Default for NvmxSubsystem {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl NvmxSubsystem {
+    /// Initialise a new subsystem that creates adminq pollers for the nvmx controllers.
+    extern "C" fn init() {
+        let adminqs = crate::core::Reactors::iter().fold(HashMap::new(), |mut acc, reactor| {
+            let core = reactor.core();
+            let thread = spdk_rs::Thread::new(format!("nvmx_poll_adminq_{core}"), core)
+                .expect("Should be able to allocate the adminq polling threads");
+            acc.insert(reactor.core(), thread.id());
+            acc
+        });
+
+        ADMINQ_POLL_THREADS.get_or_init(|| adminqs);
+
+        unsafe { spdk_subsystem_init_next(0) }
+    }
+
+    /// Get the thread id for the adminq poller running on the specified core.
+    pub fn adminq_thread_id(core: u32) -> Option<u64> {
+        let adminq = ADMINQ_POLL_THREADS.get_or_init(HashMap::new);
+        adminq.get(&core).cloned()
+    }
+
+    /// Get the [`spdk_rs::Thread`] for the adminq poller running on the specified core.
+    pub fn adminq_thread(core: u32) -> Option<spdk_rs::Thread> {
+        Self::adminq_thread_id(core).and_then(spdk_rs::Thread::by_id)
+    }
+
+    extern "C" fn fini() {
+        tracing::debug!("mayastor nvmx subsystem fini");
+        // we could delete the threads, but probably don't need to do that explicitly...
+        unsafe { spdk_subsystem_fini_next() }
+    }
+
+    fn new() -> Self {
+        tracing::info!("creating mayastor nvmx subsystem...");
+        let ss = spdk_subsystem {
+            name: b"mayastor_nvmx_registration\x00" as *const u8 as *const libc::c_char,
+            init: Some(Self::init),
+            fini: Some(Self::fini),
+            write_config_json: None,
+            tailq: unsafe { zeroed() },
+        };
+        Self(Box::into_raw(Box::new(ss)))
+    }
+
+    /// Register the subsystem with spdk.
+    pub(super) fn register() {
+        unsafe { spdk_add_subsystem(NvmxSubsystem::new().0) }
+    }
+}


### PR DESCRIPTION
    fix: add missing configuration for max number of subsystems
    
    Also increase max to 4096.
    todo: we need a better way to manage these and also relay this
    information to the control-plane.
    
---

    feat: add env variable for overriding SPDK_DEFAULT_MSG_MEMPOOL_SIZE
    
    Also added a warning message in case the value is not power of 2 - 1.
    This is preferred for optimal memory usage.
    
----

    fix(nvmx): reuse adminq threads for nvmx controllers
    
    Creating a new thread for each nvmx controller can quickly lead to
    using up most of the thread message pool.
    Only 254 connections will exhaust most of the message pool as each
    one will take 1024 entries!
    (the default pool size is 256*1024-1)
    
---

    feat(nvmx): add nvmx subsystem for preparing adminq poller threads
    
    These threads should be reused by the nvmx controllers, rather than creating
    a new thread for each connection, which would rundown the message pool!
    
---

    chore: pull in spdkrs thread and poller changes
