### PR TITLE
feat: add pool probing

### DIFF
--- a/io-engine/src/bdev/aio.rs
+++ b/io-engine/src/bdev/aio.rs
@@ -185,6 +185,12 @@ impl CreateDestroy for Aio {
     }
 }
 
+impl super::Probe for Aio {
+    fn probe(&self) -> Result<(), io_engine_api::v1::pool::ProbeError> {
+        super::probe_file(&self.name)
+    }
+}
+
 impl Aio {
     fn try_rescan(&self, bdev: UntypedBdev) -> Result<String, <Self as CreateDestroy>::Error> {
         let before = bdev.num_blocks();

--- a/io-engine/src/bdev/dev.rs
+++ b/io-engine/src/bdev/dev.rs
@@ -43,11 +43,29 @@ pub(crate) mod uri {
         bdev_api::{self, BdevError},
     };
 
+    /// Parse the given uri into a [`BdevCreateDestroy`].
     pub fn parse(uri: &str) -> Result<Box<dyn BdevCreateDestroy<Error = BdevError>>, BdevError> {
-        let url = url::Url::parse(uri).context(bdev_api::UriParseFailed {
-            uri: uri.to_string(),
-        })?;
+        parse_url(parse_uri(uri)?)
+    }
 
+    /// Parse the given uri into a [`BdevCreateDestroy`].
+    /// If the given uri is not a [`url::Url`] then we try to parse it as an aio uri.
+    pub fn try_parse_or_aio(
+        uri: &str,
+    ) -> Result<Box<dyn BdevCreateDestroy<Error = BdevError>>, BdevError> {
+        let url = match parse_uri(uri) {
+            Ok(url) => Ok(url),
+            Err(error) => match parse_uri(&format!("aio://{uri}")) {
+                Ok(url) => Ok(url),
+                Err(_) => Err(error),
+            },
+        }?;
+        parse_url(url)
+    }
+
+    fn parse_url(
+        url: url::Url,
+    ) -> Result<Box<dyn BdevCreateDestroy<Error = BdevError>>, BdevError> {
         match url.scheme() {
             "aio" => Ok(Box::new(aio::Aio::try_from(&url)?)),
             "bdev" | "loopback" => Ok(Box::new(loopback::Loopback::try_from(&url)?)),
@@ -69,6 +87,12 @@ pub(crate) mod uri {
                 scheme: scheme.to_string(),
             }),
         }
+    }
+
+    fn parse_uri(uri: &str) -> Result<url::Url, BdevError> {
+        url::Url::parse(uri).context(bdev_api::UriParseFailed {
+            uri: uri.to_string(),
+        })
     }
 }
 

--- a/io-engine/src/bdev/ftl.rs
+++ b/io-engine/src/bdev/ftl.rs
@@ -160,6 +160,7 @@ impl GetName for Ftl {
         self.name.clone()
     }
 }
+impl super::Probe for Ftl {}
 
 pub extern "C" fn ftl_bdev_init_fn_cb(
     _ptr: *const ftl_bdev_info,

--- a/io-engine/src/bdev/loopback.rs
+++ b/io-engine/src/bdev/loopback.rs
@@ -64,6 +64,7 @@ impl GetName for Loopback {
         self.name.clone()
     }
 }
+impl super::Probe for Loopback {}
 
 #[async_trait(?Send)]
 impl CreateDestroy for Loopback {

--- a/io-engine/src/bdev/lvs.rs
+++ b/io-engine/src/bdev/lvs.rs
@@ -181,6 +181,7 @@ impl GetName for Lvol {
         self.name.clone()
     }
 }
+impl super::Probe for Lvol {}
 
 #[async_trait(?Send)]
 impl CreateDestroy for Lvol {

--- a/io-engine/src/bdev/malloc.rs
+++ b/io-engine/src/bdev/malloc.rs
@@ -170,6 +170,7 @@ impl GetName for Malloc {
         self.name.clone()
     }
 }
