### PR TITLE
refactor(pool/probe): implement probe for more devices and use import

### DIFF
--- a/io-engine/src/bdev/aio.rs
+++ b/io-engine/src/bdev/aio.rs
@@ -186,7 +186,7 @@ impl CreateDestroy for Aio {
 }
 
 impl super::Probe for Aio {
-    fn probe(&self) -> Result<(), io_engine_api::v1::pool::ProbeError> {
+    fn probe(&self, _opts: &super::ProbeOpts) -> Result<(), super::ProbeError> {
         super::probe_file(&self.name)
     }
 }

--- a/io-engine/src/bdev/ftl.rs
+++ b/io-engine/src/bdev/ftl.rs
@@ -160,7 +160,13 @@ impl GetName for Ftl {
         self.name.clone()
     }
 }
-impl super::Probe for Ftl {}
+impl super::Probe for Ftl {
+    fn probe(&self, opts: &super::ProbeOpts) -> Result<(), super::ProbeError> {
+        super::probe_uri(&self.bbdev_uri, opts)?;
+        super::probe_uri(&self.cbdev_uri, opts)?;
+        Ok(())
+    }
+}
 
 pub extern "C" fn ftl_bdev_init_fn_cb(
     _ptr: *const ftl_bdev_info,

--- a/io-engine/src/bdev/loopback.rs
+++ b/io-engine/src/bdev/loopback.rs
@@ -64,7 +64,11 @@ impl GetName for Loopback {
         self.name.clone()
     }
 }
-impl super::Probe for Loopback {}
+impl super::Probe for Loopback {
+    fn probe(&self, _opts: &super::ProbeOpts) -> Result<(), super::ProbeError> {
+        super::probe_bdev(&self.name)
+    }
+}
 
 #[async_trait(?Send)]
 impl CreateDestroy for Loopback {

--- a/io-engine/src/bdev/malloc.rs
+++ b/io-engine/src/bdev/malloc.rs
@@ -170,7 +170,18 @@ impl GetName for Malloc {
         self.name.clone()
     }
 }
