### PR TITLE
Improve snapshot listing times

### DIFF
--- a/io-engine/src/core/bdev.rs
+++ b/io-engine/src/core/bdev.rs
@@ -113,11 +113,10 @@ where
 
     /// Looks up a Bdev by its uuid.
     pub fn lookup_by_uuid_str(uuid: &str) -> Option<Self> {
+        let uuid = uuid::Uuid::parse_str(uuid).ok()?;
         match Self::bdev_first() {
             None => None,
-            Some(bdev) => bdev
-                .into_iter()
-                .find(|b| b.uuid_as_string() == uuid.to_lowercase()),
+            Some(bdev) => bdev.into_iter().find(|b| b.uuid() == uuid),
         }
     }
 

--- a/io-engine/src/core/mod.rs
+++ b/io-engine/src/core/mod.rs
@@ -43,7 +43,7 @@ pub use thread::Mthread;
 
 use crate::subsys::NvmfError;
 pub use snapshot::{
-    CloneParams, CloneXattrs, ISnapshotDescriptor, LvolSnapshotOps, SnapshotDescriptor,
+    CloneParams, CloneXattrs, ISnapshotDescriptor, LvolSnapshotOps, PropXattrs, SnapshotDescriptor,
     SnapshotParams, SnapshotXattrs,
 };
 

--- a/io-engine/src/core/snapshot.rs
+++ b/io-engine/src/core/snapshot.rs
@@ -5,13 +5,13 @@ use strum_macros::{EnumCount as EnumCountMacro, EnumIter};
 /// Snapshot Captures all the Snapshot information for Lvol.
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct SnapshotParams {
-    entity_id: Option<String>,
-    parent_id: Option<String>,
-    txn_id: Option<String>,
-    snap_name: Option<String>,
-    snapshot_uuid: Option<String>,
-    create_time: Option<String>,
-    discarded_snapshot: bool,
+    pub entity_id: Option<String>,
+    pub parent_id: Option<String>,
+    pub txn_id: Option<String>,
+    pub snap_name: Option<String>,
+    pub snapshot_uuid: Option<String>,
+    pub create_time: Option<String>,
+    pub discarded_snapshot: bool,
 }
 
 /// Implement Snapshot Common Function.

--- a/io-engine/src/core/snapshot.rs
+++ b/io-engine/src/core/snapshot.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use std::fmt::Debug;
+use std::{ffi::CStr, fmt::Debug};
 use strum_macros::{EnumCount as EnumCountMacro, EnumIter};
 
 /// Snapshot Captures all the Snapshot information for Lvol.
@@ -250,8 +250,42 @@ impl SnapshotDescriptor {
     }
 }
 
+/// Lvs Extended Attributes.
+#[derive(Clone, Copy)]
+pub enum PropXattrs {
+    /// Attributes used by snapshots.
+    Snapshot(SnapshotXattrs),
+    /// Attributes used by clones.
+    Clone(CloneXattrs),
+    /// Attribute which was used as a raw string directly.
+    /// todo: check if this representation is correct as it seems to clash with
+    /// another representation.
+    BrokenEntityId,
+}
+impl PropXattrs {
+    /// The name of the property as stored in the lvs extended attributes.
+    pub const fn name(&self) -> &CStr {
+        match self {
+            Self::Snapshot(attrs) => attrs.name(),
+            Self::Clone(attrs) => attrs.name(),
+            Self::BrokenEntityId => unsafe { CStr::from_ptr(b"entity_id\0".as_ptr().cast()) },
+        }
+    }
+}
+
+impl From<SnapshotXattrs> for PropXattrs {
+    fn from(value: SnapshotXattrs) -> Self {
+        PropXattrs::Snapshot(value)
+    }
+}
+impl From<CloneXattrs> for PropXattrs {
+    fn from(value: CloneXattrs) -> Self {
+        PropXattrs::Clone(value)
+    }
+}
+
 /// Snapshot attributes used to store its properties.
