### PR TITLE
fix: speed up list-replicas gRPC

### DIFF
--- a/io-engine/examples/lvs-eval/main.rs
+++ b/io-engine/examples/lvs-eval/main.rs
@@ -176,6 +176,7 @@ async fn create_lvol(
         thin,
         entity_id: None,
         use_extent_table: Some(et),
+        wipe_super: true,
     };
 
     lvs.create_lvol_with_opts(opts).await.map_err(|err| {

--- a/io-engine/src/bdev/nexus/nexus_io_subsystem.rs
+++ b/io-engine/src/bdev/nexus/nexus_io_subsystem.rs
@@ -244,24 +244,24 @@ impl<'n> NexusIoSubsystem<'n> {
                         if let Some(subsystem) = NvmfSubsystem::nqn_lookup(&self.name) {
                             trace!(
                                 "{self:?}: subsystem '{}' not being resumed",
-                                subsystem.get_nqn()
+                                subsystem.nqn_str()
                             );
                         }
                         self.pause_state.store(NexusPauseState::Frozen);
                     } else {
                         if let Some(subsystem) = NvmfSubsystem::nqn_lookup(&self.name) {
                             self.pause_state.store(NexusPauseState::Unpausing);
-                            trace!("{self:?}: resuming subsystem '{}'...", subsystem.get_nqn());
+                            trace!("{self:?}: resuming subsystem '{}'...", subsystem.nqn_str());
                             if let Err(error) = subsystem.resume().await {
                                 // todo: handle error instead of panic, but in practice only ENOMEM can be seen here?
                                 panic!(
                                     "Failed to resume subsystem '{}: {}",
-                                    subsystem.get_nqn(),
+                                    subsystem.nqn_str(),
                                     error
                                 );
                             }
 
-                            trace!("{self:?}: subsystem '{}' resumed", subsystem.get_nqn());
+                            trace!("{self:?}: subsystem '{}' resumed", subsystem.nqn_str());
                         }
                         // todo: we may have received a Stop request whilst resuming
                         self.pause_state.store(NexusPauseState::Unpaused);

--- a/io-engine/src/core/env.rs
+++ b/io-engine/src/core/env.rs
@@ -297,6 +297,10 @@ pub struct MayastorCliArgs {
     /// [`SpdkTracingArgs`].
     #[clap(flatten)]
     pub traces: SpdkTracingArgs,
+
+    /// [`NvmeCliArgs`].
+    #[clap(flatten)]
+    pub nvme: NvmeCliArgs,
 }
 
 /// SPDK tracing related arguments.
@@ -367,6 +371,24 @@ pub struct PoolCliArgs {
     pub io_stall_transition_window: humantime::Duration,
 }
 impl Default for PoolCliArgs {
+    fn default() -> Self {
+        Self::parse_from(Vec::<String>::new())
+    }
+}
+
+/// NVMe related arguments.
+#[derive(Debug, clap::Parser, Clone)]
+pub struct NvmeCliArgs {
+    /// Maximum number of NVMe namespaces we can expose. {n}
+    /// As of today, there's a 1-1 mapping of namespaces to nvmf targets.
+    #[clap(
+        long = "nvme-max-namespaces",
+        env = "NVME_MAX_NAMESPACES",
+        default_value_t = 4096
+    )]
+    pub max_namespaces: u32,
+}
+impl Default for NvmeCliArgs {
     fn default() -> Self {
         Self::parse_from(Vec::<String>::new())
     }
@@ -496,6 +518,7 @@ pub struct MayastorEnvironment {
     rdma: bool,
     bs_cluster_unmap: bool,
     pub pool_args: PoolCliArgs,
+    pub nvme: NvmeCliArgs,
 }
 
 impl Default for MayastorEnvironment {
@@ -547,6 +570,7 @@ impl Default for MayastorEnvironment {
             bs_cluster_unmap: false,
             pool_args: PoolCliArgs::default(),
             traces: SpdkTracingArgs::default(),
+            nvme: NvmeCliArgs::default(),
         }
     }
 }
@@ -690,6 +714,7 @@ impl MayastorEnvironment {
             enable_io_all_thrd_nexus_channels: args.enable_io_all_thrd_nexus_channels,
             pool_args: args.pool,
             traces: args.traces,
+            nvme: args.nvme,
             ..Default::default()
         }
         .setup_static()

--- a/io-engine/src/core/mod.rs
+++ b/io-engine/src/core/mod.rs
@@ -21,7 +21,8 @@ pub use device_events::{
 };
 pub use device_monitor::{device_cmd_queue, device_monitor_loop, DeviceCommand};
 pub use env::{
-    mayastor_env_stop, MayastorCliArgs, MayastorEnvironment, PoolCliArgs, GLOBAL_RC, SIG_RECEIVED,
+    mayastor_env_stop, MayastorCliArgs, MayastorEnvironment, NvmeCliArgs, PoolCliArgs, GLOBAL_RC,
+    SIG_RECEIVED,
 };
 pub use handle::{BdevHandle, UntypedBdevHandle};
 pub use io_device::IoDevice;

--- a/io-engine/src/eventing/host_events.rs
+++ b/io-engine/src/eventing/host_events.rs
@@ -37,9 +37,9 @@ impl HostTargetMeta for Lvol {
 
 impl EventMetaGen for NvmfSubsystem {
     fn meta(&self) -> EventMeta {
-        let nqn = self.get_nqn();
+        let nqn = self.nqn_str();
         let event_source = EventSource::new(MayastorEnvironment::global_or_default().node_name)
-            .with_subsystem_data(&nqn);
+            .with_subsystem_data(nqn);
 
         EventMeta::from_source(event_source)
     }

--- a/io-engine/src/grpc/v1/pool.rs
+++ b/io-engine/src/grpc/v1/pool.rs
@@ -407,7 +407,8 @@ impl PoolGrpc {
                 uuid: args.uuid,
                 thin: args.thin,
                 entity_id: args.entity_id,
-                use_extent_table: None,
+                wipe_super: true,
+                ..Default::default()
             })
             .await
         {

--- a/io-engine/src/lvs/lvs_store.rs
+++ b/io-engine/src/lvs/lvs_store.rs
@@ -1068,7 +1068,8 @@ impl Lvs {
             uuid: uuid.unwrap_or("").to_string(),
             thin,
             entity_id,
-            use_extent_table: None,
+            wipe_super: true,
+            ..Default::default()
         })
         .await
     }
@@ -1166,22 +1167,24 @@ impl Lvs {
             }
         }
 
