### PR TITLE
feat(reactor): add SPDK interrupt mode support

### DIFF
--- a/io-engine/src/core/env.rs
+++ b/io-engine/src/core/env.rs
@@ -278,6 +278,11 @@ pub struct MayastorCliArgs {
     /// # Warning: Don't use this in production.
     #[clap(long, env = "MAYASTOR_DELAY", hide = true, value_parser = delay_compat)]
     pub developer_delay: bool,
+    /// Enable interrupt mode: reactors use epoll-based waiting instead of
+    /// busy-polling when idle, dramatically reducing CPU usage. {n}
+    /// Warning: Experimental. NVMe-oF TCP targets only.
+    #[clap(long = "enable-interrupt-mode", env = "ENABLE_INTERRUPT_MODE", value_parser = delay_compat)]
+    pub interrupt_mode: bool,
     /// Enables RDMA between initiator and Mayastor Nvmf target.
     #[clap(long = "enable-rdma", env = "ENABLE_RDMA", value_parser = delay_compat)]
     pub rdma: bool,
@@ -515,6 +520,7 @@ pub struct MayastorEnvironment {
     skip_sig_handler: bool,
     enable_io_all_thrd_nexus_channels: bool,
     developer_delay: bool,
+    interrupt_mode: bool,
     rdma: bool,
     bs_cluster_unmap: bool,
     pub pool_args: PoolCliArgs,
@@ -566,6 +572,7 @@ impl Default for MayastorEnvironment {
             skip_sig_handler: false,
             enable_io_all_thrd_nexus_channels: false,
             developer_delay: false,
+            interrupt_mode: false,
             rdma: false,
             bs_cluster_unmap: false,
             pool_args: PoolCliArgs::default(),
@@ -709,6 +716,7 @@ impl MayastorEnvironment {
             api_versions: args.api_versions,
             skip_sig_handler: args.skip_sig_handler,
             developer_delay: args.developer_delay,
+            interrupt_mode: args.interrupt_mode,
             rdma: args.rdma,
             bs_cluster_unmap: args.bs_cluster_unmap,
             enable_io_all_thrd_nexus_channels: args.enable_io_all_thrd_nexus_channels,
@@ -1156,7 +1164,7 @@ impl MayastorEnvironment {
         }
 
         // allocate a Reactor per core
-        Reactors::init(self.developer_delay);
+        Reactors::init(self.developer_delay, self.interrupt_mode);
 
         // launch the remote cores if any. note that during init these have to
         // be running as during setup cross call will take place.

--- a/io-engine/src/core/env.rs
+++ b/io-engine/src/core/env.rs
@@ -1254,6 +1254,13 @@ impl MayastorEnvironment {
             }
 
             let master = Reactors::current();
+            // Put the master core into interrupt mode too if the
+            // feature was enabled. The slave reactors transition via
+            // poll_reactor(); master is driven by tokio through the
+            // Future impl below, so we have to call it explicitly.
+            // No-op if interrupt mode isn't enabled on master.
+            // Threads added later are handled via add_incoming.
+            master.enter_interrupt_mode();
             master.send_future(async { f() });
             let mut futures: Vec<Pin<Box<dyn future::Future<Output = FutureResult>>>> = Vec::new();
             if let Some(grpc_endpoint) = grpc_endpoint {

--- a/io-engine/src/core/env.rs
+++ b/io-engine/src/core/env.rs
@@ -640,12 +640,15 @@ pub fn mayastor_env_stop(rc: i32) {
     let r = Reactors::master();
 
     match r.get_state() {
-        ReactorState::Running | ReactorState::Delayed | ReactorState::Init => {
+        ReactorState::Running
+        | ReactorState::Delayed
+        | ReactorState::Init
+        | ReactorState::Interrupt => {
             r.send_future(async move {
                 do_shutdown(rc as *const i32 as *mut c_void).await;
             });
         }
-        _ => {
+        ReactorState::Shutdown => {
             panic!("invalid reactor state during shutdown");
         }
     }

--- a/io-engine/src/core/reactor.rs
+++ b/io-engine/src/core/reactor.rs
@@ -159,12 +159,9 @@ impl Reactors {
             // and the rest in poll mode is worse than either pure
             // configuration (see PR #1966 review).
             if interrupt_mode {
-                let rc = spdk_rs::Thread::interrupt_mode_enable();
-                assert_eq!(
-                    rc, 0,
-                    "Failed to enable SPDK interrupt mode (rc={}); \
+                spdk_rs::Thread::interrupt_mode_enable().expect(
+                    "Failed to enable SPDK interrupt mode; \
                      aborting rather than running in mixed mode",
-                    rc,
                 );
                 info!("SPDK interrupt mode enabled globally");
             }
@@ -328,11 +325,8 @@ impl Reactor {
         // (see PR #1966 review). ENOMEM or init-order violations at
         // boot are unrecoverable anyway.
         let (fgrp, wakeup_fd) = if interrupt_enabled {
-            let fg = spdk_rs::FdGroup::create().unwrap_or_else(|rc| {
-                panic!(
-                    "Reactor core {}: failed to create fd_group (rc={})",
-                    core, rc
-                )
+            let fg = spdk_rs::FdGroup::create().unwrap_or_else(|err| {
+                panic!("Reactor core {}: failed to create fd_group ({})", core, err)
             });
             let efd = unsafe { libc::eventfd(0, libc::EFD_NONBLOCK | libc::EFD_CLOEXEC) };
             assert!(
@@ -350,11 +344,11 @@ impl Reactor {
                 std::ptr::null_mut(),
                 spdk_rs::FD_TYPE_EVENTFD,
             )
-            .unwrap_or_else(|rc| {
+            .unwrap_or_else(|err| {
                 unsafe { libc::close(efd) };
                 panic!(
-                    "Reactor core {}: failed to add wakeup eventfd to fd_group (rc={})",
-                    core, rc
+                    "Reactor core {}: failed to add wakeup eventfd to fd_group ({})",
+                    core, err
                 )
             });
             info!("Reactor core {core}: interrupt mode enabled");
@@ -663,13 +657,13 @@ impl Reactor {
             if thread_fgrp.is_null() {
                 continue;
             }
-            if let Err(rc) = fgrp.nest(thread_fgrp) {
+            if let Err(err) = fgrp.nest(thread_fgrp) {
                 error!(
-                    "Core {}: nest failed for thread '{}' (rc={}) — \
+                    "Core {}: nest failed for thread '{}' ({}) — \
                      staying in poll mode",
                     self.lcore,
                     t.name(),
-                    rc,
+                    err,
                 );
                 for n in nested {
                     let _ = fgrp.unnest(n);
@@ -778,7 +772,7 @@ impl Reactor {
             .then_some(self.fgrp.as_ref())
             .flatten();
 
-        let mut fallback_reason: Option<(String, i32)> = None;
+        let mut fallback_reason: Option<(String, Errno)> = None;
         while let Some(i) = self.incoming.pop() {
             if fallback_reason.is_none() {
                 if let Some(fgrp) = nest_into_fgrp {
@@ -792,7 +786,7 @@ impl Reactor {
                                     self.lcore,
                                 );
                             }
-                            Err(rc) => {
+                            Err(err) => {
                                 // Can't leave the reactor half-nested
                                 // (threads whose fgrps aren't under
                                 // the sleeping reactor's fd_group
@@ -800,7 +794,7 @@ impl Reactor {
                                 // Capture the reason, stop trying to
                                 // nest further incomings, fall back
                                 // below after the drain completes.
-                                fallback_reason = Some((i.name().to_string(), rc));
+                                fallback_reason = Some((i.name().to_string(), err));
                             }
                         }
                     }
@@ -809,11 +803,11 @@ impl Reactor {
             self.threads.borrow_mut().push_back(i);
         }
 
-        if let Some((name, rc)) = fallback_reason {
+        if let Some((name, err)) = fallback_reason {
             error!(
-                "Core {}: add_incoming nest failed for thread '{}' (rc={}) — \
+                "Core {}: add_incoming nest failed for thread '{}' ({}) — \
                  falling back to poll mode",
-                self.lcore, name, rc,
+                self.lcore, name, err,
             );
             self.leave_interrupt_mode();
         }

--- a/io-engine/src/core/reactor.rs
+++ b/io-engine/src/core/reactor.rs
@@ -34,7 +34,7 @@ use std::{
     collections::VecDeque,
     fmt::{self, Debug, Display, Formatter},
     future::Future,
-    os::raw::c_void,
+    os::{fd::RawFd, raw::c_void},
     pin::Pin,
     slice::Iter,
     time::Duration,
@@ -69,6 +69,8 @@ pub enum ReactorState {
     Running,
     Shutdown,
     Delayed,
+    /// Epoll-based interrupt mode: reactor sleeps until I/O events arrive.
+    Interrupt,
 }
 
 impl Display for ReactorState {
@@ -78,6 +80,7 @@ impl Display for ReactorState {
             ReactorState::Running => "Running",
             ReactorState::Shutdown => "Shutdown",
             ReactorState::Delayed => "Delayed",
+            ReactorState::Interrupt => "Interrupt",
         };
         write!(f, "{s}")
     }
@@ -122,6 +125,14 @@ pub struct Reactor {
     /// through FFI
     sx: Sender<Pin<Box<dyn Future<Output = ()> + 'static>>>,
     rx: Receiver<Pin<Box<dyn Future<Output = ()> + 'static>>>,
+    /// Whether interrupt mode is enabled for this reactor.
+    interrupt_enabled: bool,
+    /// Reactor-level fd_group for interrupt mode. Thread fd_groups are
+    /// nested into this, and spdk_fd_group_wait() blocks until events.
+    fgrp: Option<spdk_rs::FdGroup>,
+    /// eventfd registered in the reactor's fd_group to wake from
+    /// fd_group_wait when Rust futures arrive via send_future().
+    wakeup_fd: RawFd,
 }
 
 thread_local! {
@@ -131,7 +142,7 @@ thread_local! {
 
 impl Reactors {
     /// initialize the reactor subsystem for each core assigned to us
-    pub fn init(developer_delay: bool) {
+    pub fn init(developer_delay: bool, interrupt_mode: bool) {
         REACTOR_LIST.get_or_init(|| {
             let mempool_sz = try_from_env(
                 "SPDK_DEFAULT_MSG_MEMPOOL_SIZE",
@@ -140,15 +151,39 @@ impl Reactors {
             if !(mempool_sz+1).is_power_of_two() {
                 tracing::warn!("The provided SPDK_DEFAULT_MSG_MEMPOOL_SIZE ({SPDK_DEFAULT_MSG_MEMPOOL_SIZE}) is not a power of 2 - 1. This is not optimal for memory consumption");
             }
+            // Enable SPDK interrupt mode globally if requested.
+            // Must be called BEFORE spdk_thread_lib_init_ext().
+            if interrupt_mode {
+                let rc = spdk_rs::Thread::interrupt_mode_enable();
+                if rc != 0 {
+                    error!(
+                        "Failed to enable SPDK interrupt mode (rc={}), \
+                         falling back to poll mode",
+                        rc
+                    );
+                } else {
+                    info!("SPDK interrupt mode enabled globally");
+                }
+            }
+
             let rc = unsafe {
                 spdk_thread_lib_init_ext(Some(Self::do_op), Some(Self::can_op), 0, mempool_sz)
             };
             assert_eq!(rc, 0);
 
+            let interrupt_available = interrupt_mode
+                && spdk_rs::Thread::interrupt_mode_is_enabled();
+
             Reactors(
                 Cores::count()
                     .into_iter()
-                    .map(|core| Reactor::new(core, developer_delay))
+                    .map(|core| {
+                        Reactor::new(
+                            core,
+                            developer_delay,
+                            interrupt_available,
+                        )
+                    })
                     .collect::<Vec<_>>(),
             )
         });
@@ -187,6 +222,14 @@ impl Reactors {
                     r.lcore,
                 );
                 r.incoming.push(mt);
+                // Wake the target reactor if it's another core sitting
+                // in fd_group_wait — it can't drain `incoming` until it
+                // returns from the blocking wait. Without this kick a
+                // slave reactor that entered interrupt mode with zero
+                // threads would never see threads scheduled to it later.
+                if r.lcore != Cores::current() {
+                    r.wake();
+                }
                 return true;
             }
             false
@@ -279,9 +322,54 @@ impl<'a> IntoIterator for &'a Reactors {
 
 impl Reactor {
     /// create a new ['Reactor'] instance
-    fn new(core: u32, developer_delay: bool) -> Self {
+    fn new(core: u32, developer_delay: bool, interrupt_enabled: bool) -> Self {
         // create a channel to receive futures on
         let (sx, rx) = unbounded::<Pin<Box<dyn Future<Output = ()> + 'static>>>();
+
+        let mut fgrp = None;
+        let mut wakeup_fd: RawFd = -1;
+
+        if interrupt_enabled {
+            match spdk_rs::FdGroup::create() {
+                Ok(fg) => {
+                    // Create an eventfd and register it in the reactor's
+                    // fd_group so send_future() can wake us from
+                    // fd_group_wait().
+                    let efd = unsafe { libc::eventfd(0, libc::EFD_NONBLOCK | libc::EFD_CLOEXEC) };
+                    if efd >= 0 {
+                        // Register as EVENTFD type so fd_group_wait()
+                        // auto-drains it. Without this, a single
+                        // send_future() write makes the fd permanently
+                        // readable (level-triggered), spinning the reactor.
+                        match fg.add_with_fd_type(
+                            efd,
+                            Self::wakeup_handler,
+                            std::ptr::null_mut(),
+                            spdk_rs::FD_TYPE_EVENTFD,
+                        ) {
+                            Ok(()) => {
+                                wakeup_fd = efd;
+                                info!("Reactor core {}: interrupt mode enabled", core);
+                                fgrp = Some(fg);
+                            }
+                            Err(rc) => {
+                                error!("Failed to add wakeup eventfd to fd_group (rc={})", rc,);
+                                unsafe { libc::close(efd) };
+                            }
+                        }
+                    } else {
+                        error!("Failed to create wakeup eventfd for core {}", core);
+                    }
+                }
+                Err(rc) => {
+                    error!(
+                        "Failed to create fd_group for core {} (rc={}), \
+                         interrupt mode disabled",
+                        core, rc,
+                    );
+                }
+            }
+        }
 
         Self {
             threads: RefCell::new(VecDeque::new()),
@@ -292,7 +380,18 @@ impl Reactor {
             tid: Cell::new(0),
             sx,
             rx,
+            interrupt_enabled: fgrp.is_some(),
+            fgrp,
+            wakeup_fd,
         }
+    }
+
+    /// Callback for the wakeup eventfd. The eventfd is auto-drained
+    /// by `fd_group_wait()` because it is registered as
+    /// `SPDK_FD_TYPE_EVENTFD`. The actual futures are processed by
+    /// `receive_futures()` in the poll loop.
+    extern "C" fn wakeup_handler(_ctx: *mut c_void) -> i32 {
+        0
     }
 
     /// this function gets called by DPDK
@@ -333,6 +432,17 @@ impl Reactor {
         F: Future<Output = ()> + 'static,
     {
         self.sx.send(Box::pin(future)).unwrap();
+        // Wake the reactor if it's sleeping in fd_group_wait.
+        if self.wakeup_fd >= 0 {
+            let val: u64 = 1;
+            unsafe {
+                libc::write(
+                    self.wakeup_fd,
+                    &val as *const u64 as *const libc::c_void,
+                    std::mem::size_of::<u64>(),
+                );
+            }
+        }
     }
 
     /// spawn a future locally on this core; note that you can *not* use the
@@ -404,7 +514,8 @@ impl Reactor {
             ReactorState::Init
             | ReactorState::Delayed
             | ReactorState::Shutdown
-            | ReactorState::Running => {
+            | ReactorState::Running
+            | ReactorState::Interrupt => {
                 self.flags.set(state);
             }
         }
@@ -458,14 +569,39 @@ impl Reactor {
         // Initialize TID for this reactor.
         self.tid.set(gettid());
 
+        // If interrupt mode is enabled, enter it immediately. The
+        // reactor will block in fd_group_wait() until events arrive,
+        // then poll, then block again.
+        if self.interrupt_enabled {
+            self.enter_interrupt_mode();
+        }
+
         loop {
             match self.get_state() {
-                // running is the default mode for all cores. All cores, except
-                // the master core spin within this specific loop
                 ReactorState::Running => {
                     self.poll_once();
                 }
+                ReactorState::Interrupt => {
+                    // Block until I/O events or wakeup from send_future.
+                    // fd_group_wait dispatches events to the registered
+                    // interrupt callbacks (which are the poller functions).
+                    self.wait_for_events();
+                    // Restore init_thread context before running Rust
+                    // futures. fd_group_wait wrappers save/restore the
+                    // context for each event, but we set it explicitly
+                    // so gRPC futures see the app thread (required by
+                    // spdk_bdev_register and other app-thread-only APIs).
+                    if let Some(init_t) = self.threads.borrow().front() {
+                        init_t.set_current();
+                    }
+                    self.receive_futures();
+                    self.run_futures();
+                    self.add_incoming();
+                }
                 ReactorState::Shutdown => {
+                    if self.interrupt_enabled {
+                        self.exit_interrupt_mode();
+                    }
                     info!("reactor {} shutdown requested", self.lcore);
                     break;
                 }
@@ -502,6 +638,75 @@ impl Reactor {
         self.add_incoming();
     }
 
+    /// Switch all SPDK threads to interrupt mode and nest their
+    /// fd_groups into the reactor's fd_group. Called once at startup.
+    fn enter_interrupt_mode(&self) {
+        let fgrp = match &self.fgrp {
+            Some(fg) => fg,
+            None => return,
+        };
+
+        let threads = self.threads.borrow();
+        for t in threads.iter() {
+            let thread_fgrp = t.get_interrupt_fd_group();
+            if !thread_fgrp.is_null() {
+                if let Err(rc) = fgrp.nest(thread_fgrp) {
+                    warn!("Failed to nest thread '{}' fd_group (rc={})", t.name(), rc,);
+                }
+            }
+            t.set_current();
+            spdk_rs::Thread::set_interrupt_mode(true);
+        }
+
+        // Restore init_thread (first thread) as the current SPDK thread.
+        // The loop above leaves the last thread as current, but Rust
+        // futures (gRPC handlers) need the app thread context —
+        // spdk_bdev_register() requires spdk_thread_is_app_thread().
+        if let Some(init_t) = threads.front() {
+            init_t.set_current();
+        }
+
+        let count = threads.len();
+        drop(threads);
+
+        info!(
+            "Core {}: entered interrupt mode ({} threads)",
+            self.lcore, count,
+        );
+        self.set_state(ReactorState::Interrupt);
+    }
+
+    /// Switch all SPDK threads back to poll mode. Called on shutdown.
+    fn exit_interrupt_mode(&self) {
+        let fgrp = match &self.fgrp {
+            Some(fg) => fg,
+            None => return,
+        };
+
+        let threads = self.threads.borrow();
+        for t in threads.iter() {
+            t.set_current();
+            spdk_rs::Thread::set_interrupt_mode(false);
+
+            let thread_fgrp = t.get_interrupt_fd_group();
+            if !thread_fgrp.is_null() {
+                let _ = fgrp.unnest(thread_fgrp);
+            }
+        }
+        drop(threads);
+        info!("Core {}: exited interrupt mode", self.lcore);
+        self.set_state(ReactorState::Running);
+    }
+
+    /// Block until I/O events arrive or send_future() signals the
+    /// wakeup eventfd. Uses SPDK's fd_group which aggregates all
+    /// nested thread fd_groups.
+    fn wait_for_events(&self) {
+        if let Some(fgrp) = &self.fgrp {
+            fgrp.wait(-1);
+        }
+    }
+
     /// poll the threads n times but only poll the futures queue once and look
     /// for incoming only once.
     ///
@@ -524,8 +729,53 @@ impl Reactor {
     }
 
     fn add_incoming(&self) {
+        // Only nest if the reactor has actually transitioned into
+        // Interrupt state. Reactors that are still busy-polling
+        // (e.g. the master core, which is driven by Future::poll
+        // and never calls enter_interrupt_mode) must NOT have
+        // their threads' fgrps nested — spdk_thread_poll on those
+        // threads would then hit a nested fgrp and warn / no-op.
+        let nest_into_fgrp = (self.get_state() == ReactorState::Interrupt)
+            .then_some(self.fgrp.as_ref())
+            .flatten();
+
         while let Some(i) = self.incoming.pop() {
+            if let Some(fgrp) = nest_into_fgrp {
+                let thread_fgrp = i.get_interrupt_fd_group();
+                if !thread_fgrp.is_null() {
+                    if let Err(rc) = fgrp.nest(thread_fgrp) {
+                        warn!(
+                            "add_incoming: failed to nest thread '{}' fd_group on core {} (rc={})",
+                            i.name(),
+                            self.lcore,
+                            rc,
+                        );
+                    } else {
+                        info!(
+                            "add_incoming: nested thread '{}' fd_group on core {}",
+                            i.name(),
+                            self.lcore,
+                        );
+                    }
+                }
+            }
             self.threads.borrow_mut().push_back(i);
+        }
+    }
+
+    /// Wake the reactor if it's blocked in fd_group_wait. Used by
+    /// schedule() so a slave reactor sleeping with no threads gets
+    /// kicked when one is added.
+    fn wake(&self) {
+        if self.wakeup_fd >= 0 {
+            let val: u64 = 1;
+            unsafe {
+                libc::write(
+                    self.wakeup_fd,
+                    &val as *const u64 as *const libc::c_void,
+                    std::mem::size_of::<u64>(),
+                );
+            }
         }
     }
 
@@ -667,6 +917,13 @@ impl Future for &'static Reactor {
             ReactorState::Delayed => {
                 std::thread::sleep(Duration::from_millis(1));
                 self.poll_once();
+                cx.waker().wake_by_ref();
+                Poll::Pending
+            }
+            ReactorState::Interrupt => {
+                // Interrupt state is handled by poll_reactor(), not here.
+                // Fall through to Running behavior for safety.
+                self.poll_times(3);
                 cx.waker().wake_by_ref();
                 Poll::Pending
             }

--- a/io-engine/src/core/reactor.rs
+++ b/io-engine/src/core/reactor.rs
@@ -153,16 +153,20 @@ impl Reactors {
             }
             // Enable SPDK interrupt mode globally if requested.
             // Must be called BEFORE spdk_thread_lib_init_ext().
+            // Failure here (typically -ENOMEM or init-order violation)
+            // is unrecoverable and we must not silently fall back to
+            // poll mode: running a subset of reactors in interrupt mode
+            // and the rest in poll mode is worse than either pure
+            // configuration (see PR #1966 review).
             if interrupt_mode {
                 let rc = spdk_rs::Thread::interrupt_mode_enable();
-                if rc != 0 {
-                    error!(
-                        "Failed to enable SPDK interrupt mode (rc={rc}), \
-                         falling back to poll mode"
-                    );
-                } else {
-                    info!("SPDK interrupt mode enabled globally");
-                }
+                assert_eq!(
+                    rc, 0,
+                    "Failed to enable SPDK interrupt mode (rc={}); \
+                     aborting rather than running in mixed mode",
+                    rc,
+                );
+                info!("SPDK interrupt mode enabled globally");
             }
 
             let rc = unsafe {
@@ -170,19 +174,10 @@ impl Reactors {
             };
             assert_eq!(rc, 0);
 
-            let interrupt_available = interrupt_mode
-                && spdk_rs::Thread::interrupt_mode_is_enabled();
-
             Reactors(
                 Cores::count()
                     .into_iter()
-                    .map(|core| {
-                        Reactor::new(
-                            core,
-                            developer_delay,
-                            interrupt_available,
-                        )
-                    })
+                    .map(|core| Reactor::new(core, developer_delay, interrupt_mode))
                     .collect::<Vec<_>>(),
             )
         });
@@ -325,49 +320,48 @@ impl Reactor {
         // create a channel to receive futures on
         let (sx, rx) = unbounded::<Pin<Box<dyn Future<Output = ()> + 'static>>>();
 
-        let mut fgrp = None;
-        let mut wakeup_fd: RawFd = -1;
-
-        if interrupt_enabled {
-            match spdk_rs::FdGroup::create() {
-                Ok(fg) => {
-                    // Create an eventfd and register it in the reactor's
-                    // fd_group so send_future() can wake us from
-                    // fd_group_wait().
-                    let efd = unsafe { libc::eventfd(0, libc::EFD_NONBLOCK | libc::EFD_CLOEXEC) };
-                    if efd >= 0 {
-                        // Register as EVENTFD type so fd_group_wait()
-                        // auto-drains it. Without this, a single
-                        // send_future() write makes the fd permanently
-                        // readable (level-triggered), spinning the reactor.
-                        match fg.add_with_fd_type(
-                            efd,
-                            Self::wakeup_handler,
-                            std::ptr::null_mut(),
-                            spdk_rs::FD_TYPE_EVENTFD,
-                        ) {
-                            Ok(()) => {
-                                wakeup_fd = efd;
-                                info!("Reactor core {core}: interrupt mode enabled");
-                                fgrp = Some(fg);
-                            }
-                            Err(rc) => {
-                                error!("Failed to add wakeup eventfd to fd_group (rc={rc})");
-                                unsafe { libc::close(efd) };
-                            }
-                        }
-                    } else {
-                        error!("Failed to create wakeup eventfd for core {core}");
-                    }
-                }
-                Err(rc) => {
-                    error!(
-                        "Failed to create fd_group for core {core} (rc={rc}), \
-                         interrupt mode disabled"
-                    );
-                }
-            }
-        }
+        // Initialise the per-reactor fd_group + wakeup eventfd for
+        // interrupt mode. We fail the process on any setup error
+        // rather than silently falling back to poll mode: a mixed
+        // configuration where some reactors interrupt and others poll
+        // has been a source of hard-to-diagnose deadlocks in the past
+        // (see PR #1966 review). ENOMEM or init-order violations at
+        // boot are unrecoverable anyway.
+        let (fgrp, wakeup_fd) = if interrupt_enabled {
+            let fg = spdk_rs::FdGroup::create().unwrap_or_else(|rc| {
+                panic!(
+                    "Reactor core {}: failed to create fd_group (rc={})",
+                    core, rc
+                )
+            });
+            let efd = unsafe { libc::eventfd(0, libc::EFD_NONBLOCK | libc::EFD_CLOEXEC) };
+            assert!(
+                efd >= 0,
+                "Reactor core {}: failed to create wakeup eventfd",
+                core,
+            );
+            // Register as EVENTFD type so fd_group_wait() auto-drains
+            // it. Without this, a single send_future() write makes the
+            // fd permanently readable (level-triggered), spinning the
+            // reactor.
+            fg.add_with_fd_type(
+                efd,
+                Self::wakeup_handler,
+                std::ptr::null_mut(),
+                spdk_rs::FD_TYPE_EVENTFD,
+            )
+            .unwrap_or_else(|rc| {
+                unsafe { libc::close(efd) };
+                panic!(
+                    "Reactor core {}: failed to add wakeup eventfd to fd_group (rc={})",
+                    core, rc
+                )
+            });
+            info!("Reactor core {core}: interrupt mode enabled");
+            (Some(fg), efd)
+        } else {
+            (None, -1)
+        };
 
         Self {
             threads: RefCell::new(VecDeque::new()),
@@ -378,7 +372,7 @@ impl Reactor {
             tid: Cell::new(0),
             sx,
             rx,
-            interrupt_enabled: fgrp.is_some(),
+            interrupt_enabled,
             fgrp,
             wakeup_fd,
         }

--- a/io-engine/src/core/reactor.rs
+++ b/io-engine/src/core/reactor.rs
@@ -639,19 +639,47 @@ impl Reactor {
 
     /// Switch all SPDK threads to interrupt mode and nest their
     /// fd_groups into the reactor's fd_group. Called once at startup.
+    ///
+    /// Two-phase to make rollback clean: first nest every thread's
+    /// fd_group, then flip each thread to interrupt mode. If any nest
+    /// fails we unnest what we've done and return without transitioning
+    /// the reactor to Interrupt — a partially-nested reactor would
+    /// leave silent pollers (threads whose fgrps aren't under the
+    /// sleeping reactor's fd_group never fire — see PR #1966 review).
     fn enter_interrupt_mode(&self) {
         let Some(fgrp) = self.fgrp.as_ref() else {
             return;
         };
 
         let threads = self.threads.borrow();
+        // Phase 1: nest every thread's fd_group.
+        let mut nested: Vec<*mut spdk_rs::libspdk::spdk_fd_group> =
+            Vec::with_capacity(threads.len());
         for t in threads.iter() {
             let thread_fgrp = t.get_interrupt_fd_group();
-            if !thread_fgrp.is_null() {
-                if let Err(rc) = fgrp.nest(thread_fgrp) {
-                    warn!("Failed to nest thread '{}' fd_group (rc={rc})", t.name());
-                }
+            if thread_fgrp.is_null() {
+                continue;
             }
+            if let Err(rc) = fgrp.nest(thread_fgrp) {
+                error!(
+                    "Core {}: nest failed for thread '{}' (rc={}) — \
+                     staying in poll mode",
+                    self.lcore,
+                    t.name(),
+                    rc,
+                );
+                for n in nested {
+                    let _ = fgrp.unnest(n);
+                }
+                return;
+            }
+            nested.push(thread_fgrp);
+        }
+
+        // Phase 2: flip every thread to interrupt mode. Only runs if
+        // all nests succeeded above, so there's no partial state to
+        // roll back here.
+        for t in threads.iter() {
             // spdk_thread_set_interrupt_mode operates on the current
             // SPDK thread (spdk_get_thread()) -- no thread arg -- so
             // we must set_current() first.
@@ -677,8 +705,11 @@ impl Reactor {
         self.set_state(ReactorState::Interrupt);
     }
 
-    /// Switch all SPDK threads back to poll mode. Called on shutdown.
-    fn exit_interrupt_mode(&self) {
+    /// Roll this reactor back to poll mode from Interrupt. Unnests every
+    /// thread's fd_group from the reactor's fgrp and flips each thread
+    /// to poll mode. Shared by exit_interrupt_mode (shutdown) and the
+    /// add_incoming nest-failure path (runtime fallback).
+    fn leave_interrupt_mode(&self) {
         let Some(fgrp) = self.fgrp.as_ref() else {
             return;
         };
@@ -694,8 +725,13 @@ impl Reactor {
             }
         }
         drop(threads);
-        info!("Core {}: exited interrupt mode", self.lcore);
         self.set_state(ReactorState::Running);
+    }
+
+    /// Switch all SPDK threads back to poll mode. Called on shutdown.
+    fn exit_interrupt_mode(&self) {
+        self.leave_interrupt_mode();
+        info!("Core {}: exited interrupt mode", self.lcore);
     }
 
     /// Block until I/O events arrive or send_future() signals the
@@ -739,26 +775,44 @@ impl Reactor {
             .then_some(self.fgrp.as_ref())
             .flatten();
 
+        let mut fallback_reason: Option<(String, i32)> = None;
         while let Some(i) = self.incoming.pop() {
-            if let Some(fgrp) = nest_into_fgrp {
-                let thread_fgrp = i.get_interrupt_fd_group();
-                if !thread_fgrp.is_null() {
-                    if let Err(rc) = fgrp.nest(thread_fgrp) {
-                        warn!(
-                            "add_incoming: failed to nest thread '{}' fd_group on core {} (rc={rc})",
-                            i.name(),
-                            self.lcore,
-                        );
-                    } else {
-                        debug!(
-                            "add_incoming: nested thread '{}' fd_group on core {}",
-                            i.name(),
-                            self.lcore,
-                        );
+            if fallback_reason.is_none() {
+                if let Some(fgrp) = nest_into_fgrp {
+                    let thread_fgrp = i.get_interrupt_fd_group();
+                    if !thread_fgrp.is_null() {
+                        match fgrp.nest(thread_fgrp) {
+                            Ok(()) => {
+                                debug!(
+                                    "add_incoming: nested thread '{}' fd_group on core {}",
+                                    i.name(),
+                                    self.lcore,
+                                );
+                            }
+                            Err(rc) => {
+                                // Can't leave the reactor half-nested
+                                // (threads whose fgrps aren't under
+                                // the sleeping reactor's fd_group
+                                // never get polled — PR #1966 review).
+                                // Capture the reason, stop trying to
+                                // nest further incomings, fall back
+                                // below after the drain completes.
+                                fallback_reason = Some((i.name().to_string(), rc));
+                            }
+                        }
                     }
                 }
             }
             self.threads.borrow_mut().push_back(i);
+        }
+
+        if let Some((name, rc)) = fallback_reason {
+            error!(
+                "Core {}: add_incoming nest failed for thread '{}' (rc={}) — \
+                 falling back to poll mode",
+                self.lcore, name, rc,
+            );
+            self.leave_interrupt_mode();
         }
     }
 

--- a/io-engine/src/core/reactor.rs
+++ b/io-engine/src/core/reactor.rs
@@ -342,7 +342,7 @@ impl Reactor {
                 efd,
                 Self::wakeup_handler,
                 std::ptr::null_mut(),
-                spdk_rs::FD_TYPE_EVENTFD,
+                spdk_rs::libspdk::SPDK_FD_TYPE_EVENTFD,
             )
             .unwrap_or_else(|err| {
                 unsafe { libc::close(efd) };

--- a/io-engine/src/core/reactor.rs
+++ b/io-engine/src/core/reactor.rs
@@ -646,7 +646,10 @@ impl Reactor {
     /// the reactor to Interrupt — a partially-nested reactor would
     /// leave silent pollers (threads whose fgrps aren't under the
     /// sleeping reactor's fd_group never fire — see PR #1966 review).
-    fn enter_interrupt_mode(&self) {
+    ///
+    /// No-op if interrupt mode isn't enabled on this reactor (fgrp is
+    /// None). Safe to call unconditionally.
+    pub fn enter_interrupt_mode(&self) {
         let Some(fgrp) = self.fgrp.as_ref() else {
             return;
         };
@@ -974,8 +977,13 @@ impl Future for &'static Reactor {
                 Poll::Pending
             }
             ReactorState::Interrupt => {
-                // Interrupt state is handled by poll_reactor(), not here.
-                // Fall through to Running behavior for safety.
+                // Master core in interrupt mode: master is driven by
+                // the tokio runtime (via this Future impl), not by a
+                // dedicated thread in fd_group_wait, so we can't block
+                // here — tokio expects quick poll returns. CPU savings
+                // on master come from spdk_thread_poll's interrupt-
+                // mode path (pollers that wake via fds, not via every
+                // tick), not from the reactor sleeping.
                 self.poll_times(3);
                 cx.waker().wake_by_ref();
                 Poll::Pending

--- a/io-engine/src/core/reactor.rs
+++ b/io-engine/src/core/reactor.rs
@@ -157,9 +157,8 @@ impl Reactors {
                 let rc = spdk_rs::Thread::interrupt_mode_enable();
                 if rc != 0 {
                     error!(
-                        "Failed to enable SPDK interrupt mode (rc={}), \
-                         falling back to poll mode",
-                        rc
+                        "Failed to enable SPDK interrupt mode (rc={rc}), \
+                         falling back to poll mode"
                     );
                 } else {
                     info!("SPDK interrupt mode enabled globally");
@@ -349,23 +348,22 @@ impl Reactor {
                         ) {
                             Ok(()) => {
                                 wakeup_fd = efd;
-                                info!("Reactor core {}: interrupt mode enabled", core);
+                                info!("Reactor core {core}: interrupt mode enabled");
                                 fgrp = Some(fg);
                             }
                             Err(rc) => {
-                                error!("Failed to add wakeup eventfd to fd_group (rc={})", rc,);
+                                error!("Failed to add wakeup eventfd to fd_group (rc={rc})");
                                 unsafe { libc::close(efd) };
                             }
                         }
                     } else {
-                        error!("Failed to create wakeup eventfd for core {}", core);
+                        error!("Failed to create wakeup eventfd for core {core}");
                     }
                 }
                 Err(rc) => {
                     error!(
-                        "Failed to create fd_group for core {} (rc={}), \
-                         interrupt mode disabled",
-                        core, rc,
+                        "Failed to create fd_group for core {core} (rc={rc}), \
+                         interrupt mode disabled"
                     );
                 }
             }
@@ -585,6 +583,13 @@ impl Reactor {
                     // Block until I/O events or wakeup from send_future.
                     // fd_group_wait dispatches events to the registered
                     // interrupt callbacks (which are the poller functions).
+                    //
+                    // No explicit t.poll() afterwards: in interrupt mode,
+                    // spdk_thread_poll's interrupt path is invoked via the
+                    // nested thread fd_groups during fd_group_wait itself
+                    // (see spdk/lib/event/reactor.c spdk_thread_poll), so
+                    // an extra per-thread poll would just re-enter the
+                    // same code path with nothing to do.
                     self.wait_for_events();
                     // Restore init_thread context before running Rust
                     // futures. fd_group_wait wrappers save/restore the
@@ -641,9 +646,8 @@ impl Reactor {
     /// Switch all SPDK threads to interrupt mode and nest their
     /// fd_groups into the reactor's fd_group. Called once at startup.
     fn enter_interrupt_mode(&self) {
-        let fgrp = match &self.fgrp {
-            Some(fg) => fg,
-            None => return,
+        let Some(fgrp) = self.fgrp.as_ref() else {
+            return;
         };
 
         let threads = self.threads.borrow();
@@ -651,9 +655,12 @@ impl Reactor {
             let thread_fgrp = t.get_interrupt_fd_group();
             if !thread_fgrp.is_null() {
                 if let Err(rc) = fgrp.nest(thread_fgrp) {
-                    warn!("Failed to nest thread '{}' fd_group (rc={})", t.name(), rc,);
+                    warn!("Failed to nest thread '{}' fd_group (rc={rc})", t.name());
                 }
             }
+            // spdk_thread_set_interrupt_mode operates on the current
+            // SPDK thread (spdk_get_thread()) -- no thread arg -- so
+            // we must set_current() first.
             t.set_current();
             spdk_rs::Thread::set_interrupt_mode(true);
         }
@@ -678,9 +685,8 @@ impl Reactor {
 
     /// Switch all SPDK threads back to poll mode. Called on shutdown.
     fn exit_interrupt_mode(&self) {
-        let fgrp = match &self.fgrp {
-            Some(fg) => fg,
-            None => return,
+        let Some(fgrp) = self.fgrp.as_ref() else {
+            return;
         };
 
         let threads = self.threads.borrow();
@@ -745,13 +751,12 @@ impl Reactor {
                 if !thread_fgrp.is_null() {
                     if let Err(rc) = fgrp.nest(thread_fgrp) {
                         warn!(
-                            "add_incoming: failed to nest thread '{}' fd_group on core {} (rc={})",
+                            "add_incoming: failed to nest thread '{}' fd_group on core {} (rc={rc})",
                             i.name(),
                             self.lcore,
-                            rc,
                         );
                     } else {
-                        info!(
+                        debug!(
                             "add_incoming: nested thread '{}' fd_group on core {}",
                             i.name(),
                             self.lcore,

--- a/io-engine/tests/reactor_interrupt.rs
+++ b/io-engine/tests/reactor_interrupt.rs
@@ -1,0 +1,29 @@
+//! Regression test: `mayastor_env_stop` must accept the `Interrupt`
+//! reactor state. Under `--enable-interrupt-mode` the master reactor
+//! is in `ReactorState::Interrupt`, so any SIGTERM after the
+//! transition used to hit the `_ => panic!` arm at env.rs:649.
+
+use io_engine::core::{
+    mayastor_env_stop, MayastorCliArgs, MayastorEnvironment, ReactorState, Reactors,
+};
+
+pub mod common;
+
+#[common::spdk_test]
+fn reactor_interrupt_mode_shutdown() {
+    common::mayastor_test_init();
+    MayastorEnvironment::new(MayastorCliArgs {
+        reactor_mask: "0x1".into(),
+        interrupt_mode: true,
+        ..Default::default()
+    })
+    .init();
+
+    // Drive the master reactor into Interrupt state — same transition
+    // `.start()` does at env.rs:1263.
+    Reactors::master().enter_interrupt_mode();
+    assert_eq!(Reactors::master().get_state(), ReactorState::Interrupt);
+
+    // Must not panic with "invalid reactor state during shutdown".
+    mayastor_env_stop(0);
+}

--- a/test/python/tests/ana_client/docker-compose.yml
+++ b/test/python/tests/ana_client/docker-compose.yml
@@ -13,7 +13,10 @@ services:
         - NEXUS_NVMF_RESV_ENABLE=1
         - PATH=${LLVM_SYMBOLIZER_DIR:-}
         - ASAN_OPTIONS=detect_leaks=0
-    command: ${SRCDIR}/${IO_ENGINE_DIR}/io-engine -g 0.0.0.0 -l 1,2 -r /tmp/ms0.sock
+        - ENABLE_INTERRUPT_MODE=${ENABLE_INTERRUPT_MODE:-false}
+        - NVME_IOQ_POLL_PERIOD=${NVME_IOQ_POLL_PERIOD:-}
+        - RUST_LOG=${RUST_LOG:-info}
+    command: ${SRCDIR}/${IO_ENGINE_DIR}/io-engine -g 0.0.0.0 -l ${MS0_CORES:-1,2} -r /tmp/ms0.sock
     networks:
       mayastor_net:
         ipv4_address: 10.1.0.2
@@ -41,7 +44,10 @@ services:
         - NEXUS_NVMF_RESV_ENABLE=1
         - PATH=${LLVM_SYMBOLIZER_DIR:-}
         - ASAN_OPTIONS=detect_leaks=0
-    command: ${SRCDIR}/${IO_ENGINE_DIR}/io-engine -g 0.0.0.0 -l 3,4 -r /tmp/ms1.sock
+        - ENABLE_INTERRUPT_MODE=${ENABLE_INTERRUPT_MODE:-false}
+        - NVME_IOQ_POLL_PERIOD=${NVME_IOQ_POLL_PERIOD:-}
+        - RUST_LOG=${RUST_LOG:-info}
+    command: ${SRCDIR}/${IO_ENGINE_DIR}/io-engine -g 0.0.0.0 -l ${MS1_CORES:-3,4} -r /tmp/ms1.sock
     networks:
       mayastor_net:
         ipv4_address: 10.1.0.3
@@ -69,7 +75,10 @@ services:
         - NEXUS_NVMF_RESV_ENABLE=1
         - PATH=${LLVM_SYMBOLIZER_DIR:-}
         - ASAN_OPTIONS=detect_leaks=0
-    command: ${SRCDIR}/${IO_ENGINE_DIR}/io-engine -g 0.0.0.0 -l 5,6 -r /tmp/ms2.sock
+        - ENABLE_INTERRUPT_MODE=${ENABLE_INTERRUPT_MODE:-false}
+        - NVME_IOQ_POLL_PERIOD=${NVME_IOQ_POLL_PERIOD:-}
+        - RUST_LOG=${RUST_LOG:-info}
+    command: ${SRCDIR}/${IO_ENGINE_DIR}/io-engine -g 0.0.0.0 -l ${MS2_CORES:-5,6} -r /tmp/ms2.sock
     networks:
       mayastor_net:
         ipv4_address: 10.1.0.4
@@ -98,7 +107,10 @@ services:
         - NEXUS_NVMF_RESV_ENABLE=1
         - PATH=${LLVM_SYMBOLIZER_DIR:-}
         - ASAN_OPTIONS=detect_leaks=0
-    command: ${SRCDIR}/${IO_ENGINE_DIR}/io-engine -g 0.0.0.0 -l 0,7 -r /tmp/ms3.sock
+        - ENABLE_INTERRUPT_MODE=${ENABLE_INTERRUPT_MODE:-false}
+        - NVME_IOQ_POLL_PERIOD=${NVME_IOQ_POLL_PERIOD:-}
+        - RUST_LOG=${RUST_LOG:-info}
+    command: ${SRCDIR}/${IO_ENGINE_DIR}/io-engine -g 0.0.0.0 -l ${MS3_CORES:-0,7} -r /tmp/ms3.sock
     networks:
       mayastor_net:
         ipv4_address: 10.1.0.5

--- a/test/python/tests/cli_controller/docker-compose.yml
+++ b/test/python/tests/cli_controller/docker-compose.yml
@@ -13,7 +13,10 @@ services:
         - NEXUS_NVMF_RESV_ENABLE=1
         - PATH=${LLVM_SYMBOLIZER_DIR:-}
         - ASAN_OPTIONS=detect_leaks=0
-    command: ${SRCDIR}/${IO_ENGINE_DIR}/io-engine -g 0.0.0.0 -l 3,4 -r /tmp/ms1.sock
+        - ENABLE_INTERRUPT_MODE=${ENABLE_INTERRUPT_MODE:-false}
+        - NVME_IOQ_POLL_PERIOD=${NVME_IOQ_POLL_PERIOD:-}
+        - RUST_LOG=${RUST_LOG:-info}
+    command: ${SRCDIR}/${IO_ENGINE_DIR}/io-engine -g 0.0.0.0 -l ${MS1_CORES:-3,4} -r /tmp/ms1.sock
     networks:
       mayastor_net:
         ipv4_address: 10.1.0.3
@@ -41,7 +44,10 @@ services:
         - NEXUS_NVMF_RESV_ENABLE=1
         - PATH=${LLVM_SYMBOLIZER_DIR:-}
         - ASAN_OPTIONS=detect_leaks=0
-    command: ${SRCDIR}/${IO_ENGINE_DIR}/io-engine -g 0.0.0.0 -l 5,6 -r /tmp/ms2.sock
+        - ENABLE_INTERRUPT_MODE=${ENABLE_INTERRUPT_MODE:-false}
+        - NVME_IOQ_POLL_PERIOD=${NVME_IOQ_POLL_PERIOD:-}
+        - RUST_LOG=${RUST_LOG:-info}
+    command: ${SRCDIR}/${IO_ENGINE_DIR}/io-engine -g 0.0.0.0 -l ${MS2_CORES:-5,6} -r /tmp/ms2.sock
     networks:
       mayastor_net:
         ipv4_address: 10.1.0.4
@@ -70,7 +76,10 @@ services:
         - NEXUS_NVMF_RESV_ENABLE=1
         - PATH=${LLVM_SYMBOLIZER_DIR:-}
         - ASAN_OPTIONS=detect_leaks=0
-    command: ${SRCDIR}/${IO_ENGINE_DIR}/io-engine -g 0.0.0.0 -l 0,7 -r /tmp/ms3.sock
+        - ENABLE_INTERRUPT_MODE=${ENABLE_INTERRUPT_MODE:-false}
+        - NVME_IOQ_POLL_PERIOD=${NVME_IOQ_POLL_PERIOD:-}
+        - RUST_LOG=${RUST_LOG:-info}
+    command: ${SRCDIR}/${IO_ENGINE_DIR}/io-engine -g 0.0.0.0 -l ${MS3_CORES:-0,7} -r /tmp/ms3.sock
     networks:
       mayastor_net:
         ipv4_address: 10.1.0.5

--- a/test/python/tests/nexus_fault/docker-compose.yml
+++ b/test/python/tests/nexus_fault/docker-compose.yml
@@ -13,7 +13,10 @@ services:
       - NEXUS_NVMF_RESV_ENABLE=1
       - PATH=${LLVM_SYMBOLIZER_DIR:-}
       - ASAN_OPTIONS=detect_leaks=0
-    command: ${SRCDIR}/${IO_ENGINE_DIR}/io-engine -g 0.0.0.0 -l 1 -r /tmp/ms0.sock
+      - ENABLE_INTERRUPT_MODE=${ENABLE_INTERRUPT_MODE:-false}
+      - NVME_IOQ_POLL_PERIOD=${NVME_IOQ_POLL_PERIOD:-}
+      - RUST_LOG=${RUST_LOG:-info}
+    command: ${SRCDIR}/${IO_ENGINE_DIR}/io-engine -g 0.0.0.0 -l ${MS0_CORES:-1} -r /tmp/ms0.sock
     networks:
       mayastor_net:
         ipv4_address: 10.1.0.2
@@ -41,7 +44,10 @@ services:
       - NEXUS_NVMF_RESV_ENABLE=1
       - PATH=${LLVM_SYMBOLIZER_DIR:-}
       - ASAN_OPTIONS=detect_leaks=0
-    command: ${SRCDIR}/${IO_ENGINE_DIR}/io-engine -g 0.0.0.0 -l 2 -r /tmp/ms1.sock
+      - ENABLE_INTERRUPT_MODE=${ENABLE_INTERRUPT_MODE:-false}
+      - NVME_IOQ_POLL_PERIOD=${NVME_IOQ_POLL_PERIOD:-}
+      - RUST_LOG=${RUST_LOG:-info}
+    command: ${SRCDIR}/${IO_ENGINE_DIR}/io-engine -g 0.0.0.0 -l ${MS1_CORES:-2} -r /tmp/ms1.sock
     networks:
       mayastor_net:
         ipv4_address: 10.1.0.3

--- a/test/python/tests/nexus_multipath/docker-compose.yml
+++ b/test/python/tests/nexus_multipath/docker-compose.yml
@@ -13,7 +13,10 @@ services:
         - NEXUS_NVMF_RESV_ENABLE=1
         - PATH=${LLVM_SYMBOLIZER_DIR:-}
         - ASAN_OPTIONS=detect_leaks=0
-    command: ${SRCDIR}/${IO_ENGINE_DIR}/io-engine -g 0.0.0.0 -l 1,2 -r /tmp/ms0.sock
+        - ENABLE_INTERRUPT_MODE=${ENABLE_INTERRUPT_MODE:-false}
+        - NVME_IOQ_POLL_PERIOD=${NVME_IOQ_POLL_PERIOD:-}
+        - RUST_LOG=${RUST_LOG:-info}
+    command: ${SRCDIR}/${IO_ENGINE_DIR}/io-engine -g 0.0.0.0 -l ${MS0_CORES:-1,2} -r /tmp/ms0.sock
     networks:
       mayastor_net:
         ipv4_address: 10.1.0.2
@@ -41,7 +44,10 @@ services:
         - NEXUS_NVMF_RESV_ENABLE=1
         - PATH=${LLVM_SYMBOLIZER_DIR:-}
         - ASAN_OPTIONS=detect_leaks=0
-    command: ${SRCDIR}/${IO_ENGINE_DIR}/io-engine -g 0.0.0.0 -l 3,4 -r /tmp/ms1.sock
+        - ENABLE_INTERRUPT_MODE=${ENABLE_INTERRUPT_MODE:-false}
+        - NVME_IOQ_POLL_PERIOD=${NVME_IOQ_POLL_PERIOD:-}
+        - RUST_LOG=${RUST_LOG:-info}
+    command: ${SRCDIR}/${IO_ENGINE_DIR}/io-engine -g 0.0.0.0 -l ${MS1_CORES:-3,4} -r /tmp/ms1.sock
     networks:
       mayastor_net:
         ipv4_address: 10.1.0.3
@@ -69,7 +75,10 @@ services:
         - NEXUS_NVMF_RESV_ENABLE=1
         - PATH=${LLVM_SYMBOLIZER_DIR:-}
         - ASAN_OPTIONS=detect_leaks=0
-    command: ${SRCDIR}/${IO_ENGINE_DIR}/io-engine -g 0.0.0.0 -l 5,6 -r /tmp/ms2.sock
+        - ENABLE_INTERRUPT_MODE=${ENABLE_INTERRUPT_MODE:-false}
+        - NVME_IOQ_POLL_PERIOD=${NVME_IOQ_POLL_PERIOD:-}
+        - RUST_LOG=${RUST_LOG:-info}
+    command: ${SRCDIR}/${IO_ENGINE_DIR}/io-engine -g 0.0.0.0 -l ${MS2_CORES:-5,6} -r /tmp/ms2.sock
     networks:
       mayastor_net:
         ipv4_address: 10.1.0.4
@@ -98,7 +107,10 @@ services:
         - NEXUS_NVMF_RESV_ENABLE=1
         - PATH=${LLVM_SYMBOLIZER_DIR:-}
         - ASAN_OPTIONS=detect_leaks=0
-    command: ${SRCDIR}/${IO_ENGINE_DIR}/io-engine -g 0.0.0.0 -l 0,7 -r /tmp/ms3.sock
+        - ENABLE_INTERRUPT_MODE=${ENABLE_INTERRUPT_MODE:-false}
+        - NVME_IOQ_POLL_PERIOD=${NVME_IOQ_POLL_PERIOD:-}
+        - RUST_LOG=${RUST_LOG:-info}
+    command: ${SRCDIR}/${IO_ENGINE_DIR}/io-engine -g 0.0.0.0 -l ${MS3_CORES:-0,7} -r /tmp/ms3.sock
     networks:
       mayastor_net:
         ipv4_address: 10.1.0.5

--- a/test/python/tests/publish/docker-compose.yml
+++ b/test/python/tests/publish/docker-compose.yml
@@ -13,7 +13,10 @@ services:
         - NEXUS_NVMF_RESV_ENABLE=1
         - PATH=${LLVM_SYMBOLIZER_DIR:-}
         - ASAN_OPTIONS=detect_leaks=0
-    command: ${SRCDIR}/${IO_ENGINE_DIR}/io-engine -g 0.0.0.0 -l 1,2 -r /tmp/ms0.sock
+        - ENABLE_INTERRUPT_MODE=${ENABLE_INTERRUPT_MODE:-false}
+        - NVME_IOQ_POLL_PERIOD=${NVME_IOQ_POLL_PERIOD:-}
+        - RUST_LOG=${RUST_LOG:-info}
+    command: ${SRCDIR}/${IO_ENGINE_DIR}/io-engine -g 0.0.0.0 -l ${MS0_CORES:-1,2} -r /tmp/ms0.sock
     networks:
       mayastor_net:
         ipv4_address: 10.1.0.2
@@ -41,7 +44,10 @@ services:
         - NEXUS_NVMF_RESV_ENABLE=1
         - PATH=${LLVM_SYMBOLIZER_DIR:-}
         - ASAN_OPTIONS=detect_leaks=0
-    command: ${SRCDIR}/${IO_ENGINE_DIR}/io-engine -g 0.0.0.0 -l 3,4 -r /tmp/ms1.sock
+        - ENABLE_INTERRUPT_MODE=${ENABLE_INTERRUPT_MODE:-false}
+        - NVME_IOQ_POLL_PERIOD=${NVME_IOQ_POLL_PERIOD:-}
+        - RUST_LOG=${RUST_LOG:-info}
+    command: ${SRCDIR}/${IO_ENGINE_DIR}/io-engine -g 0.0.0.0 -l ${MS1_CORES:-3,4} -r /tmp/ms1.sock
     networks:
       mayastor_net:
         ipv4_address: 10.1.0.3

--- a/test/python/tests/rebuild/docker-compose.yml
+++ b/test/python/tests/rebuild/docker-compose.yml
@@ -13,7 +13,10 @@ services:
         - NEXUS_NVMF_RESV_ENABLE=1
         - PATH=${LLVM_SYMBOLIZER_DIR:-}
         - ASAN_OPTIONS=detect_leaks=0
-    command: ${SRCDIR}/${IO_ENGINE_DIR}/io-engine -g 0.0.0.0 -l 1,2 -r /tmp/ms0.sock
+        - ENABLE_INTERRUPT_MODE=${ENABLE_INTERRUPT_MODE:-false}
+        - NVME_IOQ_POLL_PERIOD=${NVME_IOQ_POLL_PERIOD:-}
+        - RUST_LOG=${RUST_LOG:-info}
+    command: ${SRCDIR}/${IO_ENGINE_DIR}/io-engine -g 0.0.0.0 -l ${MS0_CORES:-1,2} -r /tmp/ms0.sock
     networks:
       mayastor_net:
         ipv4_address: 10.1.0.2

--- a/test/python/tests/replica/docker-compose.yml
+++ b/test/python/tests/replica/docker-compose.yml
@@ -13,7 +13,10 @@ services:
         - NEXUS_NVMF_RESV_ENABLE=1
         - PATH=${LLVM_SYMBOLIZER_DIR:-}
         - ASAN_OPTIONS=detect_leaks=0
-    command: ${SRCDIR}/${IO_ENGINE_DIR}/io-engine -g 0.0.0.0 -l 1,2 -r /tmp/ms0.sock
+        - ENABLE_INTERRUPT_MODE=${ENABLE_INTERRUPT_MODE:-false}
+        - NVME_IOQ_POLL_PERIOD=${NVME_IOQ_POLL_PERIOD:-}
+        - RUST_LOG=${RUST_LOG:-info}
+    command: ${SRCDIR}/${IO_ENGINE_DIR}/io-engine -g 0.0.0.0 -l ${MS0_CORES:-1,2} -r /tmp/ms0.sock
     networks:
       mayastor_net:
         ipv4_address: 10.1.0.2

--- a/test/python/tests/replica_uuid/docker-compose.yml
+++ b/test/python/tests/replica_uuid/docker-compose.yml
@@ -13,7 +13,10 @@ services:
         - NEXUS_NVMF_RESV_ENABLE=1
         - PATH=${LLVM_SYMBOLIZER_DIR:-}
         - ASAN_OPTIONS=detect_leaks=0
-    command: ${SRCDIR}/${IO_ENGINE_DIR}/io-engine -g 0.0.0.0 -l 1,2 -r /tmp/ms0.sock
+        - ENABLE_INTERRUPT_MODE=${ENABLE_INTERRUPT_MODE:-false}
+        - NVME_IOQ_POLL_PERIOD=${NVME_IOQ_POLL_PERIOD:-}
+        - RUST_LOG=${RUST_LOG:-info}
+    command: ${SRCDIR}/${IO_ENGINE_DIR}/io-engine -g 0.0.0.0 -l ${MS0_CORES:-1,2} -r /tmp/ms0.sock
     networks:
       mayastor_net:
         ipv4_address: 10.1.0.2

--- a/test/python/tests/rpc/docker-compose.yml
+++ b/test/python/tests/rpc/docker-compose.yml
@@ -13,7 +13,10 @@ services:
         - NEXUS_NVMF_RESV_ENABLE=1
         - PATH=${LLVM_SYMBOLIZER_DIR:-}
         - ASAN_OPTIONS=detect_leaks=0
-    command: ${SRCDIR}/${IO_ENGINE_DIR}/io-engine -g 0.0.0.0 -l 3,4 -r /tmp/ms1.sock
+        - ENABLE_INTERRUPT_MODE=${ENABLE_INTERRUPT_MODE:-false}
+        - NVME_IOQ_POLL_PERIOD=${NVME_IOQ_POLL_PERIOD:-}
+        - RUST_LOG=${RUST_LOG:-info}
+    command: ${SRCDIR}/${IO_ENGINE_DIR}/io-engine -g 0.0.0.0 -l ${MS1_CORES:-3,4} -r /tmp/ms1.sock
     networks:
       mayastor_net:
         ipv4_address: 10.1.0.3

--- a/test/python/tests/rpc/test_interrupt_mode.py
+++ b/test/python/tests/rpc/test_interrupt_mode.py
@@ -1,0 +1,107 @@
+"""
+Smoke tests for reactor interrupt mode (PR #1966).
+
+Only meaningful when the compose services are started with
+`ENABLE_INTERRUPT_MODE=true`, so every test here skips otherwise.
+They cover three regressions that the existing functional tests
+would not surface:
+
+1. mode-assertion smoke   — the env var was actually honoured and
+   the reactor(s) transitioned to interrupt state
+2. idle CPU sanity        — the reactor sleeps in `fd_group_wait`
+   instead of busy-polling when no work is pending
+3. wakeup-from-sleep      — `send_future` correctly kicks the
+   reactor out of `fd_group_wait` via the wakeup eventfd
+"""
+
+import os
+import subprocess
+import time
+
+import pytest
+
+from common.mayastor import container_mod, mayastor_mod
+
+INTERRUPT_ENABLED = os.environ.get("ENABLE_INTERRUPT_MODE", "").lower() == "true"
+
+interrupt_only = pytest.mark.skipif(
+    not INTERRUPT_ENABLED,
+    reason="interrupt mode not enabled (ENABLE_INTERRUPT_MODE != true)",
+)
+
+
+@interrupt_only
+def test_reactor_state_is_interrupt(container_mod):
+    """The container log should show SPDK global interrupt mode enabled
+    and at least one reactor core transitioning into interrupt state.
+    Catches silent regressions where the env var stops being honoured."""
+    logs = str(container_mod.get("ms1").logs())
+    assert "SPDK interrupt mode enabled globally" in logs, (
+        "interrupt mode env var was not honoured — the global enable line is "
+        "missing from io-engine logs"
+    )
+    assert (
+        "entered interrupt mode" in logs
+    ), "no reactor transitioned to interrupt state — check enter_interrupt_mode"
+
+
+@interrupt_only
+def test_idle_cpu_is_low(container_mod):
+    """With no I/O driven, an interrupt-mode reactor should sleep in
+    fd_group_wait and consume near-zero CPU. A pure busy-poll reactor
+    reports ~100% per core. Use a wide margin (<50% total) to tolerate
+    noise from the SPDK heartbeat poller and reactor bookkeeping."""
+    ms1 = container_mod.get("ms1")
+
+    # Let things settle: gRPC server up, pollers registered, reactor
+    # should have transitioned and be blocked in fd_group_wait.
+    time.sleep(5)
+
+    # docker stats --no-stream reports a single CPU% snapshot. Ask for
+    # --no-trunc so the container name matches exactly; parse the %.
+    out = subprocess.check_output(
+        [
+            "docker",
+            "stats",
+            "--no-stream",
+            "--format",
+            "{{.CPUPerc}}",
+            ms1.name,
+        ],
+        text=True,
+    ).strip()
+    cpu_pct = float(out.rstrip("%"))
+
+    # 50% is a generous ceiling — interrupt mode typically lands in the
+    # single digits when idle. Poll mode would be ~100% per reactor core,
+    # i.e. well over 100% for the default 2-core container.
+    assert cpu_pct < 50.0, (
+        f"interrupt-mode container idle CPU is {cpu_pct}% — expected <50%. "
+        "Reactor is likely not sleeping in fd_group_wait."
+    )
+
+
+@interrupt_only
+def test_wakeup_from_sleep(mayastor_mod):
+    """A gRPC call against a sleeping interrupt-mode reactor must return
+    promptly: the request is delivered as a future, send_future signals
+    the reactor's wakeup eventfd, and fd_group_wait returns so the
+    future can execute. If the wakeup fd path is broken this test
+    hangs or exceeds the threshold."""
+    ms1 = mayastor_mod.get("ms1")
+
+    # Give the reactor a moment to enter fd_group_wait after startup.
+    time.sleep(2)
+
+    start = time.monotonic()
+    ms1.mayastor_info()  # simple gRPC round-trip, executes on init_thread
+    elapsed_ms = (time.monotonic() - start) * 1000
+
+    # 500 ms is several orders of magnitude more than a healthy wakeup
+    # (typically <5 ms end-to-end). Failure here means the wakeup fd
+    # wasn't registered / drained correctly and the reactor is either
+    # not sleeping or not being woken.
+    assert elapsed_ms < 500.0, (
+        f"gRPC call took {elapsed_ms:.1f} ms against a sleeping reactor — "
+        "wakeup eventfd path may be broken"
+    )


### PR DESCRIPTION
## Summary

Opt-in SPDK interrupt mode for io-engine: reactors sleep in
`fd_group_wait()` instead of busy-polling, reducing CPU from ~1000m
per core to <300m when idle.

- Enable with `ENABLE_INTERRUPT_MODE=true` (default: off, backward compatible)
- Follows Longhorn v2 hybrid pattern (LEP 2025-07-21): epoll for NVMe-oF
  TCP targets, timerfd polling for NVMe initiators
- Includes pytest compose wiring for interrupt mode testing

### Implementation

Reactor changes (`reactor.rs`, +271 lines):
- New `ReactorState::Interrupt` with `fd_group_wait`-based event loop
- Reactor-level `FdGroup` nests all thread fd_groups for hierarchical mux
- Wakeup eventfd (`FD_TYPE_EVENTFD`, auto-drained) for Rust future delivery
- Cross-core wake on thread schedule to prevent multi-core init deadlock
- Late fd_group nesting in `add_incoming()` for dynamic thread assignment
- Clean shutdown path restoring poll mode

### Why interrupt mode instead of SPDK's dynamic scheduler (#1745)

Mayastor implements its own reactor loop (`reactor.rs`), bypassing
SPDK's stock reactor entirely. SPDK's dynamic scheduler monitors thread
busyness *within SPDK's reactor* -- since mayastor's reactor replaces
it, the scheduler has nothing to observe or control.

Instead, we implement interrupt mode directly in the custom reactor,
following the same pattern validated by Longhorn v2 (LEP 2025-07-21).
This is simpler, more predictable, and doesn't require restructuring the
reactor to use SPDK's scheduler infrastructure. The dynamic scheduler
remains a future option if the reactor is ever migrated closer to SPDK's
stock implementation.

Depends-On: openebs/spdk-rs#105
Depends-On: openebs/spdk#70
Closes: #1745

## Test plan

- [x] 73/86 pytest tests pass in single-core interrupt mode
      (13 failures are env-related, identical in poll mode)
- [x] Multi-core validated (2-core smoke test)
- [x] Production: 3-node cluster, 16 volumes, CPU ~3000m to ~463m (85% reduction)
- [x] Rolling restart validated: volumes auto-recover, nexuses redistribute
- [ ] CI pipeline passes
