### PR TITLE
fix: lvs and nexus error code mapping

### DIFF
--- a/io-engine/src/bdev/nexus/nexus_bdev_error.rs
+++ b/io-engine/src/bdev/nexus/nexus_bdev_error.rs
@@ -6,7 +6,7 @@ use super::{ChildError, NbdError, NexusPauseState};
 
 use crate::{
     bdev_api::BdevError,
-    core::{CoreError, VerboseError},
+    core::{CoreError, ToErrno, VerboseError},
     rebuild::RebuildError,
     store::store_defs::StoreError,
     subsys::NvmfError,
@@ -214,6 +214,10 @@ impl From<Error> for tonic::Status {
             Error::ChildAlreadyExists { .. } => Status::already_exists(e.to_string()),
             Error::NameExists { .. } => Status::already_exists(e.to_string()),
             Error::InvalidArguments { .. } => Status::invalid_argument(e.to_string()),
+            Error::ShareNvmfNexus { ref source, .. } if source.to_errno() == Errno::EMLINK => {
+                Status::out_of_range(e.to_string())
+            }
+            Error::ShareNvmfNexus { .. } => Status::internal(e.to_string()),
             e => Status::new(Code::Internal, e.verbose()),
         }
     }

--- a/io-engine/src/bdev/nexus/nexus_bdev_error.rs
+++ b/io-engine/src/bdev/nexus/nexus_bdev_error.rs
@@ -1,8 +1,8 @@
 use nix::errno::Errno;
 use snafu::Snafu;
-use tonic::{Code, Status};
+use tonic::Status;
 