-impl super::Probe for Malloc {}
+impl super::Probe for Malloc {
+    fn probe(&self, opts: &super::ProbeOpts) -> Result<(), super::ProbeError> {
+        if opts.import {
+            Err(super::mk_probe_error_ex(
+                super::ProbeErrorCode::DiskNotImportable,
+                "Can't import malloc device",
+            ))
+        } else {
+            Ok(())
+        }
+    }
+}
 
 #[async_trait(?Send)]
 impl CreateDestroy for Malloc {

--- a/io-engine/src/bdev/mod.rs
+++ b/io-engine/src/bdev/mod.rs
@@ -7,8 +7,9 @@ pub use nvmx::{nvme_io_ctx_pool_init, NvmeController, NvmeControllerState, NVME_
 
 mod aio;
 pub(crate) mod dev;
-use crate::core::{MayastorEnvironment, PtplProps};
+use crate::core::{MayastorEnvironment, PtplProps, UntypedBdev};
 pub(crate) use dev::uri;
+pub use io_engine_api::v1::pool::{ProbeError, ProbeErrorCode};
 
 pub mod crypto;
 pub(crate) mod device;
@@ -45,26 +46,52 @@ pub trait GetName {
     fn get_name(&self) -> String;
 }
 
+/// Probe options for each device.
+pub struct ProbeOpts {
+    /// If we're probing for create or import.
+    pub import: bool,
+}
+
 /// The following trait must also be implemented for every supported
 /// device type.
 pub trait Probe {
-    fn probe(&self) -> Result<(), io_engine_api::v1::pool::ProbeError> {
-        Err(io_engine_api::v1::pool::ProbeError {
-            code: io_engine_api::v1::pool::ProbeErrorCode::InvalidDiskUri as i32,
-            msg: None,
-        })
+    fn probe(&self, _opts: &ProbeOpts) -> Result<(), ProbeError> {
+        Err(mk_probe_error(ProbeErrorCode::UriNotHandled))
     }
 }
 
-fn probe_file(file: &str) -> Result<(), io_engine_api::v1::pool::ProbeError> {
+fn mk_probe_error(code: ProbeErrorCode) -> ProbeError {
+    ProbeError {
+        code: code as i32,
+        msg: None,
+    }
+}
+fn mk_probe_error_ex(code: ProbeErrorCode, msg: impl Into<String>) -> ProbeError {
+    ProbeError {
+        code: code as i32,
+        msg: Some(msg.into()),
+    }
+}
+
+fn probe_file(file: &str) -> Result<(), ProbeError> {
     let disk_path = std::path::Path::new(file);
     if !disk_path.exists() {
-        return Err(io_engine_api::v1::pool::ProbeError {
-            code: io_engine_api::v1::pool::ProbeErrorCode::DiskNotFound as i32,
-            msg: None,
-        });
+        return Err(mk_probe_error(ProbeErrorCode::DiskNotFound));
     }
     Ok(())
+}
+
+fn probe_bdev(bdev: &str) -> Result<(), ProbeError> {
+    if UntypedBdev::lookup_by_name(bdev).is_none() {
+        return Err(mk_probe_error(ProbeErrorCode::DiskNotFound));
+    }
+    Ok(())
+}
+
+fn probe_uri(uri: &str, opts: &ProbeOpts) -> Result<(), ProbeError> {
+    uri::parse(uri)
+        .map_err(|e| mk_probe_error_ex(ProbeErrorCode::InvalidDiskUri, e.to_string()))?
+        .probe(opts)
 }
 
 /// Exposes functionality to prepare for persisting reservations in the event

--- a/io-engine/src/bdev/nvme.rs
+++ b/io-engine/src/bdev/nvme.rs
@@ -175,17 +175,17 @@ impl CreateDestroy for NVMe {
 }
 
 impl super::Probe for NVMe {
-    fn probe(&self) -> Result<(), io_engine_api::v1::pool::ProbeError> {
+    fn probe(&self, _opts: &super::ProbeOpts) -> Result<(), super::ProbeError> {
         const PCIE_DRVS: [&str; 2] = ["vfio-pci", "uio_pci_generic"];
 
         let driver = match self.pci_driver() {
             Ok(Some(driver)) if !driver.is_empty() => Ok(driver),
-            Ok(_) => Err(io_engine_api::v1::pool::ProbeError {
-                code: io_engine_api::v1::pool::ProbeErrorCode::DiskNotFound as i32,
+            Ok(_) => Err(super::ProbeError {
+                code: super::ProbeErrorCode::DiskNotFound as i32,
                 msg: None,
             }),
-            Err(error) => Err(io_engine_api::v1::pool::ProbeError {
-                code: io_engine_api::v1::pool::ProbeErrorCode::ProbeUnknown as i32,
+            Err(error) => Err(super::ProbeError {
+                code: super::ProbeErrorCode::ProbeUnknown as i32,
                 msg: Some(error.to_string()),
             }),
         }?;
@@ -195,19 +195,19 @@ impl super::Probe for NVMe {
         }
 
         if driver == "nvme" {
-            return Err(io_engine_api::v1::pool::ProbeError {
-                code: io_engine_api::v1::pool::ProbeErrorCode::PciKernelBound as i32,
+            return Err(super::ProbeError {
+                code: super::ProbeErrorCode::PciKernelBound as i32,
                 msg: None,
             });
         }
 
         let code = if self.is_pci_nvme() {
-            io_engine_api::v1::pool::ProbeErrorCode::PciDriverUnsupported
+            super::ProbeErrorCode::PciDriverUnsupported
         } else {
-            io_engine_api::v1::pool::ProbeErrorCode::PciNotNvme
+            super::ProbeErrorCode::PciNotNvme
         } as i32;
 
-        Err(io_engine_api::v1::pool::ProbeError { code, msg: None })
+        Err(super::ProbeError { code, msg: None })
     }
 }
 

--- a/io-engine/src/bdev/nvmf.rs
+++ b/io-engine/src/bdev/nvmf.rs
@@ -123,7 +123,14 @@ impl GetName for Nvmf {
         format!("{}n1", self.name)
     }
 }
-impl super::Probe for Nvmf {}
+
+impl super::Probe for Nvmf {
+    fn probe(&self, _opts: &super::ProbeOpts) -> Result<(), super::ProbeError> {
+        // eventually this means we need probe to be async, and check if we can
+        // at least discover the device.
+        Ok(())
+    }
+}
 
 #[async_trait(?Send)]
 impl CreateDestroy for Nvmf {

--- a/io-engine/src/bdev/nvmx/uri.rs
+++ b/io-engine/src/bdev/nvmx/uri.rs
@@ -183,7 +183,13 @@ impl GetName for NvmfDeviceTemplate {
         format!("{}n1", self.name)
     }
 }
-impl crate::bdev::Probe for NvmfDeviceTemplate {}
+impl crate::bdev::Probe for NvmfDeviceTemplate {
+    fn probe(&self, _opts: &crate::bdev::ProbeOpts) -> Result<(), crate::bdev::ProbeError> {
+        // eventually this means we need probe to be async, and check if we can
+        // at least discover the device.
+        Ok(())
+    }
+}
 
 // Context for an NVMe controller being created.
 pub(crate) struct NvmeControllerContext<'probe> {

--- a/io-engine/src/bdev/uring.rs
+++ b/io-engine/src/bdev/uring.rs
@@ -149,7 +149,7 @@ impl CreateDestroy for Uring {
 }
 
 impl super::Probe for Uring {
-    fn probe(&self) -> Result<(), io_engine_api::v1::pool::ProbeError> {
+    fn probe(&self, _opts: &super::ProbeOpts) -> Result<(), super::ProbeError> {
         super::probe_file(&self.name)
     }
 }

--- a/io-engine/src/bin/io-engine-client/v1/pool_cli.rs
+++ b/io-engine/src/bin/io-engine-client/v1/pool_cli.rs
@@ -298,6 +298,12 @@ pub fn subcommands() -> Command {
                 .help("encryption key2 required for AES_XTS")
                 .required_if_eq("cipher", "AES_XTS")
                 .required(false),
+        )
+        .arg(
+            Arg::new("import")
+                .long("import")
+                .help("Probe for imports")
+                .action(clap::ArgAction::SetTrue),
         );
 
     Command::new("pool")
@@ -856,6 +862,7 @@ async fn probe(mut ctx: Context, matches: &ArgMatches) -> crate::Result<()> {
         .to_owned();
     let uuid = matches.get_one::<String>("uuid");
     let cipher = matches.get_one::<String>("cipher");
+    let import = matches.get_flag("import");
 
     if let Some(c) = cipher {
         if !c.eq_ignore_ascii_case("AES_XTS") && !c.eq_ignore_ascii_case("AES_CBC") {
@@ -911,6 +918,7 @@ async fn probe(mut ctx: Context, matches: &ArgMatches) -> crate::Result<()> {
                 pooltype: v1rpc::pool::PoolType::from(pooltype) as i32,
                 encryption: enc_msg,
             }),
+            import,
             probes: None,
         })
         .await

--- a/io-engine/src/core/reactor.rs
+++ b/io-engine/src/core/reactor.rs
@@ -586,13 +586,17 @@ impl Reactor {
             Reactors::current()
                 .spawn_local(async move {
                     let result = ctx.future.await;
-                    if let Err(e) = ctx
+                    if ctx
                         .sender
                         .take()
                         .expect("sender already taken")
                         .send(result)
+                        .is_err()
                     {
-                        error!("Failed to send response future result {:?}", e);
+                        error!(
+                            "Failed to send response future result {}",
+                            std::any::type_name::<F::Output>()
+                        );
                     }
                 })
                 .detach();

--- a/io-engine/src/grpc/v1/pool.rs
+++ b/io-engine/src/grpc/v1/pool.rs
@@ -947,6 +947,9 @@ impl PoolRpc for PoolService {
                 "Pool probes are not implemented",
             ));
         }
+        let opts = crate::bdev::ProbeOpts {
+            import: request.import,
+        };
         let Some(request) = request.request else {
             return Err(Status::new(
                 Code::InvalidArgument,
@@ -975,7 +978,7 @@ impl PoolRpc for PoolService {
                     continue;
                 }
             };
-            let Err(error) = parsed.probe() else {
+            let Err(error) = parsed.probe(&opts) else {
                 continue;
             };
 


### PR DESCRIPTION

    fix: don't log debug of failed future
    
    This can be extremely large when listing large numbers of nexuses
    or replicas/snapshots.
    
---

    refactor(pool/probe): implement probe for more devices and use import
    
    Updates api to include probe option import.
    Also implement the probe for other devices, even though there's currently
    no simple way of probing (ie nvmf), as otherwise we'd be adding a breaking
    change when using the probe via the control-plane.

