### PR TITLE
adding implementation for pool io stall

### DIFF
--- a/io-engine-tests/src/compose/mod.rs
+++ b/io-engine-tests/src/compose/mod.rs
@@ -42,6 +42,14 @@ impl<'a> MayastorTest<'a> {
         rx.await.unwrap()
     }
 
+    /// spawn a future on this mayastor instance without waiting for completion.
+    pub fn spawn_detached<F>(&self, future: F)
+    where
+        F: Future<Output = ()> + 'static,
+    {
+        self.reactor.send_future(future);
+    }
+
     pub fn send<F>(&self, future: F)
     where
         F: Future<Output = ()> + 'static,

--- a/io-engine/src/lvm/dm_setup.rs
+++ b/io-engine/src/lvm/dm_setup.rs
@@ -2,7 +2,7 @@
 /// The dmsetup suspend command sets a device state to SUSPENDED.
 /// When a device is suspended, all I/O operations to that device stop.
 /// The dmsetup resume command restores a device state to ACTIVE.
-#[derive(Eq, PartialEq)]
+#[derive(Eq, PartialEq, Debug)]
 pub enum DmState {
     Suspended,
     Active,

--- a/io-engine/src/lvm/lv_replica.rs
+++ b/io-engine/src/lvm/lv_replica.rs
@@ -290,8 +290,9 @@ impl LogicalVolume {
     /// # NOTES
     ///
     /// See details from [`DmSetup::resume`].
-    pub async fn dm_resume(&mut self) -> Result<(), Error> {
-        DmSetup::resume(&self.path).await
+    pub async fn dm_resume(&mut self) -> Result<DmState, Error> {
+        DmSetup::resume(&self.path).await?;
+        self.dm_state().await
     }
 
     /// Retrieve the [`DmState`] of the [`LogicalVolume`].
@@ -331,7 +332,7 @@ impl LogicalVolume {
     }
 
     /// Undoes a borked [`LogicalVolume`] by re-applying the previous device-mapper table.
-    pub async fn unbork(&mut self, table: DmTable) -> Result<(), Error> {
+    pub async fn unbork(&mut self, table: DmTable) -> Result<DmState, Error> {
         DmSetup::load(self.path(), table).await?;
         self.dm_resume().await
     }

--- a/io-engine/src/lvm/mod.rs
+++ b/io-engine/src/lvm/mod.rs
@@ -27,7 +27,7 @@
 /// Helps run LVM commands and decode their json output and reports.
 mod cli;
 /// Device Mapper setup and info.
-mod dm_setup;
+pub mod dm_setup;
 mod error;
 /// Logical Volume management.
 mod lv_replica;

--- a/io-engine/src/lvs/lvs_store.rs
+++ b/io-engine/src/lvs/lvs_store.rs
@@ -313,59 +313,56 @@ impl Lvs {
 
     /// Enable stall detection on a given Pool.
     fn enable_stall_detection(&self) {
-        let lvs = self.as_inner_ptr();
+        let lvs = self.name();
         let environ = MayastorEnvironment::global();
-        let stall_deadline = environ.pool_args.io_stall_deadline;
-        let std_d: std::time::Duration = stall_deadline.into();
-        let secs: u64 = std_d.as_secs();
-        let rc = unsafe { vbdev_lvs_set_timeout(lvs, secs, Some(Self::lvstore_timeout_cb)) };
+        let secs: u64 = environ.pool_args.io_stall_deadline.as_secs();
+        let rc = unsafe {
+            vbdev_lvs_set_timeout(self.as_inner_ptr(), secs, Some(Self::lvstore_timeout_cb))
+        };
         if rc != 0 {
             error!(
-                "rc :{rc} while enabling stall deadline on pool {}",
-                self.name()
+                "error while enabling stall deadline on pool {}: {:?}",
+                self.name(),
+                Errno::from_raw(rc)
             );
+        } else {
+            info!("enabled stall detection of {secs}s on {lvs}");
         }
-        info!("enabled stall detection on {}", self.name());
     }
 
-    /// Disable stall detection on a given Pool.
-    /// We do this once we receive first stall notification.
+    /// Disable stall detection on a given Pool if reset is submitted successfullly.
     /// This is to stop receiving flood of callbacks as SPDK sends notification
     /// for all IOs which are stuck on the Pool in loop.
-    fn disable_stall_detection(&self) {
-        let lvs = self.as_inner_ptr();
-        let rc = unsafe { vbdev_lvs_set_timeout(lvs, 0, None) };
-        if rc != 0 {
-            error!(
-                "rc :{rc} while disabling stall deadline on pool {}",
-                self.name()
-            );
-        }
-        info!("disabled stall detection on {}", self.name());
-    }
-
-    /// Marks the pool as stalled in the cache and disables stall detection to avoid callback floods.
-    /// It also triggers a reset of the underlying bdev.
-    fn io_stalled(&self) {
-        let cache = pool_info_read();
-        let lvs = self.name();
-        if let Some(pool_lock) = cache.get(lvs) {
-            let mut pool_mut = pool_lock.write();
-            if !pool_mut.io_stalled {
-                info!("Pool {lvs} has entered IO stall");
+    fn disable_stall_detection(&self, rc: i32) {
+        if rc == 0 {
+            let lvs = self.name();
+            if let Some(pool_lock) = pool_info_read().get(lvs) {
+                let mut pool_mut = pool_lock.write();
                 pool_mut.io_stalled = true;
-                self.disable_stall_detection();
-                let p = std::ptr::null_mut();
-                unsafe { vbdev_lvs_bs_bdev_reset(self.as_inner_ptr(), Some(Self::lvstore_reset_cb), p) };
+            }
+            let rc = unsafe { vbdev_lvs_set_timeout(self.as_inner_ptr(), 0, None) };
+            if rc != 0 {
+                error!("rc {rc} while disabling stall deadline on pool {lvs}");
+            } else {
+                info!("disabled stall detection on {lvs}");
             }
         }
     }
 
+    /// Attempts to reset the pool facing IO stall and disables stall detection
+    /// to avoid flood of callbacks if reset is submitted successfully.
+    fn mark_io_stalled(&self) {
+        let p = std::ptr::null_mut();
+        let rc = unsafe {
+            vbdev_lvs_bs_bdev_reset(self.as_inner_ptr(), Some(Self::lvstore_reset_cb), p)
+        };
+        self.disable_stall_detection(rc);
+    }
+
     /// Marks the pool as recovered in the cache, update transition timestamp and re-enables stall detection.
-    fn io_resume(&self) {
-        let cache = pool_info_read();
+    fn mark_io_resume(&self) {
         let lvs = self.name();
-        if let Some(pool_lock) = cache.get(lvs) {
+        if let Some(pool_lock) = pool_info_read().get(lvs) {
             let mut pool_mut = pool_lock.write();
             pool_mut.io_stalled = false;
             info!("Pool {lvs} recovered from IO stall");
@@ -657,31 +654,33 @@ impl Lvs {
     extern "C" fn lvstore_timeout_cb(ctx: *mut c_void, _bdev_io: *mut spdk_bdev_io) {
         let lv_store = ctx as *mut spdk_lvol_store;
         let lvs: Lvs = Lvs::from_inner_ptr(lv_store);
-        lvs.io_stalled();
+        lvs.mark_io_stalled();
     }
 
     /// Callback function called by SPDK when reset completes.
-    extern "C" fn lvstore_reset_cb(lvs: *mut spdk_lvol_store, _success: bool, _ctx: *mut c_void) {
-        let lvs: Lvs = Lvs::from_inner_ptr(lvs);
-        let bs = lvs.blob_store();
-        let ctx = Box::new(BsTimeoutCtx {
-            pool_name: lvs.name().to_string(),
-        });
-        let ctx_ptr = Box::into_raw(ctx) as *mut c_void;
+    extern "C" fn lvstore_reset_cb(lvs: *mut spdk_lvol_store, success: bool, _ctx: *mut c_void) {
+        let lvs_wrapper: Lvs = Lvs::from_inner_ptr(lvs);
+        let lvs_name = lvs_wrapper.name().to_string();
+        if let Ok(bdev) = lvs_wrapper.base_bdev() {
+            let driver = bdev.driver();
+            info!("reset completed with status: {success} on {lvs_name} of bdev type: {driver}");
+        }
         Reactors::master().send_future(async move {
-            unsafe { spdk_bs_read_super(bs, Some(Self::bs_super_read_cb), ctx_ptr) }
+            if let Some(lvs) = Lvs::lookup(&lvs_name) {
+                let bs = lvs.blob_store();
+                let lvs_ptr = lvs.as_inner_ptr();
+                unsafe {
+                    spdk_bs_read_super(bs, Some(Self::bs_super_read_cb), lvs_ptr as *mut c_void)
+                }
+            }
         });
     }
 
     /// Callback function called by SPDK when superblock read completes.
-    extern "C" fn bs_super_read_cb(ctx: *mut c_void, errno: i32) {
-        if errno == 0 {
-            let ctx_str = unsafe { &*(ctx as *mut BsTimeoutCtx) };
-            let pool = &ctx_str.pool_name;
-            let lvs = Lvs::lookup(pool).unwrap();
-            lvs.io_resume();
-        }
-        // Shall we attempt to read again if it fails?
+    extern "C" fn bs_super_read_cb(ctx: *mut c_void, _errno: i32) {
+        let lvs_raw = ctx as *mut spdk_lvol_store;
+        let lvs: Lvs = Lvs::from_inner_ptr(lvs_raw);
+        lvs.mark_io_resume();
     }
 
     /// Imports the pool if it exists, otherwise tries to create a new pool.
@@ -879,7 +878,7 @@ impl Lvs {
                 base_bdev = c;
             }
         }
-        info!(
+        debug!(
             "Deleting bdev {}, uri {:?}",
             base_bdev.name(),
             base_bdev.bdev_uri_original_str()
@@ -1352,8 +1351,4 @@ impl PtplFileOps for LvsPtpl {
     fn subpath(&self) -> std::path::PathBuf {
         std::path::PathBuf::from("pool/").join(self.uuid())
     }
-}
-
-struct BsTimeoutCtx {
-    pool_name: String,
 }

--- a/io-engine/src/lvs/lvs_store.rs
+++ b/io-engine/src/lvs/lvs_store.rs
@@ -5,18 +5,22 @@ use futures::channel::oneshot;
 use nix::errno::Errno;
 use parking_lot::RwLock;
 use pin_utils::core_reexport::fmt::Formatter;
-use std::{convert::TryFrom, fmt::Debug, os::raw::c_void, pin::Pin, ptr::NonNull, str::FromStr};
+use std::{
+    convert::TryFrom, fmt::Debug, os::raw::c_void, pin::Pin, ptr::NonNull, str::FromStr,
+    time::Instant,
+};
 use url::Url;
 
 use spdk_rs::libspdk::{
-    bdev_aio_rescan, bdev_uring_rescan, spdk_bdev_update_bs_blockcnt, spdk_blob_store,
-    spdk_bs_free_cluster_count, spdk_bs_get_cluster_size, spdk_bs_get_max_growable_size,
-    spdk_bs_get_md_len, spdk_bs_get_page_size, spdk_bs_get_used_md,
-    spdk_bs_total_data_cluster_count, spdk_lvol, spdk_lvol_opts, spdk_lvol_opts_init,
-    spdk_lvol_store, spdk_lvs_grow_live, vbdev_get_lvol_store_by_name,
+    bdev_aio_rescan, bdev_uring_rescan, spdk_bdev_io, spdk_bdev_update_bs_blockcnt,
+    spdk_blob_store, spdk_bs_free_cluster_count, spdk_bs_get_cluster_size,
+    spdk_bs_get_max_growable_size, spdk_bs_get_md_len, spdk_bs_get_page_size, spdk_bs_get_used_md,
+    spdk_bs_read_super, spdk_bs_total_data_cluster_count, spdk_lvol, spdk_lvol_opts,
+    spdk_lvol_opts_init, spdk_lvol_store, spdk_lvs_grow_live, vbdev_get_lvol_store_by_name,
     vbdev_get_lvol_store_by_uuid, vbdev_get_lvs_bdev_by_lvs, vbdev_lvol_create_with_opts,
-    vbdev_lvs_create_ext, vbdev_lvs_create_with_uuid, vbdev_lvs_destruct, vbdev_lvs_import,
-    vbdev_lvs_unload, LVOL_CLEAR_WITH_NONE, LVOL_CLEAR_WITH_UNMAP, LVS_CLEAR_WITH_NONE,
+    vbdev_lvs_bs_bdev_reset, vbdev_lvs_create_ext, vbdev_lvs_create_with_uuid, vbdev_lvs_destruct,
+    vbdev_lvs_import, vbdev_lvs_set_timeout, vbdev_lvs_unload, LVOL_CLEAR_WITH_NONE,
+    LVOL_CLEAR_WITH_UNMAP, LVS_CLEAR_WITH_NONE,
 };
 
 use super::{BsError, ImportErrorReason, Lvol, LvsError, LvsIter, PropName, PropValue};
@@ -28,8 +32,8 @@ use crate::{
     },
     bdev_api::{bdev_destroy, BdevError},
     core::{
-        logical_volume::LogicalVolume, snapshot::LvolSnapshotOps, Bdev, IoType, NvmfShareProps,
-        Share, UntypedBdev,
+        logical_volume::LogicalVolume, snapshot::LvolSnapshotOps, Bdev, IoType,
+        MayastorEnvironment, NvmfShareProps, Reactors, Share, UntypedBdev,
     },
     eventing::Event,
     ffihelper::{cb_arg, pair, AsStr, ErrnoResult, FfiResult, IntoCString},
@@ -38,7 +42,7 @@ use crate::{
         LvolSnapshotDescriptor,
     },
     pool_backend::{PoolArgs, ReplicaArgs},
-    pool_information::{pool_info_write, PoolInfo},
+    pool_information::{pool_info_read, pool_info_write, PoolInfo},
     sleep::mayastor_sleep,
 };
 
@@ -307,6 +311,74 @@ impl Lvs {
         cache.remove(pool);
     }
 
+    /// Enable stall detection on a given Pool.
+    fn enable_stall_detection(&self) {
+        let lvs = self.as_inner_ptr();
+        let environ = MayastorEnvironment::global();
+        let stall_deadline = environ.pool_args.io_stall_deadline;
+        let std_d: std::time::Duration = stall_deadline.into();
+        let secs: u64 = std_d.as_secs();
+        let rc = unsafe { vbdev_lvs_set_timeout(lvs, secs, Some(Self::lvstore_timeout_cb)) };
+        if rc != 0 {
+            error!(
+                "rc :{rc} while enabling stall deadline on pool {}",
+                self.name()
+            );
+        }
+        info!("enabled stall detection on {}", self.name());
+    }
+
+    /// Disable stall detection on a given Pool.
+    /// We do this once we receive first stall notification.
+    /// This is to stop receiving flood of callbacks as SPDK sends notification
+    /// for all IOs which are stuck on the Pool in loop.
+    fn disable_stall_detection(&self) {
+        let lvs = self.as_inner_ptr();
+        let rc = unsafe { vbdev_lvs_set_timeout(lvs, 0, None) };
+        if rc != 0 {
+            error!(
+                "rc :{rc} while disabling stall deadline on pool {}",
+                self.name()
+            );
+        }
+        info!("disabled stall detection on {}", self.name());
+    }
+
+    /// Marks the pool as stalled in the cache and disables stall detection to avoid callback floods.
+    /// It also triggers a reset of the underlying bdev.
+    fn io_stalled(&self) {
+        let cache = pool_info_read();
+        let lvs = self.name();
+        if let Some(pool_lock) = cache.get(lvs) {
+            let mut pool_mut = pool_lock.write();
+            if !pool_mut.io_stalled {
+                info!("Pool {lvs} has entered IO stall");
+                pool_mut.io_stalled = true;
+                self.disable_stall_detection();
+                let p = std::ptr::null_mut();
+                unsafe { vbdev_lvs_bs_bdev_reset(self.as_inner_ptr(), Some(Self::lvstore_reset_cb), p) };
+            }
+        }
+    }
+
+    /// Marks the pool as recovered in the cache, update transition timestamp and re-enables stall detection.
+    fn io_resume(&self) {
+        let cache = pool_info_read();
+        let lvs = self.name();
+        if let Some(pool_lock) = cache.get(lvs) {
+            let mut pool_mut = pool_lock.write();
+            pool_mut.io_stalled = false;
+            info!("Pool {lvs} recovered from IO stall");
+            let cli_args = MayastorEnvironment::global();
+            let max_entries = cli_args.pool_args.io_stall_transition_threshold * 10;
+            if pool_mut.transition_timestamps.len() == max_entries as usize {
+                let _ = pool_mut.transition_timestamps.pop_front();
+            }
+            pool_mut.transition_timestamps.push_back(Instant::now());
+        }
+        self.enable_stall_detection();
+    }
+
     // checks for the disks length and parses to correct format
     pub fn parse_disk(disks: &[String]) -> Result<String, LvsError> {
         let disk = match disks.first() {
@@ -402,6 +474,7 @@ impl Lvs {
             lvs.share_all().await;
             info!("{:?}: existing lvs imported successfully", lvs);
             lvs.add_info();
+            lvs.enable_stall_detection();
             Ok(lvs)
         }
     }
@@ -570,6 +643,7 @@ impl Lvs {
             Some(pool) => {
                 info!("{pool:?}: new lvs created successfully");
                 pool.add_info();
+                pool.enable_stall_detection();
                 Ok(pool)
             }
             None => Err(LvsError::PoolCreate {
@@ -577,6 +651,37 @@ impl Lvs {
                 name: args.name.clone(),
             }),
         }
+    }
+
+    /// Callback function called by SPDK when IO stalls beyond stall deadline period.
+    extern "C" fn lvstore_timeout_cb(ctx: *mut c_void, _bdev_io: *mut spdk_bdev_io) {
+        let lv_store = ctx as *mut spdk_lvol_store;
+        let lvs: Lvs = Lvs::from_inner_ptr(lv_store);
+        lvs.io_stalled();
+    }
+
+    /// Callback function called by SPDK when reset completes.
+    extern "C" fn lvstore_reset_cb(lvs: *mut spdk_lvol_store, _success: bool, _ctx: *mut c_void) {
+        let lvs: Lvs = Lvs::from_inner_ptr(lvs);
+        let bs = lvs.blob_store();
+        let ctx = Box::new(BsTimeoutCtx {
+            pool_name: lvs.name().to_string(),
+        });
+        let ctx_ptr = Box::into_raw(ctx) as *mut c_void;
+        Reactors::master().send_future(async move {
+            unsafe { spdk_bs_read_super(bs, Some(Self::bs_super_read_cb), ctx_ptr) }
+        });
+    }
+
+    /// Callback function called by SPDK when superblock read completes.
+    extern "C" fn bs_super_read_cb(ctx: *mut c_void, errno: i32) {
+        if errno == 0 {
+            let ctx_str = unsafe { &*(ctx as *mut BsTimeoutCtx) };
+            let pool = &ctx_str.pool_name;
+            let lvs = Lvs::lookup(pool).unwrap();
+            lvs.io_resume();
+        }
+        // Shall we attempt to read again if it fails?
     }
 
     /// Imports the pool if it exists, otherwise tries to create a new pool.
@@ -627,7 +732,7 @@ impl Lvs {
 
         let result = r
             .await
-            .expect("callback gone while exporting lvs")
+            .expect("callback gone while destroying lvs")
             .to_result(|e| LvsError::Export {
                 source: BsError::from_i32(e),
                 name: pool.clone(),
@@ -774,7 +879,7 @@ impl Lvs {
                 base_bdev = c;
             }
         }
-        trace!(
+        info!(
             "Deleting bdev {}, uri {:?}",
             base_bdev.name(),
             base_bdev.bdev_uri_original_str()
@@ -1247,4 +1352,8 @@ impl PtplFileOps for LvsPtpl {
     fn subpath(&self) -> std::path::PathBuf {
         std::path::PathBuf::from("pool/").join(self.uuid())
     }
+}
+
+struct BsTimeoutCtx {
+    pool_name: String,
 }

--- a/io-engine/src/pool_information.rs
+++ b/io-engine/src/pool_information.rs
@@ -14,7 +14,7 @@ pub static POOL_INFO: Lazy<RwLock<HashMap<String, RwLock<PoolInfo>>>> =
 pub struct PoolInfo {
     /// Set when Pools io is under stall.
     pub io_stalled: bool,
-    /// Contains list of timestamps when pool went into stall state.
+    /// Contains list of timestamps when pool resumed from stall state.
     pub transition_timestamps: VecDeque<Instant>,
 }
 

--- a/io-engine/tests/lvs_pool.rs
+++ b/io-engine/tests/lvs_pool.rs
@@ -7,7 +7,8 @@ use io_engine::{
         Protocol, Share, ToErrno, UntypedBdev,
     },
     grpc::v1::pool::pool_to_proto,
-    lvs::{LvolSnapshotOps, Lvs, LvsLvol, PropName, PropValue},
+    lvm::dm_setup::DmState,
+    lvs::{LvolSnapshotOps, Lvs, LvsError, LvsLvol, PropName, PropValue},
     pool_backend::{PoolArgs, PoolBackend, PoolOps, ReplicaArgs},
     subsys::NvmfSubsystem,
 };
@@ -16,7 +17,8 @@ use io_engine_api::v1::{
     replica::ListReplicaOptions,
 };
 use once_cell::sync::OnceCell;
-use std::pin::Pin;
+use std::{pin::Pin, str::FromStr};
+use tokio::time::sleep;
 
 pub mod common;
 
@@ -28,6 +30,9 @@ static DISK_CRYPTO: &str = "/tmp/io-engine-tests/crypto_disk.img";
 static XTS_KEY: &str = "2b7e151628aed2a6abf7158809cf4f3c";
 static XTS_KEY2: &str = "2b7e151628aed2a6abf7158809cf4f3d";
 const IO_ERROR_THRESHOLD: u64 = 5;
+const IO_STALL_TRANSITION_WINDOW: &str = "12s";
+const IO_STALL_DEADLINE: &str = "1s";
+const IO_STALL_TRANSITION_THRESHOLD: u64 = 3;
 
 static MAYASTOR: OnceCell<MayastorTest> = OnceCell::new();
 
@@ -37,7 +42,11 @@ fn ms() -> &'static MayastorTest<'static> {
             reactor_mask: "0x3".into(),
             pool: PoolCliArgs {
                 io_error_threshold: IO_ERROR_THRESHOLD,
-                ..Default::default()
+                io_stall_transition_threshold: IO_STALL_TRANSITION_THRESHOLD,
+                io_stall_transition_window: IO_STALL_TRANSITION_WINDOW
+                    .parse::<humantime::Duration>()
+                    .unwrap(),
+                io_stall_deadline: IO_STALL_DEADLINE.parse::<humantime::Duration>().unwrap(),
             },
             // log_components: vec!["all".into()],
             nvme: NvmeCliArgs {
@@ -693,6 +702,175 @@ async fn lvs_errors() {
     .await;
 
     vg_pool.purge().await.unwrap();
+}
+
+#[tokio::test]
+async fn lvs_stall() {
+    let _ = std::process::Command::new("mkdir")
+        .args(["-p"])
+        .args([TESTDIR])
+        .output()
+        .expect("failed to execute mkdir");
+
+    common::delete_file(&[DISKNAME1.into()]);
+    common::truncate_file(DISKNAME1, 128 * 1024);
+
+    const VG_NAME: &str = "vg-1";
+    const LV_NAME: &str = "lvol1";
+
+    struct TestGuard {
+        loop_dev: Option<String>,
+    }
+    impl Drop for TestGuard {
+        fn drop(&mut self) {
+            if let Some(loop_dev) = self.loop_dev.take() {
+                let script = r#"
+                    export LVM_SUPPRESS_FD_WARNINGS=1
+                    dmsetup resume $2/lvol1
+                    lvremove -f vg-1/lvol1
+                    vgremove -f -y $2
+                    pvremove -f $3
+                "#;
+                let args = vec![DISKNAME2.into(), VG_NAME.into(), loop_dev.clone()];
+                run_script::run_script!(script, args, run_script::ScriptOptions::new()).ok();
+                common::detach_loopdev(&loop_dev);
+            }
+        }
+    }
+    let mut guard = TestGuard { loop_dev: None };
+
+    //setup disk1 via loop device using a sector size of 4096.
+    let ldev = common::setup_loopdev_file(DISKNAME1, Some(4096));
+    guard.loop_dev = Some(ldev.clone());
+
+    let vg_pool = io_engine::lvm::VolumeGroup::create(PoolArgs {
+        name: VG_NAME.into(),
+        disks: vec![ldev.clone()],
+        no_spdk: true,
+        ..Default::default()
+    })
+    .await
+    .unwrap();
+
+    let mut lvol = vg_pool
+        .create_lvol(ReplicaArgs {
+            name: LV_NAME.into(),
+            uuid: LV_NAME.into(),
+            size: 64 * 1024 * 1024,
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+    let pool_args = PoolArgs {
+        name: "tpool".into(),
+        disks: vec![format!("aio://{}", lvol.path())],
+        backend: PoolBackend::Lvs,
+        ..Default::default()
+    };
+
+    let ms = ms();
+    ms.spawn(async move {
+        Lvs::create_or_import(pool_args).await.unwrap();
+    })
+    .await;
+
+    ms.spawn(async move {
+        let lvs = Lvs::lookup("tpool").unwrap();
+        let r = lvs.grow().await.unwrap_err();
+        assert!(matches!(r, LvsError::BdevNotExtended { .. }));
+    })
+    .await;
+
+    for i in 1..(IO_STALL_TRANSITION_THRESHOLD + 1) {
+        let state = lvol.dm_suspend().await.unwrap();
+
+        assert_eq!(state, DmState::Suspended);
+        ms.spawn_detached(async move {
+            let lvs = Lvs::lookup("tpool").unwrap();
+            let _ = lvs.grow().await;
+        });
+
+        let duration: std::time::Duration = humantime::Duration::from_str(IO_STALL_DEADLINE)
+            .unwrap()
+            .into();
+
+        sleep(duration * 2).await;
+
+        let (pool, _errors, alerts) = ms
+            .spawn(async {
+                let lvs = Lvs::lookup("tpool").unwrap();
+                pool_info(&lvs).await
+            })
+            .await;
+
+        assert_eq!(pool.state(), PoolState::PoolSuspected);
+        assert_eq!(alerts.critical, vec![PoolAlert::IoStalled as i32]);
+        assert_eq!(alerts.status(), PoolAlertStatus::Critical);
+
+        let state = lvol.dm_resume().await.unwrap();
+        assert_eq!(state, DmState::Active);
+
+        ms.spawn(async move {
+            let lvs = Lvs::lookup("tpool").unwrap();
+            let r = lvs.grow().await.unwrap_err();
+            assert!(matches!(r, LvsError::BdevNotExtended { .. }));
+        })
+        .await;
+
+        if 1 < i && i < IO_STALL_TRANSITION_THRESHOLD {
+            let (pool, errors, alerts) = ms
+                .spawn(async {
+                    let lvs = Lvs::lookup("tpool").unwrap();
+                    pool_info(&lvs).await
+                })
+                .await;
+
+            assert_eq!(pool.state(), PoolState::PoolOnline);
+            assert_eq!(errors.io_stall_transition_count, i);
+            assert_eq!(
+                alerts.attention,
+                vec![PoolAlert::IoStallIntermittent as i32]
+            );
+            assert_eq!(alerts.status(), PoolAlertStatus::Attention);
+        }
+    }
+
+    ms.spawn(async move {
+        let lvs = Lvs::lookup("tpool").unwrap();
+        let (pool, errors, alerts) = pool_info(&lvs).await;
+        assert_eq!(pool.state(), PoolState::PoolSuspected);
+        assert_eq!(
+            errors.io_stall_transition_count,
+            IO_STALL_TRANSITION_THRESHOLD
+        );
+        assert_eq!(
+            alerts.warning,
+            vec![PoolAlert::IoStallIntermittentExc as i32]
+        );
+        assert_eq!(alerts.status(), PoolAlertStatus::Warning);
+    })
+    .await;
+
+    sleep(
+        humantime::Duration::from_str(IO_STALL_TRANSITION_WINDOW)
+            .unwrap()
+            .into(),
+    )
+    .await;
+
+    ms.spawn(async move {
+        let lvs = Lvs::lookup("tpool").unwrap();
+        let (pool, errors, _alerts) = pool_info(&lvs).await;
+        assert_eq!(pool.state(), PoolState::PoolOnline);
+        assert_eq!(errors.io_stall_transition_count, 0);
+    })
+    .await;
+
+    ms.spawn(async move {
+        let lvs = Lvs::lookup("tpool").unwrap();
+        lvs.destroy().await.unwrap();
+    })
+    .await;
 }
 
 async fn pool_info(pool: &dyn PoolOps) -> (Pool, PoolErrors, PoolAlerts) {


### PR DESCRIPTION
This PR:

Sets up timeout detection on blobstore desc on pool create and import. Also, adds callback handling incase of stall notification. We attempt to reset lvstore (works only for aio, not implemented for uring). When reset completes, we try to read superblock, when read completes we mark pool as IO resumed.

Adds unit test for the pool stall feature.