-#[derive(Debug, EnumCountMacro, EnumIter)]
+#[derive(Debug, Clone, Copy, EnumCountMacro, EnumIter)]
 pub enum SnapshotXattrs {
     TxId,
     EntityId,
@@ -266,20 +300,23 @@ pub enum SnapshotXattrs {
 }
 
 impl SnapshotXattrs {
-    pub fn name(&self) -> &'static str {
-        match *self {
-            Self::TxId => "io-engine.tx_id",
-            Self::EntityId => "io-engine.entity_id",
-            Self::ParentId => "io-engine.parent_id",
-            Self::SnapshotUuid => "uuid",
-            Self::SnapshotCreateTime => "io-engine.snapshot_create_time",
-            Self::DiscardedSnapshot => "io-engine.discarded_snapshot",
+    /// The name of the property as stored in the lvs extended attributes.
+    pub const fn name(&self) -> &CStr {
+        unsafe {
+            CStr::from_ptr(match *self {
+                Self::TxId => b"io-engine.tx_id\0".as_ptr().cast(),
+                Self::EntityId => b"io-engine.entity_id\0".as_ptr().cast(),
+                Self::ParentId => b"io-engine.parent_id\0".as_ptr().cast(),
+                Self::SnapshotUuid => b"uuid\0".as_ptr().cast(),
+                Self::SnapshotCreateTime => b"io-engine.snapshot_create_time\0".as_ptr().cast(),
+                Self::DiscardedSnapshot => b"io-engine.discarded_snapshot\0".as_ptr().cast(),
+            })
         }
     }
 }
 
 /// Clone attributes used to store its properties.
-#[derive(Debug, EnumCountMacro, EnumIter)]
+#[derive(Debug, Clone, Copy, EnumCountMacro, EnumIter)]
 pub enum CloneXattrs {
     CloneUuid,
     SourceUuid,
@@ -287,11 +324,14 @@ pub enum CloneXattrs {
 }
 
 impl CloneXattrs {
-    pub fn name(&self) -> &'static str {
-        match *self {
-            Self::CloneUuid => "uuid",
-            Self::SourceUuid => "io-engine.source_uuid",
-            Self::CloneCreateTime => "io-engine.clone_create_time",
+    /// The name of the property as stored in the lvs extended attributes.
+    pub const fn name(&self) -> &CStr {
+        unsafe {
+            CStr::from_ptr(match *self {
+                Self::CloneUuid => "uuid\0".as_ptr().cast(),
+                Self::SourceUuid => "io-engine.source_uuid\0".as_ptr().cast(),
+                Self::CloneCreateTime => "io-engine.clone_create_time\0".as_ptr().cast(),
+            })
         }
     }
 }

--- a/io-engine/src/core/snapshot.rs
+++ b/io-engine/src/core/snapshot.rs
@@ -287,9 +287,9 @@ impl From<CloneXattrs> for PropXattrs {
 /// Snapshot attributes used to store its properties.
 #[derive(Debug, Clone, Copy, EnumCountMacro, EnumIter)]
 pub enum SnapshotXattrs {
+    ParentId,
     TxId,
     EntityId,
-    ParentId,
     SnapshotUuid,
     SnapshotCreateTime,
     /// if any snapshot delete gRPC request came and there are valid clones

--- a/io-engine/src/lvs/lvol_snapshot.rs
+++ b/io-engine/src/lvs/lvol_snapshot.rs
@@ -729,7 +729,7 @@ impl LvolSnapshotOps for Lvol {
         };
         bdev.into_iter()
             .filter_map(Lvol::ok_from)
-            .filter(|b| b.is_snapshot_clone().is_some())
+            .filter(|b| b.is_clone())
             .collect::<Vec<Lvol>>()
     }
 
@@ -778,14 +778,14 @@ impl LvolSnapshotOps for Lvol {
             let parent = self
                 .lvs()
                 .lookup_lvol_by_uuid_str(self.blob_xattr(SnapshotXattrs::ParentId)?)?;
-            let parent_snap_lvol = parent.is_snapshot_clone()?;
+            let parent_snap_lvol = parent.clone_source()?;
 
             let usage = parent_snap_lvol.usage();
             let usage = total_ancestor_snap_size
                 - (usage.allocated_bytes_snapshots + usage.allocated_bytes);
             Some(usage)
         // if self is clone.
-        } else if self.is_snapshot_clone().is_some() {
+        } else if self.is_clone() {
             let sum = Lvol::list_all_lvol_snapshots(Some(self))
                 .iter()
                 .map(|v| v.snapshot_lvol().allocated())

--- a/io-engine/src/lvs/lvol_snapshot.rs
+++ b/io-engine/src/lvs/lvol_snapshot.rs
@@ -698,6 +698,7 @@ impl LvolSnapshotOps for Lvol {
 
     /// List clones based on snapshot_uuid.
     fn list_clones_by_snapshot_uuid(&self) -> Vec<Lvol> {
+        let su = self.as_inner_ref().uuid_str.as_ptr();
         let bdev = match UntypedBdev::bdev_first() {
             Some(b) => b,
             None => return Vec::new(), /* No devices available, no clones */
@@ -705,9 +706,8 @@ impl LvolSnapshotOps for Lvol {
         bdev.into_iter()
             .filter_map(|b| {
                 let b = Lvol::ok_from(b)?;
-                // how many clones from this snapshot
-                let snap_lvol = b.is_snapshot_clone()?;
-                if snap_lvol.is_same(self) {
+                let source_uuid = b.blob_xattr(CloneXattrs::SourceUuid)?;
+                if unsafe { std::ffi::CStr::from_ptr(su) }.to_bytes() == source_uuid.as_bytes() {
                     Some(b)
                 } else {
                     None

--- a/io-engine/src/lvs/lvol_snapshot.rs
+++ b/io-engine/src/lvs/lvol_snapshot.rs
@@ -553,7 +553,7 @@ impl LvolSnapshotOps for Lvol {
             parent_uuid,
             self.allocated(),
             snapshot_param,
-            self.list_clones_by_snapshot_uuid().len() as u64,
+            self.clone_count(),
             valid_snapshot,
         );
         Some(snapshot_descriptor)
@@ -591,7 +591,7 @@ impl LvolSnapshotOps for Lvol {
 
     /// Destroy snapshot.
     async fn destroy_snapshot(mut self) -> Result<(), Self::Error> {
-        if self.list_clones_by_snapshot_uuid().is_empty() {
+        if !self.has_clones() {
             self.destroy().await?;
         } else {
             self.set_blob_attr(SnapshotXattrs::DiscardedSnapshot, true.to_string(), true)
@@ -745,11 +745,7 @@ impl LvolSnapshotOps for Lvol {
         let snap_list = bdev
             .into_iter()
             .filter_map(Lvol::ok_from)
-            .filter(|b| {
-                b.is_snapshot()
-                    && b.is_discarded_snapshot()
-                    && b.list_clones_by_snapshot_uuid().is_empty()
-            })
+            .filter(|b| b.is_snapshot() && b.is_discarded_snapshot() && !b.has_clones())
             .collect::<Vec<Lvol>>();
         for snap in &snap_list {
             snap.reset_snapshot_tree_usage_cache(false);

--- a/io-engine/src/lvs/lvol_snapshot.rs
+++ b/io-engine/src/lvs/lvol_snapshot.rs
@@ -1,5 +1,4 @@
 use std::{
-    convert::TryFrom,
     ffi::{c_ushort, c_void, CString},
     mem::zeroed,
     ops::Deref,
@@ -22,7 +21,7 @@ use crate::{
     core::{
         logical_volume::LogicalVolume,
         snapshot::{CloneParams, ISnapshotDescriptor, SnapshotDescriptor, SnapshotInfo},
-        Bdev, CloneXattrs, SnapshotParams, SnapshotXattrs, UntypedBdev,
+        CloneXattrs, SnapshotParams, SnapshotXattrs, UntypedBdev,
     },
     eventing::Event,
     ffihelper::{cb_arg, done_cb, IntoCString},
@@ -229,8 +228,8 @@ impl AsyncParentIterator for LvolSnapshotIter {
         } else {
             let mut parent_blob = unsafe { self.inner_lvol.bs_iter_parent(self.inner_blob) }?;
             let uuid = Lvol::get_blob_xattr(&mut parent_blob, SnapshotXattrs::SnapshotUuid)?;
-            let snap_lvol =
-                UntypedBdev::lookup_by_uuid_str(uuid).and_then(|bdev| Lvol::try_from(bdev).ok())?;
+            // todo: search own lvstore only...
+            let snap_lvol = Lvol::lookup_by_uuid_str(uuid)?;
             self.inner_blob = parent_blob;
             self.inner_lvol = snap_lvol.clone();
             snap_lvol.lvol_snapshot_descriptor(None)
@@ -500,6 +499,7 @@ impl LvolSnapshotOps for Lvol {
 
     /// Common API to set SnapshotDescriptor for ListReplicaSnapshot.
     fn snapshot_descriptor_info(&self, parent: Option<&Lvol>) -> Option<SnapshotInfo> {
+        let parent_uuid = parent.map(|p| p.uuid());
         let mut valid_snapshot = true;
         let mut snapshot_param: SnapshotParams = Default::default();
         for attr in SnapshotXattrs::iter() {
@@ -512,9 +512,9 @@ impl LvolSnapshotOps for Lvol {
             };
             match attr {
                 SnapshotXattrs::ParentId => {
-                    if let Some(parent_lvol) = parent {
+                    if let Some(ref parent_uuid) = parent_uuid {
                         // Skip snapshots if it's parent is not matched.
-                        if curr_attr_val != parent_lvol.uuid() {
+                        if curr_attr_val != parent_uuid {
                             return None;
                         }
                     }
@@ -541,13 +541,16 @@ impl LvolSnapshotOps for Lvol {
         // set remaining snapshot parameters for snapshot list
         snapshot_param.set_name(self.name());
         // set parent replica uuid and size of the snapshot
-        let parent_uuid = if let Some(parent_lvol) = parent {
-            parent_lvol.uuid()
+        let parent_uuid = if let Some(parent_uuid) = parent_uuid {
+            parent_uuid
         } else {
-            let parent = snapshot_param
-                .parent_id()
-                .and_then(|p| Bdev::lookup_by_uuid_str(&p).and_then(Lvol::ok_from));
-            parent.map(|p| p.uuid()).unwrap_or_default()
+            // todo: when the parent has been deleted, the parent_uuid is not being
+            // exposed, was this intended like so?
+            let parent = snapshot_param.parent_id.as_ref();
+            parent
+                .and_then(|u| self.lvs().lookup_lvol_by_uuid_str(u))
+                .map(|l| l.uuid())
+                .unwrap_or_default()
         };
         let snapshot_descriptor = SnapshotInfo::new(
             parent_uuid,
@@ -767,9 +770,10 @@ impl LvolSnapshotOps for Lvol {
     fn calculate_clone_source_snap_usage(&self, total_ancestor_snap_size: u64) -> Option<u64> {
         // if self is snapshot created from clone.
         if self.is_snapshot() {
-            let parent_bdev =
-                UntypedBdev::lookup_by_uuid_str(self.blob_xattr(SnapshotXattrs::ParentId)?)?;
-            let parent_snap_lvol = Lvol::ok_from(parent_bdev)?.is_snapshot_clone()?;
+            let parent = self
+                .lvs()
+                .lookup_lvol_by_uuid_str(self.blob_xattr(SnapshotXattrs::ParentId)?)?;
+            let parent_snap_lvol = parent.is_snapshot_clone()?;
 
             let usage = parent_snap_lvol.usage();
             let usage = total_ancestor_snap_size
@@ -794,13 +798,11 @@ impl LvolSnapshotOps for Lvol {
             return;
         }
         if let Some(snapshot_parent_uuid) = self.blob_xattr(SnapshotXattrs::ParentId) {
-            if let Some(bdev) = UntypedBdev::lookup_by_uuid_str(snapshot_parent_uuid) {
-                if let Ok(parent_lvol) = Lvol::try_from(bdev) {
-                    unsafe {
-                        spdk_blob_reset_used_clusters_cache(parent_lvol.blob_checked());
-                    }
-                    reset_snapshot_tree_usage_cache_with_parent_uuid(&parent_lvol);
+            if let Some(parent_lvol) = self.lvs().lookup_lvol_by_uuid_str(snapshot_parent_uuid) {
+                unsafe {
+                    spdk_blob_reset_used_clusters_cache(parent_lvol.blob_checked());
                 }
+                reset_snapshot_tree_usage_cache_with_parent_uuid(&parent_lvol);
             } else {
                 reset_snapshot_tree_usage_cache_with_wildcard(self, snapshot_parent_uuid);
             }

--- a/io-engine/src/lvs/lvol_snapshot.rs
+++ b/io-engine/src/lvs/lvol_snapshot.rs
@@ -544,12 +544,10 @@ impl LvolSnapshotOps for Lvol {
         let parent_uuid = if let Some(parent_lvol) = parent {
             parent_lvol.uuid()
         } else {
-            match Bdev::lookup_by_uuid_str(snapshot_param.parent_id().unwrap_or_default().as_str())
-                .and_then(|b| Lvol::try_from(b).ok())
-            {
-                Some(parent) => parent.uuid(),
-                None => String::default(),
-            }
+            let parent = snapshot_param
+                .parent_id()
+                .and_then(|p| Bdev::lookup_by_uuid_str(&p).and_then(|b| Lvol::try_from(b).ok()));
+            parent.map(|p| p.uuid()).unwrap_or_default()
         };
         let snapshot_descriptor = SnapshotInfo::new(
             parent_uuid,

--- a/io-engine/src/lvs/lvol_snapshot.rs
+++ b/io-engine/src/lvs/lvol_snapshot.rs
@@ -544,13 +544,7 @@ impl LvolSnapshotOps for Lvol {
         let parent_uuid = if let Some(parent_uuid) = parent_uuid {
             parent_uuid
         } else {
-            // todo: when the parent has been deleted, the parent_uuid is not being
-            // exposed, was this intended like so?
-            let parent = snapshot_param.parent_id.as_ref();
-            parent
-                .and_then(|u| self.lvs().lookup_lvol_by_uuid_str(u))
-                .map(|l| l.uuid())
-                .unwrap_or_default()
+            snapshot_param.parent_id().unwrap_or_default()
         };
         let snapshot_descriptor = SnapshotInfo::new(
             parent_uuid,

--- a/io-engine/src/lvs/lvol_snapshot.rs
+++ b/io-engine/src/lvs/lvol_snapshot.rs
@@ -189,6 +189,10 @@ impl LvolSnapshotDescriptor {
     pub fn snapshot_lvol(&self) -> &Lvol {
         &self.snapshot_lvol
     }
+    /// Get the snapshot lvol.
+    pub fn into_snapshot_lvol(self) -> Lvol {
+        self.snapshot_lvol
+    }
     /// Get snapshot info.
     pub fn info(&self) -> &SnapshotInfo {
         &self.info
@@ -223,10 +227,10 @@ impl AsyncParentIterator for LvolSnapshotIter {
         if self.inner_blob.is_null() {
             None
         } else {
-            let parent_blob = unsafe { self.inner_lvol.bs_iter_parent(self.inner_blob) }?;
-            let uuid = Lvol::get_blob_xattr(parent_blob, SnapshotXattrs::SnapshotUuid.name())?;
-            let snap_lvol = UntypedBdev::lookup_by_uuid_str(&uuid)
-                .and_then(|bdev| Lvol::try_from(bdev).ok())?;
+            let mut parent_blob = unsafe { self.inner_lvol.bs_iter_parent(self.inner_blob) }?;
+            let uuid = Lvol::get_blob_xattr(&mut parent_blob, SnapshotXattrs::SnapshotUuid.name())?;
+            let snap_lvol =
+                UntypedBdev::lookup_by_uuid_str(uuid).and_then(|bdev| Lvol::try_from(bdev).ok())?;
             self.inner_blob = parent_blob;
             self.inner_lvol = snap_lvol.clone();
             snap_lvol.lvol_snapshot_descriptor(None)
@@ -499,7 +503,7 @@ impl LvolSnapshotOps for Lvol {
         let mut valid_snapshot = true;
         let mut snapshot_param: SnapshotParams = Default::default();
         for attr in SnapshotXattrs::iter() {
-            let curr_attr_val = match Self::get_blob_xattr(self.blob_checked(), attr.name()) {
+            let curr_attr_val = match self.blob_xattr(attr.name()) {
                 Some(val) => val,
                 None => {
                     valid_snapshot = false;
@@ -514,19 +518,19 @@ impl LvolSnapshotOps for Lvol {
                             return None;
                         }
                     }
-                    snapshot_param.set_parent_id(curr_attr_val);
+                    snapshot_param.set_parent_id(curr_attr_val.to_string());
                 }
                 SnapshotXattrs::EntityId => {
-                    snapshot_param.set_entity_id(curr_attr_val);
+                    snapshot_param.set_entity_id(curr_attr_val.to_string());
                 }
                 SnapshotXattrs::TxId => {
-                    snapshot_param.set_txn_id(curr_attr_val);
+                    snapshot_param.set_txn_id(curr_attr_val.to_string());
                 }
                 SnapshotXattrs::SnapshotUuid => {
-                    snapshot_param.set_snapshot_uuid(curr_attr_val);
+                    snapshot_param.set_snapshot_uuid(curr_attr_val.to_string());
                 }
                 SnapshotXattrs::SnapshotCreateTime => {
-                    snapshot_param.set_create_time(curr_attr_val);
+                    snapshot_param.set_create_time(curr_attr_val.to_string());
                 }
                 SnapshotXattrs::DiscardedSnapshot => {
                     snapshot_param
@@ -658,8 +662,7 @@ impl LvolSnapshotOps for Lvol {
 
         let lvol_devices = bdev
             .into_iter()
-            .filter(|b| b.driver() == "lvol")
-            .map(|b| Lvol::try_from(b).unwrap())
+            .filter_map(|b| Lvol::try_from(b).ok())
             .collect::<Vec<Lvol>>();
 
         for snapshot_lvol in lvol_devices {
@@ -731,13 +734,10 @@ impl LvolSnapshotOps for Lvol {
 
     /// Check if the snapshot has been discarded.
     fn is_discarded_snapshot(&self) -> bool {
-        Lvol::get_blob_xattr(
-            self.blob_checked(),
-            SnapshotXattrs::DiscardedSnapshot.name(),
-        )
-        .unwrap_or_default()
-        .parse()
-        .unwrap_or_default()
+        self.blob_xattr(SnapshotXattrs::DiscardedSnapshot.name())
+            .unwrap_or_default()
+            .parse()
+            .unwrap_or_default()
     }
 
     /// During destroying the last linked cloned, if there is any fault
@@ -780,7 +780,7 @@ impl LvolSnapshotOps for Lvol {
         // if self is snapshot created from clone.
         if self.is_snapshot() {
             match UntypedBdev::lookup_by_uuid_str(
-                &Lvol::get_blob_xattr(self.blob_checked(), SnapshotXattrs::ParentId.name())
+                self.blob_xattr(SnapshotXattrs::ParentId.name())
                     .unwrap_or_default(),
             ) {
                 Some(bdev) => match Lvol::try_from(bdev) {
@@ -817,10 +817,8 @@ impl LvolSnapshotOps for Lvol {
             reset_snapshot_tree_usage_cache_with_parent_uuid(self);
             return;
         }
-        if let Some(snapshot_parent_uuid) =
-            Lvol::get_blob_xattr(self.blob_checked(), SnapshotXattrs::ParentId.name())
-        {
-            if let Some(bdev) = UntypedBdev::lookup_by_uuid_str(snapshot_parent_uuid.as_str()) {
+        if let Some(snapshot_parent_uuid) = self.blob_xattr(SnapshotXattrs::ParentId.name()) {
+            if let Some(bdev) = UntypedBdev::lookup_by_uuid_str(snapshot_parent_uuid) {
                 if let Ok(parent_lvol) = Lvol::try_from(bdev) {
                     unsafe {
                         spdk_blob_reset_used_clusters_cache(parent_lvol.blob_checked());
@@ -857,14 +855,14 @@ fn reset_snapshot_tree_usage_cache_with_parent_uuid(lvol: &Lvol) {
 /// bdev by matching parent uuid got from snapshot attribute.
 /// todo: need more optimization to adding new function in spdk to relate
 /// snapshot and clone blobs.
-fn reset_snapshot_tree_usage_cache_with_wildcard(lvol: &Lvol, snapshot_parent_uuid: String) {
+fn reset_snapshot_tree_usage_cache_with_wildcard(lvol: &Lvol, snapshot_parent_uuid: &str) {
     let mut successor_clones: Vec<Lvol> = vec![];
 
     let mut successor_snapshots = Lvol::list_all_lvol_snapshots(None)
         .iter()
         .map(|v| v.snapshot_lvol())
         .filter_map(|l| {
-            let uuid = Lvol::get_blob_xattr(lvol.blob_checked(), SnapshotXattrs::ParentId.name());
+            let uuid = lvol.blob_xattr(SnapshotXattrs::ParentId.name());
             match uuid {
                 Some(uuid) if uuid == snapshot_parent_uuid => Some(l.clone()),
                 _ => None,
@@ -886,8 +884,8 @@ fn reset_snapshot_tree_usage_cache_with_wildcard(lvol: &Lvol, snapshot_parent_uu
                 spdk_blob_reset_used_clusters_cache(clone.blob_checked());
             }
             let new_snap_list = Lvol::list_all_lvol_snapshots(Some(&clone))
-                .iter()
-                .map(|v| v.snapshot_lvol().clone())
+                .into_iter()
+                .map(|v| v.into_snapshot_lvol())
                 .collect::<Vec<Lvol>>();
             successor_snapshots.extend(new_snap_list);
         }

--- a/io-engine/src/lvs/lvol_snapshot.rs
+++ b/io-engine/src/lvs/lvol_snapshot.rs
@@ -698,22 +698,27 @@ impl LvolSnapshotOps for Lvol {
 
     /// List clones based on snapshot_uuid.
     fn list_clones_by_snapshot_uuid(&self) -> Vec<Lvol> {
-        let su = self.as_inner_ref().uuid_str.as_ptr();
-        let bdev = match UntypedBdev::bdev_first() {
-            Some(b) => b,
-            None => return Vec::new(), /* No devices available, no clones */
-        };
-        bdev.into_iter()
-            .filter_map(|b| {
-                let b = Lvol::ok_from(b)?;
-                let source_uuid = b.blob_xattr(CloneXattrs::SourceUuid)?;
-                if unsafe { std::ffi::CStr::from_ptr(su) }.to_bytes() == source_uuid.as_bytes() {
-                    Some(b)
-                } else {
-                    None
+        // todo: optimize this process, avoid multiple calls to spdk_blob_get_clones.
+        let clone_count = 100; /* self.blob_clone_count() as usize */
+        let mut clones = Vec::with_capacity(clone_count);
+        unsafe {
+            extern "C" fn cb(cb_arg: *mut c_void, lvol: *mut spdk_lvol) -> i32 {
+                let ctx = cb_arg as *mut Vec<Lvol>;
+                let lvol = Lvol::from_inner_ptr(lvol);
+                if lvol.is_clone() {
+                    unsafe {
+                        (*ctx).push(lvol);
+                    }
                 }
-            })
-            .collect::<Vec<Lvol>>()
+                0
+            }
+            spdk_rs::libspdk::spdk_lvol_iter_immediate_clones(
+                self.as_inner_ptr(),
+                Some(cb),
+                &mut clones as *mut _ as *mut std::ffi::c_void,
+            );
+        }
+        clones
     }
 
     /// List All Clones.

--- a/io-engine/src/lvs/lvol_snapshot.rs
+++ b/io-engine/src/lvs/lvol_snapshot.rs
@@ -656,7 +656,7 @@ impl LvolSnapshotOps for Lvol {
 
         let lvol_devices = bdev
             .into_iter()
-            .filter_map(|b| Lvol::try_from(b).ok())
+            .filter_map(Lvol::ok_from)
             .collect::<Vec<Lvol>>();
 
         for snapshot_lvol in lvol_devices {
@@ -700,11 +700,11 @@ impl LvolSnapshotOps for Lvol {
             None => return Vec::new(), /* No devices available, no clones */
         };
         bdev.into_iter()
-            .filter(|b| b.driver() == "lvol")
-            .map(|b| Lvol::try_from(b).unwrap())
             .filter_map(|b| {
-                let snap_lvol = b.is_snapshot_clone();
-                if snap_lvol.is_some() && snap_lvol.unwrap().uuid() == self.uuid() {
+                let b = Lvol::ok_from(b)?;
+                // how many clones from this snapshot
+                let snap_lvol = b.is_snapshot_clone()?;
+                if snap_lvol.is_same(self) {
                     Some(b)
                 } else {
                     None
@@ -720,8 +720,7 @@ impl LvolSnapshotOps for Lvol {
             None => return Vec::new(), /* No devices available, no clones */
         };
         bdev.into_iter()
-            .filter(|b| b.driver() == "lvol")
-            .map(|b| Lvol::try_from(b).unwrap())
+            .filter_map(Lvol::ok_from)
             .filter(|b| b.is_snapshot_clone().is_some())
             .collect::<Vec<Lvol>>()
     }
@@ -745,8 +744,7 @@ impl LvolSnapshotOps for Lvol {
         };
         let snap_list = bdev
             .into_iter()
-            .filter(|b| b.driver() == "lvol")
-            .map(|b| Lvol::try_from(b).unwrap())
+            .filter_map(Lvol::ok_from)
             .filter(|b| {
                 b.is_snapshot()
                     && b.is_discarded_snapshot()
@@ -773,33 +771,21 @@ impl LvolSnapshotOps for Lvol {
     fn calculate_clone_source_snap_usage(&self, total_ancestor_snap_size: u64) -> Option<u64> {
         // if self is snapshot created from clone.
         if self.is_snapshot() {
-            match UntypedBdev::lookup_by_uuid_str(
-                self.blob_xattr(SnapshotXattrs::ParentId)
-                    .unwrap_or_default(),
-            ) {
-                Some(bdev) => match Lvol::try_from(bdev) {
-                    Ok(l) => match l.is_snapshot_clone() {
-                        Some(parent_snap_lvol) => {
-                            let usage = parent_snap_lvol.usage();
-                            Some(
-                                total_ancestor_snap_size
-                                    - (usage.allocated_bytes_snapshots + usage.allocated_bytes),
-                            )
-                        }
-                        None => None,
-                    },
-                    _ => None,
-                },
-                _ => None,
-            }
+            let parent_bdev =
+                UntypedBdev::lookup_by_uuid_str(self.blob_xattr(SnapshotXattrs::ParentId)?)?;
+            let parent_snap_lvol = Lvol::ok_from(parent_bdev)?.is_snapshot_clone()?;
+
+            let usage = parent_snap_lvol.usage();
+            let usage = total_ancestor_snap_size
+                - (usage.allocated_bytes_snapshots + usage.allocated_bytes);
+            Some(usage)
         // if self is clone.
         } else if self.is_snapshot_clone().is_some() {
-            Some(
-                Lvol::list_all_lvol_snapshots(Some(self))
-                    .iter()
-                    .map(|v| v.snapshot_lvol().allocated())
-                    .sum(),
-            )
+            let sum = Lvol::list_all_lvol_snapshots(Some(self))
+                .iter()
+                .map(|v| v.snapshot_lvol().allocated())
+                .sum();
+            Some(sum)
         } else {
             None
         }
@@ -853,14 +839,11 @@ fn reset_snapshot_tree_usage_cache_with_wildcard(lvol: &Lvol, snapshot_parent_uu
     let mut successor_clones: Vec<Lvol> = vec![];
 
     let mut successor_snapshots = Lvol::list_all_lvol_snapshots(None)
-        .iter()
-        .map(|v| v.snapshot_lvol())
-        .filter_map(|l| {
-            let uuid = lvol.blob_xattr(SnapshotXattrs::ParentId);
-            match uuid {
-                Some(uuid) if uuid == snapshot_parent_uuid => Some(l.clone()),
-                _ => None,
-            }
+        .into_iter()
+        .map(|v| v.into_snapshot_lvol())
+        .filter_map(|l| match lvol.blob_xattr(SnapshotXattrs::ParentId) {
+            Some(uuid) if uuid == snapshot_parent_uuid => Some(l),
+            _ => None,
         })
         .collect::<Vec<Lvol>>();
 

--- a/io-engine/src/lvs/lvol_snapshot.rs
+++ b/io-engine/src/lvs/lvol_snapshot.rs
@@ -228,7 +228,7 @@ impl AsyncParentIterator for LvolSnapshotIter {
             None
         } else {
             let mut parent_blob = unsafe { self.inner_lvol.bs_iter_parent(self.inner_blob) }?;
-            let uuid = Lvol::get_blob_xattr(&mut parent_blob, SnapshotXattrs::SnapshotUuid.name())?;
+            let uuid = Lvol::get_blob_xattr(&mut parent_blob, SnapshotXattrs::SnapshotUuid)?;
             let snap_lvol =
                 UntypedBdev::lookup_by_uuid_str(uuid).and_then(|bdev| Lvol::try_from(bdev).ok())?;
             self.inner_blob = parent_blob;
@@ -301,7 +301,7 @@ impl LvolSnapshotOps for Lvol {
                 },
                 SnapshotXattrs::DiscardedSnapshot => params.discarded_snapshot().to_string(),
             };
-            let attr_name = attr.name().to_string().into_cstring();
+            let attr_name = attr.name().to_string_lossy().into_cstring();
             let attr_val = av.into_cstring();
             attr_descrs[idx].name = attr_name.as_ptr() as *mut c_char;
             attr_descrs[idx].value = attr_val.as_ptr() as *mut c_void;
@@ -414,7 +414,7 @@ impl LvolSnapshotOps for Lvol {
                     }
                 },
             };
-            let attr_name = attr.name().to_string().into_cstring();
+            let attr_name = std::ffi::CString::from(attr.name());
             let attr_val = av.into_cstring();
             attr_descrs[idx].name = attr_name.as_ptr() as *mut c_char;
             attr_descrs[idx].value = attr_val.as_ptr() as *mut c_void;
@@ -503,7 +503,7 @@ impl LvolSnapshotOps for Lvol {
         let mut valid_snapshot = true;
         let mut snapshot_param: SnapshotParams = Default::default();
         for attr in SnapshotXattrs::iter() {
-            let curr_attr_val = match self.blob_xattr(attr.name()) {
+            let curr_attr_val = match self.blob_xattr(attr) {
                 Some(val) => val,
                 None => {
                     valid_snapshot = false;
@@ -546,7 +546,7 @@ impl LvolSnapshotOps for Lvol {
         } else {
             let parent = snapshot_param
                 .parent_id()
-                .and_then(|p| Bdev::lookup_by_uuid_str(&p).and_then(|b| Lvol::try_from(b).ok()));
+                .and_then(|p| Bdev::lookup_by_uuid_str(&p).and_then(Lvol::ok_from));
             parent.map(|p| p.uuid()).unwrap_or_default()
         };
         let snapshot_descriptor = SnapshotInfo::new(
@@ -594,12 +594,8 @@ impl LvolSnapshotOps for Lvol {
         if self.list_clones_by_snapshot_uuid().is_empty() {
             self.destroy().await?;
         } else {
-            self.set_blob_attr(
-                SnapshotXattrs::DiscardedSnapshot.name(),
-                true.to_string(),
-                true,
-            )
-            .await?;
+            self.set_blob_attr(SnapshotXattrs::DiscardedSnapshot, true.to_string(), true)
+                .await?;
         }
 
         Ok(())
@@ -732,7 +728,7 @@ impl LvolSnapshotOps for Lvol {
 
     /// Check if the snapshot has been discarded.
     fn is_discarded_snapshot(&self) -> bool {
-        self.blob_xattr(SnapshotXattrs::DiscardedSnapshot.name())
+        self.blob_xattr(SnapshotXattrs::DiscardedSnapshot)
             .unwrap_or_default()
             .parse()
             .unwrap_or_default()
@@ -778,7 +774,7 @@ impl LvolSnapshotOps for Lvol {
         // if self is snapshot created from clone.
         if self.is_snapshot() {
             match UntypedBdev::lookup_by_uuid_str(
-                self.blob_xattr(SnapshotXattrs::ParentId.name())
+                self.blob_xattr(SnapshotXattrs::ParentId)
                     .unwrap_or_default(),
             ) {
                 Some(bdev) => match Lvol::try_from(bdev) {
@@ -815,7 +811,7 @@ impl LvolSnapshotOps for Lvol {
             reset_snapshot_tree_usage_cache_with_parent_uuid(self);
             return;
         }
-        if let Some(snapshot_parent_uuid) = self.blob_xattr(SnapshotXattrs::ParentId.name()) {
+        if let Some(snapshot_parent_uuid) = self.blob_xattr(SnapshotXattrs::ParentId) {
             if let Some(bdev) = UntypedBdev::lookup_by_uuid_str(snapshot_parent_uuid) {
                 if let Ok(parent_lvol) = Lvol::try_from(bdev) {
                     unsafe {
@@ -860,7 +856,7 @@ fn reset_snapshot_tree_usage_cache_with_wildcard(lvol: &Lvol, snapshot_parent_uu
         .iter()
         .map(|v| v.snapshot_lvol())
         .filter_map(|l| {
-            let uuid = lvol.blob_xattr(SnapshotXattrs::ParentId.name());
+            let uuid = lvol.blob_xattr(SnapshotXattrs::ParentId);
             match uuid {
                 Some(uuid) if uuid == snapshot_parent_uuid => Some(l.clone()),
                 _ => None,

--- a/io-engine/src/lvs/lvs_error.rs
+++ b/io-engine/src/lvs/lvs_error.rs
@@ -14,6 +14,8 @@ use crate::{
 pub enum ImportErrorReason {
     #[snafu(display(""))]
     None,
+    #[snafu(display(": pool metadata is corrupted/invalid"))]
+    NotFound,
     #[snafu(display(": failed to inspect disk contents"))]
     IoError,
     #[snafu(display(": existing pool disk has different name: {name}"))]
@@ -215,6 +217,7 @@ impl ToErrno for LvsError {
                 crate::lvs::ImportErrorReason::NameMismatch { .. } => Errno::EMEDIUMTYPE,
                 crate::lvs::ImportErrorReason::NameClash { .. } => Errno::ENOTUNIQ,
                 crate::lvs::ImportErrorReason::UuidMismatch { .. } => Errno::EMEDIUMTYPE,
+                crate::lvs::ImportErrorReason::NotFound => Errno::EILSEQ,
             },
             Self::Import { source, .. } => source.to_errno(),
             Self::PoolCreate { source, .. } => source.to_errno(),

--- a/io-engine/src/lvs/lvs_lvol.rs
+++ b/io-engine/src/lvs/lvs_lvol.rs
@@ -588,8 +588,9 @@ pub trait LvsLvol: LogicalVolume + Share {
     fn as_bdev(&self) -> UntypedBdev;
 
     /// Lvol is considered as clone if its sourceuuid attribute is a valid
-    /// snapshot. if it is clone, return the snapshot lvol.
-    fn is_snapshot_clone(&self) -> Option<Lvol>;
+    /// snapshot.
+    /// And if it is clone, return the snapshot Lvol.
+    fn clone_source(&self) -> Option<Lvol>;
 
     /// Get/Read a property of this lvol from the in-memory metadata copy.
     async fn get(&self, prop: PropName) -> Result<PropValue, LvsError>;
@@ -770,7 +771,7 @@ impl LogicalVolume for Lvol {
     }
 
     fn is_clone(&self) -> bool {
-        self.is_snapshot_clone().is_some()
+        self.blob_xattr(CloneXattrs::SourceUuid).is_some()
     }
 
     fn backend(&self) -> PoolBackend {
@@ -812,8 +813,9 @@ impl LvsLvol for Lvol {
     }
 
     /// Lvol is considered as clone if its sourceuuid attribute is a valid
-    /// snapshot. if it is clone, return the snapshot lvol.
-    fn is_snapshot_clone(&self) -> Option<Lvol> {
+    /// snapshot.
+    /// And if it is clone, return the snapshot Lvol.
+    fn clone_source(&self) -> Option<Lvol> {
         let source_uuid = self.blob_xattr(CloneXattrs::SourceUuid)?;
         self.lvs().lookup_lvol_by_uuid_str(source_uuid)
     }
@@ -1048,7 +1050,7 @@ impl LvsLvol for Lvol {
     /// Wrapper function to destroy replica and its associated snapshot if
     /// replica is identified as last clone.
     async fn destroy_replica(mut self) -> Result<String, LvsError> {
-        let snapshot_lvol = self.is_snapshot_clone();
+        let snapshot_lvol = self.clone_source();
         let name = self.name();
         self.destroy().await?;
 

--- a/io-engine/src/lvs/lvs_lvol.rs
+++ b/io-engine/src/lvs/lvs_lvol.rs
@@ -326,19 +326,18 @@ impl Lvol {
         LvolPtpl::from(self)
     }
 
-    /// Common API to get the xattr from blob.
-    pub fn get_blob_xattr(blob: *mut spdk_blob, attr: &str) -> Option<String> {
-        if blob.is_null() {
-            return None;
-        }
-        let blob_inner = blob;
+    /// Get the attribute value for the specified attribute name.
+    /// # Safety
+    /// You should use the safe [`Self::blob_xattr`] and [`Self::get_blob_xattr`] which ensure the
+    /// value doesn't live beyong the specified blob.
+    unsafe fn blob_xattr_<'a>(blob: *mut spdk_blob, attr: &str) -> Option<&'a str> {
         let mut val: *const libc::c_char = std::ptr::null::<libc::c_char>();
         let mut size: u64 = 0;
         let attribute = attr.into_cstring();
 
         unsafe {
             let r = spdk_blob_get_xattr_value(
-                blob_inner,
+                blob,
                 attribute.as_ptr(),
                 &mut val as *mut *const c_char as *mut *const c_void,
                 &mut size as *mut u64,
@@ -389,9 +388,24 @@ impl Lvol {
                     );
                     None
                 },
-                |v| Some(v.to_string()),
+                Some,
             )
         }
+    }
+
+    /// Get the given blob's attribute value for the specified attribute name.
+    /// The attribute value's lifecycle is tied to the blob.
+    pub fn get_blob_xattr<'a>(blob: &'a mut *mut spdk_blob, attr: &str) -> Option<&'a str> {
+        if blob.is_null() {
+            return None;
+        }
+        unsafe { Self::blob_xattr_(*blob, attr) }
+    }
+
+    /// Get the attribute value for the specified attribute name.
+    /// The attribute value's lifecycle is tied to the lvol object.
+    pub fn blob_xattr<'a>(&'a self, attr: &str) -> Option<&'a str> {
+        unsafe { Self::blob_xattr_(self.blob_checked(), attr) }
     }
 
     /// Low-level function to set blob attributes.
@@ -607,7 +621,7 @@ impl LogicalVolume for Lvol {
 
     /// Returns entity id of the Logical Volume.
     fn entity_id(&self) -> Option<String> {
-        Lvol::get_blob_xattr(self.blob_checked(), "entity_id")
+        self.blob_xattr("entity_id").map(Into::into)
     }
 
     /// Returns a boolean indicating if the Logical Volume is thin provisioned.
@@ -651,6 +665,8 @@ impl LogicalVolume for Lvol {
             let num_allocated_clusters_snapshots = {
                 let mut c: u64 = 0;
 
+                // this approach is wholy inneficient as we have a large chain we are iterating
+                // the same blobs multiple times
                 match spdk_blob_get_num_clusters_ancestors(bs, blob, &mut c) {
                     0 => c,
                     errno => {
@@ -690,11 +706,8 @@ impl LogicalVolume for Lvol {
     /// Looks like a bug in SPDK, but all snapshot attribute are intact in
     /// SPDK after io-engine restarts.
     fn is_snapshot(&self) -> bool {
-        Lvol::get_blob_xattr(
-            self.blob_checked(),
-            SnapshotXattrs::SnapshotCreateTime.name(),
-        )
-        .is_some()
+        self.blob_xattr(SnapshotXattrs::SnapshotCreateTime.name())
+            .is_some()
     }
 
     fn is_clone(&self) -> bool {
@@ -706,7 +719,8 @@ impl LogicalVolume for Lvol {
     }
 
     fn snapshot_uuid(&self) -> Option<String> {
-        Lvol::get_blob_xattr(self.blob_checked(), CloneXattrs::SourceUuid.name())
+        self.blob_xattr(CloneXattrs::SourceUuid.name())
+            .map(Into::into)
     }
 
     fn share_protocol(&self) -> Protocol {
@@ -742,10 +756,8 @@ impl LvsLvol for Lvol {
     /// Lvol is considered as clone if its sourceuuid attribute is a valid
     /// snapshot. if it is clone, return the snapshot lvol.
     fn is_snapshot_clone(&self) -> Option<Lvol> {
-        if let Some(source_uuid) =
-            Lvol::get_blob_xattr(self.blob_checked(), CloneXattrs::SourceUuid.name())
-        {
-            let snap_lvol = match UntypedBdev::lookup_by_uuid_str(source_uuid.as_str()) {
+        if let Some(source_uuid) = self.blob_xattr(CloneXattrs::SourceUuid.name()) {
+            let snap_lvol = match UntypedBdev::lookup_by_uuid_str(source_uuid) {
                 Some(bdev) => match Lvol::try_from(bdev) {
                     Ok(l) => l,
                     _ => return None,

--- a/io-engine/src/lvs/lvs_lvol.rs
+++ b/io-engine/src/lvs/lvs_lvol.rs
@@ -513,6 +513,21 @@ impl Lvol {
         };
         count
     }
+    /// Count how many clones are dependent on this snapshot.
+    /// # Warning
+    /// These clones may be snapshots or "real_clones".
+    pub fn blob_clone_count(&self) -> u64 {
+        let mut count: u64 = 0;
+        unsafe {
+            spdk_rs::libspdk::spdk_blob_get_clones(
+                self.lvs().blob_store(),
+                self.as_inner_ref().blob_id,
+                std::ptr::null_mut(),
+                &mut count,
+            )
+        };
+        count
+    }
 }
 
 pub struct LvolPtpl {

--- a/io-engine/src/lvs/lvs_lvol.rs
+++ b/io-engine/src/lvs/lvs_lvol.rs
@@ -480,6 +480,26 @@ impl Lvol {
             }
         }
     }
+
+    /// Check if this snapshot has dependent clones.
+    pub fn has_clones(&self) -> bool {
+        self.clone_count() > 0
+    }
+
+    /// Count how many clones are dependent on this snapshot.
+    pub fn clone_count(&self) -> u64 {
+        let mut count: u64 = 0;
+        unsafe {
+            spdk_rs::libspdk::spdk_blob_get_real_clones(
+                self.lvs().blob_store(),
+                self.as_inner_ref().blob_id,
+                std::ptr::null_mut(),
+                &mut count,
+                CloneXattrs::SourceUuid.name().as_ptr() as *const c_char,
+            )
+        };
+        count
+    }
 }
 
 pub struct LvolPtpl {
@@ -1009,9 +1029,7 @@ impl LvsLvol for Lvol {
         // clone from the snapshot, destroy the snapshot
         // if it is already marked as discarded snapshot.
         if let Some(snapshot_lvol) = snapshot_lvol {
-            if snapshot_lvol.list_clones_by_snapshot_uuid().is_empty()
-                && snapshot_lvol.is_discarded_snapshot()
-            {
+            if !snapshot_lvol.has_clones() && snapshot_lvol.is_discarded_snapshot() {
                 snapshot_lvol.destroy().await?;
             }
         }

--- a/io-engine/src/lvs/lvs_lvol.rs
+++ b/io-engine/src/lvs/lvs_lvol.rs
@@ -263,6 +263,11 @@ impl Lvol {
         unsafe { self.inner.as_ref() }
     }
 
+    /// Is the provided Lvol pointing to the same `spdk_lvol` as us?
+    pub fn is_same(&self, b: &Self) -> bool {
+        self.inner.as_ptr() == b.inner.as_ptr()
+    }
+
     pub fn ok_from(mut bdev: UntypedBdev) -> Option<Self> {
         if !Self::is_lvol(&bdev) {
             return None;
@@ -761,17 +766,9 @@ impl LvsLvol for Lvol {
     /// Lvol is considered as clone if its sourceuuid attribute is a valid
     /// snapshot. if it is clone, return the snapshot lvol.
     fn is_snapshot_clone(&self) -> Option<Lvol> {
-        if let Some(source_uuid) = self.blob_xattr(CloneXattrs::SourceUuid) {
-            let snap_lvol = match UntypedBdev::lookup_by_uuid_str(source_uuid) {
-                Some(bdev) => match Lvol::try_from(bdev) {
-                    Ok(l) => l,
-                    _ => return None,
-                },
-                None => return None,
-            };
-            return Some(snap_lvol);
-        }
-        None
+        let source_uuid = self.blob_xattr(CloneXattrs::SourceUuid)?;
+        let snap_bdev = UntypedBdev::lookup_by_uuid_str(source_uuid)?;
+        Lvol::ok_from(snap_bdev)
     }
 
     /// Get/Read a property of this lvol from the in-memory metadata copy.

--- a/io-engine/src/lvs/lvs_lvol.rs
+++ b/io-engine/src/lvs/lvs_lvol.rs
@@ -285,6 +285,19 @@ impl Lvol {
         bdev.driver() == "lvol"
     }
 
+    /// Lookup an [`Lvol`] by its string uuid.
+    pub fn lookup_by_uuid_str(uuid: &str) -> Option<Self> {
+        let uuid = uuid::Uuid::parse_str(uuid).ok()?;
+        let uuid = crate::spdk_rs::Uuid::from(uuid);
+
+        // todo: add get_by_uuid for our lvs, we don't need to query all of them!
+        let lvol = unsafe { spdk_rs::libspdk::spdk_lvol_get_by_uuid(&uuid.into_raw()) };
+        if lvol.is_null() {
+            return None;
+        }
+        Some(Self::from_inner_ptr(lvol))
+    }
+
     /// Wipe the first 8MB if unmap is not supported on failure the operation
     /// needs to be repeated.
     pub async fn wipe_super(&self) -> Result<(), LvsError> {
@@ -486,7 +499,7 @@ impl Lvol {
         self.clone_count() > 0
     }
 
-    /// Count how many clones are dependent on this snapshot.
+    /// Count how many replica clones are dependent on this snapshot.
     pub fn clone_count(&self) -> u64 {
         let mut count: u64 = 0;
         unsafe {
@@ -787,8 +800,7 @@ impl LvsLvol for Lvol {
     /// snapshot. if it is clone, return the snapshot lvol.
     fn is_snapshot_clone(&self) -> Option<Lvol> {
         let source_uuid = self.blob_xattr(CloneXattrs::SourceUuid)?;
-        let snap_bdev = UntypedBdev::lookup_by_uuid_str(source_uuid)?;
-        Lvol::ok_from(snap_bdev)
+        self.lvs().lookup_lvol_by_uuid_str(source_uuid)
     }
 
     /// Get/Read a property of this lvol from the in-memory metadata copy.

--- a/io-engine/src/lvs/lvs_lvol.rs
+++ b/io-engine/src/lvs/lvs_lvol.rs
@@ -27,7 +27,7 @@ use crate::{
     bdev::PtplFileOps,
     core::{
         logical_volume::{LogicalVolume, LvolSpaceUsage},
-        Bdev, CloneXattrs, LvolSnapshotOps, NvmfShareProps, Protocol, PtplProps, Share,
+        Bdev, CloneXattrs, LvolSnapshotOps, NvmfShareProps, PropXattrs, Protocol, PtplProps, Share,
         SnapshotXattrs, UntypedBdev, UpdateProps,
     },
     eventing::Event,
@@ -330,10 +330,14 @@ impl Lvol {
     /// # Safety
     /// You should use the safe [`Self::blob_xattr`] and [`Self::get_blob_xattr`] which ensure the
     /// value doesn't live beyong the specified blob.
-    unsafe fn blob_xattr_<'a>(blob: *mut spdk_blob, attr: &str) -> Option<&'a str> {
+    unsafe fn blob_xattr_<'a, I: Into<PropXattrs>>(
+        blob: *mut spdk_blob,
+        attr: I,
+    ) -> Option<&'a str> {
         let mut val: *const libc::c_char = std::ptr::null::<libc::c_char>();
         let mut size: u64 = 0;
-        let attribute = attr.into_cstring();
+        let attr: PropXattrs = attr.into();
+        let attribute = attr.name();
 
         unsafe {
             let r = spdk_blob_get_xattr_value(
@@ -382,7 +386,7 @@ impl Lvol {
             std::str::from_utf8(sl).map_or_else(
                 |error| {
                     warn!(
-                        attribute = attr,
+                        ?attribute,
                         ?error,
                         "Failed to parse attribute, default to empty string"
                     );
@@ -395,7 +399,7 @@ impl Lvol {
 
     /// Get the given blob's attribute value for the specified attribute name.
     /// The attribute value's lifecycle is tied to the blob.
-    pub fn get_blob_xattr<'a>(blob: &'a mut *mut spdk_blob, attr: &str) -> Option<&'a str> {
+    pub fn get_blob_xattr<I: Into<PropXattrs>>(blob: &mut *mut spdk_blob, attr: I) -> Option<&str> {
         if blob.is_null() {
             return None;
         }
@@ -404,14 +408,14 @@ impl Lvol {
 
     /// Get the attribute value for the specified attribute name.
     /// The attribute value's lifecycle is tied to the lvol object.
-    pub fn blob_xattr<'a>(&'a self, attr: &str) -> Option<&'a str> {
+    pub fn blob_xattr<I: Into<PropXattrs>>(&self, attr: I) -> Option<&str> {
         unsafe { Self::blob_xattr_(self.blob_checked(), attr) }
     }
 
     /// Low-level function to set blob attributes.
-    pub async fn set_blob_attr<A: AsRef<str>>(
+    pub async fn set_blob_attr<I: Into<PropXattrs>>(
         &self,
-        attr: A,
+        attr: I,
         value: String,
         sync_metadata: bool,
     ) -> Result<(), LvsError> {
@@ -419,7 +423,8 @@ impl Lvol {
             done_cb(cb_arg, errno);
         }
 
-        let attr_name = attr.as_ref().into_cstring();
+        let attr: PropXattrs = attr.into();
+        let attr_name = attr.name();
         let attr_val = value.clone().into_cstring();
 
         let r = unsafe {
@@ -432,16 +437,17 @@ impl Lvol {
         };
 
         if r != 0 {
+            let attr = attr.name().to_string_lossy();
             error!(
                 lvol = self.name(),
-                attr = attr.as_ref(),
+                %attr,
                 value,
                 errno = r,
                 "Failed to set blob attribute"
             );
             return Err(LvsError::SetProperty {
                 source: BsError::from_i32(r),
-                prop: attr.as_ref().to_owned(),
+                prop: attr.to_string(),
                 name: self.name(),
             });
         }
@@ -621,7 +627,7 @@ impl LogicalVolume for Lvol {
 
     /// Returns entity id of the Logical Volume.
     fn entity_id(&self) -> Option<String> {
-        self.blob_xattr("entity_id").map(Into::into)
+        self.blob_xattr(PropXattrs::BrokenEntityId).map(Into::into)
     }
 
     /// Returns a boolean indicating if the Logical Volume is thin provisioned.
@@ -706,7 +712,7 @@ impl LogicalVolume for Lvol {
     /// Looks like a bug in SPDK, but all snapshot attribute are intact in
     /// SPDK after io-engine restarts.
     fn is_snapshot(&self) -> bool {
-        self.blob_xattr(SnapshotXattrs::SnapshotCreateTime.name())
+        self.blob_xattr(SnapshotXattrs::SnapshotCreateTime)
             .is_some()
     }
 
@@ -719,8 +725,7 @@ impl LogicalVolume for Lvol {
     }
 
     fn snapshot_uuid(&self) -> Option<String> {
-        self.blob_xattr(CloneXattrs::SourceUuid.name())
-            .map(Into::into)
+        self.blob_xattr(CloneXattrs::SourceUuid).map(Into::into)
     }
 
     fn share_protocol(&self) -> Protocol {
@@ -756,7 +761,7 @@ impl LvsLvol for Lvol {
     /// Lvol is considered as clone if its sourceuuid attribute is a valid
     /// snapshot. if it is clone, return the snapshot lvol.
     fn is_snapshot_clone(&self) -> Option<Lvol> {
-        if let Some(source_uuid) = self.blob_xattr(CloneXattrs::SourceUuid.name()) {
+        if let Some(source_uuid) = self.blob_xattr(CloneXattrs::SourceUuid) {
             let snap_lvol = match UntypedBdev::lookup_by_uuid_str(source_uuid) {
                 Some(bdev) => match Lvol::try_from(bdev) {
                     Ok(l) => l,

--- a/io-engine/src/lvs/lvs_store.rs
+++ b/io-engine/src/lvs/lvs_store.rs
@@ -180,6 +180,20 @@ impl Lvs {
         }
     }
 
+    /// Lookup an [`Lvol`] by its string uuid.
+    pub fn lookup_lvol_by_uuid_str(&self, uuid: &str) -> Option<Lvol> {
+        let uuid = uuid::Uuid::parse_str(uuid).ok()?;
+        let uuid = crate::spdk_rs::Uuid::from(uuid);
+
+        let lvol = unsafe {
+            spdk_rs::libspdk::spdk_lvs_lvol_get_by_uuid(self.as_inner_ptr(), &uuid.into_raw())
+        };
+        if lvol.is_null() {
+            return None;
+        }
+        Some(Lvol::from_inner_ptr(lvol))
+    }
+
     /// return the name of the current store
     pub fn name(&self) -> &str {
         self.as_inner_ref().name.as_str()
@@ -945,7 +959,7 @@ impl Lvs {
             LVOL_CLEAR_WITH_NONE
         };
 
-        if !opts.uuid.is_empty() && UntypedBdev::lookup_by_uuid_str(&opts.uuid).is_some() {
+        if !opts.uuid.is_empty() && self.lookup_lvol_by_uuid_str(&opts.uuid).is_some() {
             return Err(LvsError::RepExists {
                 source: BsError::VolAlreadyExists {},
                 name: opts.uuid,

--- a/io-engine/src/lvs/lvs_store.rs
+++ b/io-engine/src/lvs/lvs_store.rs
@@ -379,7 +379,11 @@ impl Lvs {
             .map_err(|err| LvsError::Import {
                 source: BsError::from_errno(err),
                 name: name.into(),
-                reason: ImportErrorReason::IoError,
+                reason: if err == nix::Error::EILSEQ {
+                    ImportErrorReason::NotFound
+                } else {
+                    ImportErrorReason::IoError
+                },
             })?;
 
         if name != lvs.name() {

--- a/io-engine/src/lvs/mod.rs
+++ b/io-engine/src/lvs/mod.rs
@@ -19,7 +19,7 @@ pub use lvs_error::{BsError, ImportErrorReason, LvsError};
 pub use lvs_iter::{LvsBdevIter, LvsIter};
 pub use lvs_lvol::{Lvol, LvsLvol, PropName, PropValue};
 pub use lvs_store::Lvs;
-use std::{convert::TryFrom, pin::Pin};
+use std::pin::Pin;
 
 mod lvol_iter;
 mod lvol_snapshot;
@@ -349,9 +349,7 @@ impl IReplicaFactory for ReplLvsFactory {
         &self,
         args: &FindReplicaArgs,
     ) -> Result<Option<Box<dyn ReplicaOps>>, crate::pool_backend::Error> {
-        let lvol = crate::core::Bdev::lookup_by_uuid_str(&args.uuid)
-            .map(Lvol::try_from)
-            .transpose()?;
+        let lvol = Lvol::lookup_by_uuid_str(&args.uuid);
         Ok(lvol.map(|l| Box::new(l) as _))
     }
 
@@ -359,9 +357,7 @@ impl IReplicaFactory for ReplLvsFactory {
         &self,
         args: &FindSnapshotArgs,
     ) -> Result<Option<Box<dyn SnapshotOps>>, crate::pool_backend::Error> {
-        let lvol = crate::core::Bdev::lookup_by_uuid_str(&args.uuid)
-            .map(Lvol::try_from)
-            .transpose()?;
+        let lvol = Lvol::lookup_by_uuid_str(&args.uuid);
         if let Some(lvol) = &lvol {
             // should this be an error?
             if !lvol.is_snapshot() {
@@ -390,8 +386,8 @@ impl IReplicaFactory for ReplLvsFactory {
     ) -> Result<Vec<SnapshotDescriptor>, crate::pool_backend::Error> {
         // if snapshot_uuid is input, get specific snapshot result
         Ok(if let Some(ref snapshot_uuid) = args.uuid {
-            let lvol = match crate::core::UntypedBdev::lookup_by_uuid_str(snapshot_uuid) {
-                Some(bdev) => Lvol::try_from(bdev)?,
+            let lvol = match Lvol::lookup_by_uuid_str(snapshot_uuid) {
+                Some(lvol) => lvol,
                 None => {
                     return Err(LvsError::Invalid {
                         source: BsError::LvolNotFound {},
@@ -402,8 +398,8 @@ impl IReplicaFactory for ReplLvsFactory {
             };
             lvol.list_snapshot_by_snapshot_uuid()
         } else if let Some(ref replica_uuid) = args.source_uuid {
-            let lvol = match crate::core::UntypedBdev::lookup_by_uuid_str(replica_uuid) {
-                Some(bdev) => Lvol::try_from(bdev)?,
+            let lvol = match Lvol::lookup_by_uuid_str(replica_uuid) {
+                Some(lvol) => lvol,
                 None => {
                     return Err(LvsError::Invalid {
                         source: BsError::LvolNotFound {},
@@ -423,8 +419,8 @@ impl IReplicaFactory for ReplLvsFactory {
         args: &ListCloneArgs,
     ) -> Result<Vec<Box<dyn ReplicaOps>>, crate::pool_backend::Error> {
         let clones = if let Some(snapshot_uuid) = &args.snapshot_uuid {
-            let snap_lvol = match crate::core::UntypedBdev::lookup_by_uuid_str(snapshot_uuid) {
-                Some(bdev) => Lvol::try_from(bdev),
+            let snap_lvol = match Lvol::lookup_by_uuid_str(snapshot_uuid) {
+                Some(lvol) => Ok(lvol),
                 None => Err(LvsError::Invalid {
                     source: BsError::LvolNotFound {},
                     msg: format!("Snapshot {snapshot_uuid} not found"),

--- a/io-engine/tests/lvs_pool.rs
+++ b/io-engine/tests/lvs_pool.rs
@@ -975,7 +975,7 @@ async fn lvol_snap_list() {
 
     // this could vary depending on the system where we're running, but this is large enough that
     // it should run on weaker systems as well as low enough to ensure we're testing the fix.
-    let max_dur = std::time::Duration::from_secs(4);
+    let max_dur = std::time::Duration::from_millis(300);
 
     let list_tm = std::time::Instant::now();
     ms.spawn(async move {

--- a/io-engine/tests/lvs_pool.rs
+++ b/io-engine/tests/lvs_pool.rs
@@ -7,7 +7,7 @@ use io_engine::{
         Protocol, Share, ToErrno, UntypedBdev,
     },
     grpc::v1::pool::pool_to_proto,
-    lvs::{Lvs, LvsLvol, PropName, PropValue},
+    lvs::{LvolSnapshotOps, Lvs, LvsLvol, PropName, PropValue},
     pool_backend::{PoolArgs, PoolBackend, PoolOps, ReplicaArgs},
     subsys::NvmfSubsystem,
 };
@@ -923,4 +923,67 @@ async fn lvol_list() {
         }
     })
     .await;
+}
+
+#[tokio::test]
+async fn lvol_snap_list() {
+    let ms = ms();
+
+    let pool_size = "4GiB";
+    let repl_size = 4 * 1024 * 1024;
+
+    use io_engine::pool_backend::PoolMetadataArgs;
+    let pool_args = PoolArgs {
+        name: "tpool".into(),
+        disks: vec![format!("malloc:///m?size={pool_size}")],
+        backend: PoolBackend::Lvs,
+        md_args: Some(PoolMetadataArgs {
+            max_expansion: Some("300GiB".into()),
+        }),
+        ..Default::default()
+    };
+
+    ms.start_grpc();
+    ms.start_device_monitor();
+
+    ms.spawn(async move {
+        let lvs_pool = Lvs::create_or_import(pool_args).await.unwrap();
+
+        for i in 1..=1 {
+            let name = format!("replica-{i}");
+            let opts = ReplicaArgs::new(name, repl_size)
+                .wipe_super(false)
+                .thin(true);
+            let repl = lvs_pool.create_lvol_with_opts(opts).await.unwrap();
+            use io_engine::core::SnapshotParams;
+            for j in 1..=3000 {
+                repl.create_snapshot(SnapshotParams {
+                    entity_id: Some(format!("e-{i}-{j}")),
+                    parent_id: Some(repl.uuid()),
+                    txn_id: Some(format!("txn-{i}-{j}")),
+                    snap_name: Some(format!("snap-{i}-{j}")),
+                    snapshot_uuid: Some(uuid::Uuid::new_v4().to_string()),
+                    create_time: Some(chrono::Utc::now().to_string()),
+                    discarded_snapshot: false,
+                })
+                .await
+                .unwrap();
+            }
+        }
+    })
+    .await;
+
+    // this could vary depending on the system where we're running, but this is large enough that
+    // it should run on weaker systems as well as low enough to ensure we're testing the fix.
+    let max_dur = std::time::Duration::from_secs(4);
+
+    let list_tm = std::time::Instant::now();
+    ms.spawn(async move {
+        use io_engine::lvs::Lvol;
+        let _snaps = Lvol::list_all_snapshots(None);
+    })
+    .await;
+    let elapsed = list_tm.elapsed();
+    println!("Snapshot List: {elapsed:?}");
+    assert!(elapsed <= max_dur, "Listing snapshots took too long");
 }

--- a/io-engine/tests/lvs_pool.rs
+++ b/io-engine/tests/lvs_pool.rs
@@ -949,25 +949,36 @@ async fn lvol_snap_list() {
     ms.spawn(async move {
         let lvs_pool = Lvs::create_or_import(pool_args).await.unwrap();
 
-        for i in 1..=1 {
+        for i in 1..=10 {
             let name = format!("replica-{i}");
             let opts = ReplicaArgs::new(name, repl_size)
                 .wipe_super(false)
                 .thin(true);
             let repl = lvs_pool.create_lvol_with_opts(opts).await.unwrap();
             use io_engine::core::SnapshotParams;
-            for j in 1..=3000 {
-                repl.create_snapshot(SnapshotParams {
-                    entity_id: Some(format!("e-{i}-{j}")),
-                    parent_id: Some(repl.uuid()),
-                    txn_id: Some(format!("txn-{i}-{j}")),
-                    snap_name: Some(format!("snap-{i}-{j}")),
-                    snapshot_uuid: Some(uuid::Uuid::new_v4().to_string()),
-                    create_time: Some(chrono::Utc::now().to_string()),
-                    discarded_snapshot: false,
-                })
-                .await
-                .unwrap();
+            for j in 1..=512 {
+                let snapshot = repl
+                    .create_snapshot(SnapshotParams {
+                        entity_id: Some(format!("e-{i}-{j}")),
+                        parent_id: Some(repl.uuid()),
+                        txn_id: Some(format!("txn-{i}-{j}")),
+                        snap_name: Some(format!("snap-{i}-{j}")),
+                        snapshot_uuid: Some(uuid::Uuid::new_v4().to_string()),
+                        create_time: Some(chrono::Utc::now().to_string()),
+                        discarded_snapshot: false,
+                    })
+                    .await
+                    .unwrap();
+                let n = uuid::Uuid::new_v4().to_string();
+                let _clone = snapshot
+                    .create_clone(io_engine::core::CloneParams {
+                        clone_name: Some(n.clone()),
+                        clone_uuid: Some(n.clone()),
+                        source_uuid: Some(snapshot.uuid()),
+                        clone_create_time: Some(chrono::Utc::now().to_string()),
+                    })
+                    .await
+                    .unwrap();
             }
         }
     })
@@ -975,15 +986,24 @@ async fn lvol_snap_list() {
 
     // this could vary depending on the system where we're running, but this is large enough that
     // it should run on weaker systems as well as low enough to ensure we're testing the fix.
-    let max_dur = std::time::Duration::from_millis(300);
+    let max_dur = std::time::Duration::from_secs(1);
 
     let list_tm = std::time::Instant::now();
     ms.spawn(async move {
         use io_engine::lvs::Lvol;
-        let _snaps = Lvol::list_all_snapshots(None);
+        for snap in Lvol::list_all_snapshots(None) {
+            assert_eq!(snap.info().num_clones, 1);
+        }
     })
     .await;
     let elapsed = list_tm.elapsed();
     println!("Snapshot List: {elapsed:?}");
     assert!(elapsed <= max_dur, "Listing snapshots took too long");
+
+    ms.spawn(async move {
+        for lvs_pool in Lvs::iter() {
+            lvs_pool.destroy().await.unwrap();
+        }
+    })
+    .await;
 }

--- a/io-engine/tests/snapshot_lvol.rs
+++ b/io-engine/tests/snapshot_lvol.rs
@@ -1050,13 +1050,13 @@ async fn test_snapshot_clone() {
         assert_eq!(clones.len(), 2, "Number of Clones Doesn't match");
         for clone in &clones {
             assert!(
-                clone.is_snapshot_clone().is_some(),
+                clone.clone_source().is_some(),
                 "Wrongly judge as not a clone"
             );
         }
-        assert!(lvol.is_snapshot_clone().is_none(), "Wrongly judge as clone");
+        assert!(lvol.clone_source().is_none(), "Wrongly judge as clone");
         assert!(
-            snapshot_lvol.is_snapshot_clone().is_none(),
+            snapshot_lvol.clone_source().is_none(),
             "Wrongly judge as clone"
         );
         for clone in clones {

--- a/io-engine/tests/snapshot_lvol.rs
+++ b/io-engine/tests/snapshot_lvol.rs
@@ -103,7 +103,8 @@ async fn check_snapshot(params: SnapshotParams) {
         .expect("Can't find target snapshot device");
 
     for (attr_name, attr_value) in attrs {
-        let v = Lvol::get_blob_xattr(lvol.blob_checked(), attr_name.name())
+        let v = lvol
+            .blob_xattr(attr_name.name())
             .expect("Failed to get snapshot attribute");
         assert_eq!(v, attr_value, "Snapshot attr doesn't match");
     }
@@ -119,7 +120,8 @@ async fn check_clone(clone_lvol: Lvol, params: CloneParams) {
         (CloneXattrs::CloneUuid, params.clone_uuid().unwrap()),
     ];
     for (attr_name, attr_value) in attrs {
-        let v = Lvol::get_blob_xattr(clone_lvol.blob_checked(), attr_name.name())
+        let v = clone_lvol
+            .blob_xattr(attr_name.name())
             .expect("Failed to get clone attribute");
         assert_eq!(v, attr_value, "clone attr doesn't match");
     }
@@ -1196,7 +1198,8 @@ async fn test_snapshot_attr() {
             .expect("Failed to set snapshot attribute");
 
         // Check attribute.
-        let v = Lvol::get_blob_xattr(snapshot_lvol.blob_checked(), &snap_attr_name)
+        let v = snapshot_lvol
+            .blob_xattr(&snap_attr_name)
             .expect("Failed to get snapshot attribute");
         assert_eq!(v, snap_attr_value, "Snapshot attribute doesn't match");
 
@@ -1237,7 +1240,8 @@ async fn test_snapshot_attr() {
         .unwrap();
 
         // Get attribute from imported snapshot and check.
-        let v = Lvol::get_blob_xattr(imported_snapshot_lvol.blob_checked(), &snap_attr_name)
+        let v = imported_snapshot_lvol
+            .blob_xattr(&snap_attr_name)
             .expect("Failed to get snapshot attribute");
         assert_eq!(v, snap_attr_value, "Snapshot attribute doesn't match");
         clean_snapshots(snapshot_list).await;

--- a/io-engine/tests/snapshot_lvol.rs
+++ b/io-engine/tests/snapshot_lvol.rs
@@ -1044,10 +1044,7 @@ async fn test_snapshot_clone() {
             .await
             .expect("Failed to create a clone");
         check_clone(clone2, clone_param).await;
-        info!(
-            "Total number of Clones: {:?}",
-            snapshot_lvol.list_clones_by_snapshot_uuid().len()
-        );
+        info!("Total number of Clones: {:?}", snapshot_lvol.clone_count());
         let clones = snapshot_lvol.list_clones_by_snapshot_uuid();
 
         assert_eq!(clones.len(), 2, "Number of Clones Doesn't match");

--- a/io-engine/tests/snapshot_lvol.rs
+++ b/io-engine/tests/snapshot_lvol.rs
@@ -104,7 +104,7 @@ async fn check_snapshot(params: SnapshotParams) {
 
     for (attr_name, attr_value) in attrs {
         let v = lvol
-            .blob_xattr(attr_name.name())
+            .blob_xattr(attr_name)
             .expect("Failed to get snapshot attribute");
         assert_eq!(v, attr_value, "Snapshot attr doesn't match");
     }
@@ -121,7 +121,7 @@ async fn check_clone(clone_lvol: Lvol, params: CloneParams) {
     ];
     for (attr_name, attr_value) in attrs {
         let v = clone_lvol
-            .blob_xattr(attr_name.name())
+            .blob_xattr(attr_name)
             .expect("Failed to get clone attribute");
         assert_eq!(v, attr_value, "clone attr doesn't match");
     }
@@ -1189,17 +1189,18 @@ async fn test_snapshot_attr() {
         .unwrap();
 
         // Set snapshot attribute.
-        let snap_attr_name = String::from("my.attr.name");
+        let snap_attr_name: io_engine::core::PropXattrs =
+            io_engine::core::SnapshotXattrs::TxId.into();
         let snap_attr_value = String::from("top_secret");
 
         snapshot_lvol
-            .set_blob_attr(snap_attr_name.clone(), snap_attr_value.clone(), true)
+            .set_blob_attr(snap_attr_name, snap_attr_value.clone(), true)
             .await
             .expect("Failed to set snapshot attribute");
 
         // Check attribute.
         let v = snapshot_lvol
-            .blob_xattr(&snap_attr_name)
+            .blob_xattr(snap_attr_name)
             .expect("Failed to get snapshot attribute");
         assert_eq!(v, snap_attr_value, "Snapshot attribute doesn't match");
 
@@ -1241,7 +1242,7 @@ async fn test_snapshot_attr() {
 
         // Get attribute from imported snapshot and check.
         let v = imported_snapshot_lvol
-            .blob_xattr(&snap_attr_name)
+            .blob_xattr(snap_attr_name)
             .expect("Failed to get snapshot attribute");
         assert_eq!(v, snap_attr_value, "Snapshot attribute doesn't match");
         clean_snapshots(snapshot_list).await;

--- a/io-engine/tests/snapshot_nexus.rs
+++ b/io-engine/tests/snapshot_nexus.rs
@@ -194,6 +194,9 @@ async fn create_device(url: &str) -> String {
 }
 
 fn check_replica_snapshot(params: &SnapshotParams, snapshot: &SnapshotInfo) {
+    println!("{params:#?}");
+    println!("{snapshot:#?}");
+
     assert_eq!(
         snapshot.snapshot_uuid,
         params.snapshot_uuid().unwrap(),
@@ -273,7 +276,7 @@ async fn test_replica_handle_snapshot() {
         Some(Utc::now().to_string()),
         false,
     );
-    let mut snapshot_params_clone = snapshot_params.clone();
+    let snapshot_params_clone = snapshot_params.clone();
 
     ms.spawn(async move {
         let device_name = create_device(&urls[0]).await;
@@ -299,7 +302,6 @@ async fn test_replica_handle_snapshot() {
         .expect("Failed to list snapshots on replica node")
         .into_inner()
         .snapshots;
-    snapshot_params_clone.set_parent_id(String::default());
     check_replica_snapshot(
         &snapshot_params_clone,
         snapshots


### PR DESCRIPTION
    test: add multi-replica and clone check to lvol_snap_list
    
    Ensures the num_clones is set correctly
    Spreads snapshots across a number of replicas
    Creates a clone for each snapshot.
    
    todo: investigate warn message:
    Using passed in clear method 0x2 instead of stored value of 0x0
    
---

    fix(lvs): don't query snapshot parent for listing
    
    I'm not sure why this was being done as we can simply return the uuid
    itself, rather than query only to return the same value...
    It's possible that we wanted to return the uuid only if the parent
    still existings, but it's not clear from the api and would be a strange
    behaviour...
    
    So we now drop this, and simply return the parent uuid.

---

    refactor(lvs): reorder xattr to list parent id as the first
    
    This makes snapshot searching quicker, as we don't need to load
    the other attributes when it's a mismatch.
    
---

    refactor(lvs): clarify is_snapshot_clone api
    
    Renames is_snapshot_clone into clone_source, where the Lvol snapshot
    is returned if found.
    Added new api method is_clone which checks if the current Lvol is a
    cloned lvol.
    
    This both clarifies the previous method and also makes it more efficient
    as we don't need to lookup the source snapshot all the times.
    
---

    refactor(lvs): replace list clones logic with spdk immediate clone
    
    Rather than looping all bdevs, we get the list of clones directly
    from the snapshot using spdk_lvol_iter_immediate_clones.
    Further we trim this down to "real_clones" by filtering out snapshots
    from the returned list.
    
    todo: can we optimize this process, we don't need 2 lists?
    
---

    refactor(lvs): compare snapshot uuid_str with potential clone parent
    
    When listing all potential bdevs to find matching clones, don't bother
    looking up the snapshot from each potential clone.
    Instead, simply compare the uuid with the snapshot.
    
---

    refactor(lvs): add lvol uuid lookup function
    
    Lookup lvol directly, rather than iterating all bdevs.

---

    refactor(lvs): count snapshot clones using spdk_blob_get_clones
    
    This api is much faster than iterating all bdevs, map them to lvols and then
    iterating again all bdevs to find the clones...
    
    This reduces the lvol_snap_list all the way to 50ms!

---

    refactor(lvs): simplify bdev to Lvol mappings
    
    Simplify all the iterations which try to load a bdev as an lvol.
    
    Also when comparing lvol's when listing clones, don't use the uuid
    as the comparisson method as it's an expensive operation requiring
    allocation of memory and string copies.
    Rather, we can simply compare the spdk_lvol pointer.
    
    This further reduces the slvol_snap_list test by another ~.5s
    
---

    refactor(lvs/xattr): change blob attr api to use compile constants
    
    Using a type which can yield &CStr avoids having to convert strings
    to CString at runtime.
    This reduces the snapshot list test by ~0.5s.
    
---

    refactor: compare bdev uuid bytes rather than string
    
    It's faster to compare the 16bytes rather than the stringified version.
    
---

    refactor: use new api for blob xattr reading
    
    We don't always need an owned string for the attribute values, as sometimes
    we only want to check/compare the value.
    I refactored the apis to returned a string with the lifetime of the lvol or
    the specified blob.
    The internal function is marked as unsafe and should not be directly used
    as the returned value is a pointer from the lvol, and must not be used
    beyong the blob's lifetime.
    
---

    test: add lvs snapshot list timing test
    
    Creates 3000 snapshots from a single replica and time out long it takes
    to list all snapshots.