+impl super::Probe for Malloc {}
 
 #[async_trait(?Send)]
 impl CreateDestroy for Malloc {

--- a/io-engine/src/bdev/mod.rs
+++ b/io-engine/src/bdev/mod.rs
@@ -26,9 +26,9 @@ mod nx;
 mod uring;
 pub mod util;
 
-pub trait BdevCreateDestroy: CreateDestroy + GetName + std::fmt::Debug {}
+pub trait BdevCreateDestroy: CreateDestroy + Probe + GetName + std::fmt::Debug {}
 
-impl<T: CreateDestroy + GetName + std::fmt::Debug> BdevCreateDestroy for T {}
+impl<T: CreateDestroy + GetName + Probe + std::fmt::Debug> BdevCreateDestroy for T {}
 
 #[async_trait(?Send)]
 /// Main trait that must be implemented for every supported device type.
@@ -43,6 +43,28 @@ pub trait CreateDestroy {
 /// device type.
 pub trait GetName {
     fn get_name(&self) -> String;
+}
+
+/// The following trait must also be implemented for every supported
+/// device type.
+pub trait Probe {
+    fn probe(&self) -> Result<(), io_engine_api::v1::pool::ProbeError> {
+        Err(io_engine_api::v1::pool::ProbeError {
+            code: io_engine_api::v1::pool::ProbeErrorCode::InvalidDiskUri as i32,
+            msg: None,
+        })
+    }
+}
+
+fn probe_file(file: &str) -> Result<(), io_engine_api::v1::pool::ProbeError> {
+    let disk_path = std::path::Path::new(file);
+    if !disk_path.exists() {
+        return Err(io_engine_api::v1::pool::ProbeError {
+            code: io_engine_api::v1::pool::ProbeErrorCode::DiskNotFound as i32,
+            msg: None,
+        });
+    }
+    Ok(())
 }
 
 /// Exposes functionality to prepare for persisting reservations in the event

--- a/io-engine/src/bdev/null_bdev.rs
+++ b/io-engine/src/bdev/null_bdev.rs
@@ -141,6 +141,7 @@ impl GetName for Null {
         self.name.clone()
     }
 }
+impl super::Probe for Null {}
 
 #[async_trait(?Send)]
 impl CreateDestroy for Null {

--- a/io-engine/src/bdev/nvme.rs
+++ b/io-engine/src/bdev/nvme.rs
@@ -30,6 +30,29 @@ pub(super) struct NVMe {
     url: Url,
 }
 
+impl NVMe {
+    /// Returns the driver name bound to a PCI device (e.g., "vfio-pci", "nvme")
+    fn pci_driver(&self) -> Result<Option<String>, std::io::Error> {
+        let driver_path = format!("/sys/bus/pci/devices/{}/driver", self.name);
+        let path = std::path::Path::new(&driver_path);
+
+        if !path.exists() {
+            return Ok(None);
+        }
+
+        // Resolve the symlink: /sys/.../driver -> ../../../bus/pci/drivers/<driver>
+        let driver_link = path.read_link()?;
+
+        // Extract the last component (driver name)
+        let driver = driver_link.file_name().and_then(|os| os.to_str());
+        Ok(driver.map(ToString::to_string))
+    }
+    fn is_pci_nvme(&self) -> bool {
+        let pci = format!("/sys/module/nvme/drivers/pci:nvme/{}", self.name);
+        std::fs::exists(&pci).unwrap_or_default()
+    }
+}
+
 /// Convert a URI to NVMe object
 impl TryFrom<&Url> for NVMe {
     type Error = BdevError;
@@ -148,6 +171,43 @@ impl CreateDestroy for NVMe {
                 name: self.get_name(),
             })
         }
+    }
+}
+
+impl super::Probe for NVMe {
+    fn probe(&self) -> Result<(), io_engine_api::v1::pool::ProbeError> {
+        const PCIE_DRVS: [&str; 2] = ["vfio-pci", "uio_pci_generic"];
+
+        let driver = match self.pci_driver() {
+            Ok(Some(driver)) if !driver.is_empty() => Ok(driver),
+            Ok(_) => Err(io_engine_api::v1::pool::ProbeError {
+                code: io_engine_api::v1::pool::ProbeErrorCode::DiskNotFound as i32,
+                msg: None,
+            }),
+            Err(error) => Err(io_engine_api::v1::pool::ProbeError {
+                code: io_engine_api::v1::pool::ProbeErrorCode::ProbeUnknown as i32,
+                msg: Some(error.to_string()),
+            }),
+        }?;
+
+        if PCIE_DRVS.contains(&driver.as_str()) {
+            return Ok(());
+        }
+
+        if driver == "nvme" {
+            return Err(io_engine_api::v1::pool::ProbeError {
+                code: io_engine_api::v1::pool::ProbeErrorCode::PciKernelBound as i32,
+                msg: None,
+            });
+        }
+
+        let code = if self.is_pci_nvme() {
+            io_engine_api::v1::pool::ProbeErrorCode::PciDriverUnsupported
+        } else {
+            io_engine_api::v1::pool::ProbeErrorCode::PciNotNvme
+        } as i32;
+
+        Err(io_engine_api::v1::pool::ProbeError { code, msg: None })
     }
 }
 

