### PR TITLE
refactor: use new impl of snapshot clone counting

### DIFF
--- a/io-engine/src/lvs/lvol_snapshot.rs
+++ b/io-engine/src/lvs/lvol_snapshot.rs
@@ -692,27 +692,37 @@ impl LvolSnapshotOps for Lvol {
 
     /// List clones based on snapshot_uuid.
     fn list_clones_by_snapshot_uuid(&self) -> Vec<Lvol> {
-        // todo: optimize this process, avoid multiple calls to spdk_blob_get_clones.
-        let clone_count = 100; /* self.blob_clone_count() as usize */
-        let mut clones = Vec::with_capacity(clone_count);
+        let uuid = self.uuid().into_cstring();
+        let clone_count = 100; /* self.clone_count() as usize */
+        struct SnapClones {
+            lvs: super::Lvs,
+            clones: Vec<Lvol>,
+        }
+        let mut snap_clones = SnapClones {
+            lvs: self.lvs(),
+            clones: Vec::with_capacity(clone_count),
+        };
         unsafe {
-            extern "C" fn cb(cb_arg: *mut c_void, lvol: *mut spdk_lvol) -> i32 {
-                let ctx = cb_arg as *mut Vec<Lvol>;
-                let lvol = Lvol::from_inner_ptr(lvol);
-                if lvol.is_clone() {
-                    unsafe {
-                        (*ctx).push(lvol);
-                    }
+            extern "C" fn cb(cb_arg: *mut c_void, blobid: spdk_rs::libspdk::spdk_blob_id) {
+                let ctx = cb_arg as *mut SnapClones;
+                let lvstore = unsafe { (*ctx).lvs.as_inner_ptr() };
+                let lvol = unsafe { spdk_rs::libspdk::lvs_get_lvol_by_blob_id(lvstore, blobid) };
+                if lvol.is_null() {
+                    return;
                 }
-                0
+                unsafe {
+                    (*ctx).clones.push(Lvol::from_inner_ptr(lvol));
+                }
             }
-            spdk_rs::libspdk::spdk_lvol_iter_immediate_clones(
-                self.as_inner_ptr(),
+            spdk_rs::libspdk::spdk_blob_get_real_clones(
+                self.lvs().blob_store(),
+                CloneXattrs::SourceUuid.name().as_ptr() as *const c_char,
+                uuid.as_ptr() as *const c_char,
                 Some(cb),
-                &mut clones as *mut _ as *mut std::ffi::c_void,
+                &mut snap_clones as *mut _ as *mut std::ffi::c_void,
             );
         }
-        clones
+        snap_clones.clones
     }
 
     /// List All Clones.

--- a/io-engine/src/lvs/lvs_lvol.rs
+++ b/io-engine/src/lvs/lvs_lvol.rs
@@ -501,18 +501,16 @@ impl Lvol {
 
     /// Count how many replica clones are dependent on this snapshot.
     pub fn clone_count(&self) -> u64 {
-        let mut count: u64 = 0;
+        let uuid = self.uuid().into_cstring();
         unsafe {
-            spdk_rs::libspdk::spdk_blob_get_real_clones(
+            spdk_rs::libspdk::spdk_blob_count_real_clones(
                 self.lvs().blob_store(),
-                self.as_inner_ref().blob_id,
-                std::ptr::null_mut(),
-                &mut count,
                 CloneXattrs::SourceUuid.name().as_ptr() as *const c_char,
+                uuid.as_ptr() as *const c_char,
             )
-        };
-        count
+        }
     }
+
     /// Count how many clones are dependent on this snapshot.
     /// # Warning
     /// These clones may be snapshots or "real_clones".

--- a/io-engine/tests/lvs_pool.rs
+++ b/io-engine/tests/lvs_pool.rs
@@ -949,14 +949,17 @@ async fn lvol_snap_list() {
     ms.spawn(async move {
         let lvs_pool = Lvs::create_or_import(pool_args).await.unwrap();
 
-        for i in 1..=10 {
+        for i in 1..=1024 {
             let name = format!("replica-{i}");
             let opts = ReplicaArgs::new(name, repl_size)
                 .wipe_super(false)
                 .thin(true);
             let repl = lvs_pool.create_lvol_with_opts(opts).await.unwrap();
+            if i > 10 {
+                continue;
+            }
             use io_engine::core::SnapshotParams;
-            for j in 1..=512 {
+            for j in 1..=256 {
                 let snapshot = repl
                     .create_snapshot(SnapshotParams {
                         entity_id: Some(format!("e-{i}-{j}")),
@@ -986,7 +989,7 @@ async fn lvol_snap_list() {
 
     // this could vary depending on the system where we're running, but this is large enough that
     // it should run on weaker systems as well as low enough to ensure we're testing the fix.
-    let max_dur = std::time::Duration::from_secs(1);
+    let max_dur = std::time::Duration::from_secs(3);
 
     let list_tm = std::time::Instant::now();
     ms.spawn(async move {


### PR DESCRIPTION
The previous impl did not account for chaining. This was only found during control-plane tests which is showing that the snapshot testing in this repo is lacking!

I was not able to modify the existing impl to traverse the chain in an optimal way so instead I've added a hammer approach which iterates all blobs and finds clones.

It's still much faster than what we had before but there's still room for improvement, namely chaning the snapshot chain to rb tree.