### PR TITLE
refactor(lvs/lvol): add lvol iterator to the Lvs

### DIFF
--- a/io-engine/examples/lvs-eval/display.rs
+++ b/io-engine/examples/lvs-eval/display.rs
@@ -93,7 +93,7 @@ pub fn print_lvs_data(lvs: &Lvs) {
 pub fn print_replicas(lvs: &Lvs) {
     print_separator("Replicas", 0);
 
-    for (idx, lvol) in lvs.lvols().unwrap().enumerate() {
+    for (idx, lvol) in lvs.lvols().enumerate() {
         print_separator(&format!("Replica #{idx}:"), 1);
         print_replica(&lvol);
     }

--- a/io-engine/src/bdev/lvs.rs
+++ b/io-engine/src/bdev/lvs.rs
@@ -299,10 +299,7 @@ impl Lvs {
                 name: self.name.to_owned(),
             });
         };
-        let Some(lvols) = lvs.lvols() else {
-            return Ok(());
-        };
-        let Some(lvol) = lvols.into_iter().find(|l| l.name() == name) else {
+        let Some(lvol) = lvs.lvols().find(|l| l.name() == name) else {
             return Ok(());
         };
         lvol.destroy()

--- a/io-engine/src/lvs/lvol_iter.rs
+++ b/io-engine/src/lvs/lvol_iter.rs
@@ -26,3 +26,34 @@ impl Iterator for LvolIter {
         None
     }
 }
+
+/// Iterator over [`Lvol`] belonging to a specific [`crate::lvs::Lvs`].
+/// # Safety
+/// The list must not be modified whilst we are iterating over it.
+/// This means you should not run any async code, or any other which would
+/// lead to adding or removing lvols from the list.
+pub struct LvsLvolIter {
+    next: *mut spdk_rs::libspdk::spdk_lvol,
+}
+
+impl LvsLvolIter {
+    /// Create a new [`LvsLvolIter`] for the specified [`crate::lvs::Lvs`].
+    pub fn new(lvs: &crate::lvs::Lvs) -> Self {
+        Self {
+            next: lvs.as_inner_ref().lvols.tqh_first,
+        }
+    }
+}
+
+impl Iterator for LvsLvolIter {
+    type Item = Lvol;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.next.is_null() {
+            return None;
+        }
+        let lvol = self.next;
+        self.next = unsafe { *self.next }.link.tqe_next;
+        Some(Lvol::from_inner_ptr(lvol))
+    }
+}

