### PR TITLE
fix(lvs): handle I/O errors during lvs lifecycle operations

### DIFF
--- a/io-engine/examples/lvs-eval/display.rs
+++ b/io-engine/examples/lvs-eval/display.rs
@@ -13,7 +13,7 @@ use spdk_rs::libspdk::{
 pub async fn print_lvs(lvs: &Lvs) {
     print_separator("LVS", 0);
 
-    print_bdev(lvs.base_bdev());
+    print_bdev(lvs.base_bdev_());
     print_lvs_data(lvs);
     print_replicas(lvs);
 }

--- a/io-engine/src/bdev/lvs.rs
+++ b/io-engine/src/bdev/lvs.rs
@@ -245,11 +245,10 @@ impl Lvs {
     }
 
     async fn wipe_super(args: PoolArgs) -> Result<(), BdevError> {
-        let disk =
-            crate::lvs::Lvs::parse_disk(args.disks.clone()).map_err(|_| BdevError::InvalidUri {
-                uri: String::new(),
-                message: String::new(),
-            })?;
+        let disk = crate::lvs::Lvs::parse_disk(&args.disks).map_err(|_| BdevError::InvalidUri {
+            uri: String::new(),
+            message: String::new(),
+        })?;
 
         let parsed = super::uri::parse(&disk)?;
         let bdev_str = parsed.create().await?;

--- a/io-engine/src/grpc/v0/mayastor_grpc.rs
+++ b/io-engine/src/grpc/v0/mayastor_grpc.rs
@@ -309,7 +309,10 @@ impl From<Lvs> for Pool {
     fn from(l: Lvs) -> Self {
         Self {
             name: l.name().into(),
-            disks: vec![l.base_bdev().bdev_uri_str().unwrap_or_else(|| "".into())],
+            disks: vec![l
+                .base_bdev_opt()
+                .and_then(|b| b.bdev_uri_str())
+                .unwrap_or_else(|| "".into())],
             state: PoolState::PoolOnline.into(),
             capacity: l.capacity(),
             used: l.used(),

--- a/io-engine/src/grpc/v1/stats.rs
+++ b/io-engine/src/grpc/v1/stats.rs
@@ -140,6 +140,8 @@ impl StatsRpc for StatsService {
                 let pools_stats = join_all(pools_stats_future).await.into_iter();
                 let stats = pools_stats
                     .map(|d| d.map(Into::into))
+                    // todo: it will error out if any error is encountered
+                    // this may not be ideal since we'd miss out of other stats!
                     .collect::<Result<Vec<_>, _>>()?;
 
                 Ok(PoolIoStatsResponse { stats })

--- a/io-engine/src/lvs/lvs_bdev.rs
+++ b/io-engine/src/lvs/lvs_bdev.rs
@@ -37,6 +37,15 @@ impl LvsBdev {
         Lvs::from_inner_ptr(self.as_inner_ref().lvs)
     }
 
+    /// Returns Lvs instance for this LVS Bdev.
+    /// todo: hide lvs which has no base bdev?
+    #[inline]
+    pub fn lvs_opt(&self) -> Option<Lvs> {
+        let lvs = self.lvs();
+        lvs.base_bdev_opt()?;
+        Some(lvs)
+    }
+
     /// Get name of the pool.
     pub fn name(&self) -> String {
         self.lvs().name().to_string()
@@ -49,6 +58,6 @@ impl LvsBdev {
 
     /// Iterate Lvs Bdevs.
     pub fn iter() -> LvsBdevIter {
-        LvsBdevIter::new()
+        LvsBdevIter::new(false)
     }
 }

--- a/io-engine/src/lvs/lvs_error.rs
+++ b/io-engine/src/lvs/lvs_error.rs
@@ -14,6 +14,8 @@ use crate::{
 pub enum ImportErrorReason {
     #[snafu(display(""))]
     None,
+    #[snafu(display(": failed to inspect disk contents"))]
+    IoError,
     #[snafu(display(": existing pool disk has different name: {name}"))]
     NameMismatch { name: String },
     #[snafu(display(": another pool already exists with this name: {name}"))]
@@ -206,6 +208,7 @@ impl ToErrno for LvsError {
                 ..
             } => match reason {
                 crate::lvs::ImportErrorReason::None => Errno::EINVAL,
+                crate::lvs::ImportErrorReason::IoError => Errno::EIO,
                 crate::lvs::ImportErrorReason::NameMismatch { .. } => Errno::EMEDIUMTYPE,
                 crate::lvs::ImportErrorReason::NameClash { .. } => Errno::ENOTUNIQ,
                 crate::lvs::ImportErrorReason::UuidMismatch { .. } => Errno::EMEDIUMTYPE,

--- a/io-engine/src/lvs/lvs_error.rs
+++ b/io-engine/src/lvs/lvs_error.rs
@@ -53,6 +53,8 @@ pub enum BsError {
     CapacityOverflow {},
     #[snafu(display("{source}: crypto vbdev error"))]
     LvsCryptoVbdev { source: Errno },
+    #[snafu(display(": Lvs is removing, bdev not found"))]
+    LvsRemoving {},
 }
 
 impl BsError {
@@ -106,6 +108,7 @@ impl ToErrno for BsError {
             Self::OutOfMetadata {} => Errno::EMFILE,
             Self::CapacityOverflow {} => Errno::EOVERFLOW,
             Self::LvsCryptoVbdev { source } => *source,
+            Self::LvsRemoving {} => Errno::EINPROGRESS,
         }
     }
 }

--- a/io-engine/src/lvs/lvs_iter.rs
+++ b/io-engine/src/lvs/lvs_iter.rs
@@ -5,13 +5,15 @@ use super::{Lvs, LvsBdev};
 /// Iterator over available LvsBdevs.
 pub struct LvsBdevIter {
     inner: *mut lvol_store_bdev,
+    list_removing: bool,
 }
 
 impl LvsBdevIter {
     /// Returns a new LvsBdev iterator.
-    pub(super) fn new() -> Self {
+    pub(super) fn new(list_removing: bool) -> Self {
         Self {
             inner: unsafe { vbdev_lvol_store_first() },
+            list_removing,
         }
     }
 }
@@ -37,8 +39,8 @@ pub struct LvsIter(LvsBdevIter);
 
 impl LvsIter {
     /// Returns a new Lvs iterator.
-    pub(super) fn new() -> Self {
-        Self(LvsBdevIter::new())
+    pub(super) fn new(list_removing: bool) -> Self {
+        Self(LvsBdevIter::new(list_removing))
     }
 }
 
@@ -46,6 +48,10 @@ impl Iterator for LvsIter {
     type Item = Lvs;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.0.next().map(|l| l.lvs())
+        if self.0.list_removing {
+            self.0.next().map(|l| l.lvs())
+        } else {
+            self.0.next().and_then(|l| l.lvs_opt())
+        }
     }
 }

--- a/io-engine/src/lvs/lvs_store.rs
+++ b/io-engine/src/lvs/lvs_store.rs
@@ -29,7 +29,7 @@ use crate::{
     bdev_api::{bdev_destroy, BdevError},
     core::{
         logical_volume::LogicalVolume, snapshot::LvolSnapshotOps, Bdev, IoType, NvmfShareProps,
-        Share, UntypedBdev,
+        Share, ToErrno, UntypedBdev,
     },
     eventing::Event,
     ffihelper::{cb_arg, pair, AsStr, ErrnoResult, FfiResult, IntoCString},
@@ -562,7 +562,7 @@ impl Lvs {
         info!("{self_str}: exporting lvs...");
 
         let pool = self.name().to_string();
-        let mut base_bdev = self.base_bdev();
+        let base_bdev = self.base_bdev().name().to_string();
         let (s, r) = pair::<i32>();
 
         self.unshare_all().await;
@@ -584,43 +584,11 @@ impl Lvs {
         // todo: if result is EIO error, then delete the bdevs as well here?
         //  note that in this case we'd have to re-lookup the bdevs again as
         //  they may have been hot-removed!
-
         result?;
 
-        info!(
-            "{self_str}: lvs exported successfully. base bdev: {}",
-            base_bdev.name()
-        );
+        info!("{self_str}: lvs exported successfully. base bdev: {base_bdev}");
 
-        // If the base_bdev is a crypto vbdev then we need to destroy both - the crypto vbdev and it's base.
-        if base_bdev.driver() == "crypto" {
-            let cbdev = base_bdev.crypto_base_bdev();
-
-            if let Err(e) = destroy_crypto_vbdev(base_bdev.name().to_string(), None).await {
-                error!(
-                    "failed to delete crypto vbdev {:?} during lvs export. {e}",
-                    base_bdev.name()
-                );
-            }
-
-            // A None cbdev here is highly unlikely as the vbdev can't exist in thin air.
-            // If cbdev is somehow None anyway, then the following bdev_destroy will likely
-            // fail, and we can let it.
-            if let Some(c) = cbdev {
-                base_bdev = Bdev::new(c);
-            }
-        }
-        trace!(
-            "Deleting bdev {}, uri {:?}",
-            base_bdev.name(),
-            base_bdev.bdev_uri_original_str()
-        );
-        if let Some(u) = base_bdev.bdev_uri_original_str() {
-            bdev_destroy(&u).await.map_err(|e| LvsError::Destroy {
-                source: e,
-                name: base_bdev.name().to_string(),
-            })?;
-        }
+        Self::lvs_cleanup(&base_bdev, "export").await?;
 
         Ok(())
     }
@@ -682,7 +650,7 @@ impl Lvs {
         // when destroying a pool unshare all volumes
         self.unshare_all().await;
 
-        let mut base_bdev = self.base_bdev();
+        let base_bdev = self.base_bdev().name().to_string();
 
         let evt = self.event(EventAction::Delete);
 
@@ -702,30 +670,42 @@ impl Lvs {
 
         result?;
 
-        info!(
-            "{}: lvs destroyed successfully. base_bdev: {base_bdev:?}",
-            self_str
-        );
-
+        info!("{self_str}: lvs destroyed successfully. base_bdev: {base_bdev}");
         evt.generate();
+
+        Self::lvs_cleanup(&base_bdev, "destroy").await?;
+
+        if let Err(error) = ptpl.destroy() {
+            tracing::error!(
+                "{self_str}: Failed to clean up persistence through power loss for pool: {error}",
+            );
+        }
+
+        Ok(())
+    }
+
+    async fn lvs_cleanup(base_bdev: &str, op: &str) -> Result<(), LvsError> {
+        tracing::debug!(base_bdev, op, "Cleanup of lvs backing storage");
+
+        let Some(mut base_bdev) = UntypedBdev::lookup_by_name(base_bdev) else {
+            return Ok(());
+        };
 
         // If the base_bdev is a crypto vbdev then we need to destroy both - the crypto vbdev and it's base.
         if base_bdev.driver() == "crypto" {
             let cbdev = base_bdev.crypto_base_bdev();
-            let _ = destroy_crypto_vbdev(base_bdev.name().to_string(), None)
-                .await
-                .map_err(|e| {
-                    error!(
-                        "failed to delete crypto vbdev {:?} during pool destroy. {e}",
-                        base_bdev.name()
-                    );
-                });
+            let cbdev_name = cbdev.map(|c| c.name().to_string());
+            let name = base_bdev.name();
+
+            if let Err(e) = destroy_crypto_vbdev(name.to_string(), None).await {
+                error!("failed to delete crypto vbdev {name} during lvs {op}: {e}");
+            }
 
             // A None cbdev here is highly unlikely as the vbdev can't exist in thin air.
             // If cbdev is somehow None anyway, then the following bdev_destroy will likely
             // fail, and we can let it.
-            if let Some(c) = cbdev {
-                base_bdev = Bdev::new(c);
+            if let Some(c) = cbdev_name.and_then(|c| UntypedBdev::lookup_by_name(&c)) {
+                base_bdev = c;
             }
         }
         trace!(
@@ -738,14 +718,6 @@ impl Lvs {
                 source: e,
                 name: base_bdev.name().to_string(),
             })?;
-        }
-
-        if let Err(error) = ptpl.destroy() {
-            tracing::error!(
-                "{}: Failed to clean up persistence through power loss for pool: {}",
-                self_str,
-                error
-            );
         }
 
         Ok(())

--- a/io-engine/src/lvs/lvs_store.rs
+++ b/io-engine/src/lvs/lvs_store.rs
@@ -584,7 +584,12 @@ impl Lvs {
         // todo: if result is EIO error, then delete the bdevs as well here?
         //  note that in this case we'd have to re-lookup the bdevs again as
         //  they may have been hot-removed!
-        result?;
+        if let Err(error) = result {
+            if Lvs::lookup(&pool).is_none() {
+                Self::lvs_cleanup(&base_bdev, "export").await?;
+            }
+            return Err(error);
+        }
 
         info!("{self_str}: lvs exported successfully. base bdev: {base_bdev}");
 
@@ -668,7 +673,15 @@ impl Lvs {
             Lvs::remove_info(&pool);
         }
 
-        result?;
+        if let Err(error) = result {
+            if Lvs::lookup(&pool).is_none() {
+                // todo: need another spdk fix as blobstore is not fully clean in case of -EIO
+                if error.to_errno() != nix::Error::EIO {
+                    Self::lvs_cleanup(&base_bdev, "destroy").await?;
+                }
+            }
+            return Err(error);
+        }
 
         info!("{self_str}: lvs destroyed successfully. base_bdev: {base_bdev}");
         evt.generate();

--- a/io-engine/src/lvs/lvs_store.rs
+++ b/io-engine/src/lvs/lvs_store.rs
@@ -29,7 +29,7 @@ use crate::{
     bdev_api::{bdev_destroy, BdevError},
     core::{
         logical_volume::LogicalVolume, snapshot::LvolSnapshotOps, Bdev, IoType, NvmfShareProps,
-        Share, ToErrno, UntypedBdev,
+        Share, UntypedBdev,
     },
     eventing::Event,
     ffihelper::{cb_arg, pair, AsStr, ErrnoResult, FfiResult, IntoCString},
@@ -675,10 +675,7 @@ impl Lvs {
 
         if let Err(error) = result {
             if Lvs::lookup(&pool).is_none() {
-                // todo: need another spdk fix as blobstore is not fully clean in case of -EIO
-                if error.to_errno() != nix::Error::EIO {
-                    Self::lvs_cleanup(&base_bdev, "destroy").await?;
-                }
+                Self::lvs_cleanup(&base_bdev, "destroy").await?;
             }
             return Err(error);
         }

--- a/io-engine/src/lvs/lvs_store.rs
+++ b/io-engine/src/lvs/lvs_store.rs
@@ -24,7 +24,7 @@ use super::{BsError, ImportErrorReason, Lvol, LvsError, LvsIter, PropName, PropV
 use crate::{
     bdev::{
         crypto::{create_crypto_vbdev_on_base_bdev, destroy_crypto_vbdev},
-        uri, PtplFileOps,
+        uri, BdevCreateDestroy, PtplFileOps,
     },
     bdev_api::{bdev_destroy, BdevError},
     core::{
@@ -60,6 +60,25 @@ impl Debug for Lvs {
             Byte::from(self.capacity()).get_appropriate_unit(byte_unit::UnitType::Binary)
         )
     }
+}
+
+struct LvsBackendBdevs {
+    /// The pool arguments.
+    args: PoolArgs,
+
+    /// The bdev ops for the base pool disk.
+    bdev_ops: Box<dyn BdevCreateDestroy<Error = BdevError>>,
+    /// The name of the base bdev.
+    bdev_name: String,
+    /// Whether we've created the bdev in this attempt.
+    /// If so, then we should cleanup.
+    created_bdev: bool,
+
+    /// Whether we've created the crypto bdev in this attempt.
+    created_crypto: bool,
+
+    /// The lvs backing bdev, which is either the crypto of the base bdev name.
+    pool_bdev_name: String,
 }
 
 /// Logical Volume Store (LVS) stores the lvols
@@ -237,7 +256,7 @@ impl Lvs {
     }
 
     // checks for the disks length and parses to correct format
-    pub fn parse_disk(disks: Vec<String>) -> Result<String, LvsError> {
+    pub fn parse_disk(disks: &[String]) -> Result<String, LvsError> {
         let disk = match disks.first() {
             Some(disk) if disks.len() == 1 => {
                 if Url::parse(disk).is_err() {
@@ -249,7 +268,7 @@ impl Lvs {
             _ => {
                 return Err(LvsError::Invalid {
                     source: BsError::InvalidArgument {},
-                    msg: format!("invalid number {} of devices {:?}", disks.len(), disks,),
+                    msg: format!("invalid number {} of devices {:?}", disks.len(), disks),
                 })
             }
         };
@@ -308,7 +327,7 @@ impl Lvs {
             .map_err(|err| LvsError::Import {
                 source: BsError::from_errno(err),
                 name: name.into(),
-                reason: ImportErrorReason::None,
+                reason: ImportErrorReason::IoError,
             })?;
 
         if name != lvs.name() {
@@ -334,104 +353,32 @@ impl Lvs {
     /// Imports a pool based on its name, uuid and base bdev name.
     #[tracing::instrument(level = "debug", err)]
     pub async fn import_from_args(args: PoolArgs) -> Result<Lvs, LvsError> {
-        Self::import_from_args_(args).await
+        let backend = LvsBackendBdevs::new(args, false).await?;
+        match Self::import_from_args_(&backend).await {
+            Ok(lvs) => Ok(lvs),
+            Err(error) => {
+                backend.undo().await;
+                Err(error)
+            }
+        }
     }
 
     /// Imports a pool based on its name, uuid and base bdev name.
-    pub async fn import_from_args_(args: PoolArgs) -> Result<Lvs, LvsError> {
-        let disk = Self::parse_disk(args.disks.clone())?;
-
-        let parsed = uri::parse(&disk).map_err(|e| LvsError::InvalidBdev {
-            source: e,
-            name: args.name.clone(),
-        })?;
-
-        // If we are requesting for an encrypted pool, then we should match existing pool (if any)
-        // by pool's bdev name as crypto bdev name.
-        let pool_bdev_name = if let Some(c) = args.crypto_vbdev_name.as_ref() {
-            c
-        } else {
-            &parsed.get_name()
-        };
-
-        // At any point two pools with the same name should not exists so returning error
-        if let Some(pool) = Self::lookup(&args.name) {
-            let pool_name = pool.base_bdev().name().to_string();
-            return if pool_name.as_str() == pool_bdev_name {
-                Err(LvsError::Import {
-                    source: BsError::VolAlreadyExists {},
-                    name: args.name.clone(),
-                    reason: ImportErrorReason::None,
-                })
-            } else {
-                Err(LvsError::Import {
-                    source: BsError::InvalidArgument {},
-                    name: args.name.clone(),
-                    reason: ImportErrorReason::NameClash { name: pool_name },
-                })
-            };
-        }
-
-        let bdev = match parsed.create().await {
-            Err(e) => match e {
-                BdevError::BdevExists { .. } => Ok(parsed.get_name()),
-                BdevError::CreateBdevInvalidParams {
-                    source: Errno::EEXIST,
-                    ..
-                } => Ok(parsed.get_name()),
-                _ => {
-                    tracing::error!("Failed to create pool bdev: {e:?}");
-                    Err(LvsError::InvalidBdev {
-                        source: e,
-                        name: args.disks[0].clone(),
-                    })
-                }
-            },
-            Ok(name) => Ok(name),
-        }?;
-
-        if let Some(ref cname) = args.crypto_vbdev_name {
-            // Only if bdev doesn't exist. e.g. direct import path.
-            if UntypedBdev::lookup_by_name(cname).is_none() {
-                if let Some(e) = args.enc_key {
-                    match create_crypto_vbdev_on_base_bdev(cname, &bdev, &e) {
-                        Ok(_) => {}
-                        Err(berr) => {
-                            let _ = parsed.destroy().await.map_err(|e| {
-                                    error!(
-                                        "failed to delete base_bdev {bdev} after failed crypto vbdev creation. {e:?}"
-                                    );
-                                });
-                            return Err(LvsError::PoolCreate {
-                                source: BsError::LvsCryptoVbdev {
-                                    source: match berr {
-                                        BdevError::CreateBdevFailed { source, .. } => source,
-                                        _ => Errno::EINVAL,
-                                    },
-                                },
-                                name: args.name.clone(),
-                            });
-                        }
-                    }
-                }
-            }
-        }
-
-        let bsdev_name = args.crypto_vbdev_name.as_ref().unwrap_or(&bdev);
-        let pool = Self::import(&args.name, bsdev_name).await?;
+    async fn import_from_args_(backend: &LvsBackendBdevs) -> Result<Lvs, LvsError> {
+        let pool = Self::import(&backend.args.name, &backend.pool_bdev_name).await?;
         // Try to destroy the pending snapshots without catching the error.
         Lvol::destroy_pending_discarded_snapshot().await;
         // if the uuid is provided for the import request check
         // for the pool uuid to make sure it is the correct one
-        if let Some(uuid) = args.uuid {
+        if let Some(ref uuid) = backend.args.uuid {
             let pool_uuid = pool.uuid();
-            if pool_uuid == uuid {
+            if &pool_uuid == uuid {
                 Ok(pool)
             } else {
                 pool.export().await?;
                 Err(LvsError::Import {
                     source: BsError::InvalidArgument {},
-                    name: args.name,
+                    name: backend.args.name.clone(),
                     reason: ImportErrorReason::UuidMismatch { uuid: pool_uuid },
                 })
             }
@@ -478,14 +425,9 @@ impl Lvs {
     /// This function is made public for tests purposes.
     pub async fn create_from_args_inner(args: PoolArgs) -> Result<Lvs, LvsError> {
         assert_eq!(args.disks.len(), 1);
-        let bdev = args.disks[0].clone();
+        let bdev_name = args.disks[0].clone();
 
         let pool_name = args.name.clone().into_cstring();
-        let bdev_name = if let Some(ref c) = args.crypto_vbdev_name {
-            c.clone().into_cstring()
-        } else {
-            bdev.clone().into_cstring()
-        };
 
         let cluster_size = if let Some(cluster_size) = args.cluster_size {
             if cluster_size % ROUND_TO_MB == 0 {
@@ -506,12 +448,13 @@ impl Lvs {
                 msg: format!("{cluster_size}, larger than max limit {MAX_CLUSTER_SIZE}"),
             });
         }
-        let bdev = UntypedBdev::lookup_by_name(&bdev).ok_or(LvsError::InvalidBdev {
+        let bdev = UntypedBdev::lookup_by_name(&bdev_name).ok_or(LvsError::InvalidBdev {
             source: BdevError::BdevNotFound {
-                name: bdev.to_string(),
+                name: bdev_name.to_string(),
             },
-            name: bdev.to_string(),
+            name: bdev_name.to_string(),
         })?;
+        let bdev_name = bdev_name.into_cstring();
         let bdev_capacity = bdev.num_blocks() * bdev.block_len() as u64;
         let mdp_ratio = Self::md_resv_ratio(&args, bdev_capacity)?;
         let (sender, receiver) = pair::<ErrnoResult<Lvs>>();
@@ -584,119 +527,18 @@ impl Lvs {
     /// This function creates the underlying bdev if it does not exist.
     #[tracing::instrument(level = "debug", err)]
     pub async fn create_or_import(args: PoolArgs) -> Result<Lvs, LvsError> {
-        let disk = Self::parse_disk(args.disks.clone())?;
-        let name = &args.name;
-        let enc = if args.crypto_vbdev_name.is_some() {
-            "encrypted"
-        } else {
-            "non-encrypted"
-        };
+        let backend = LvsBackendBdevs::new(args, true).await?;
 
-        info!("Creating or importing {enc} lvs '{name}' from '{disk}'...");
-
-        let bdev_ops = uri::parse(&disk).map_err(|e| LvsError::InvalidBdev {
-            source: e,
-            name: args.name.clone(),
-        })?;
-
-        // If we are requesting for an encrypted pool, then we should lookup existing pool(if any)
-        // by pool's bdev name as crypto bdev name.
-        let pool_bdev_name = if let Some(c) = args.crypto_vbdev_name.as_ref() {
-            c
-        } else {
-            &bdev_ops.get_name()
-        };
-
-        if let Some(pool) = Self::lookup(&args.name) {
-            return if pool.base_bdev().name() == pool_bdev_name {
-                Err(LvsError::PoolCreate {
-                    source: BsError::VolAlreadyExists {},
-                    name: args.name.clone(),
-                })
-            } else {
-                Err(LvsError::PoolCreate {
-                    source: BsError::InvalidArgument {},
-                    name: args.name.clone(),
-                })
-            };
-        }
-        // Create the underlying bdev.
-        let bdev_name = match bdev_ops.create().await {
-            Err(e) => match e {
-                BdevError::BdevExists { .. } => Ok(bdev_ops.get_name()),
-                BdevError::CreateBdevInvalidParams {
-                    source: Errno::EEXIST,
-                    ..
-                } => Ok(bdev_ops.get_name()),
-                _ => {
-                    tracing::error!("Failed to create pool bdev: {e:?}");
-                    Err(LvsError::InvalidBdev {
-                        source: e,
-                        name: args.disks[0].clone(),
-                    })
-                }
-            },
-            Ok(name) => Ok(name),
-        }?;
-
-        // Create crypto bdev now if required.
-        if let Some(ref cname) = args.crypto_vbdev_name {
-            if let Some(ref e) = args.enc_key {
-                match create_crypto_vbdev_on_base_bdev(cname, &bdev_name, e) {
-                    Ok(_) => {}
-                    Err(berr) => {
-                        let _ = bdev_ops.destroy().await.map_err(|e| {
-                                error!(
-                                    "failed to delete base_bdev {bdev_name} after failed crypto vbdev creation. {e:?}"
-                                );
-                            });
-                        return Err(LvsError::PoolCreate {
-                            source: BsError::LvsCryptoVbdev {
-                                source: match berr {
-                                    BdevError::CreateBdevFailed { source, .. } => source,
-                                    _ => Errno::EINVAL,
-                                },
-                            },
-                            name: args.name.clone(),
-                        });
-                    }
-                }
-            }
-        }
-
-        match Self::import_from_args_(args.clone()).await {
+        match Self::import_from_args_(&backend).await {
             Ok(pool) => Ok(pool),
-            // try to create the pool
             Err(LvsError::Import {
                 source: BsError::CannotImportLvs {},
                 ..
             }) => {
-                let cbdev_name: Option<String> = args.crypto_vbdev_name.clone();
-                let key_name = args.enc_key.as_ref().map(|e| e.key_name.clone());
-                match Self::create_from_args_inner(PoolArgs {
-                    disks: vec![bdev_name.clone()],
-                    ..args
-                })
-                .await
-                {
+                // No pool found, so we try to create it.
+                match Self::create_from_args_inner(backend.args.clone()).await {
                     Err(create) => {
-                        // destroy crypto vbdev first.
-                        if let Some(c) = cbdev_name.as_ref() {
-                            let _ = destroy_crypto_vbdev(c.clone(), key_name).await.map_err(|e| {
-                                error!(
-                                    "failed to delete crypto vbdev {c} after failed pool creation. {e}"
-                                );
-                            });
-                        }
-
-                        let _ = bdev_ops.destroy().await.map_err(|_e| {
-                            // we failed to delete the base_bdev be loud about it
-                            // there is not much we can do about it here, likely
-                            // some desc is still holding on to it or something.
-                            error!(
-                                "failed to delete base_bdev {bdev_name} after failed pool creation"
-                            );
-                        });
+                        backend.undo().await;
                         Err(create)
                     }
                     Ok(pool) => {
@@ -705,8 +547,10 @@ impl Lvs {
                     }
                 }
             }
-            // some other error, bubble it back up
-            Err(e) => Err(e),
+            Err(e) => {
+                backend.undo().await;
+                Err(e)
+            }
         }
     }
 
@@ -1192,6 +1036,150 @@ impl Lvs {
     /// Get a `PtplFileOps` from `&self`.
     pub(crate) fn ptpl(&self) -> impl PtplFileOps {
         LvsPtpl::from(self)
+    }
+}
+
+impl LvsBackendBdevs {
+    async fn new(mut args: PoolArgs, create: bool) -> Result<Self, LvsError> {
+        let disk = Lvs::parse_disk(&args.disks)?;
+        let name = &args.name;
+        let enc = if args.crypto_vbdev_name.is_some() {
+            "encrypted"
+        } else {
+            "non-encrypted"
+        };
+        if create {
+            info!("Creating or importing {enc} lvs '{name}' from '{disk}'...");
+        } else {
+            info!("Importing {enc} lvs '{name}' from '{disk}'...");
+        }
+
+        let bdev_ops = uri::parse(&disk).map_err(|e| LvsError::InvalidBdev {
+            source: e,
+            name: args.name.clone(),
+        })?;
+        let bdev_name = bdev_ops.get_name();
+
+        // If we are requesting for an encrypted pool, then we should lookup existing pool(if any)
+        // by pool's bdev name as crypto bdev name.
+        let pool_bdev_name = args.crypto_vbdev_name.clone().unwrap_or(bdev_name.clone());
+
+        if let Some(pool) = Lvs::lookup(&args.name) {
+            let source = if pool.base_bdev().name() == pool_bdev_name {
+                // todo: this error makes no sense
+                BsError::VolAlreadyExists {}
+            } else {
+                BsError::InvalidArgument {}
+            };
+            return if create {
+                Err(LvsError::PoolCreate {
+                    source,
+                    name: args.name.clone(),
+                })
+            } else {
+                let pool_name = pool.base_bdev().name().to_string();
+                Err(LvsError::Import {
+                    source,
+                    name: args.name.clone(),
+                    reason: ImportErrorReason::NameClash { name: pool_name },
+                })
+            };
+        }
+
+        let created_bdev = UntypedBdev::lookup_by_name(&bdev_name).is_none();
+
+        // Create the underlying bdev.
+        let bdev_name = match bdev_ops.create().await {
+            Err(e) => match e {
+                BdevError::BdevExists { .. } => Ok(bdev_ops.get_name()),
+                BdevError::CreateBdevInvalidParams {
+                    source: Errno::EEXIST,
+                    ..
+                } => Ok(bdev_ops.get_name()),
+                _ => {
+                    tracing::error!("Failed to create pool bdev: {e:?}");
+                    Err(LvsError::InvalidBdev {
+                        source: e,
+                        name: bdev_ops.get_name(),
+                    })
+                }
+            },
+            Ok(name) => Ok(name),
+        }?;
+
+        // Create crypto bdev now if required.
+        let mut created_crypto = false;
+        if let Some(ref cname) = args.crypto_vbdev_name {
+            if let Some(ref e) = args.enc_key {
+                if UntypedBdev::lookup_by_name(cname).is_none() {
+                    if let Err(error) = create_crypto_vbdev_on_base_bdev(cname, &bdev_name, e) {
+                        let _ = bdev_ops.destroy().await.map_err(|e| {
+                            error!(
+                                "failed to delete base_bdev {bdev_name} after failed crypto vbdev creation. {e:?}"
+                            );
+                        });
+                        return Err(LvsError::PoolCreate {
+                            source: BsError::LvsCryptoVbdev {
+                                source: match error {
+                                    BdevError::CreateBdevFailed { source, .. } => source,
+                                    _ => Errno::EINVAL,
+                                },
+                            },
+                            name: args.name.clone(),
+                        });
+                    }
+                    created_crypto = true;
+                }
+            }
+        }
+
+        // override disks with the bdev name of the top-level bdev
+        args.disks = vec![pool_bdev_name.clone()];
+
+        Ok(LvsBackendBdevs {
+            args,
+            bdev_name: bdev_ops.get_name(),
+            bdev_ops,
+            created_bdev,
+            created_crypto,
+            pool_bdev_name,
+        })
+    }
+
+    /// Cleans up any created bdev.
+    async fn undo(self) {
+        tracing::info!(
+            name = self.args.name,
+            bdev_name = self.bdev_name,
+            pool_bdev_name = self.pool_bdev_name,
+            "Undoing created bdevs for failed pool create/import"
+        );
+
+        // destroy crypto vbdev first.
+        if self.created_crypto {
+            if let Some(c) = self.args.crypto_vbdev_name.as_ref() {
+                let key_name = self.args.enc_key.as_ref().map(|e| e.key_name.clone());
+                let _ = destroy_crypto_vbdev(c.clone(), key_name)
+                    .await
+                    .map_err(|e| {
+                        error!("failed to delete crypto vbdev {c} after failed pool creation. {e}");
+                    });
+            }
+        }
+
+        if self.created_bdev {
+            let bdev_name = self.bdev_name;
+            let _ = self.bdev_ops.destroy().await.map_err(|error| {
+                // we failed to delete the base_bdev be loud about it
+                // there is not much we can do about it here, likely
+                // some desc is still holding on to it or something.
+                error!(
+                    %error,
+                    bdev_name,
+                    "failed to delete base_bdev after failed pool creation",
+                );
+            });
+        }
     }
 }
 

--- a/io-engine/src/lvs/lvs_store.rs
+++ b/io-engine/src/lvs/lvs_store.rs
@@ -50,12 +50,17 @@ static MAX_CLUSTER_SIZE: u32 = 1024 * 1024 * 1024;
 
 impl Debug for Lvs {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let bdev = self.base_bdev_opt();
+        let (name, uuid) = match &bdev {
+            Some(bdev) => (bdev.name(), bdev.uuid().to_string()),
+            None => ("bdev~removing", "~".into()),
+        };
         write!(
             f,
             "Lvs '{}' [{}/{}] ({:.2}/{:.2})",
             self.name(),
-            self.base_bdev().name(),
-            self.base_bdev().uuid(),
+            name,
+            uuid,
             Byte::from(self.available()).get_appropriate_unit(byte_unit::UnitType::Binary),
             Byte::from(self.capacity()).get_appropriate_unit(byte_unit::UnitType::Binary)
         )
@@ -134,9 +139,14 @@ impl Lvs {
         sender.send(errno).unwrap();
     }
 
-    /// returns a new iterator over all lvols
+    /// returns a new iterator over all lvs
     pub fn iter() -> LvsIter {
-        LvsIter::new()
+        LvsIter::new(false)
+    }
+
+    /// Returns a new iterator over all lvs, including ones which are removing.
+    pub fn iter_all() -> LvsIter {
+        LvsIter::new(true)
     }
 
     /// export all LVS instances
@@ -199,15 +209,43 @@ impl Lvs {
     }
 
     /// returns the base bdev of this lvs
-    pub fn base_bdev(&self) -> UntypedBdev {
+    pub fn base_bdev_(&self) -> UntypedBdev {
         let p = unsafe { (*vbdev_get_lvs_bdev_by_lvs(self.as_inner_ptr())).bdev };
         Bdev::checked_from_ptr(p).unwrap()
     }
 
+    /// returns the base bdev of this lvs
+    pub fn base_bdev_name(&self) -> String {
+        self.base_bdev_opt()
+            .map(|b| b.name().to_string())
+            .unwrap_or_else(|| "~removing".to_string())
+    }
+
+    /// Returns the base bdev of this lvs if not pending removal.
+    pub fn base_bdev_opt(&self) -> Option<UntypedBdev> {
+        let lvs = unsafe { vbdev_get_lvs_bdev_by_lvs(self.as_inner_ptr()) };
+        if lvs.is_null() {
+            return None;
+        }
+        Bdev::checked_from_ptr(unsafe { (*lvs).bdev })
+    }
+
+    /// Returns the base bdev of this lvs if not pending removal.
+    pub fn base_bdev(&self) -> Result<UntypedBdev, LvsError> {
+        match self.base_bdev_opt() {
+            Some(bdev) => Ok(bdev),
+            None => Err(LvsError::Invalid {
+                source: BsError::LvsRemoving {},
+                msg: self.name().to_string(),
+            }),
+        }
+    }
+
     /// Is the Lvs/pool encrypted.
     pub fn encrypted(&self) -> bool {
-        let b = self.base_bdev();
-        b.driver() == "crypto"
+        let base = self.base_bdev_opt();
+        let driver = base.as_ref().map(|b| b.driver());
+        driver == Some("crypto")
     }
 
     /// Returns blobstore cluster size.
@@ -562,7 +600,7 @@ impl Lvs {
         info!("{self_str}: exporting lvs...");
 
         let pool = self.name().to_string();
-        let base_bdev = self.base_bdev().name().to_string();
+        let base_bdev = self.base_bdev()?.name().to_string();
         let (s, r) = pair::<i32>();
 
         self.unshare_all().await;
@@ -655,7 +693,7 @@ impl Lvs {
         // when destroying a pool unshare all volumes
         self.unshare_all().await;
 
-        let base_bdev = self.base_bdev().name().to_string();
+        let base_bdev = self.base_bdev()?.name().to_string();
 
         let evt = self.event(EventAction::Delete);
 
@@ -739,11 +777,11 @@ impl Lvs {
         info!("{self:?}: growing lvs...");
         let lvs_name = self.name();
 
-        let disk_bdev = self
-            .base_bdev()
+        let base_bdev = self.base_bdev()?;
+        let disk_bdev = base_bdev
             .crypto_base_bdev()
             .map(Bdev::new)
-            .unwrap_or_else(|| self.base_bdev());
+            .unwrap_or_else(|| base_bdev);
 
         let uri_str = disk_bdev.bdev_uri_str().unwrap_or_default();
         let url = Url::parse(&uri_str).map_err(|source| LvsError::InvalidBdev {
@@ -767,17 +805,14 @@ impl Lvs {
         if errno != 0 {
             return Err(LvsError::BdevRescanFailed {
                 source: BsError::from_i32(errno),
-                name: self.base_bdev().name().to_string(),
+                name: self.base_bdev_name(),
             });
         }
 
         if self.encrypted() && !self.crypto_vbdev_resized().await {
-            error!(
-                "crypto bdev {} has not resized",
-                self.base_bdev().name().to_string()
-            );
+            error!("crypto bdev {} has not resized", self.base_bdev_name());
             return Err(LvsError::CryptoBdevNotResized {
-                name: self.base_bdev().name().to_string(),
+                name: self.base_bdev_name(),
             });
         }
 
@@ -804,7 +839,7 @@ impl Lvs {
 
         if self.capacity() == capacity_before_grow {
             return Err(LvsError::BdevNotExtended {
-                name: self.base_bdev().name().to_string(),
+                name: self.base_bdev_name(),
             });
         }
 
@@ -819,11 +854,13 @@ impl Lvs {
     /// This delay gives the crypto bdev time to process the resize event asynchronously.
     async fn crypto_vbdev_resized(&self) -> bool {
         for _i in 1..=30 {
-            let base_bdev = self.base_bdev();
+            let Some(base_bdev) = self.base_bdev_opt() else {
+                return false;
+            };
             let disk_bdev = base_bdev
                 .crypto_base_bdev()
                 .map(Bdev::new)
-                .unwrap_or_else(|| self.base_bdev());
+                .unwrap_or_else(|| base_bdev);
             let disk_bdev_size = disk_bdev.num_blocks() * disk_bdev.block_len() as u64;
             let crypto_bdev_size = base_bdev.num_blocks() * base_bdev.block_len() as u64;
             if crypto_bdev_size == disk_bdev_size {
@@ -902,7 +939,7 @@ impl Lvs {
 
     /// create a new lvol on this pool
     pub async fn create_lvol_with_opts(&self, opts: ReplicaArgs) -> Result<Lvol, LvsError> {
-        let clear_method = if self.base_bdev().io_type_supported(IoType::Unmap) {
+        let clear_method = if self.base_bdev()?.io_type_supported(IoType::Unmap) {
             LVOL_CLEAR_WITH_UNMAP
         } else {
             LVOL_CLEAR_WITH_NONE
@@ -1047,7 +1084,7 @@ impl LvsBackendBdevs {
         let pool_bdev_name = args.crypto_vbdev_name.clone().unwrap_or(bdev_name.clone());
 
         if let Some(pool) = Lvs::lookup(&args.name) {
-            let source = if pool.base_bdev().name() == pool_bdev_name {
+            let source = if pool.base_bdev()?.name() == pool_bdev_name {
                 // todo: this error makes no sense
                 BsError::VolAlreadyExists {}
             } else {
@@ -1059,7 +1096,7 @@ impl LvsBackendBdevs {
                     name: args.name.clone(),
                 })
             } else {
-                let pool_name = pool.base_bdev().name().to_string();
+                let pool_name = pool.base_bdev()?.name().to_string();
                 Err(LvsError::Import {
                     source,
                     name: args.name.clone(),

--- a/io-engine/src/lvs/mod.rs
+++ b/io-engine/src/lvs/mod.rs
@@ -158,7 +158,7 @@ impl PoolOps for Lvs {
     }
 
     async fn reset_errors(&self) -> Result<(), crate::pool_backend::Error> {
-        self.base_bdev()
+        self.base_bdev()?
             .reset_stats_ext(spdk_rs::BdevStatsResetMode::Errors)
             .await
             .map_err(|errno| crate::pool_backend::Error::Gen {
@@ -168,22 +168,31 @@ impl PoolOps for Lvs {
     }
 }
 
+fn lvs_bdev(lvs: &Lvs) -> Result<UntypedBdev, CoreError> {
+    match lvs.base_bdev_opt() {
+        Some(bdev) => Ok(bdev),
+        None => Err(CoreError::OpenBdev {
+            source: nix::Error::EINPROGRESS,
+        }),
+    }
+}
+
 #[async_trait::async_trait(?Send)]
 impl BdevStater for Lvs {
     type Stats = BdevStats;
 
     async fn stats(&self) -> Result<BdevStats, CoreError> {
-        let stats = self.base_bdev().stats_async().await?;
+        let stats = lvs_bdev(self)?.stats_async().await?;
         Ok(BdevStats::new(self.name().to_string(), self.uuid(), stats))
     }
 
     async fn error_stats(&self) -> Result<BdevErrorStats, CoreError> {
-        let stats = self.base_bdev().stats_errors_async().await?;
+        let stats = lvs_bdev(self)?.stats_errors_async().await?;
         Ok(BdevErrorStats(stats))
     }
 
     async fn reset_stats(&self) -> Result<(), CoreError> {
-        self.base_bdev().reset_bdev_io_stats().await
+        lvs_bdev(self)?.reset_bdev_io_stats().await
     }
 }
 
@@ -201,18 +210,22 @@ impl IPoolProps for Lvs {
     }
 
     fn disks(&self) -> Vec<String> {
+        let Some(base_bdev) = self.base_bdev_opt() else {
+            return vec![];
+        };
         // Calling crypto_base_bdev() on non crypto bdev returns None.
-        let disk_bdev = self
-            .base_bdev()
+        let disk_bdev = base_bdev
             .crypto_base_bdev()
             .map(Bdev::new)
-            .unwrap_or_else(|| self.base_bdev());
+            .unwrap_or(base_bdev);
 
         vec![disk_bdev.bdev_uri_original_str().unwrap_or_default()]
     }
 
     fn disk_capacity(&self) -> u64 {
-        self.base_bdev().size_in_bytes()
+        self.base_bdev_opt()
+            .map(|b| b.size_in_bytes())
+            .unwrap_or_default()
     }
 
     fn cluster_size(&self) -> u32 {

--- a/io-engine/tests/lvs_pool.rs
+++ b/io-engine/tests/lvs_pool.rs
@@ -680,15 +680,14 @@ async fn lvs_errors() {
 
         lvol.unbork(table).await.unwrap();
 
-        // pending an spdk fix...
-        // let lvs = Lvs::create_or_import(pool_args.clone()).await.unwrap();
+        let lvs = Lvs::create_or_import(pool_args.clone()).await.unwrap();
 
-        // let table = lvol.bork().await.unwrap();
+        let table = lvol.bork().await.unwrap();
 
-        // let result = lvs.destroy().await.expect_err("EIO");
-        // assert_eq!(result.to_errno(), nix::Error::EIO, "{result:#?}");
+        let result = lvs.destroy().await.expect_err("EIO");
+        assert_eq!(result.to_errno(), nix::Error::EIO, "{result:#?}");
 
-        // lvol.unbork(table).await.unwrap();
+        lvol.unbork(table).await.unwrap();
     })
     .await;
 

--- a/io-engine/tests/lvs_pool.rs
+++ b/io-engine/tests/lvs_pool.rs
@@ -573,7 +573,7 @@ async fn lvs_errors() {
     .await
     .unwrap();
 
-    let mut lvol = vg_pool
+    let glvol = vg_pool
         .create_lvol(ReplicaArgs {
             name: LV_NAME.into(),
             uuid: LV_NAME.into(),
@@ -582,16 +582,18 @@ async fn lvs_errors() {
         })
         .await
         .unwrap();
-    let pool_args = PoolArgs {
+    let gpool_args = PoolArgs {
         name: "tpool".into(),
-        disks: vec![format!("aio://{}", lvol.path())],
+        disks: vec![format!("aio://{}", glvol.path())],
         backend: PoolBackend::Lvs,
         ..Default::default()
     };
+    let pool_args = gpool_args.clone();
+    let mut lvol = glvol.clone();
 
-    let ms = ms();
+    let ms: &MayastorTest<'_> = ms();
     ms.spawn(async move {
-        let lvs_pool = Lvs::create_or_import(pool_args).await.unwrap();
+        let lvs_pool = Lvs::create_or_import(pool_args.clone()).await.unwrap();
 
         // We bork the device, making it return -EIO for all I/O
         let table = lvol.bork().await.unwrap();
@@ -644,6 +646,49 @@ async fn lvs_errors() {
         assert_eq!(alerts.status(), PoolAlertStatus::Healthy);
 
         lvs_pool.destroy().await.unwrap();
+        lvol
+    })
+    .await;
+
+    let pool_args = gpool_args;
+    let mut lvol = glvol;
+    ms.spawn(async move {
+        // We bork the device, making it return -EIO for all I/O
+        let table = lvol.bork().await.unwrap();
+
+        let result = Lvs::create_or_import(pool_args.clone())
+            .await
+            .expect_err("EIO");
+        assert_eq!(result.to_errno(), nix::Error::EIO, "{result:#?}");
+
+        let result = Lvs::import_from_args(pool_args.clone())
+            .await
+            .expect_err("EIO");
+        assert_eq!(result.to_errno(), nix::Error::EIO, "{result:#?}");
+
+        let backend = UntypedBdev::lookup_by_name(lvol.path());
+        assert!(backend.is_none(), "Disk Bdev should have been cleaned up");
+
+        lvol.unbork(table).await.unwrap();
+
+        let lvs = Lvs::create_or_import(pool_args.clone()).await.unwrap();
+
+        let table = lvol.bork().await.unwrap();
+
+        let result = lvs.export().await.expect_err("EIO");
+        assert_eq!(result.to_errno(), nix::Error::EIO, "{result:#?}");
+
+        lvol.unbork(table).await.unwrap();
+
+        // pending an spdk fix...
+        // let lvs = Lvs::create_or_import(pool_args.clone()).await.unwrap();
+
+        // let table = lvol.bork().await.unwrap();
+
+        // let result = lvs.destroy().await.expect_err("EIO");
+        // assert_eq!(result.to_errno(), nix::Error::EIO, "{result:#?}");
+
+        // lvol.unbork(table).await.unwrap();
     })
     .await;
 

--- a/io-engine/tests/lvs_pool.rs
+++ b/io-engine/tests/lvs_pool.rs
@@ -39,6 +39,7 @@ fn ms() -> &'static MayastorTest<'static> {
                 io_error_threshold: IO_ERROR_THRESHOLD,
                 ..Default::default()
             },
+            // log_components: vec!["all".into()],
             nvme: NvmeCliArgs {
                 max_namespaces: 8192,
             },
@@ -120,7 +121,7 @@ async fn lvs_pool_test() {
         assert_eq!(pool.name(), "tpool");
         assert_eq!(pool.used(), 0);
         dbg!(pool.uuid());
-        assert_eq!(pool.base_bdev().name(), DISKNAME1);
+        assert_eq!(pool.base_bdev_().name(), DISKNAME1);
     })
     .await;
 
@@ -473,7 +474,7 @@ async fn lvs_pool_test() {
         })
         .await
         .unwrap();
-        assert_eq!(pool.base_bdev().driver(), "aio");
+        assert_eq!(pool.base_bdev_().driver(), "aio");
     })
     .await;
 
@@ -500,7 +501,7 @@ async fn lvs_pool_test() {
         })
         .await
         .unwrap();
-        let pool_base_bdev = pool.base_bdev();
+        let pool_base_bdev = pool.base_bdev_();
         assert_eq!(pool_base_bdev.driver(), "crypto");
         let underlying_bdev = pool_base_bdev.crypto_base_bdev().unwrap();
         // we internally use diskname as aio bdev name.
@@ -764,7 +765,18 @@ async fn lvs_hot_remove() {
     ms().start_grpc();
 
     ms().spawn(async move {
-        let lvs_pool = Lvs::create_or_import(pool_args).await.unwrap();
+        let lvs_pool = Lvs::create_or_import(pool_args.clone()).await.unwrap();
+
+        // NOTE: There's currently an issue when we destroy a replica manually and at the same time the hot-removal
+        // is happening. In this case looks like the check for no lvols is done before the callbacks for this replica
+        // destroy attempt completes, and so we end up with a stuck lvs which needs to be retried again.
+        // To make matters worse, the bdev is removing, so it's not returned by `vbdev_get_lvs_bdev_by_lvs` leaving
+        // us with no base bdev, and no way to determine if we need tear down of the bdevs behind the base...
+        // Creating this dud will allow it's closure to trigger proper lvs unload...
+        let _dud = lvs_pool
+            .create_lvol("dud", 8 * 1024 * 1024, None, true, None)
+            .await
+            .unwrap();
 
         let repl = lvs_pool
             .create_lvol("ok", 8 * 1024 * 1024, None, true, None)
@@ -783,6 +795,28 @@ async fn lvs_hot_remove() {
 
         let error = repl.destroy().await.expect_err("-EIO");
         assert_eq!(error.to_errno(), nix::Error::EIO);
+
+        lvs_pool.destroy().await.ok();
+
+        assert_eq!(Lvs::iter_all().count(), 1);
+        assert_eq!(Lvs::iter().count(), 0);
+
+        let error = Lvs::create_or_import(pool_args.clone())
+            .await
+            .expect_err("removing");
+        assert_eq!(error.to_errno(), nix::Error::EINPROGRESS);
+
+        for _ in 0..10 {
+            if Lvs::iter_all().count() == 0 {
+                break;
+            }
+            io_engine::sleep::mayastor_sleep(std::time::Duration::from_millis(100))
+                .await
+                .unwrap();
+        }
+
+        assert_eq!(Lvs::iter_all().count(), 0);
+        assert_eq!(Lvs::iter().count(), 0);
     })
     .await;
 }


### PR DESCRIPTION
    fix(lvs): destroy with failing disk
    
    Pull in the spdk fix for blobstore deletion with -EIO.
    The destroy can now destroy the backing bdev when it fails
    with -EIO.
    Also we update the test to include the destroy workflow.

---

    test(lvs): add pool operations with broken backend
    
    The destroy is not working due an spdk bug.
    
---

    fix(lvs): cleanup pool backend devices
    
    When destroy/export fails we should clean up the backend devices.
    Currently destroy cleanup is getting stuck due an spdk bug, so
    for now we leave it in case of -EIO.
    
---

    refactor(lvs): reduce duplicated code on destroy/export
    
    Adds common cleanup function for both destroy/export.
    
---

    refactor(lvs): reduce duplicate code and fix undo on failed creates
    
    With the new blobstore fixes, failed creates now take a different path
    depending on the error code.
    
    This means we now also have to cleanup in another "match arm", though is
    a fix as otherwise we would try to create the pool in case of any error
    and not just EILSEQ!!!!
    
    A lot of code was duplicated between the create and import, so I also
    refactored that.
    This also fixes a missing check for crypto bdev existence in the create
    path!
    
---

    build: pull latest spdk-rs with blobstore fixes