--- a/io-engine/src/bdev/nvmf.rs
+++ b/io-engine/src/bdev/nvmf.rs
@@ -123,6 +123,7 @@ impl GetName for Nvmf {
         format!("{}n1", self.name)
     }
 }
+impl super::Probe for Nvmf {}
 
 #[async_trait(?Send)]
 impl CreateDestroy for Nvmf {

--- a/io-engine/src/bdev/nvmx/uri.rs
+++ b/io-engine/src/bdev/nvmx/uri.rs
@@ -183,6 +183,7 @@ impl GetName for NvmfDeviceTemplate {
         format!("{}n1", self.name)
     }
 }
+impl crate::bdev::Probe for NvmfDeviceTemplate {}
 
 // Context for an NVMe controller being created.
 pub(crate) struct NvmeControllerContext<'probe> {

--- a/io-engine/src/bdev/nx.rs
+++ b/io-engine/src/bdev/nx.rs
@@ -103,6 +103,7 @@ impl GetName for Nexus {
         self.name.clone()
     }
 }
+impl super::Probe for Nexus {}
 
 #[async_trait(?Send)]
 impl CreateDestroy for Nexus {

--- a/io-engine/src/bdev/uring.rs
+++ b/io-engine/src/bdev/uring.rs
@@ -147,3 +147,9 @@ impl CreateDestroy for Uring {
         }
     }
 }
+
+impl super::Probe for Uring {
+    fn probe(&self) -> Result<(), io_engine_api::v1::pool::ProbeError> {
+        super::probe_file(&self.name)
+    }
+}

--- a/io-engine/src/bin/io-engine-client/v1/pool_cli.rs
+++ b/io-engine/src/bin/io-engine-client/v1/pool_cli.rs
@@ -245,6 +245,61 @@ pub fn subcommands() -> Command {
                 .help("Disk devices to clear errors or all if not specified"),
         );
 
+    let probe = Command::new("probe")
+        .about("Probes storage pool")
+        .arg(
+            Arg::new("pool")
+                .required(true)
+                .index(1)
+                .help("Storage pool name"),
+        )
+        .arg(
+            Arg::new("uuid")
+                .short('u')
+                .long("uuid")
+                .required(false)
+                .help("Storage pool uuid"),
+        )
+        .arg(
+            Arg::new("disk")
+                .required(true)
+                .action(clap::ArgAction::Append)
+                .index(2)
+                .help("Disk device files"),
+        )
+        .arg(
+            Arg::new("type")
+                .short('t')
+                .long("type")
+                .help("The type of the pool")
+                .required(false)
+                .value_parser(PoolType::types().to_vec())
+                .default_value(PoolType::Lvs.as_ref()),
+        )
+        .arg(
+            Arg::new("cipher")
+                .short('c')
+                .long("cipher")
+                .help("The cipher to use for encryption")
+                .required(false)
+                .requires("encryption-key"),
+        )
+        .arg(
+            Arg::new("encryption-key")
+                .short('k')
+                .long("encryption-key")
+                .help("The encryption key of the pool in hexlified format")
+                .required(false),
+        )
+        .arg(
+            Arg::new("xts-key")
+                .short('e')
+                .long("xts-key")
+                .help("encryption key2 required for AES_XTS")
+                .required_if_eq("cipher", "AES_XTS")
+                .required(false),
+        );
+
     Command::new("pool")
         .subcommand_required(true)
         .arg_required_else_help(true)
