### PR TITLE
Pool stall fixes

### DIFF
--- a/io-engine/src/bdev/device.rs
+++ b/io-engine/src/bdev/device.rs
@@ -1,16 +1,10 @@
 //!
 //! Trait implementation for native bdev
 
-use std::{
-    collections::HashMap,
-    convert::TryFrom,
-    os::raw::c_void,
-    sync::{Arc, Mutex},
-};
-
 use async_trait::async_trait;
 use nix::errno::Errno;
 use once_cell::sync::{Lazy, OnceCell};
+use std::{collections::HashMap, convert::TryFrom, os::raw::c_void, rc::Rc, sync::Mutex};
 
 use spdk_rs::{
     libspdk::{
@@ -137,11 +131,11 @@ impl BlockDevice for SpdkBlockDevice {
 
 /// Wrapper around native SPDK block device descriptor, which mimics target SPDK
 /// descriptor as an abstract BlockDeviceDescriptor instance.
-struct SpdkBlockDeviceDescriptor(Arc<UntypedDescriptorGuard>);
+struct SpdkBlockDeviceDescriptor(Rc<UntypedDescriptorGuard>);
 
 impl From<UntypedDescriptorGuard> for SpdkBlockDeviceDescriptor {
     fn from(descr: UntypedDescriptorGuard) -> Self {
-        Self(Arc::new(descr))
+        Self(Rc::new(descr))
     }
 }
 
@@ -182,10 +176,10 @@ struct SpdkBlockDeviceHandle {
     handle: UntypedBdevHandle,
 }
 
-impl TryFrom<Arc<UntypedDescriptorGuard>> for SpdkBlockDeviceHandle {
+impl TryFrom<Rc<UntypedDescriptorGuard>> for SpdkBlockDeviceHandle {
     type Error = CoreError;
 
-    fn try_from(desc: Arc<UntypedDescriptorGuard>) -> Result<Self, Self::Error> {
+    fn try_from(desc: Rc<UntypedDescriptorGuard>) -> Result<Self, Self::Error> {
         let handle = BdevHandle::try_from(desc)?;
         Ok(SpdkBlockDeviceHandle::from(handle))
     }

--- a/io-engine/src/core/descriptor.rs
+++ b/io-engine/src/core/descriptor.rs
@@ -13,7 +13,7 @@ use crate::{
 
 /// RAII Wrapper for spdk_rs::BdevDesc<T>.
 /// When this structure is dropped, the descriptor is closed.
-pub struct DescriptorGuard<T: BdevOps>(BdevDesc<T>);
+pub struct DescriptorGuard<T: BdevOps>(BdevDesc<T>, Option<Thread>);
 
 pub type UntypedDescriptorGuard = DescriptorGuard<()>;
 
@@ -28,7 +28,7 @@ impl<T: BdevOps> Deref for DescriptorGuard<T> {
 impl<T: BdevOps> DescriptorGuard<T> {
     /// TODO
     pub(crate) fn new(d: BdevDesc<T>) -> Self {
-        Self(d)
+        Self(d, Thread::current())
     }
 
     /// claim the bdev for exclusive access, when the descriptor is in read-only
@@ -76,7 +76,9 @@ impl<T: BdevOps> DescriptorGuard<T> {
 /// running on their own thread.
 impl<T: BdevOps> Drop for DescriptorGuard<T> {
     fn drop(&mut self) {
-        if Thread::current().unwrap() == Thread::primary() {
+        if let Some(th) = &self.1 {
+            th.send_msg(self.0.clone(), |mut d| d.close());
+        } else if Thread::current().unwrap() == Thread::primary() {
             self.0.close()
         } else {
             Thread::primary().send_msg(self.0.clone(), |mut d| d.close());
@@ -88,9 +90,10 @@ impl<T: BdevOps> Debug for DescriptorGuard<T> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
         write!(
             f,
-            "Descriptor {:p} for bdev: {}",
+            "Descriptor {:p} for bdev: {}, thread: {:?}",
             self.legacy_as_ptr(),
-            self.0.bdev().name()
+            self.0.bdev().name(),
+            self.1
         )
     }
 }

--- a/io-engine/src/core/handle.rs
+++ b/io-engine/src/core/handle.rs
@@ -1,12 +1,11 @@
-use std::{
-    convert::TryFrom,
-    fmt::{Debug, Error, Formatter},
-    sync::Arc,
-};
-
 use futures::channel::oneshot;
 use libc::c_void;
 use nix::errno::Errno;
+use std::{
+    convert::TryFrom,
+    fmt::{Debug, Error, Formatter},
+    rc::Rc,
+};
 
 use spdk_rs::{
     libspdk::{
@@ -31,7 +30,7 @@ pub struct BdevHandle<T: BdevOps> {
     /// dropped before we close the descriptor
     channel: IoChannelGuard<T::ChannelData>,
     /// TODO
-    desc: Arc<DescriptorGuard<T>>,
+    desc: Rc<DescriptorGuard<T>>,
 }
 
 pub type UntypedBdevHandle = BdevHandle<()>;
@@ -44,7 +43,7 @@ impl<T: BdevOps> BdevHandle<T> {
             if claim && !desc.claim() {
                 return Err(CoreError::BdevNotFound { name: name.into() });
             }
-            return BdevHandle::try_from(Arc::new(desc));
+            return BdevHandle::try_from(Rc::new(desc));
         }
 
         Err(CoreError::BdevNotFound { name: name.into() })
@@ -53,7 +52,7 @@ impl<T: BdevOps> BdevHandle<T> {
     /// Opens a new bdev handle given a bdev.
     pub fn open_with_bdev(bdev: &Bdev<T>, read_write: bool) -> Result<BdevHandle<T>, CoreError> {
         let desc = bdev.open(read_write)?;
-        BdevHandle::try_from(Arc::new(desc))
+        BdevHandle::try_from(Rc::new(desc))
     }
 
     /// Closes the BdevHandle.
@@ -307,14 +306,14 @@ impl<T: BdevOps> TryFrom<DescriptorGuard<T>> for BdevHandle<T> {
     type Error = CoreError;
 
     fn try_from(desc: DescriptorGuard<T>) -> Result<Self, Self::Error> {
-        Self::try_from(Arc::new(desc))
+        Self::try_from(Rc::new(desc))
     }
 }
 
-impl<T: BdevOps> TryFrom<Arc<DescriptorGuard<T>>> for BdevHandle<T> {
+impl<T: BdevOps> TryFrom<Rc<DescriptorGuard<T>>> for BdevHandle<T> {
     type Error = CoreError;
 
-    fn try_from(desc: Arc<DescriptorGuard<T>>) -> Result<Self, Self::Error> {
+    fn try_from(desc: Rc<DescriptorGuard<T>>) -> Result<Self, Self::Error> {
         if let Ok(channel) = desc.io_channel() {
             return Ok(Self { channel, desc });
         }

--- a/io-engine/src/lvs/lvs_store.rs
+++ b/io-engine/src/lvs/lvs_store.rs
@@ -841,13 +841,14 @@ impl Lvs {
         let mut share_lvols = Vec::with_capacity(lvols.len());
 
         for mut l in lvols {
-            // First we unshare to ensure we clean up resources on re-import when the backend
-            // is hot-removed and then hot-attached again.
-            let unshare = Some(UnshareProps::new(false));
-            Pin::new(&mut l).unshare(unshare).await.ok();
-
             match l.get(PropName::Shared).await {
                 Ok(PropValue::Shared(true)) => {
+                    if crate::core::is_shared(&l.as_bdev()) == Some(Protocol::Nvmf) {
+                        // First we unshare to ensure we clean up resources on re-import when the backend
+                        // is hot-removed and then hot-attached again.
+                        let unshare = Some(UnshareProps::new(false));
+                        Pin::new(&mut l).unshare(unshare).await.ok();
+                    }
                     share_lvols.push(l);
                 }
                 Ok(PropValue::Shared(false)) => {

--- a/io-engine/src/lvs/lvs_store.rs
+++ b/io-engine/src/lvs/lvs_store.rs
@@ -42,7 +42,7 @@ use crate::{
         LvolSnapshotDescriptor,
     },
     pool_backend::{PoolArgs, ReplicaArgs},
-    pool_information::{pool_info_read, pool_info_write, PoolInfo},
+    pool_information::{pool_info_write, PoolInfo},
     sleep::mayastor_sleep,
 };
 
@@ -312,70 +312,129 @@ impl Lvs {
 
     /// Enable stall detection on a given Pool.
     fn enable_stall_detection(&self) {
-        let lvs = self.name();
         let environ = MayastorEnvironment::global();
-        let secs: u64 = environ.pool_args.io_stall_deadline.as_secs();
+        self.enable_stall_detection_(&environ)
+    }
+
+    /// Enable stall detection on a given Pool.
+    fn enable_stall_detection_(&self, environ: &MayastorEnvironment) {
+        let secs = environ.pool_args.io_stall_deadline.as_secs();
         let rc = unsafe {
             vbdev_lvs_set_timeout(self.as_inner_ptr(), secs, Some(Self::lvstore_timeout_cb))
         };
         if rc != 0 {
-            error!(
-                "error while enabling stall deadline on pool {}: {:?}",
-                self.name(),
-                Errno::from_raw(rc)
-            );
+            let error = Errno::from_raw(rc);
+            error!("{self:?}: failed to enable I/O stall detection: {error:?}");
         } else {
-            info!("enabled stall detection of {secs}s on {lvs}");
+            info!("{self:?}: enabled I/O stall detection @{secs}s");
         }
     }
 
-    /// Disable stall detection on a given Pool if reset is submitted successfullly.
+    /// Disable stall detection on a given Pool if reset is submitted successfully.
     /// This is to stop receiving flood of callbacks as SPDK sends notification
     /// for all IOs which are stuck on the Pool in loop.
-    fn disable_stall_detection(&self, rc: i32) {
-        if rc == 0 {
-            let lvs = self.name();
-            if let Some(pool_lock) = pool_info_read().get(lvs) {
-                let mut pool_mut = pool_lock.write();
-                if !pool_mut.io_stalled {
-                    info!("pool {lvs} entered IO stall");
-                    pool_mut.io_stalled = true;
-                }
-            }
-            let rc = unsafe { vbdev_lvs_set_timeout(self.as_inner_ptr(), 0, None) };
-            if rc != 0 {
-                error!("rc {rc} while disabling stall deadline on pool {lvs}");
-            } else {
-                info!("disabled stall detection on {lvs}");
-            }
+    fn disable_stall_detection(&self) {
+        if !self.is_stalled() {
+            // we only disable the detection when we're already stalled
+            return;
         }
+
+        let rc = unsafe { vbdev_lvs_set_timeout(self.as_inner_ptr(), 0, None) };
+        if rc != 0 {
+            // This can't fail when timeout_in_sec is 0.
+            let error = Errno::from_raw(rc.abs());
+            error!("{self:?}: failed to disable stall detection: {error}");
+        } else {
+            info!("{self:?}: disabled I/O stall detection");
+        }
+    }
+
+    /// Check if the pool metadata indicates we're stalled.
+    fn is_stalled(&self) -> bool {
+        PoolInfo::get(self.name())
+            .map(|guard| guard.read().io_stalled)
+            .unwrap_or_default()
+    }
+    /// Update the pool metadata to indicate we're stalled.
+    fn set_stalled(&self) -> Option<bool> {
+        PoolInfo::get(self.name()).map(|guard| {
+            let mut info = guard.write();
+            if !info.io_stalled {
+                warn!("{self:?}: detected I/O stall");
+                info.io_stalled = true;
+                true
+            } else {
+                false
+            }
+        })
+    }
+    /// Update the pool metadata to indicate we're not stalled.
+    fn clear_stalled(&self) {
+        let Some(pool_lock) = PoolInfo::get(self.name()) else {
+            return;
+        };
+        pool_lock.write().io_stalled = false;
     }
 
     /// Attempts to reset the pool facing IO stall and disables stall detection
     /// to avoid flood of callbacks if reset is submitted successfully.
     fn mark_io_stalled(&self) {
+        let Some(set_stalled) = self.set_stalled() else {
+            tracing::error!("{self:?}: not found in cache");
+            return;
+        };
+
+        // When multiple I/Os are stalled, we get callbacks for each I/O.
+        // In this case, we proceed only for the stalled I/O which has set the pool as stalled.
+        if !set_stalled {
+            return;
+        }
+
         let p = std::ptr::null_mut();
         let rc = unsafe {
             vbdev_lvs_bs_bdev_reset(self.as_inner_ptr(), Some(Self::lvstore_reset_cb), p)
         };
-        self.disable_stall_detection(rc);
+        if rc != 0 {
+            // For some reason we've failed to trigger the reset, so we clear the stalled flag
+            // since we currently have no way of clearing it otherwise.
+            // todo: add out of band way of clearing the stall to handle this corner case.
+            self.clear_stalled();
+            let error = nix::Error::from_raw(rc.abs());
+            tracing::warn!("{self:?}: clearing I/O stall due to reset failure: {error}");
+            return;
+        }
+
+        let name = self.name().to_string();
+        Reactors::master().send_future(async move {
+            if let Some(lvs) = Lvs::lookup(&name) {
+                // we now disable the stall detection since we don't need to get notified
+                // of the stall until such time we recover (ie when the reset completes)
+                lvs.disable_stall_detection();
+            }
+        });
     }
 
     /// Marks the pool as recovered in the cache, update transition timestamp and re-enables stall detection.
-    fn mark_io_resume(&self) {
-        let lvs = self.name();
-        if let Some(pool_lock) = pool_info_read().get(lvs) {
-            let mut pool_mut = pool_lock.write();
-            pool_mut.io_stalled = false;
-            info!("Pool {lvs} recovered from IO stall");
-            let cli_args = MayastorEnvironment::global();
-            let max_entries = cli_args.pool_args.io_stall_transition_threshold * 10;
-            if pool_mut.transition_timestamps.len() == max_entries as usize {
-                let _ = pool_mut.transition_timestamps.pop_front();
-            }
-            pool_mut.transition_timestamps.push_back(Instant::now());
+    fn mark_io_resumed(&self) {
+        let Some(pool_guard) = PoolInfo::get(self.name()) else {
+            return;
+        };
+        let mut pool_info = pool_guard.write();
+        if !pool_info.io_stalled {
+            return;
         }
-        self.enable_stall_detection();
+
+        pool_info.io_stalled = false;
+        info!("{self:?}: recovered from I/O stall");
+
+        let environ = MayastorEnvironment::global();
+        let max_entries = environ.pool_args.io_stall_transition_threshold * 10;
+        if pool_info.transition_timestamps.len() == max_entries as usize {
+            let _ = pool_info.transition_timestamps.pop_front();
+        }
+        pool_info.transition_timestamps.push_back(Instant::now());
+
+        self.enable_stall_detection_(&environ);
     }
 
     // checks for the disks length and parses to correct format
@@ -661,11 +720,11 @@ impl Lvs {
 
     /// Callback function called by SPDK when reset completes.
     extern "C" fn lvstore_reset_cb(lvs: *mut spdk_lvol_store, success: bool, _ctx: *mut c_void) {
-        let lvs_wrapper: Lvs = Lvs::from_inner_ptr(lvs);
-        let lvs_name = lvs_wrapper.name().to_string();
-        if let Ok(bdev) = lvs_wrapper.base_bdev() {
+        let lvs: Lvs = Lvs::from_inner_ptr(lvs);
+        let lvs_name = lvs.name().to_string();
+        if let Ok(bdev) = lvs.base_bdev() {
             let driver = bdev.driver();
-            info!("reset completed with status: {success} on {lvs_name} of bdev type: {driver}");
+            info!("{lvs:?}: reset completed with success={success}, bdev_type={driver}");
         }
         Reactors::master().send_future(async move {
             if let Some(lvs) = Lvs::lookup(&lvs_name) {
@@ -682,7 +741,7 @@ impl Lvs {
     extern "C" fn bs_super_read_cb(ctx: *mut c_void, _errno: i32) {
         let lvs_raw = ctx as *mut spdk_lvol_store;
         let lvs: Lvs = Lvs::from_inner_ptr(lvs_raw);
-        lvs.mark_io_resume();
+        lvs.mark_io_resumed();
     }
 
     /// Imports the pool if it exists, otherwise tries to create a new pool.

--- a/io-engine/src/lvs/lvs_store.rs
+++ b/io-engine/src/lvs/lvs_store.rs
@@ -858,7 +858,7 @@ impl Lvs {
         }
 
         let start = Instant::now();
-        loop {
+        while !share_lvols.is_empty() {
             let lvols = std::mem::take(&mut share_lvols);
             for mut l in lvols {
                 // Unsharing is completing asynchronously, but whilst that is happening we can't

--- a/io-engine/src/pool_information.rs
+++ b/io-engine/src/pool_information.rs
@@ -24,6 +24,10 @@ impl PoolInfo {
         self.transition_timestamps
             .retain(|ts| ts.elapsed() < stall_transition_window);
     }
+    /// Get the [`PoolInfo`] for the given pool, if present.
+    pub fn get(id: &str) -> Option<parking_lot::MappedRwLockReadGuard<'static, RwLock<PoolInfo>>> {
+        pool_info(id)
+    }
 }
 
 /// Returns write lock of the hashmap.
@@ -34,4 +38,10 @@ pub fn pool_info_write() -> RwLockWriteGuard<'static, HashMap<String, RwLock<Poo
 /// Returns read lock of the hashmap.
 pub fn pool_info_read() -> RwLockReadGuard<'static, HashMap<String, RwLock<PoolInfo>>> {
     POOL_INFO.read()
+}
+
+fn pool_info(id: &str) -> Option<parking_lot::MappedRwLockReadGuard<'static, RwLock<PoolInfo>>> {
+    let read = POOL_INFO.read();
+
+    parking_lot::RwLockReadGuard::try_map(read, |info| info.get(id)).ok()
 }

--- a/io-engine/src/subsys/config/opts.rs
+++ b/io-engine/src/subsys/config/opts.rs
@@ -89,9 +89,11 @@ impl NvmfTransportOpts {
     fn for_rdma(mut self) -> Self {
         self.in_capsule_data_size =
             try_from_env("NVMF_RDMA_IN_CAPSULE_DATA_SIZE", self.in_capsule_data_size);
+        self.max_io_size = try_from_env("NVMF_RDMA_MAX_IO_SIZE", self.max_io_size);
         self.io_unit_size = try_from_env("NVMF_RDMA_IO_UNIT_SIZE", 8192); // SPDK_NVMF_RDMA_MIN_IO_BUFFER_SIZE
         self.data_wr_pool_size = try_from_env("NVMF_RDMA_DATA_WR_POOL_SIZE", 4095); // SPDK_NVMF_RDMA_DEFAULT_DATA_WR_POOL_SIZE
         self.num_shared_buf = try_from_env("NVMF_RDMA_NUM_SHARED_BUF", self.num_shared_buf);
+        self.buf_cache_size = try_from_env("NVMF_RDMA_BUF_CACHE_SIZE", self.buf_cache_size);
         self
     }
 }
@@ -136,14 +138,15 @@ impl From<NvmfTgtConfig> for Box<spdk_nvmf_target_opts> {
 impl Default for NvmfTgtConfig {
     fn default() -> Self {
         let args = MayastorEnvironment::global_or_default();
+        let opts_tcp = NvmfTransportOpts::default();
         Self {
             name: "mayastor_target".to_string(),
             max_namespaces: args.nvme.max_namespaces,
             crdt: args.nvmf_tgt_crdt,
-            opts_tcp: NvmfTransportOpts::default(),
+            opts_tcp,
             interface: None,
             rdma: None,
-            opts_rdma: NvmfTransportOpts::default().for_rdma(),
+            opts_rdma: opts_tcp.for_rdma(),
         }
     }
 }
@@ -282,9 +285,9 @@ impl Default for NvmfTransportOpts {
     fn default() -> Self {
         Self {
             max_queue_depth: try_from_env("NVMF_TCP_MAX_QUEUE_DEPTH", 32),
-            in_capsule_data_size: 4096,
-            max_io_size: 131_072,
-            io_unit_size: 131_072,
+            in_capsule_data_size: try_from_env("NVMF_TCP_IN_CAPSULE_DATA_SIZE", 4096),
+            max_io_size: try_from_env("NVMF_TCP_MAX_IO_SIZE", 131_072),
+            io_unit_size: try_from_env("NVMF_TCP_IO_UNIT_SIZE", 131_072),
             max_qpairs_per_ctrl: try_from_env("NVMF_TCP_MAX_QPAIRS_PER_CTRL", 32),
             num_shared_buf: try_from_env("NVMF_TCP_NUM_SHARED_BUF", 2047),
             buf_cache_size: try_from_env("NVMF_TCP_BUF_CACHE_SIZE", 64),

--- a/io-engine/tests/lvs_pool.rs
+++ b/io-engine/tests/lvs_pool.rs
@@ -1,14 +1,15 @@
 use common::MayastorTest;
+use futures::channel::oneshot;
 use io_engine::{
     bdev::crypto::{Cipher, EncryptionKey},
     bdev_api::bdev_create,
     core::{
-        logical_volume::LogicalVolume, MayastorCliArgs, NvmeCliArgs, PoolCliArgs, Protocol, Share,
-        ToErrno, UnshareProps, UntypedBdev,
+        logical_volume::LogicalVolume, CoreError, MayastorCliArgs, NvmeCliArgs, PoolCliArgs,
+        Protocol, Reactors, Share, ToErrno, UnshareProps, UntypedBdev,
     },
     grpc::v1::pool::pool_to_proto,
     lvm::dm_setup::DmState,
-    lvs::{Lvs, LvsError, LvsLvol, PropName, PropValue},
+    lvs::{Lvs, LvsLvol, PropName, PropValue},
     pool_backend::{PoolArgs, PoolBackend, PoolOps, ReplicaArgs},
     subsys::NvmfSubsystem,
 };
@@ -16,7 +17,7 @@ use io_engine_api::v1::pool::{
     Pool, PoolAlert, PoolAlertStatus, PoolAlerts, PoolErrors, PoolState,
 };
 use once_cell::sync::OnceCell;
-use std::{pin::Pin, str::FromStr};
+use std::{pin::Pin, time::Duration};
 use tokio::time::sleep;
 
 pub mod common;
@@ -29,8 +30,8 @@ static DISK_CRYPTO: &str = "/tmp/io-engine-tests/crypto_disk.img";
 static XTS_KEY: &str = "2b7e151628aed2a6abf7158809cf4f3c";
 static XTS_KEY2: &str = "2b7e151628aed2a6abf7158809cf4f3d";
 const IO_ERROR_THRESHOLD: u64 = 5;
-const IO_STALL_TRANSITION_WINDOW: &str = "12s";
-const IO_STALL_DEADLINE: &str = "1s";
+const IO_STALL_TRANSITION_WINDOW: Duration = Duration::from_secs(12);
+const IO_STALL_DEADLINE: Duration = Duration::from_secs(1);
 const IO_STALL_TRANSITION_THRESHOLD: u64 = 3;
 
 static MAYASTOR: OnceCell<MayastorTest> = OnceCell::new();
@@ -42,10 +43,8 @@ fn ms() -> &'static MayastorTest<'static> {
             pool: PoolCliArgs {
                 io_error_threshold: IO_ERROR_THRESHOLD,
                 io_stall_transition_threshold: IO_STALL_TRANSITION_THRESHOLD,
-                io_stall_transition_window: IO_STALL_TRANSITION_WINDOW
-                    .parse::<humantime::Duration>()
-                    .unwrap(),
-                io_stall_deadline: IO_STALL_DEADLINE.parse::<humantime::Duration>().unwrap(),
+                io_stall_transition_window: IO_STALL_TRANSITION_WINDOW.into(),
+                io_stall_deadline: IO_STALL_DEADLINE.into(),
             },
             // log_components: vec!["all".into()],
             nvme: NvmeCliArgs {
@@ -765,6 +764,9 @@ async fn lvs_stall() {
     .await
     .unwrap();
 
+    const REPL: &str = "replica-1";
+    const POOL: &str = "pool-1";
+
     let mut lvol = vg_pool
         .create_lvol(ReplicaArgs {
             name: LV_NAME.into(),
@@ -775,7 +777,7 @@ async fn lvs_stall() {
         .await
         .unwrap();
     let pool_args = PoolArgs {
-        name: "tpool".into(),
+        name: POOL.into(),
         disks: vec![format!("aio://{}", lvol.path())],
         backend: PoolBackend::Lvs,
         ..Default::default()
@@ -783,14 +785,11 @@ async fn lvs_stall() {
 
     let ms = ms();
     ms.spawn(async move {
-        Lvs::create_or_import(pool_args).await.unwrap();
-    })
-    .await;
-
-    ms.spawn(async move {
-        let lvs = Lvs::lookup("tpool").unwrap();
-        let r = lvs.grow().await.unwrap_err();
-        assert!(matches!(r, LvsError::BdevNotExtended { .. }));
+        let lvs = Lvs::create_or_import(pool_args).await.unwrap();
+        let _repl = lvs
+            .create_lvol(REPL, 8 * 1024 * 1024, None, true, None)
+            .await
+            .unwrap();
     })
     .await;
 
@@ -798,22 +797,23 @@ async fn lvs_stall() {
         let state = lvol.dm_suspend().await.unwrap();
 
         assert_eq!(state, DmState::Suspended);
-        ms.spawn_detached(async move {
-            let lvs = Lvs::lookup("tpool").unwrap();
-            let _ = lvs.grow().await;
-        });
 
-        let duration: std::time::Duration = humantime::Duration::from_str(IO_STALL_DEADLINE)
-            .unwrap()
-            .into();
+        // Will write to all these reactor cores
+        let cores = 2;
+        let mut io_completions = vec![];
+        for core in 0..cores {
+            write_reactor(REPL, core, io_completions.as_mut());
+        }
 
-        sleep(duration * 2).await;
+        sleep(IO_STALL_DEADLINE).await;
+
+        // staggard write I/O
+        write_reactor(REPL, cores - 1, io_completions.as_mut());
+
+        sleep(IO_STALL_DEADLINE).await;
 
         let (pool, _errors, alerts) = ms
-            .spawn(async {
-                let lvs = Lvs::lookup("tpool").unwrap();
-                pool_info(&lvs).await
-            })
+            .spawn(async { pool_info(&Lvs::lookup(POOL).unwrap()).await })
             .await;
 
         assert_eq!(pool.state(), PoolState::PoolSuspected);
@@ -823,19 +823,20 @@ async fn lvs_stall() {
         let state = lvol.dm_resume().await.unwrap();
         assert_eq!(state, DmState::Active);
 
-        ms.spawn(async move {
-            let lvs = Lvs::lookup("tpool").unwrap();
-            let r = lvs.grow().await.unwrap_err();
-            assert!(matches!(r, LvsError::BdevNotExtended { .. }));
-        })
-        .await;
+        // Backend device is active, I/Os should now complete inline here...
+        let result = ms
+            .spawn(async move { common::bdev_io::write_some(REPL, 8192, 1, 0xbb).await })
+            .await;
+        assert!(result.is_ok(), "I/O: {:?}", result);
+        // Original stalled I/Os should also have completed!
+        for (i, r) in io_completions.into_iter().enumerate() {
+            let result = r.await.unwrap();
+            assert!(result.is_ok(), "I/O[{i}] => {:?}", result);
+        }
 
         if 1 < i && i < IO_STALL_TRANSITION_THRESHOLD {
             let (pool, errors, alerts) = ms
-                .spawn(async {
-                    let lvs = Lvs::lookup("tpool").unwrap();
-                    pool_info(&lvs).await
-                })
+                .spawn(async { pool_info(&Lvs::lookup(POOL).unwrap()).await })
                 .await;
 
             assert_eq!(pool.state(), PoolState::PoolOnline);
@@ -849,7 +850,7 @@ async fn lvs_stall() {
     }
 
     ms.spawn(async move {
-        let lvs = Lvs::lookup("tpool").unwrap();
+        let lvs = Lvs::lookup(POOL).unwrap();
         let (pool, errors, alerts) = pool_info(&lvs).await;
         assert_eq!(pool.state(), PoolState::PoolSuspected);
         assert_eq!(
@@ -864,15 +865,10 @@ async fn lvs_stall() {
     })
     .await;
 
-    sleep(
-        humantime::Duration::from_str(IO_STALL_TRANSITION_WINDOW)
-            .unwrap()
-            .into(),
-    )
-    .await;
+    sleep(IO_STALL_TRANSITION_WINDOW).await;
 
     ms.spawn(async move {
-        let lvs = Lvs::lookup("tpool").unwrap();
+        let lvs = Lvs::lookup(POOL).unwrap();
         let (pool, errors, _alerts) = pool_info(&lvs).await;
         assert_eq!(pool.state(), PoolState::PoolOnline);
         assert_eq!(errors.io_stall_transition_count, 0);
@@ -880,10 +876,26 @@ async fn lvs_stall() {
     .await;
 
     ms.spawn(async move {
-        let lvs = Lvs::lookup("tpool").unwrap();
+        let lvs = Lvs::lookup(POOL).unwrap();
         lvs.destroy().await.unwrap();
     })
     .await;
+}
+
+fn write_reactor(
+    repl: &'static str,
+    core: u64,
+    io_completions: &mut Vec<oneshot::Receiver<Result<(), CoreError>>>,
+) {
+    let reactor = Reactors::get_by_core(core as u32).unwrap();
+    let (s, r) = oneshot::channel();
+    reactor.send_future(async move {
+        tracing::info!("Writing I/O to {repl} on reactor #{core}");
+        let res = common::bdev_io::write_some(repl, core * 4096, 1, 0xaa).await;
+        tracing::info!("Completed I/O to {repl} on reactor #{core} => {res:?}");
+        s.send(res).unwrap();
+    });
+    io_completions.push(r);
 }
 
 async fn pool_info(pool: &dyn PoolOps) -> (Pool, PoolErrors, PoolAlerts) {

--- a/scripts/clean-cargo-tests.sh
+++ b/scripts/clean-cargo-tests.sh
@@ -23,6 +23,13 @@ done
 for device in $(losetup -l -J | jq -r --arg tmp_dir $back_dir '.loopdevices[]|select(."back-file" | startswith($tmp_dir)) | .name'); do
   echo "Found stale loop device: $device"
 
+  vgs=$(nix-sudo vgs --noheadings -o vg_name --select "pv_name=$device")
+  for vg in $vgs; do
+      for lvpath in $(nix-sudo lvs --noheadings --select="vg_name=$vg" -o lv_path "$vg"); do
+          nix-sudo dmsetup resume "$lvpath" || echo "Could not resume: $lvpath"
+      done
+  done
+
   nix-sudo $(which vgremove) -y --select="pv_name=$device" || :
   nix-sudo $(which pvremove) -y "$device" || :
   sudo losetup -d "$device" || :

--- a/scripts/clean-cargo-tests.sh
+++ b/scripts/clean-cargo-tests.sh
@@ -3,6 +3,11 @@
 SCRIPT_DIR="$(dirname "$0")"
 ROOT_DIR=$(realpath "$SCRIPT_DIR/..")
 
+if ! command -v nix-sudo >/dev/null; then
+  echo "Please run this from the nix-shell environment" >&2
+  exit 1
+fi
+
 nix-sudo nvme disconnect-all
 
 # Clean up ublk devices
@@ -15,19 +20,19 @@ nix-sudo ublk list -v | jq -r --arg dir "$back_dir" '
     nix-sudo ublk del -n "$id" --async
 done
 
-# Detach any loop devices created for test purposes
-for back_file in "/tmp/io-engine-tests"/*; do
-    # Find loop devices associated with the disk image
-    devices=$(losetup -j "$back_file" -O NAME --noheadings)
+for device in $(losetup -l -J | jq -r --arg tmp_dir $back_dir '.loopdevices[]|select(."back-file" | startswith($tmp_dir)) | .name'); do
+  echo "Found stale loop device: $device"
 
-    # Detach each loop device found
-    while IFS= read -r device; do
-        if [ -n "$device" ]; then
-            echo "Detaching loop device: $device"
-            sudo losetup -d "$device"
-        fi
-    done <<< "$devices"
+  nix-sudo $(which vgremove) -y --select="pv_name=$device" || :
+  nix-sudo $(which pvremove) -y "$device" || :
+  sudo losetup -d "$device" || :
+
+  for file in $(losetup -l -J | jq -r --arg tmp_dir $back_dir --arg dev $device '.loopdevices[]|select((."back-file" | startswith($tmp_dir)) and .name == $dev) | ."back-file"'); do
+    [ "$file" == "(deleted)" ] && continue;
+    echo "Left stale file: $file"
+  done
 done
+
 # Delete the directory too
 nix-sudo rmdir --ignore-fail-on-non-empty "/tmp/io-engine-tests" 2>/dev/null
 

--- a/shell.nix
+++ b/shell.nix
@@ -45,6 +45,7 @@ let
         xfsprogs
         nixpkgs-fmt
         ublksrv
+        jq
       ];
 
       shellEnv = with pkgs; {


### PR DESCRIPTION
    fix(lvs/stall): i/o on non-init thread and concurrent stalls
    
    A collection of fixes and refactorings, namely:
    failures when the stalled i/o was sent from !init-thread
    multiple i/os failing and triggering the stall callback
    handling of concurrency when modifying the stall flag
    
---

    test(lvs/stall): make stall test more robust
    
    Test the stalls by issuing actual I/O against a replica bdev.
    Also send this I/O via master and non-master reactors, concurrently,
    as well as sending staggard I/O.
    
    All in all, this test needs to be made even more robust, perhaps
    running fio, though E2E should be sufficient as well.
    
---

    fix(handle/guard): store current thread in the handle guard
    
    When a device handle is dropped, it gets sent to the primary thread.
    However, this doesn't work when we open the device handle in another thread,
    which is how I found this whilst testing writing directly from another
    reactors thread.

---

    test: resume suspended lv's when cleaning up
    
    Some tests may suspend the lv's, so we should resume them, otherwise
    cleanup may get stuck..
    
---

    test: clean up stale lvm and loop devices properly
    
    The backing file for the loop may have been deleted, so rather than
    inspecting the back directory use losetup itself to find the leaked
    devices.