### PR TITLE
refactor: refactor lvol clusters and nvmf subsystem

### DIFF
--- a/io-engine/examples/lvs-eval/display.rs
+++ b/io-engine/examples/lvs-eval/display.rs
@@ -5,7 +5,7 @@ use io_engine::{
 use prettytable::{row, Table};
 use spdk_rs::libspdk::{
     spdk_bit_array, spdk_bit_array_capacity, spdk_bit_array_get, spdk_bit_pool,
-    spdk_bit_pool_capacity, spdk_bit_pool_is_allocated, spdk_blob_calc_used_clusters,
+    spdk_bit_pool_capacity, spdk_bit_pool_is_allocated, spdk_blob_get_num_allocated_clusters,
     spdk_blob_is_thin_provisioned, spdk_blob_mut_data, spdk_blob_store,
 };
 
@@ -109,7 +109,7 @@ pub fn print_replica(lvol: &Lvol) {
     let mut tab = Table::new();
 
     let num_allocated_clusters =
-        unsafe { spdk_blob_calc_used_clusters(blob as *const _ as *mut _) };
+        unsafe { spdk_blob_get_num_allocated_clusters(blob as *const _ as *mut _) };
 
     tab.add_row(row!["id", format!("0x{:x}", blob.id)]);
     tab.add_row(row!["parent_id", format!("0x{:x}", blob.parent_id)]);

--- a/io-engine/src/bdev/nexus/nexus_io_subsystem.rs
+++ b/io-engine/src/bdev/nexus/nexus_io_subsystem.rs
@@ -122,21 +122,21 @@ impl<'n> NexusIoSubsystem<'n> {
                             let nqn = subsystem.get_nqn();
                             trace!("{self:?}: pausing subsystem '{nqn}'...");
 
-                            let result = subsystem.pause().await;
-                            if let Err(ref error) = result {
+                            match subsystem.pause().await {
+                                Ok(_) => trace!("{self:?}: subsystem '{nqn}' paused"),
                                 // todo: handle error instead of panic, but in practice only ENOMEM can be seen here?
-                                if error.errno() != nix::Error::EPERM {
-                                    panic!("Failed to pause subsystem: {}", error);
+                                // ENODEV can be seen when nexus is being unshared concurrently
+                                Err(error)
+                                    if matches!(
+                                        error.errno(),
+                                        nix::Error::EPERM | nix::Error::ECANCELED
+                                    ) =>
+                                {
+                                    warn!("{self:?}: subsystem '{nqn}' not paused: {error}")
                                 }
-                                // Can't pause a stopped subsystem, but we're essentially paused anyway.
-                                // However, there's a race here as, resume may resume a stopped subsystem.
-                                // We should prevent this on the spdk nvmf subsystem state mgmt.
-                            }
-
-                            if result.is_ok() {
-                                trace!("{self:?}: subsystem '{nqn}' paused");
-                            } else {
-                                warn!("{self:?}: subsystem '{nqn}' stopped");
+                                Err(error) => {
+                                    panic!("Failed to pause subsystem '{}: {}", nqn, error)
+                                }
                             }
                         }
                     }
@@ -250,18 +250,23 @@ impl<'n> NexusIoSubsystem<'n> {
                         self.pause_state.store(NexusPauseState::Frozen);
                     } else {
                         if let Some(subsystem) = NvmfSubsystem::nqn_lookup(&self.name) {
+                            let nqn = subsystem.get_nqn();
                             self.pause_state.store(NexusPauseState::Unpausing);
-                            trace!("{self:?}: resuming subsystem '{}'...", subsystem.nqn_str());
-                            if let Err(error) = subsystem.resume().await {
-                                // todo: handle error instead of panic, but in practice only ENOMEM can be seen here?
-                                panic!(
-                                    "Failed to resume subsystem '{}: {}",
-                                    subsystem.nqn_str(),
-                                    error
-                                );
+                            trace!("{self:?}: resuming subsystem '{nqn}'...");
+                            match subsystem.resume().await {
+                                Ok(_) => trace!("{self:?}: subsystem '{nqn}' resumed"),
+                                Err(error)
+                                    if matches!(
+                                        error.errno(),
+                                        nix::Error::EPERM | nix::Error::ECANCELED
+                                    ) =>
+                                {
+                                    warn!("{self:?}: subsystem '{nqn}' not resumed: {error}");
+                                }
+                                Err(error) => {
+                                    panic!("Failed to resume subsystem '{}: {}", nqn, error)
+                                }
                             }
-
-                            trace!("{self:?}: subsystem '{}' resumed", subsystem.nqn_str());
                         }
                         // todo: we may have received a Stop request whilst resuming
                         self.pause_state.store(NexusPauseState::Unpaused);

--- a/io-engine/src/core/bdev.rs
+++ b/io-engine/src/core/bdev.rs
@@ -266,10 +266,7 @@ where
         match is_shared(self.deref()) {
             Some(Protocol::Nvmf) => {
                 if let Some(ss) = NvmfSubsystem::nqn_lookup(self.name()) {
-                    ss.stop().await.context(UnshareNvmf {})?;
-                    unsafe {
-                        ss.shutdown_unsafe();
-                    }
+                    ss.stop_for_destroy().await.context(UnshareNvmf {})?;
                 }
             }
             Some(Protocol::Off) | None => {}

--- a/io-engine/src/lvs/lvol_snapshot.rs
+++ b/io-engine/src/lvs/lvol_snapshot.rs
@@ -13,8 +13,8 @@ use strum::{EnumCount, IntoEnumIterator};
 use events_api::event::EventAction;
 
 use spdk_rs::libspdk::{
-    spdk_blob, spdk_blob_reset_used_clusters_cache, spdk_lvol, spdk_xattr_descriptor,
-    vbdev_lvol_create_clone_ext, vbdev_lvol_create_snapshot_ext,
+    spdk_blob, spdk_lvol, spdk_xattr_descriptor, vbdev_lvol_create_clone_ext,
+    vbdev_lvol_create_snapshot_ext,
 };
 
 use crate::{
@@ -147,12 +147,6 @@ pub trait LvolSnapshotOps {
     /// If self is clone or a snapshot whose parent is clone, then do ancestor
     /// calculation for all snapshot linked to clone.
     fn calculate_clone_source_snap_usage(&self, total_ancestor_snap_size: u64) -> Option<u64>;
-
-    /// Reset snapshot tree usage cache. if the lvol is replica, then reset
-    /// cache will be based on replica uuid, which is parent uuid for all
-    /// snapshots created from the replica. if the lvol is not replica, then
-    /// reset cache  will be judge based on lvol tree present in the system.
-    fn reset_snapshot_tree_usage_cache(&self, is_replica: bool);
 }
 
 /// Snapshot Descriptor to respond back as part of listsnapshot.
@@ -759,9 +753,7 @@ impl LvolSnapshotOps for Lvol {
             .filter_map(Lvol::ok_from)
             .filter(|b| b.is_snapshot() && b.is_discarded_snapshot() && !b.has_clones())
             .collect::<Vec<Lvol>>();
-        for snap in &snap_list {
-            snap.reset_snapshot_tree_usage_cache(false);
-        }
+
         let futures = snap_list.into_iter().map(|s| s.destroy());
         let result = join_all(futures).await;
         for r in result {
@@ -797,81 +789,6 @@ impl LvolSnapshotOps for Lvol {
             Some(sum)
         } else {
             None
-        }
-    }
-
-    /// Reset snapshot tree usage cache.
-    fn reset_snapshot_tree_usage_cache(&self, is_replica: bool) {
-        if is_replica {
-            reset_snapshot_tree_usage_cache_with_parent_uuid(self);
-            return;
-        }
-        if let Some(snapshot_parent_uuid) = self.blob_xattr(SnapshotXattrs::ParentId) {
-            if let Some(parent_lvol) = self.lvs().lookup_lvol_by_uuid_str(snapshot_parent_uuid) {
-                unsafe {
-                    spdk_blob_reset_used_clusters_cache(parent_lvol.blob_checked());
-                }
-                reset_snapshot_tree_usage_cache_with_parent_uuid(&parent_lvol);
-            } else {
-                reset_snapshot_tree_usage_cache_with_wildcard(self, snapshot_parent_uuid);
-            }
-        }
-    }
-}
-
-/// When snapshot is destroyed, if snapshot parent exist, reset cache of
-/// linked snapshot and clone tree based on snapshot parent.
-fn reset_snapshot_tree_usage_cache_with_parent_uuid(lvol: &Lvol) {
-    let mut lvol_iter = LvolSnapshotIter::new(lvol.clone());
-    while let Some(volume_snap_descr) = lvol_iter.parent() {
-        let curr_snap_lvol = volume_snap_descr.snapshot_lvol();
-        unsafe {
-            spdk_blob_reset_used_clusters_cache(curr_snap_lvol.blob_checked());
-        }
-        let clone_list = curr_snap_lvol.list_clones_by_snapshot_uuid();
-        for clone in clone_list {
-            unsafe {
-                spdk_blob_reset_used_clusters_cache(clone.blob_checked());
-            }
-        }
-    }
-}
-
-/// When snapshot is destroyed, if snapshot parent not exist, reset cache of
-/// linked snapshot and clone tree based on wildcard search through complete
-/// bdev by matching parent uuid got from snapshot attribute.
-/// todo: need more optimization to adding new function in spdk to relate
-/// snapshot and clone blobs.
-fn reset_snapshot_tree_usage_cache_with_wildcard(lvol: &Lvol, snapshot_parent_uuid: &str) {
-    let mut successor_clones: Vec<Lvol> = vec![];
-
-    let mut successor_snapshots = Lvol::list_all_lvol_snapshots(None)
-        .into_iter()
-        .map(|v| v.into_snapshot_lvol())
-        .filter_map(|l| match lvol.blob_xattr(SnapshotXattrs::ParentId) {
-            Some(uuid) if uuid == snapshot_parent_uuid => Some(l),
-            _ => None,
-        })
-        .collect::<Vec<Lvol>>();
-
-    while !successor_snapshots.is_empty() || !successor_clones.is_empty() {
-        if let Some(snapshot) = successor_snapshots.pop() {
-            unsafe {
-                spdk_blob_reset_used_clusters_cache(snapshot.blob_checked());
-            }
-            let new_clone_list = snapshot.list_clones_by_snapshot_uuid();
-            successor_clones.extend(new_clone_list);
-        }
-
-        if let Some(clone) = successor_clones.pop() {
-            unsafe {
-                spdk_blob_reset_used_clusters_cache(clone.blob_checked());
-            }
-            let new_snap_list = Lvol::list_all_lvol_snapshots(Some(&clone))
-                .into_iter()
-                .map(|v| v.into_snapshot_lvol())
-                .collect::<Vec<Lvol>>();
-            successor_snapshots.extend(new_snap_list);
         }
     }
 }

--- a/io-engine/src/lvs/lvs_lvol.rs
+++ b/io-engine/src/lvs/lvs_lvol.rs
@@ -14,7 +14,7 @@ use std::{
 };
 
 use spdk_rs::libspdk::{
-    spdk_blob, spdk_blob_calc_used_clusters, spdk_blob_get_num_clusters,
+    spdk_blob, spdk_blob_get_num_allocated_clusters, spdk_blob_get_num_clusters,
     spdk_blob_get_num_clusters_ancestors, spdk_blob_get_xattr_value, spdk_blob_is_read_only,
     spdk_blob_is_thin_provisioned, spdk_blob_set_xattr, spdk_blob_sync_md,
     spdk_bs_get_cluster_size, spdk_bs_get_parent_blob, spdk_bs_iter_next, spdk_lvol,
@@ -718,7 +718,7 @@ impl LogicalVolume for Lvol {
         let bs = self.lvs().blob_store();
         let blob = self.blob_checked();
         let cluster_size = unsafe { spdk_bs_get_cluster_size(bs) };
-        let num_allocated_clusters = unsafe { spdk_blob_calc_used_clusters(blob) };
+        let num_allocated_clusters = unsafe { spdk_blob_get_num_allocated_clusters(blob) };
         cluster_size * num_allocated_clusters
     }
     /// Returns Lvol disk space usage.
@@ -728,7 +728,7 @@ impl LogicalVolume for Lvol {
         unsafe {
             let cluster_size = spdk_bs_get_cluster_size(bs);
             let num_clusters = spdk_blob_get_num_clusters(blob);
-            let num_allocated_clusters = spdk_blob_calc_used_clusters(blob);
+            let num_allocated_clusters = spdk_blob_get_num_allocated_clusters(blob);
 
             let num_allocated_clusters_snapshots = {
                 let mut c: u64 = 0;
@@ -882,7 +882,6 @@ impl LvsLvol for Lvol {
             let sender = unsafe { Box::from_raw(sender as *mut oneshot::Sender<i32>) };
             sender.send(errno).unwrap();
         }
-        self.reset_snapshot_tree_usage_cache(!self.is_snapshot());
         // We must always unshare before destroying bdev.
         let _ = Pin::new(&mut self)
             .unshare(Some(UnshareProps::new(false)))

--- a/io-engine/src/subsys/nvmf/subsystem.rs
+++ b/io-engine/src/subsys/nvmf/subsystem.rs
@@ -27,8 +27,9 @@ use spdk_rs::{
         spdk_nvmf_subsystem_set_ana_state, spdk_nvmf_subsystem_set_cntlid_range,
         spdk_nvmf_subsystem_set_event_cb, spdk_nvmf_subsystem_set_mn, spdk_nvmf_subsystem_set_sn,
         spdk_nvmf_subsystem_start, spdk_nvmf_subsystem_state_change_done, spdk_nvmf_subsystem_stop,
-        spdk_nvmf_tgt, spdk_nvmf_tgt_find_subsystem, spdk_nvmf_tgt_get_transport,
-        SPDK_NVME_SCT_GENERIC, SPDK_NVME_SC_CAPACITY_EXCEEDED, SPDK_NVME_SC_RESERVATION_CONFLICT,
+        spdk_nvmf_subsystem_stop_for_destroy, spdk_nvmf_tgt, spdk_nvmf_tgt_find_subsystem,
+        spdk_nvmf_tgt_get_transport, NVMF_SUBSYSTEM_DESTROY_IN_PROGRESS, SPDK_NVME_SCT_GENERIC,
+        SPDK_NVME_SC_CAPACITY_EXCEEDED, SPDK_NVME_SC_RESERVATION_CONFLICT,
         SPDK_NVMF_SUBTYPE_DISCOVERY, SPDK_NVMF_SUBTYPE_NVME,
     },
     struct_size_init, NvmeStatus, NvmfController, NvmfSubsystemEvent,
@@ -559,7 +560,7 @@ impl NvmfSubsystem {
     ///
     /// The subsystem must paused or stopped.
     unsafe fn destroy_unsafe(&self) -> i32 {
-        if (*self.0.as_ptr()).destroying {
+        if (*self.0.as_ptr()).destroy_state == NVMF_SUBSYSTEM_DESTROY_IN_PROGRESS {
             warn!("Subsystem destruction already started");
             return -libc::EALREADY;
         }
@@ -895,12 +896,37 @@ impl NvmfSubsystem {
         }
     }
 
-    /// stop the subsystem
+    /// Stop the subsystem.
+    /// # Warning
+    /// It may be restarted as the destroy must be called after stop.
+    /// Use [`Self::stop_for_destroy`] if you want to stop *and* destroy the subsystem.
     pub async fn stop(&self) -> Result<(), Error> {
         self.change_state("stop", |ss, cb, arg| unsafe {
             spdk_nvmf_subsystem_stop(ss, cb, arg)
         })
         .await
+    }
+
+    /// Stop *and* destroy the subsystem.
+    /// # Warning
+    /// We are still not stopping for destroy correctly since the spdk `stop_for_destroy`
+    /// does not queue other operations currently, meaning that a pause would fail with
+    /// `-ENODEV` and the device would not be paused, meaning it's not safe to use yet.
+    pub async fn stop_for_destroy(&self) -> Result<(), Error> {
+        self.change_state("stop_destroy", |ss, cb, arg| unsafe {
+            let safe = false;
+            if safe {
+                spdk_nvmf_subsystem_stop_for_destroy(ss, cb, arg)
+            } else {
+                spdk_nvmf_subsystem_stop(ss, cb, arg)
+            }
+        })
+        .await?;
+
+        unsafe {
+            self.shutdown_unsafe();
+        }
+        Ok(())
     }
 
     /// transition the subsystem to paused state

--- a/io-engine/src/target/nvmf.rs
+++ b/io-engine/src/target/nvmf.rs
@@ -25,10 +25,7 @@ where
 /// Unsharing a replica which is not shared is not an error.
 pub async fn unshare(uuid: &str) -> Result<(), NvmfError> {
     if let Some(ss) = NvmfSubsystem::nqn_lookup(uuid) {
-        ss.stop().await?;
-        unsafe {
-            ss.shutdown_unsafe();
-        }
+        ss.stop_for_destroy().await?;
     }
     Ok(())
 }


### PR DESCRIPTION
    refactor: prepare for subsystem stop-destroy

    A new spdk api stops the subsystem for destroy, preventing operations
    from further modifying the subsystem.
    This is useful to avoid a race where resume could race with unpublish.

    However we can't make use of this api yet because it'd break our current
    use of the queued subsystem operations.
    Once stop-for-destroy is issued, any operation will fail straight away
    with -ENODEV, rather than only once the subsystem is actually stopped.
    This means a pause would fail with -ENODEV straightaway, which is not
    what we want since we need all IOs to complete!!

    In addition, we currently have code which takes the subsystem and then
    loops inside with async code.
    This also does not seem safe as in case of a destroy we'd be holding a
    dangling pointer!

---

    refactor: replace cache with spdk num allocated cluster

    Revert the added blob cache and use the blob's num_allocated_clusters.
    The cache was just a short-term solution and it's not needed since we
    can get the clusters from the spdk blob.