-use super::{ChildError, NbdError, NexusPauseState};
+use super::{ChildError, NbdError};
 
 use crate::{
     bdev_api::BdevError,
@@ -29,10 +29,6 @@ pub enum Error {
     NameExists { name: String },
     #[snafu(display("Invalid encryption key"))]
     InvalidKey {},
-    #[snafu(display("Failed to create crypto bdev for nexus {}", name))]
-    CreateCryptoBdev { source: Errno, name: String },
-    #[snafu(display("Failed to destroy crypto bdev for nexus {}", name))]
-    DestroyCryptoBdev { source: Errno, name: String },
     #[snafu(display("The nexus {} has been already shared with a different protocol", name))]
     AlreadyShared { name: String },
     #[snafu(display("The nexus {} has not been shared", name))]
@@ -81,8 +77,6 @@ pub enum Error {
     ChildGeometry { child: String, name: String },
     #[snafu(display("Child {} of nexus {} cannot be found", child, name))]
     ChildMissing { child: String, name: String },
-    #[snafu(display("Child {} of nexus {} has no error store", child, name))]
-    ChildMissingErrStore { child: String, name: String },
     #[snafu(display(
         "Failed to acquire write exclusive reservation on child {} of nexus {}",
         child,
@@ -121,8 +115,6 @@ pub enum Error {
     ChildDeviceNotOpen { child: String, name: String },
     #[snafu(display("Child {} of nexus {} already exists", child, name))]
     ChildAlreadyExists { child: String, name: String },
-    #[snafu(display("Failed to pause child {} of nexus {}", child, name))]
-    PauseChild { child: String, name: String },
     #[snafu(display("Suitable rebuild source for nexus {} not found", name))]
     NoRebuildSource { name: String },
     #[snafu(display("Failed to create rebuild job for child {} of nexus {}", child, name,))]
@@ -159,17 +151,10 @@ pub enum Error {
         name: String,
         state: String,
     },
-    #[snafu(display("Failed to get BdevHandle for snapshot operation"))]
-    FailedGetHandle,
     #[snafu(display("Failed to create snapshot on nexus {}: {}", name, reason))]
     FailedCreateSnapshot { name: String, reason: String },
     #[snafu(display("NVMf subsystem error: {}", e))]
     SubsysNvmf { e: String },
-    #[snafu(display("failed to pause {} current state {:?}", name, state))]
-    Pause {
-        state: NexusPauseState,
-        name: String,
-    },
     #[snafu(display("Operation not allowed: {}", reason))]
     OperationNotAllowed { reason: String },
     #[snafu(display("Invalid value for nvme reservation: {}", reservation))]
@@ -190,7 +175,8 @@ impl From<NvmfError> for Error {
 
 impl From<Error> for tonic::Status {
     fn from(e: Error) -> Self {
-        match e {
+        let errno = e.to_errno();
+        let mut status = match e {
             Error::InvalidUuid { .. } => Status::invalid_argument(e.to_string()),
             Error::InvalidKey { .. } => Status::invalid_argument(e.to_string()),
             Error::InvalidShareProtocol { .. } => Status::invalid_argument(e.to_string()),
@@ -218,7 +204,98 @@ impl From<Error> for tonic::Status {
                 Status::out_of_range(e.to_string())
             }
             Error::ShareNvmfNexus { .. } => Status::internal(e.to_string()),
-            e => Status::new(Code::Internal, e.verbose()),
+            Error::NexusInitialising { .. } => Status::internal(e.to_string()),
+            Error::UuidExists { .. } => Status::internal(e.to_string()),
+            Error::ShareNbdNexus { .. } => Status::internal(e.to_string()),
+            Error::UnshareNexus { .. } => Status::internal(e.to_string()),
+            Error::RegisterNexus { .. } => Status::internal(e.to_string()),
+            Error::ChildMissing { .. } => Status::internal(e.to_string()),
+            Error::ChildWriteExclusiveResvFailed { .. } => Status::internal(e.to_string()),
+            Error::OnlineChild { .. } => Status::internal(e.to_string()),
+            Error::CloseChild { .. } => Status::internal(e.to_string()),
+            Error::ChildDeviceNotOpen { .. } => Status::failed_precondition(e.to_string()),
+            Error::NoRebuildSource { .. } => Status::failed_precondition(e.to_string()),
+            Error::CreateRebuild { .. } => Status::already_exists(e.to_string()),
+            Error::RebuildJobAlreadyExists { .. } => Status::already_exists(e.to_string()),
+            Error::RebuildOperation { .. } => Status::internal(e.to_string()),
+            Error::InvalidNvmeAnaState { .. } => Status::invalid_argument(e.to_string()),
+            Error::NexusCreate { .. } => Status::internal(e.to_string()),
+            Error::NexusDestroy { .. } => Status::internal(e.to_string()),
+            Error::ChildNotDegraded { .. } => Status::failed_precondition(e.to_string()),
+            Error::FailedCreateSnapshot { .. } => Status::internal(e.to_string()),
+            Error::SubsysNvmf { .. } => Status::internal(e.to_string()),
+            Error::UpdateShareProperties { .. } => Status::internal(e.to_string()),
+            Error::SaveStateFailed { .. } => Status::data_loss(e.to_string()),
+        };
+        status
+            .metadata_mut()
+            .insert("errno", tonic::metadata::MetadataValue::from(errno as i32));
+        status
+    }
+}
+
+impl ToErrno for Error {
+    fn to_errno(&self) -> nix::Error {
+        match self {
+            Error::ShareNvmfNexus { source, .. } | Error::UnshareNexus { source, .. } => {
+                source.to_errno()
+            }
+            Error::RegisterNexus { source, .. } => *source,
+            // todo: need to change spdk_nvme_connect_async to include the probe_error callback
+            // otherwise the source errno here is always -ENXIO for nvmx failures.
+            Error::CreateChild { source, .. } => source.to_errno(),
+            Error::ChildWriteExclusiveResvFailed { .. } => nix::Error::EKEYREJECTED,
+            Error::OpenChild { source, .. } => source.to_errno(),
+            Error::OnlineChild { source, .. } => source.to_errno(),
+            Error::CloseChild { source, .. } => source.to_errno(),
+            Error::CreateRebuild { .. } => nix::Error::EPIPE,
+            Error::RebuildOperation { .. } => nix::Error::EPIPE,
+            Error::NexusResize { source, .. } => *source,
+            Error::UpdateShareProperties { source, .. } => source.to_errno(),
+            Error::SaveStateFailed { .. } => nix::Error::ENODATA,
+
+            Error::ShareNbdNexus { .. } => Errno::ENOTSUP,
+
+            Error::NexusNotFound { .. }
+            | Error::ChildMissing { .. }
+            | Error::ChildNotFound { .. }
+            | Error::RebuildJobNotFound { .. } => Errno::ENOENT,
+
+            Error::UuidExists { .. }
+            | Error::NameExists { .. }
+            | Error::ChildAlreadyExists { .. }
+            | Error::RebuildJobAlreadyExists { .. } => Errno::EEXIST,
+
+            Error::InvalidUuid { .. }
+            | Error::InvalidKey { .. }
+            | Error::InvalidShareProtocol { .. }
+            | Error::InvalidNvmeAnaState { .. }
+            | Error::InvalidArguments { .. }
+            | Error::InvalidReservation { .. } => Errno::EINVAL,
+
+            Error::NexusInitialising { .. } => Errno::EBUSY,
+
+            Error::AlreadyShared { .. }
+            | Error::NotShared { .. }
+            | Error::NotSharedNvmf { .. }
+            | Error::OperationNotAllowed { .. }
+            | Error::RemoveLastChild { .. }
+            | Error::RemoveLastHealthyChild { .. }
+            | Error::ChildNotDegraded { .. } => Errno::EPERM,
+
+            Error::ChildDeviceNotOpen { .. }
+            | Error::ChildGeometry { .. }
+            | Error::ChildTooSmall { .. }
+            | Error::SubsysNvmf { .. } => Errno::EIO,
+
+            Error::NexusIncomplete { .. }
+            | Error::NexusCreate { .. }
+            | Error::NexusDestroy { .. }
+            | Error::FailedCreateSnapshot { .. }
+            | Error::NoRebuildSource { .. } => Errno::EFAULT,
+
+            // This is something we'll have to handle better
+            Error::MixedBlockSizes { .. } => Errno::EINVAL,
         }
     }
 }

--- a/io-engine/src/bdev/nexus/nexus_child.rs
+++ b/io-engine/src/bdev/nexus/nexus_child.rs
@@ -19,7 +19,7 @@ use crate::{
     bdev::{device_create, device_destroy, device_lookup},
     bdev_api::BdevError,
     core::{
-        BlockDevice, BlockDeviceDescriptor, BlockDeviceHandle, CoreError, DeviceEventSink,
+        BlockDevice, BlockDeviceDescriptor, BlockDeviceHandle, CoreError, DeviceEventSink, ToErrno,
         VerboseError,
     },
     eventing::replica_events::state_change_event_meta,
@@ -95,6 +95,33 @@ pub enum ChildError {
     NvmeHostId { source: CoreError },
     #[snafu(display("Failed to create a BlockDevice for child {}", child))]
     ChildBdevCreate { child: String, source: BdevError },
+}
+
+impl ToErrno for ChildError {
+    fn to_errno(&self) -> Errno {
+        match self {
+            ChildError::PermanentlyFaulted { .. } => Errno::EFAULT,
+            ChildError::ChildFaulted { .. } => Errno::EFAULT,
+            ChildError::ChildBeingDestroyed { .. } => Errno::EBUSY,
+            ChildError::ChildTooSmall { .. } => Errno::EINVAL,
+            ChildError::ChildInaccessible { .. } => Errno::ENXIO,
+            ChildError::CannotOnlineChild { .. } => Errno::ERFKILL,
+            ChildError::ResvType { .. } => Errno::EINVAL,
+            ChildError::ResvNoHolder { .. } => Errno::EPERM,
+            ChildError::Holder { .. } => Errno::EPERM,
+            ChildError::ClaimChild { source } => *source,
+            ChildError::OpenChild { source } => source.to_errno(),
+            ChildError::HandleCreate { source } => source.to_errno(),
+            ChildError::HandleOpen { source } => source.to_errno(),
+            ChildError::HandleDmaMalloc { .. } => Errno::ENOMEM,
+            ChildError::ResvRegisterKey { source } => source.to_errno(),
+            ChildError::ResvAcquire { source } => source.to_errno(),
+            ChildError::ResvRelease { source } => source.to_errno(),
+            ChildError::ResvReport { source } => source.to_errno(),
+            ChildError::NvmeHostId { source } => source.to_errno(),
+            ChildError::ChildBdevCreate { source, .. } => source.to_errno(),
+        }
+    }
 }
 
 /// Fault reason.
@@ -927,10 +954,7 @@ impl<'c> NexusChild<'c> {
         let state = self.state.load();
 
         if state.is_open_or_init() {
-            warn!(
-                "{:?}: child is in {} state and cannot be onlined",
-                self, state
-            );
+            warn!("{self:?}: child is in {state} state and cannot be onlined");
             return Err(ChildError::CannotOnlineChild {});
         }
 
@@ -940,10 +964,7 @@ impl<'c> NexusChild<'c> {
         }
 
         if !state.is_recoverable() {
-            warn!(
-                "{:?}: child is permanently faulted and cannot be onlined",
-                self
-            );
+            warn!("{self:?}: child is permanently faulted and cannot be onlined",);
             return Err(ChildError::PermanentlyFaulted {});
         }
 
@@ -955,10 +976,7 @@ impl<'c> NexusChild<'c> {
 
         self.device = device_lookup(&name);
         if self.device.is_none() {
-            error!(
-                "{:?}: failed to find device after successful creation",
-                self,
-            );
+            error!("{self:?}: failed to find device after successful creation",);
             return Err(ChildError::ChildInaccessible {});
         }
 

--- a/io-engine/src/bdev/nvmx/controller.rs
+++ b/io-engine/src/bdev/nvmx/controller.rs
@@ -1230,8 +1230,8 @@ pub(crate) mod transport {
             self
         }
         /// svcid (port) to connect to
-        pub fn with_svcid(mut self, svcid: &str) -> Self {
-            self.svcid = svcid.to_string();
+        pub fn with_svcid<I: Into<String>>(mut self, svcid: I) -> Self {
+            self.svcid = svcid.into();
             self
         }
 

--- a/io-engine/src/bdev/nvmx/uri.rs
+++ b/io-engine/src/bdev/nvmx/uri.rs
@@ -199,7 +199,7 @@ impl NvmeControllerContext<'_> {
     pub fn new(template: &NvmfDeviceTemplate) -> NvmeControllerContext {
         let trid = controller::transport::Builder::new()
             .with_subnqn(&template.subnqn)
-            .with_svcid(&template.port.to_string())
+            .with_svcid(template.port.to_string())
             .with_traddr(&template.host)
             .build();
 

--- a/io-engine/src/bdev_api.rs
+++ b/io-engine/src/bdev_api.rs
@@ -6,7 +6,7 @@ use url::ParseError;
 
 use crate::{
     bdev::uri,
-    core::{Bdev, Share},
+    core::{Bdev, Share, ToErrno},
 };
 
 // parse URI and bdev create/destroy errors common for all types of bdevs
@@ -90,6 +90,31 @@ pub enum BdevError {
     BdevCommandCanceled { source: Canceled, name: String },
     #[snafu(display("Failed to wipe the BDEV"))]
     WipeFailed {},
+}
+
+impl ToErrno for BdevError {
+    fn to_errno(&self) -> Errno {
+        match self {
+            BdevError::UriParseFailed { .. } => Errno::EINVAL,
+            BdevError::BdevNoMatchingUri { .. } => Errno::EPIPE,
+            BdevError::UriSchemeUnsupported { .. } => Errno::ENOTSUP,
+            BdevError::InvalidUri { .. } => Errno::EINVAL,
+            BdevError::BoolParamParseFailed { .. } => Errno::EINVAL,
+            BdevError::IntParamParseFailed { .. } => Errno::EINVAL,
+            BdevError::UuidParamParseFailed { .. } => Errno::EINVAL,
+            BdevError::BdevExists { .. } => Errno::ENOENT,
+            BdevError::BdevWrongUuid { .. } => Errno::EINVAL,
+            BdevError::BdevNotFound { .. } => Errno::ENOENT,
+            BdevError::CreateBdevInvalidParams { source, .. } => *source,
+            BdevError::CreateBdevFailed { source, .. } => *source,
+            BdevError::DestroyBdevFailed { source, .. } => *source,
+            BdevError::ResizeBdevFailed { source, .. } => *source,
+            BdevError::CreateBdevFailedStr { .. } => Errno::EPERM,
+            BdevError::DestroyBdevFailedStr { .. } => Errno::EPERM,
+            BdevError::BdevCommandCanceled { .. } => Errno::EPIPE,
+            BdevError::WipeFailed {} => Errno::EPERM,
+        }
+    }
 }
 
 /// Parse URI and create bdev described in the URI.

--- a/io-engine/src/grpc/v0/mayastor_grpc.rs
+++ b/io-engine/src/grpc/v0/mayastor_grpc.rs
@@ -272,7 +272,22 @@ impl From<LvsError> for tonic::Status {
             LvsError::LvolShare { .. } if errno == Errno::EMLINK => {
                 Status::out_of_range(e.to_string())
             }
-            _ => Status::internal(e.to_string()),
+            LvsError::LvolShare { .. } => Status::internal(e.to_string()),
+            LvsError::InvalidClusterSize { .. } => Status::invalid_argument(e.to_string()),
+            LvsError::Export { .. }
+            | LvsError::InvalidMetadataParam { .. }
+            | LvsError::NotALvol { .. }
+            | LvsError::GetProperty { .. }
+            | LvsError::FlushFailed { .. }
+            | LvsError::SnapshotConfigFailed { .. }
+            | LvsError::CloneConfigFailed { .. }
+            | LvsError::CryptoBdevNotResized { .. }
+            | LvsError::Property { .. }
+            | LvsError::SyncProperty { .. }
+            | LvsError::LvolUnShare { .. }
+            | LvsError::UpdateShareProperties { .. }
+            | LvsError::SnapshotCreate { .. }
+            | LvsError::SnapshotCloneCreate { .. } => Status::internal(e.to_string()),
         };
         status
             .metadata_mut()


### PR DESCRIPTION
    refactor(nexus): convert nexus error into granular status
    
    Finer control of the nexus error into tonic status.
    Also includes the errno in the status header.
    
---

    fix(nexus/share): return oor and emlink when reached max subsystems
    
    Similar to lvol/share, return out of range with emlink when we've reached
    the maximum number of namespaces/subsystems.
    
---

    fix(pool/lvs): use invalid argument for invalid cluster size
    
    Return correct gRPC status code when creating a pool with an invalid
    cluster size.
    
    Also, don't default error core to gRPC status, as this makes it very
    easy to add a new error and rely on the default of internal error!