-        info!("{lvol:?}: wiping super");
+        if opts.wipe_super {
+            info!("{lvol:?}: wiping super");
 
-        if let Err(error) = lvol.wipe_super().await {
-            // If we fail to destroy it hopefully the control-plane will clean
-            // it up, though it's possible it may attempt to use it...
-            // todo: address this; with a property?
-            let lvol_uuid = lvol.uuid();
-            if let Err(error) = lvol.destroy().await {
-                warn!(
-                    "uuid/{lvol_uuid}: failed to destroy lvol after failing to wipe super: {error:?}",
-                );
+            if let Err(error) = lvol.wipe_super().await {
+                // If we fail to destroy it hopefully the control-plane will clean
+                // it up, though it's possible it may attempt to use it...
+                // todo: address this; with a property?
+                let lvol_uuid = lvol.uuid();
+                if let Err(error) = lvol.destroy().await {
+                    warn!(
+                        "uuid/{lvol_uuid}: failed to destroy lvol after failing to wipe super: {error:?}",
+                    );
+                }
+                return Err(error);
             }
-            return Err(error);
         }
-
         info!("{lvol:?}: created");
+
         lvol.event(EventAction::Create).generate();
         Ok(lvol)
     }

--- a/io-engine/src/pool_backend.rs
+++ b/io-engine/src/pool_backend.rs
@@ -58,6 +58,27 @@ pub struct ReplicaArgs {
     pub thin: bool,
     pub entity_id: Option<String>,
     pub use_extent_table: Option<bool>,
+    pub wipe_super: bool,
+}
+impl ReplicaArgs {
+    /// Create [`ReplicaArgs`] with the given name and size.
+    pub fn new<S: Into<String>>(name: S, size: u64) -> Self {
+        Self {
+            name: name.into(),
+            size,
+            ..Default::default()
+        }
+    }
+    /// Specify the `wipe_super` argument.
+    pub fn wipe_super(mut self, wipe_super: bool) -> Self {
+        self.wipe_super = wipe_super;
+        self
+    }
+    /// Specify the `thin` argument.
+    pub fn thin(mut self, thin: bool) -> Self {
+        self.thin = thin;
+        self
+    }
 }
 
 /// Generic Errors shared by all backends.

--- a/io-engine/src/subsys/config/opts.rs
+++ b/io-engine/src/subsys/config/opts.rs
@@ -138,7 +138,7 @@ impl Default for NvmfTgtConfig {
         let args = MayastorEnvironment::global_or_default();
         Self {
             name: "mayastor_target".to_string(),
-            max_namespaces: try_from_env("NVME_MAX_NAMESPACES", 4096),
+            max_namespaces: args.nvme.max_namespaces,
             crdt: args.nvmf_tgt_crdt,
             opts_tcp: NvmfTransportOpts::default(),
             interface: None,

--- a/io-engine/src/subsys/nvmf/subsystem.rs
+++ b/io-engine/src/subsys/nvmf/subsystem.rs
@@ -1031,10 +1031,16 @@ impl NvmfSubsystem {
 
     /// Lookup a subsystem by its nqn.
     pub fn nqn_lookup_(nqn: &str) -> Option<NvmfSubsystem> {
-        NvmfSubsystem::first()
-            .unwrap()
-            .into_iter()
-            .find(|s| s.nqn_str() == nqn)
+        NVMF_TGT.with(|t| {
+            let nqn = nqn.into_cstring();
+            let ss = unsafe { spdk_nvmf_tgt_find_subsystem(t.borrow().tgt.as_ptr(), nqn.as_ptr()) };
+
+            if ss.is_null() {
+                None
+            } else {
+                Some(NvmfSubsystem(NonNull::new(ss).unwrap()))
+            }
+        })
     }
 
     /// get the bdev associated with this subsystem -- we implicitly assume the

--- a/io-engine/src/subsys/nvmf/subsystem.rs
+++ b/io-engine/src/subsys/nvmf/subsystem.rs
@@ -1,6 +1,6 @@
 use std::{
     convert::TryFrom,
-    ffi::{c_void, CString},
+    ffi::{c_void, CStr, CString},
     fmt::{self, Debug, Display, Formatter},
     mem::zeroed,
     ptr::{self, NonNull},
@@ -220,7 +220,7 @@ impl NvmfSubsystem {
 
         debug!("NVMF subsystem event {s:?}: {event:?}");
 
-        let nqn_tgt = NqnTarget::lookup(&s.get_nqn());
+        let nqn_tgt = NqnTarget::lookup(s.nqn_str());
         if matches!(nqn_tgt, NqnTarget::None) {
             warn!(
                 "NVMF subsystem event {s:?}: {event:?}: \
@@ -298,7 +298,7 @@ impl NvmfSubsystem {
             "Host '{host}' connected to subsystem '{subsys}' on \
             nexus '{nex:?}'",
             host = ctrlr.hostnqn(),
-            subsys = self.get_nqn(),
+            subsys = self.nqn_str(),
         );
 
         nex.add_initiator(&ctrlr.hostnqn());
@@ -318,7 +318,7 @@ impl NvmfSubsystem {
             "Host '{host}' disconnected from subsystem '{subsys}' on \
             nexus '{nex:?}'",
             host = ctrlr.hostnqn(),
-            subsys = self.get_nqn(),
+            subsys = self.nqn_str(),
         );
 
         nex.rm_initiator(&ctrlr.hostnqn());
@@ -334,7 +334,7 @@ impl NvmfSubsystem {
             "Host '{host}': keep alive timeout on subsystem '{subsys}' on \
             nexus '{nex:?}'",
             host = ctrlr.hostnqn(),
-            subsys = self.get_nqn(),
+            subsys = self.nqn_str(),
         );
 
         nex.initiator_keep_alive_timeout(&ctrlr.hostnqn());
@@ -370,7 +370,7 @@ impl NvmfSubsystem {
             "Host '{host}' connected to subsystem '{subsys}' on \
             replica '{lvol:?}'",
             host = ctrlr.hostnqn(),
-            subsys = self.get_nqn(),
+            subsys = self.nqn_str(),
         );
 
         unsafe {
@@ -388,7 +388,7 @@ impl NvmfSubsystem {
             "Host '{host}' disconnected from subsystem '{subsys}' on \
             replica '{lvol:?}'",
             host = ctrlr.hostnqn(),
-            subsys = self.get_nqn(),
+            subsys = self.nqn_str(),
         );
 
         unsafe {
@@ -402,7 +402,7 @@ impl NvmfSubsystem {
             "Host '{host}': keep alive timeout on subsystem '{subsys}' on \
             replica '{lvol:?}'",
             host = ctrlr.hostnqn(),
-            subsys = self.get_nqn(),
+            subsys = self.nqn_str(),
         );
     }
 
@@ -569,12 +569,25 @@ impl NvmfSubsystem {
     }
 
     /// Get NVMe subsystem's NQN
+    /// # Warning
+    /// If used as a lookup, this can be very expensive when very large clusters as it's
+    /// allocating and copying a new string rather than returning a reference.
     pub fn get_nqn(&self) -> String {
         unsafe {
             spdk_nvmf_subsystem_get_nqn(self.0.as_ptr())
                 .as_str()
                 .to_string()
         }
+    }
+
+    /// Get NVMe subsystem's NQN as a [`CStr`] reference
+    pub fn nqn_cstr(&self) -> &CStr {
+        unsafe { CStr::from_ptr(spdk_nvmf_subsystem_get_nqn(self.0.as_ptr())) }
+    }
+
+    /// Get NVMe subsystem's NQN as a [`CStr`] reference
+    pub fn nqn_str(&self) -> &str {
+        self.nqn_cstr().to_str().unwrap_or("")
     }
 
     fn cstr(host: &str) -> Result<CString, Error> {
@@ -804,7 +817,7 @@ impl NvmfSubsystem {
 
                 warn!(
                     "Failed to {op} '{}': subsystem is busy, retrying {n}...",
-                    self.get_nqn()
+                    self.nqn_str()
                 );
 
                 crate::sleep::mayastor_sleep(std::time::Duration::from_millis(100))
@@ -1015,7 +1028,7 @@ impl NvmfSubsystem {
         NvmfSubsystem::first()
             .unwrap()
             .into_iter()
-            .find(|s| s.get_nqn() == nqn)
+            .find(|s| s.nqn_str() == nqn)
     }
 
     /// get the bdev associated with this subsystem -- we implicitly assume the
@@ -1078,12 +1091,9 @@ impl NvmfSubsystem {
 
     /// return the URI's this subsystem is listening on
     pub fn uri_endpoints(&self) -> Option<Vec<String>> {
-        if let Some(v) = self.listeners_to_vec() {
-            let nqn = self.get_nqn();
-            Some(v.iter().map(|t| format!("{t}/{nqn}")).collect::<Vec<_>>())
-        } else {
-            None
-        }
+        let nqn = self.nqn_str();
+        self.listeners_to_vec()
+            .map(|v| v.iter().map(|t| format!("{t}/{nqn}")).collect())
     }
 }
 

--- a/io-engine/src/subsys/nvmf/subsystem.rs
+++ b/io-engine/src/subsys/nvmf/subsystem.rs
@@ -219,8 +219,7 @@ impl NvmfSubsystem {
         let event = NvmfSubsystemEvent::from_cb_args(event, ctx);
 
         debug!("NVMF subsystem event {s:?}: {event:?}");
-
-        let nqn_tgt = NqnTarget::lookup(s.nqn_str());
+        let nqn_tgt = NqnTarget::from(&s);
         if matches!(nqn_tgt, NqnTarget::None) {
             warn!(
                 "NVMF subsystem event {s:?}: {event:?}: \
@@ -1022,9 +1021,16 @@ impl NvmfSubsystem {
         })
     }
 
-    /// lookup a subsystem by its UUID
+    /// Lookup a subsystem by its UUID.
+    /// # Warning
+    /// This is a misnomer, as the function input is a name/uuid!
     pub fn nqn_lookup(uuid: &str) -> Option<NvmfSubsystem> {
         let nqn = make_nqn(uuid);
+        Self::nqn_lookup_(&nqn)
+    }
+
+    /// Lookup a subsystem by its nqn.
+    pub fn nqn_lookup_(nqn: &str) -> Option<NvmfSubsystem> {
         NvmfSubsystem::first()
             .unwrap()
             .into_iter()
@@ -1109,31 +1115,15 @@ pub enum NqnTarget<'a> {
     None,
 }
 
-impl NqnTarget<'_> {
-    pub fn lookup(nqn: &str) -> Self {
-        let Some(bdev) = UntypedBdev::bdev_first() else {
+impl From<&'_ NvmfSubsystem> for NqnTarget<'_> {
+    fn from(value: &'_ NvmfSubsystem) -> Self {
+        let Some(bdev) = value.bdev() else {
             return Self::None;
         };
-
-        let parts: Vec<&str> = nqn.split(':').collect();
-        if parts.len() != 2 || parts[0] != NVME_NQN_PREFIX {
-            return Self::None;
+        match bdev.driver() {
+            NEXUS_MODULE_NAME => Self::Nexus(unsafe { Nexus::unsafe_from_untyped_bdev(*bdev) }),
+            "lvol" => Lvol::try_from(bdev).map_or(Self::None, Self::Replica),
+            _ => Self::None,
         }
-
-        let name = parts[1];
-
-        for b in bdev.into_iter() {
-            match b.driver() {
-                NEXUS_MODULE_NAME if b.name() == name => {
-                    return Self::Nexus(unsafe { Nexus::unsafe_from_untyped_bdev(*b) });
-                }
-                "lvol" if b.name() == name => {
-                    return Lvol::try_from(b).map_or(Self::None, Self::Replica)
-                }
-                _ => {}
-            }
-        }
-
-        Self::None
     }
 }

--- a/io-engine/tests/lvs_pool.rs
+++ b/io-engine/tests/lvs_pool.rs
@@ -3,8 +3,8 @@ use io_engine::{
     bdev::crypto::{Cipher, EncryptionKey},
     bdev_api::bdev_create,
     core::{
-        logical_volume::LogicalVolume, MayastorCliArgs, NvmfShareProps, PoolCliArgs, Protocol,
-        Share, ToErrno, UntypedBdev,
+        logical_volume::LogicalVolume, MayastorCliArgs, NvmeCliArgs, NvmfShareProps, PoolCliArgs,
+        Protocol, Share, ToErrno, UntypedBdev,
     },
     grpc::v1::pool::pool_to_proto,
     lvs::{Lvs, LvsLvol, PropName, PropValue},
@@ -38,6 +38,9 @@ fn ms() -> &'static MayastorTest<'static> {
             pool: PoolCliArgs {
                 io_error_threshold: IO_ERROR_THRESHOLD,
                 ..Default::default()
+            },
+            nvme: NvmeCliArgs {
+                max_namespaces: 8192,
             },
             ..Default::default()
         })

--- a/io-engine/tests/lvs_pool.rs
+++ b/io-engine/tests/lvs_pool.rs
@@ -3,16 +3,17 @@ use io_engine::{
     bdev::crypto::{Cipher, EncryptionKey},
     bdev_api::bdev_create,
     core::{
-        logical_volume::LogicalVolume, MayastorCliArgs, PoolCliArgs, Protocol, Share, ToErrno,
-        UntypedBdev,
+        logical_volume::LogicalVolume, MayastorCliArgs, NvmfShareProps, PoolCliArgs, Protocol,
+        Share, ToErrno, UntypedBdev,
     },
     grpc::v1::pool::pool_to_proto,
     lvs::{Lvs, LvsLvol, PropName, PropValue},
     pool_backend::{PoolArgs, PoolBackend, PoolOps, ReplicaArgs},
     subsys::NvmfSubsystem,
 };
-use io_engine_api::v1::pool::{
-    Pool, PoolAlert, PoolAlertStatus, PoolAlerts, PoolErrors, PoolState,
+use io_engine_api::v1::{
+    pool::{Pool, PoolAlert, PoolAlertStatus, PoolAlerts, PoolErrors, PoolState},
+    replica::ListReplicaOptions,
 };
 use once_cell::sync::OnceCell;
 use std::pin::Pin;
@@ -735,6 +736,110 @@ async fn lvs_hot_remove() {
 
         let error = repl.destroy().await.expect_err("-EIO");
         assert_eq!(error.to_errno(), nix::Error::EIO);
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn lvol_list() {
+    let ms = ms();
+
+    let pool_size = "4GiB";
+    let repl_size = 4 * 1024 * 1024;
+
+    use io_engine::pool_backend::PoolMetadataArgs;
+    let pool_args = PoolArgs {
+        name: "tpool".into(),
+        disks: vec![format!("malloc:///m?size={pool_size}")],
+        backend: PoolBackend::Lvs,
+        md_args: Some(PoolMetadataArgs {
+            max_expansion: Some("300GiB".into()),
+        }),
+        ..Default::default()
+    };
+
+    ms.start_grpc();
+    ms.start_device_monitor();
+
+    ms.spawn(async move {
+        let lvs_pool = Lvs::create_or_import(pool_args).await.unwrap();
+
+        for i in 1..8000 {
+            let name = format!("replica-{i}");
+            let opts = ReplicaArgs::new(name, repl_size)
+                .wipe_super(false)
+                .thin(true);
+            let _repl = lvs_pool.create_lvol_with_opts(opts).await.unwrap();
+        }
+    })
+    .await;
+
+    // this could vary depending on the system where we're running, but this is large enough that
+    // it should run on weaker systems as well as low enough to ensure we're testing the fix.
+    let max_dur = std::time::Duration::from_millis(300);
+
+    // 1. this list is "quicker" as there's no nvmf subsystems
+    let list_tm = std::time::Instant::now();
+    ms.spawn(async move {
+        for lvs_pool in Lvs::iter() {
+            for lvol in lvs_pool.lvols().unwrap() {
+                let _replica: io_engine_api::v1::replica::Replica = lvol.into();
+            }
+        }
+    })
+    .await;
+    let no_uri_elapsed = list_tm.elapsed();
+    println!("Lvol List: {no_uri_elapsed:?}");
+    assert!(no_uri_elapsed <= max_dur, "Listing replicas took too long");
+
+    // 2. we share all replicas, so each replica now must search its subsystems
+    ms.spawn(async move {
+        for lvs_pool in Lvs::iter() {
+            for mut lvol in lvs_pool.lvols().unwrap() {
+                use io_engine::replica_backend::ReplicaOps;
+                lvol.share_nvmf(NvmfShareProps::new()).await.unwrap();
+            }
+        }
+    })
+    .await;
+
+    // 3. we have to iter but also convert each lvol to a Replica so we can exercise the subsystem listing
+    let list_tm = std::time::Instant::now();
+    ms.spawn(async move {
+        let list_tm = std::time::Instant::now();
+        for lvs_pool in Lvs::iter() {
+            for lvol in lvs_pool.lvols().unwrap() {
+                let _replica: io_engine_api::v1::replica::Replica = lvol.into();
+            }
+        }
+        println!("Lvol List time: {:?}", list_tm.elapsed());
+    })
+    .await;
+    let uri_elapsed = list_tm.elapsed();
+    println!("Lvol List: {uri_elapsed:?}");
+    assert!(uri_elapsed <= max_dur, "Listing replicas took too long");
+
+    use io_engine_api::v1::replica::ReplicaRpcClient;
+    let mut h = ReplicaRpcClient::connect("http://localhost:10124")
+        .await
+        .unwrap();
+
+    let list_tm = std::time::Instant::now();
+    h.list_replicas(ListReplicaOptions::default())
+        .await
+        .unwrap();
+    let grpc_elapsed = list_tm.elapsed();
+    println!("gRPC Lvol List: {grpc_elapsed:?}");
+    assert!(
+        // adds some extra buffer for gRPC
+        grpc_elapsed <= (max_dur + std::time::Duration::from_millis(100)),
+        "Listing replicas took too long"
+    );
+
+    ms.spawn(async move {
+        for lvs_pool in Lvs::iter() {
+            lvs_pool.destroy().await.unwrap();
+        }
     })
     .await;
 }


### PR DESCRIPTION
    fix: lookup nvmf subsystem using rb-tree find methods
    
    This avoids iterating over the entire list of subsystems which can
    greatly reduce lookup when the nr of subsystems is in the thousands.
    
---

    refactor: lookup nqn for events using subsystem api
    
    Don't convert the nqn to a uuid since we can get the bdev
    from the subsystem itself.
    
---

    fix: use nqn as cstr instead of copying
    
    Avoid copying the nqn into a new string everything it's inspected.
    
---

    refactor: add nvme max-namespaces to the cli and env args
    
    This makes it easier to modify tests to override the values.
    todo: we should change all other random bits of env parsing args
    to use this.
    
---

    test: ensure list replicas don't take "too long"
    
    No sure what the expected duration should be, but 300ms seems reasonably
    long to list all replicas.
    
    Note that most of the time was measure to come from the subsystem get/list.
    
---

    refactor: add wipe super to ReplicaArgs
    
    This will allow us to create replicas without wiping the "super block",
    which would be useful for testing with a very large number of replicas,
    without having to wipe and allocate the initial clusters.
