### PR TITLE
feat: add `poolname` and `pooluuid` label to replica metrics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,3 +76,6 @@ regex = "1.11.1"
 
 async-nats = { version = "0.37.0", default-features = false }
 
+k8s-openapi = { version = "0.22.0", features = ["v1_24"] }
+kube = { version = "0.94.2", features = ["derive", "runtime"] }
+

--- a/io-engine/src/grpc/v1/stats.rs
+++ b/io-engine/src/grpc/v1/stats.rs
@@ -256,6 +256,8 @@ impl From<ReplicaBdevStats> for ReplicaIoStats {
         Self {
             entity_id: value.entity_id,
             stats: Some(value.stats.into()),
+            poolname: value.poolname,
+            pooluuid: value.pooluuid,
         }
     }
 }

--- a/io-engine/src/lvs/mod.rs
+++ b/io-engine/src/lvs/mod.rs
@@ -107,7 +107,12 @@ impl BdevStater for Lvol {
 
     async fn stats(&self) -> Result<ReplicaBdevStats, CoreError> {
         let stats = self.as_bdev().stats().await?;
-        Ok(ReplicaBdevStats::new(stats, self.entity_id()))
+        Ok(ReplicaBdevStats::new(
+            stats,
+            self.entity_id(),
+            Some(self.pool_name()),
+            Some(self.pool_uuid()),
+        ))
     }
 
     async fn reset_stats(&self) -> Result<(), CoreError> {

--- a/io-engine/src/replica_backend.rs
+++ b/io-engine/src/replica_backend.rs
@@ -191,11 +191,23 @@ pub trait IReplicaFactory {
 pub struct ReplicaBdevStats {
     pub stats: BdevStats,
     pub entity_id: Option<String>,
+    pub poolname: Option<String>,
+    pub pooluuid: Option<String>,
 }
 impl ReplicaBdevStats {
     /// Create a new `Self` from the given parts.
-    pub fn new(stats: BdevStats, entity_id: Option<String>) -> Self {
-        Self { stats, entity_id }
+    pub fn new(
+        stats: BdevStats,
+        entity_id: Option<String>,
+        poolname: Option<String>,
+        pooluuid: Option<String>,
+    ) -> Self {
+        Self {
+            stats,
+            entity_id,
+            poolname,
+            pooluuid,
+        }
     }
 }
 


### PR DESCRIPTION
Part of series of changes to add `poolname` and `pooluuid` to ReplicaIoStats

- previous: https://github.com/openebs/mayastor-dependencies/pull/157

Next changes in: 
- control-plane - submodule bump to pick up new proto
- mayastor-extensions — emit pool_name as a Prometheus label on replica I/O metrics

Motivation and Context:
Described at https://github.com/openebs/mayastor/issues/1990

Initial map based approach at https://github.com/openebs/mayastor-extensions/pull/860