@@ -256,6 +311,7 @@ pub fn subcommands() -> Command {
         .subcommand(expand)
         .subcommand(list)
         .subcommand(clear)
+        .subcommand(probe)
 }
 
 pub async fn handler(ctx: Context, matches: &ArgMatches) -> crate::Result<()> {
@@ -267,6 +323,7 @@ pub async fn handler(ctx: Context, matches: &ArgMatches) -> crate::Result<()> {
         ("expand", args) => expand(ctx, args).await,
         ("list", args) => list(ctx, args).await,
         ("clear-errors", args) => clear_errors(ctx, args).await,
+        ("probe", args) => probe(ctx, args).await,
         (cmd, _) => {
             Err(Status::not_found(format!("command {cmd} does not exist"))).context(GrpcStatus)
         }
@@ -788,6 +845,94 @@ async fn clear_errors(mut ctx: Context, matches: &ArgMatches) -> crate::Result<(
         .context(GrpcStatus)?;
 
     list_pools(ctx, either::Left(response.into_inner()))
+}
+
+async fn probe(mut ctx: Context, matches: &ArgMatches) -> crate::Result<()> {
+    let name = matches
+        .get_one::<String>("pool")
+        .ok_or_else(|| ClientError::MissingValue {
+            field: "pool".to_string(),
+        })?
+        .to_owned();
+    let uuid = matches.get_one::<String>("uuid");
+    let cipher = matches.get_one::<String>("cipher");
+
+    if let Some(c) = cipher {
+        if !c.eq_ignore_ascii_case("AES_XTS") && !c.eq_ignore_ascii_case("AES_CBC") {
+            return Err(Status::invalid_argument(
+                "Need valid cipher(AES_XTS or AES_CBC)",
+            ))
+            .context(GrpcStatus);
+        }
+    }
+
+    let enc_key = matches.get_one::<String>("encryption-key");
+    let xts_key = matches.get_one::<String>("xts-key");
+
+    let disks_list = matches
+        .get_many::<String>("disk")
+        .ok_or_else(|| ClientError::MissingValue {
+            field: "disk".to_string(),
+        })?
+        .map(|dev| dev.to_owned())
+        .collect();
+    let pooltype = matches
+        .get_one::<String>("type")
+        .map(|s| PoolType::from_str(s.as_str()))
+        .unwrap()
+        .map_err(|e| Status::invalid_argument(e.to_string()))
+        .context(GrpcStatus)?;
+
+    let enc_key_msg = enc_key.map(|k| v1rpc::common::EncryptionKey {
+        key_name: "key_".to_owned() + k,
+        key: k.clone().into(),
+        key_length: k.len() as u32,
+        key2: xts_key.map(|k2| k2.clone().into()),
+        key2_length: xts_key.map(|x| x.len() as u32),
+    });
+
+    let enc_msg = enc_key_msg.map(|e| {
+        v1rpc::common::import_pool_request::Encryption::Data(v1rpc::common::EncryptionData {
+            cipher: v1rpc::common::Cipher::from_str_name(cipher.unwrap())
+                .unwrap()
+                .into(),
+            key: Some(e),
+        })
+    });
+
+    let response = ctx
+        .v1
+        .pool
+        .probe_pool(v1rpc::pool::ProbePoolRequest {
+            request: Some(v1rpc::pool::ImportPoolRequest {
+                name: name.clone(),
+                uuid: uuid.map(ToString::to_string),
+                disks: disks_list,
+                pooltype: v1rpc::pool::PoolType::from(pooltype) as i32,
+                encryption: enc_msg,
+            }),
+            probes: None,
+        })
+        .await
+        .context(GrpcStatus)?
+        .into_inner();
+
+    match ctx.output {
+        OutputFormat::Json => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&response)
+                    .unwrap()
+                    .to_colored_json_auto()
+                    .unwrap()
+            );
+        }
+        OutputFormat::Default => {
+            println!("{response:#?}");
+        }
+    };
+
+    Ok(())
 }
 
 fn pool_state_to_str(idx: i32) -> &'static str {