--- a/io-engine/src/lvs/lvs_store.rs
+++ b/io-engine/src/lvs/lvs_store.rs
@@ -222,8 +222,7 @@ impl Lvs {
 
     /// returns committed size
     pub fn committed(&self) -> u64 {
-        self.lvols()
-            .map_or(0, |vols| vols.fold(0, |acc, r| acc + r.committed()))
+        self.lvols().fold(0, |acc, r| acc + r.committed())
     }
 
     /// returns the base bdev of this lvs
@@ -760,7 +759,7 @@ impl Lvs {
 
     /// unshare all lvols prior to export or destroy
     async fn unshare_all(&self) {
-        for l in self.lvols().unwrap() {
+        for l in self.lvols() {
             // notice we dont use the unshare impl of the bdev
             // here. we do this to avoid the on disk persistence
             let mut bdev = l.as_bdev();
@@ -773,29 +772,27 @@ impl Lvs {
     /// share all lvols who have the shared property set, this is implicitly
     /// shared over nvmf
     async fn share_all(&self) {
-        if let Some(lvols) = self.lvols() {
-            for mut l in lvols {
-                let allowed_hosts = match l.get(PropName::AllowedHosts).await {
-                    Ok(PropValue::AllowedHosts(hosts)) => hosts,
-                    _ => vec![],
-                };
+        for mut l in self.lvols() {
+            let allowed_hosts = match l.get(PropName::AllowedHosts).await {
+                Ok(PropValue::AllowedHosts(hosts)) => hosts,
+                _ => vec![],
+            };
 
-                if let Ok(prop) = l.get(PropName::Shared).await {
-                    match prop {
-                        PropValue::Shared(true) => {
-                            let name = l.name().clone();
-                            let props = NvmfShareProps::new()
-                                .with_allowed_hosts(allowed_hosts)
-                                .with_ptpl(l.ptpl().create().unwrap_or_default());
-                            if let Err(e) = Pin::new(&mut l).share_nvmf(Some(props)).await {
-                                error!("failed to share {} {}", name, e.to_string());
-                            }
+            if let Ok(prop) = l.get(PropName::Shared).await {
+                match prop {
+                    PropValue::Shared(true) => {
+                        let name = l.name().clone();
+                        let props = NvmfShareProps::new()
+                            .with_allowed_hosts(allowed_hosts)
+                            .with_ptpl(l.ptpl().create().unwrap_or_default());
+                        if let Err(e) = Pin::new(&mut l).share_nvmf(Some(props)).await {
+                            error!("failed to share {} {}", name, e.to_string());
                         }
-                        PropValue::Shared(false) => {
-                            debug!("{} not shared on disk", l.name())
-                        }
-                        _ => {}
                     }
+                    PropValue::Shared(false) => {
+                        debug!("{} not shared on disk", l.name())
+                    }
+                    _ => {}
                 }
             }
         }
@@ -1023,8 +1020,8 @@ impl Lvs {
 
     /// return an iterator that filters out all bdevs that patch the pool
     /// signature
-    pub fn lvols(&self) -> Option<impl Iterator<Item = Lvol>> {
-        Some(super::lvol_iter::LvsLvolIter::new(self))
+    pub fn lvols(&self) -> impl Iterator<Item = Lvol> {
+        super::lvol_iter::LvsLvolIter::new(self)
     }
 
     /// create a new lvol on this pool

--- a/io-engine/src/lvs/lvs_store.rs
+++ b/io-engine/src/lvs/lvs_store.rs
@@ -112,7 +112,7 @@ impl Lvs {
 
     /// TODO
     #[inline(always)]
-    fn as_inner_ref(&self) -> &spdk_lvol_store {
+    pub(super) fn as_inner_ref(&self) -> &spdk_lvol_store {
         unsafe { self.inner.as_ref() }
     }
 
@@ -1024,18 +1024,7 @@ impl Lvs {
     /// return an iterator that filters out all bdevs that patch the pool
     /// signature
     pub fn lvols(&self) -> Option<impl Iterator<Item = Lvol>> {
-        if let Some(bdev) = UntypedBdev::bdev_first() {
-            let pool_name = format!("{}/", self.name());
-            Some(
-                bdev.into_iter()
-                    .filter(move |b| {
-                        b.driver() == "lvol" && b.aliases().iter().any(|a| a.contains(&pool_name))
-                    })
-                    .map(|b| Lvol::try_from(b).unwrap()),
-            )
-        } else {
-            None
-        }
+        Some(super::lvol_iter::LvsLvolIter::new(self))
     }
 
     /// create a new lvol on this pool

--- a/io-engine/tests/lvs_import.rs
+++ b/io-engine/tests/lvs_import.rs
@@ -120,7 +120,7 @@ async fn lvs_import_many_volume() {
 
         // Check that all volumes were properly imported.
         let mut imported = HashSet::new();
-        lvs.lvols().unwrap().for_each(|v| {
+        lvs.lvols().for_each(|v| {
             imported.insert(v.name());
         });
 

--- a/io-engine/tests/lvs_pool.rs
+++ b/io-engine/tests/lvs_pool.rs
@@ -198,7 +198,7 @@ async fn lvs_pool_test() {
                 .unwrap();
         }
 
-        assert_eq!(pool.lvols().unwrap().count(), 10);
+        assert_eq!(pool.lvols().count(), 10);
     })
     .await;
 
@@ -226,10 +226,10 @@ async fn lvs_pool_test() {
                 .unwrap();
         }
 
-        assert_eq!(pool2.lvols().unwrap().count(), 5);
+        assert_eq!(pool2.lvols().count(), 5);
 
         let pool = Lvs::lookup("tpool").unwrap();
-        assert_eq!(pool.lvols().unwrap().count(), 10);
+        assert_eq!(pool.lvols().count(), 10);
     })
     .await;
 
@@ -249,13 +249,9 @@ async fn lvs_pool_test() {
         .await
         .unwrap();
 
-        assert_eq!(pool.lvols().unwrap().count(), 10);
+        assert_eq!(pool.lvols().count(), 10);
 
-        let df = pool
-            .lvols()
-            .unwrap()
-            .map(|r| r.destroy())
-            .collect::<Vec<_>>();
+        let df = pool.lvols().map(|r| r.destroy()).collect::<Vec<_>>();
         assert_eq!(df.len(), 10);
         futures::future::join_all(df).await;
     })
@@ -264,7 +260,7 @@ async fn lvs_pool_test() {
     // share all the replica's on the pool tpool2
     ms.spawn(async {
         let pool2 = Lvs::lookup("tpool2").unwrap();
-        for mut l in pool2.lvols().unwrap() {
+        for mut l in pool2.lvols() {
             Pin::new(&mut l).share_nvmf(None).await.unwrap();
         }
     })
@@ -335,7 +331,7 @@ async fn lvs_pool_test() {
                 .unwrap();
         }
 
-        for mut l in pool.lvols().unwrap() {
+        for mut l in pool.lvols() {
             let l = Pin::new(&mut l);
             l.share_nvmf(None).await.unwrap();
         }
@@ -358,7 +354,7 @@ async fn lvs_pool_test() {
             .await
             .unwrap();
 
-        for l in pool.lvols().unwrap() {
+        for l in pool.lvols() {
             if l.name() == "notshared" {
                 assert_eq!(l.shared().unwrap(), Protocol::Off);
             } else {
@@ -388,7 +384,7 @@ async fn lvs_pool_test() {
 
         assert_eq!(NvmfSubsystem::first().unwrap().into_iter().count(), 1);
 
-        assert_eq!(pool.lvols().unwrap().count(), 0);
+        assert_eq!(pool.lvols().count(), 0);
         pool.export().await.unwrap();
     })
     .await;
@@ -523,12 +519,8 @@ async fn lvs_pool_test() {
                 .await
                 .unwrap();
         }
-        assert_eq!(pool.lvols().unwrap().count(), 5);
-        let dest = pool
-            .lvols()
-            .unwrap()
-            .map(|r| r.destroy())
-            .collect::<Vec<_>>();
+        assert_eq!(pool.lvols().count(), 5);
+        let dest = pool.lvols().map(|r| r.destroy()).collect::<Vec<_>>();
         assert_eq!(dest.len(), 5);
         futures::future::join_all(dest).await;
         pool.destroy().await.unwrap();
@@ -1045,13 +1037,13 @@ async fn lvol_list() {
             println!();
             for _ in 0..100 {
                 let mut count = 0;
-                for _lvol in lvs_pool.lvols().unwrap() {
+                for _lvol in lvs_pool.lvols() {
                     count += 1;
                 }
                 assert_eq!(count, replicas);
             }
 
-            for lvol in lvs_pool.lvols().unwrap() {
+            for lvol in lvs_pool.lvols() {
                 let _replica: io_engine_api::v1::replica::Replica = lvol.into();
             }
         }
@@ -1064,7 +1056,7 @@ async fn lvol_list() {
     // 2. we share all replicas, so each replica now must search its subsystems
     ms.spawn(async move {
         for lvs_pool in Lvs::iter() {
-            for mut lvol in lvs_pool.lvols().unwrap() {
+            for mut lvol in lvs_pool.lvols() {
                 use io_engine::replica_backend::ReplicaOps;
                 lvol.share_nvmf(NvmfShareProps::new()).await.unwrap();
             }
@@ -1077,7 +1069,7 @@ async fn lvol_list() {
     ms.spawn(async move {
         let list_tm = std::time::Instant::now();
         for lvs_pool in Lvs::iter() {
-            for lvol in lvs_pool.lvols().unwrap() {
+            for lvol in lvs_pool.lvols() {
                 let _replica: io_engine_api::v1::replica::Replica = lvol.into();
             }
         }

--- a/io-engine/tests/lvs_pool.rs
+++ b/io-engine/tests/lvs_pool.rs
@@ -13,7 +13,7 @@ use io_engine::{
     subsys::NvmfSubsystem,
 };
 use io_engine_api::v1::{
-    pool::{Pool, PoolAlert, PoolAlertStatus, PoolAlerts, PoolErrors, PoolState},
+    pool::{ListPoolOptions, Pool, PoolAlert, PoolAlertStatus, PoolAlerts, PoolErrors, PoolState},
     replica::ListReplicaOptions,
 };
 use once_cell::sync::OnceCell;
@@ -1005,6 +1005,7 @@ async fn lvol_list() {
 
     let pool_size = "4GiB";
     let repl_size = 4 * 1024 * 1024;
+    let replicas = 8000;
 
     use io_engine::pool_backend::PoolMetadataArgs;
     let pool_args = PoolArgs {
@@ -1023,7 +1024,7 @@ async fn lvol_list() {
     ms.spawn(async move {
         let lvs_pool = Lvs::create_or_import(pool_args).await.unwrap();
 
-        for i in 1..8000 {
+        for i in 1..=replicas {
             let name = format!("replica-{i}");
             let opts = ReplicaArgs::new(name, repl_size)
                 .wipe_super(false)
@@ -1041,6 +1042,15 @@ async fn lvol_list() {
     let list_tm = std::time::Instant::now();
     ms.spawn(async move {
         for lvs_pool in Lvs::iter() {
+            println!();
+            for _ in 0..100 {
+                let mut count = 0;
+                for _lvol in lvs_pool.lvols().unwrap() {
+                    count += 1;
+                }
+                assert_eq!(count, replicas);
+            }
+
             for lvol in lvs_pool.lvols().unwrap() {
                 let _replica: io_engine_api::v1::replica::Replica = lvol.into();
             }
@@ -1093,6 +1103,21 @@ async fn lvol_list() {
         // adds some extra buffer for gRPC
         grpc_elapsed <= (max_dur + std::time::Duration::from_millis(100)),
         "Listing replicas took too long"
+    );
+
+    use io_engine_api::v1::pool::PoolRpcClient;
+    let mut h = PoolRpcClient::connect("http://localhost:10124")
+        .await
+        .unwrap();
+
+    let list_tm = std::time::Instant::now();
+    h.list_pools(ListPoolOptions::default()).await.unwrap();
+    let grpc_elapsed = list_tm.elapsed();
+    println!("gRPC Lvs List: {grpc_elapsed:?}");
+    assert!(
+        // adds some extra buffer for gRPC
+        grpc_elapsed <= (max_dur + std::time::Duration::from_millis(100)),
+        "Listing pools took too long"
     );
 
     ms.spawn(async move {

--- a/shell.nix
+++ b/shell.nix
@@ -75,6 +75,7 @@ let
         # Prevent Rust tooling to fallback to potentially incompatible host clang compiler
         export CLANG_PATH="$NIX_CC_FOR_TARGET/bin/clang"
 
+        mkdir -p "$SRCDIR/.vscode"
         cat > "$SRCDIR/.vscode/settings.json" <<EOF
         {
             "nixEnvSelector.args": "--argstr rust ${rust} --argstr spdk ${spdk}${nix-spdk-path}",


### PR DESCRIPTION
Adds an iterator for an lvs lvol's, avoiding having to iterate the
entire list of bdevs and trying to figure out if they're part of an
lvol which belongs to the lvs we want.

This is achieved by iterating the linked list from the spdk's lvol store.