--- a/io-engine/src/grpc/v1/pool.rs
+++ b/io-engine/src/grpc/v1/pool.rs
@@ -23,6 +23,7 @@ use io_engine_api::v1::{
 };
 use secret_provider::secret_data;
 use std::{
+    collections::HashMap,
     convert::{TryFrom, TryInto},
     fmt::Debug,
     ops::Deref,
@@ -341,8 +342,8 @@ impl TryFrom<ImportPoolRequest> for PoolArgs {
             msg: format!("invalid pooltype provided: {}", args.pooltype),
         })?;
         if backend == PoolType::Lvs {
-            if let Some(s) = args.uuid.clone() {
-                let _uuid = uuid::Uuid::parse_str(s.as_str()).map_err(|e| LvsError::Invalid {
+            if let Some(ref s) = args.uuid {
+                let _uuid = uuid::Uuid::parse_str(s).map_err(|e| LvsError::Invalid {
                     source: BsError::InvalidArgument {},
                     msg: format!("invalid uuid provided, {e}"),
                 })?;
@@ -930,5 +931,64 @@ impl PoolRpc for PoolService {
             },
         )
         .await
+    }
+
+    async fn probe_pool(
+        &self,
+        request: Request<ProbePoolRequest>,
+    ) -> GrpcResult<ProbePoolResponse> {
+        let request = request.into_inner();
+
+        // todo: implement probes
+        if request.probes.is_some() {
+            return Err(Status::new(
+                Code::InvalidArgument,
+                "Pool probes are not implemented",
+            ));
+        }
+        let Some(request) = request.request else {
+            return Err(Status::new(
+                Code::InvalidArgument,
+                "Pool import request is missing",
+            ));
+        };
+        if request.disks.is_empty() {
+            return Err(Status::new(
+                Code::InvalidArgument,
+                "No pool disks specified",
+            ));
+        }
+
+        let mut errors = HashMap::new();
+        for disk_uri in request.disks {
+            let parsed = match crate::bdev::uri::try_parse_or_aio(&disk_uri) {
+                Ok(parsed) => parsed,
+                Err(error) => {
+                    let error = vec![ProbeError {
+                        code: ProbeErrorCode::InvalidDiskUri as i32,
+                        msg: Some(error.to_string()),
+                    }];
+                    let disk = disk_uri.clone();
+                    let info = ProbeDiskInfo { disk, error };
+                    errors.insert(disk_uri, info);
+                    continue;
+                }
+            };
+            let Err(error) = parsed.probe() else {
+                continue;
+            };
+
+            let error = vec![error];
+            let disk = disk_uri.clone();
+            let info = ProbeDiskInfo { disk, error };
+            errors.insert(disk_uri, info);
+        }
+
+        Ok(tonic::Response::new(ProbePoolResponse {
+            success: errors.is_empty(),
+            probed: None,
+            metadata: None,
+            errors,
+        }))
     }
 }

--- a/shell.nix
+++ b/shell.nix
@@ -17,6 +17,7 @@ let
     (ps: with ps; [ virtualenv grpcio grpcio-tools asyncssh black ]);
 
   nix-file = "\\$" + "{workspaceFolder}/shell.nix";
+  nix-spdk-path = if spdk-path != null then " --argstr spdk-path $(realpath ${toString spdk-path})" else "";
 
   shellAttrs = import ./spdk-rs/nix/shell {
     inherit rust;
@@ -76,7 +77,7 @@ let
 
         cat > "$SRCDIR/.vscode/settings.json" <<EOF
         {
-            "nixEnvSelector.args": "--argstr rust ${rust} --argstr spdk ${spdk} --argstr spdk-path $(realpath ${toString spdk-path})",
+            "nixEnvSelector.args": "--argstr rust ${rust} --argstr spdk ${spdk}${nix-spdk-path}",
             "nixEnvSelector.nixFile": "${toString nix-file}"
         }
         EOF


### PR DESCRIPTION
Allows us to quickly check if a pool disk is available for use, reporting
anything wrong with the disks such as not found, invalid uri, etc

This api is meant to be used for probing for device issues without flooding
the logs with errors messages during pool import attempts.

SuperBlock read/validation is not added as part of this, will be added later,
which would allow for verification of the pool.