### PR TITLE
Enable support for RDMA for both initiator and target

### DIFF
--- a/io-engine-tests/src/compose/rpc/v1.rs
+++ b/io-engine-tests/src/compose/rpc/v1.rs
@@ -165,6 +165,20 @@ impl<'a> GrpcConnect<'a> {
         }
     }
 
+    /// return grpc handle to the container
+    pub async fn grpc_handle_ext(&self, name: &str, port: u16) -> Result<RpcHandle, String> {
+        match self.ct.containers().iter().find(|&c| c.0 == name) {
+            Some(container) => Ok(RpcHandle::connect(
+                container.0.clone(),
+                format!("{}:{}", container.1 .1, port)
+                    .parse::<std::net::SocketAddr>()
+                    .unwrap(),
+            )
+            .await?),
+            None => Err(format!("Container {name} not found!")),
+        }
+    }
+
     pub async fn grpc_handle_shared(&self, name: &str) -> Result<SharedRpcHandle, String> {
         self.grpc_handle(name).await.map(|rpc| {
             let name = rpc.name.clone();

--- a/io-engine-tests/src/lib.rs
+++ b/io-engine-tests/src/lib.rs
@@ -578,6 +578,7 @@ pub fn setup_rdma_rxe_device() -> String {
         .next()
         .unwrap()
         .to_owned();
+    println!("Test host IP address: {test_host_ip}");
 
     let ent = &run_command_args(
         "ip",

--- a/io-engine/src/bdev/nvmx/controller.rs
+++ b/io-engine/src/bdev/nvmx/controller.rs
@@ -1114,7 +1114,10 @@ pub(crate) mod options {
 pub(crate) mod transport {
     use std::{ffi::CStr, fmt::Debug, str::FromStr};
 
-    use spdk_rs::{ffihelper::copy_str_with_null, libspdk::spdk_nvme_transport_id};
+    use spdk_rs::{
+        ffihelper::copy_str_with_null,
+        libspdk::{spdk_nvme_transport_id, SPDK_NVME_TRANSPORT_RDMA, SPDK_NVME_TRANSPORT_TCP},
+    };
 
     pub struct NvmeTransportId(spdk_nvme_transport_id);
 
@@ -1169,21 +1172,6 @@ pub(crate) mod transport {
     }
 
     #[derive(Debug, Default)]
-    #[allow(clippy::upper_case_acronyms)]
-    enum TransportId {
-        #[default]
-        TCP = 0x3,
-    }
-
-    impl From<TransportId> for String {
-        fn from(t: TransportId) -> Self {
-            match t {
-                TransportId::TCP => String::from("tcp"),
-            }
-        }
-    }
-
-    #[derive(Debug, Default)]
     #[allow(dead_code)]
     pub(crate) enum AdressFamily {
         #[default]
@@ -1194,10 +1182,34 @@ pub(crate) mod transport {
         NvmfAdrfamLoop = 0xfe,
     }
 
+    /// Transport selected for an outgoing nvmf connection.
+    #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, strum_macros::EnumIter)]
+    #[allow(clippy::upper_case_acronyms)]
+    pub enum TrType {
+        #[default]
+        TCP,
+        RDMA,
+    }
+
+    impl TrType {
+        fn spdk_type(self) -> u32 {
+            match self {
+                Self::TCP => SPDK_NVME_TRANSPORT_TCP,
+                Self::RDMA => SPDK_NVME_TRANSPORT_RDMA,
+            }
+        }
+        fn trstring(self) -> &'static str {
+            match self {
+                Self::TCP => "TCP",
+                Self::RDMA => "RDMA",
+            }
+        }
+    }
+
     #[derive(Default, Debug)]
     #[allow(dead_code)]
     pub struct Builder {
-        trid: TransportId,
+        trtype: TrType,
         adrfam: AdressFamily,
         svcid: String,
         traddr: String,
@@ -1230,17 +1242,21 @@ pub(crate) mod transport {
             self.subnqn = subnqn.to_string();
             self
         }
+        /// supports different transport types
+        pub fn with_trtype(mut self, t: TrType) -> Self {
+            self.trtype = t;
+            self
+        }
 
         /// builder for transportID currently defaults to TCP IPv4
         pub fn build(self) -> NvmeTransportId {
-            let trtype = String::from(TransportId::TCP);
             let mut trid = spdk_nvme_transport_id {
                 adrfam: self.adrfam as u32,
-                trtype: TransportId::TCP as u32,
+                trtype: self.trtype.spdk_type(),
                 ..Default::default()
             };
 
-            copy_str_with_null(&trtype, &mut trid.trstring);
+            copy_str_with_null(self.trtype.trstring(), &mut trid.trstring);
             copy_str_with_null(&self.traddr, &mut trid.traddr);
             copy_str_with_null(&self.svcid, &mut trid.trsvcid);
             copy_str_with_null(&self.subnqn, &mut trid.subnqn);
@@ -1255,15 +1271,24 @@ pub(crate) mod transport {
 
         #[test]
         fn test_transport_id() {
+            use strum::IntoEnumIterator;
+            for tr_type in transport::TrType::iter() {
+                test_transport(tr_type);
+            }
+        }
+
+        fn test_transport(tr_type: transport::TrType) {
             let transport = transport::Builder::new()
-                .with_subnqn("nqn.2021-01-01:test.nqn")
+                .with_trtype(tr_type)
+                .with_subnqn("nqn.2021-01-01.test.nqn")
                 .with_svcid("4420")
                 .with_traddr("127.0.0.1")
                 .build();
 
             assert_eq!(transport.traddr(), "127.0.0.1");
-            assert_eq!(transport.subnqn(), "nqn.2021-01-01:test.nqn");
+            assert_eq!(transport.subnqn(), "nqn.2021-01-01.test.nqn");
             assert_eq!(transport.svcid(), "4420");
+            assert_eq!(transport.trtype(), tr_type.trstring());
         }
     }
 }

--- a/io-engine/src/bdev/nvmx/uri.rs
+++ b/io-engine/src/bdev/nvmx/uri.rs
@@ -20,6 +20,7 @@ use std::{
 use url::Url;
 use uuid::Uuid;
 
+use super::controller::transport::{NvmeTransportId, TrType};
 use controller::options::NvmeControllerOpts;
 
 use spdk_rs::{
@@ -44,8 +45,6 @@ use crate::{
     ffihelper::ErrnoResult,
     subsys::Config,
 };
-
-use super::controller::transport::NvmeTransportId;
 
 const DEFAULT_NVMF_PORT: u16 = 8420;
 // Callback to be called once NVMe controller attach sequence completes.
@@ -103,6 +102,8 @@ pub struct NvmfDeviceTemplate {
     uuid: Option<uuid::Uuid>,
     /// The HostNqn to connect to the nvmf target with.
     hostnqn: Option<String>,
+    /// Don't ignore transport type
+    trtype: TrType,
 }
 
 impl TryFrom<&Url> for NvmfDeviceTemplate {
@@ -165,6 +166,24 @@ impl TryFrom<&Url> for NvmfDeviceTemplate {
             .trim_start_matches("[")
             .trim_end_matches("]")
             .to_string();
+
+        let trtype = match url.scheme() {
+            "nvmf" | "nvmf+tcp" => TrType::TCP,
+            "nvmf+rdma+tcp" => {
+                if MayastorEnvironment::global().rdma() {
+                    TrType::RDMA
+                } else {
+                    TrType::TCP
+                }
+            }
+            other => {
+                return Err(BdevError::InvalidUri {
+                    uri: url.to_string(),
+                    message: format!("unsupported nvmf scheme '{other}'"),
+                })
+            }
+        };
+
         Ok(NvmfDeviceTemplate {
             name: url[url::Position::BeforeHost..url::Position::AfterPath].to_string(),
             alias: url.to_string(),
@@ -174,6 +193,7 @@ impl TryFrom<&Url> for NvmfDeviceTemplate {
             prchk_flags,
             uuid,
             hostnqn,
+            trtype,
         })
     }
 }
@@ -205,6 +225,7 @@ pub(crate) struct NvmeControllerContext<'probe> {
 impl NvmeControllerContext<'_> {
     pub fn new(template: &NvmfDeviceTemplate) -> NvmeControllerContext<'_> {
         let trid = controller::transport::Builder::new()
+            .with_trtype(template.trtype)
             .with_subnqn(&template.subnqn)
             .with_svcid(template.port.to_string())
             .with_traddr(&template.host)

--- a/io-engine/src/bdev/nvmx/uri.rs
+++ b/io-engine/src/bdev/nvmx/uri.rs
@@ -168,21 +168,27 @@ impl TryFrom<&Url> for NvmfDeviceTemplate {
             .to_string();
 
         let trtype = match url.scheme() {
-            "nvmf" | "nvmf+tcp" => TrType::TCP,
-            "nvmf+rdma+tcp" => {
-                if MayastorEnvironment::global().rdma() {
-                    TrType::RDMA
-                } else {
-                    TrType::TCP
+            "nvmf" | "nvmf+tcp" => Ok(TrType::TCP),
+            // The target we're connecting to supports rdma, but we can only
+            // make use of it if this host can do rdma as well, which our own
+            // target having bound rdma is proof of.
+            "nvmf+rdma+tcp" => match MayastorEnvironment::global().rdma() {
+                None => Ok(TrType::TCP),
+                Some(rdma) if rdma.target() => Ok(TrType::RDMA),
+                Some(rdma) if rdma.fallback() => {
+                    warn!("RDMA is enabled but not available, connecting to {url} over tcp");
+                    Ok(TrType::TCP)
                 }
-            }
-            other => {
-                return Err(BdevError::InvalidUri {
+                Some(_) => Err(BdevError::RdmaUnavailable {
                     uri: url.to_string(),
-                    message: format!("unsupported nvmf scheme '{other}'"),
-                })
-            }
-        };
+                }),
+            },
+            other => Err(BdevError::InvalidUri {
+                uri: url.to_string(),
+                message: format!("unsupported nvmf scheme '{other}'"),
+            }),
+        }?;
+        warn!("Connecting to {url} over {trtype:?}");
 
         Ok(NvmfDeviceTemplate {
             name: url[url::Position::BeforeHost..url::Position::AfterPath].to_string(),

--- a/io-engine/src/bdev_api.rs
+++ b/io-engine/src/bdev_api.rs
@@ -25,6 +25,12 @@ pub enum BdevError {
     // Scheme-specific URI format errors.
     #[snafu(display("Invalid URI '{}': {}", uri, message))]
     InvalidUri { uri: String, message: String },
+    // The URI requires RDMA, which this node can't do.
+    #[snafu(display(
+        "Cannot connect to '{uri}' over RDMA as RDMA is not available on this node, \
+        and falling back to TCP is not enabled"
+    ))]
+    RdmaUnavailable { uri: String },
     // Bad value of a boolean parameter.
     #[snafu(display(
         "Invalid URI '{}': could not parse value of parameter '{}': '{}' is given, \
@@ -99,6 +105,7 @@ impl ToErrno for BdevError {
             BdevError::BdevNoMatchingUri { .. } => Errno::EPIPE,
             BdevError::UriSchemeUnsupported { .. } => Errno::ENOTSUP,
             BdevError::InvalidUri { .. } => Errno::EINVAL,
+            BdevError::RdmaUnavailable { .. } => Errno::ENOTSUP,
             BdevError::BoolParamParseFailed { .. } => Errno::EINVAL,
             BdevError::IntParamParseFailed { .. } => Errno::EINVAL,
             BdevError::UuidParamParseFailed { .. } => Errno::EINVAL,

--- a/io-engine/src/bin/io-engine.rs
+++ b/io-engine/src/bin/io-engine.rs
@@ -97,7 +97,17 @@ fn start_tokio_runtime(args: &MayastorCliArgs) {
 
     if args.rdma {
         env::set_var("ENABLE_RDMA", "true");
-        warn!("RDMA is requested to be enabled for Mayastor NVMEoF target");
+        // The nvmf target has been brought up by now, so rather than the
+        // request we can report what came of it.
+        let rdma_target = MayastorEnvironment::global().rdma_target();
+        if rdma_target {
+            warn!("RDMA is enabled for the Mayastor NVMEoF target");
+        } else {
+            warn!(
+                "RDMA was requested but is not available, \
+                the Mayastor NVMEoF target will only use tcp"
+            );
+        }
     }
 
     // Use as-is basis for diskpool encryption since the spdk build is enabled

--- a/io-engine/src/core/bdev.rs
+++ b/io-engine/src/core/bdev.rs
@@ -11,13 +11,13 @@ use snafu::ResultExt;
 use spdk_rs::libspdk::{spdk_bdev, spdk_get_ticks_hz};
 
 use crate::{
-    bdev::{bdev_event_callback, nexus::NEXUS_MODULE_NAME},
+    bdev::bdev_event_callback,
     bdev_api::bdev_uri_eq,
     core::{
         block_device::BlockDeviceIoErrorStats,
         share::{NvmfShareProps, Protocol, Share, UpdateProps},
-        BlockDeviceIoStats, CoreError, DescriptorGuard, PtplProps, ShareNvmf, UnshareNvmf,
-        UnshareProps,
+        BlockDeviceIoStats, CoreError, DescriptorGuard, MayastorEnvironment, PtplProps, ShareNvmf,
+        UnshareNvmf, UnshareProps,
     },
     subsys::NvmfSubsystem,
     target::nvmf,
@@ -212,7 +212,6 @@ where
     ) -> Result<Self::Output, Self::Error> {
         let me = unsafe { self.get_unchecked_mut() };
         let props = NvmfShareProps::from(props);
-        let is_nexus_bdev = me.driver() == NEXUS_MODULE_NAME;
 
         let ptpl = props.ptpl().as_ref().map(|ptpl| ptpl.path());
 
@@ -233,7 +232,8 @@ where
             .await
             .context(ShareNvmf {})?;
 
-        subsystem.start(is_nexus_bdev).await.context(ShareNvmf {})
+        let rdma = MayastorEnvironment::global().rdma();
+        subsystem.start(rdma).await.context(ShareNvmf {})
     }
 
     fn create_ptpl(&self) -> Result<Option<PtplProps>, Self::Error> {

--- a/io-engine/src/core/bdev.rs
+++ b/io-engine/src/core/bdev.rs
@@ -232,7 +232,8 @@ where
             .await
             .context(ShareNvmf {})?;
 
-        let rdma = MayastorEnvironment::global().rdma();
+        // Only add an rdma listener if our target is actually listening over rdma.
+        let rdma = MayastorEnvironment::global().rdma_target();
         subsystem.start(rdma).await.context(ShareNvmf {})
     }
 

--- a/io-engine/src/core/env.rs
+++ b/io-engine/src/core/env.rs
@@ -1,7 +1,7 @@
 use std::{
     env,
     ffi::CString,
-    os::raw::{c_char, c_void},
+    os::raw::{c_char, c_int, c_void},
     pin::Pin,
     str::FromStr,
     sync::{
@@ -25,10 +25,11 @@ use spdk_rs::{
     libspdk::{
         spdk_app_shutdown_cb, spdk_env_dpdk_post_init, spdk_env_dpdk_rte_eal_init, spdk_env_fini,
         spdk_log_close, spdk_log_level, spdk_log_open, spdk_log_set_flag, spdk_log_set_level,
-        spdk_log_set_print_level, spdk_pci_addr, spdk_rpc_finish, spdk_rpc_initialize,
-        spdk_rpc_set_state, spdk_subsystem_fini, spdk_subsystem_init, spdk_thread_lib_fini,
-        spdk_thread_send_critical_msg, spdk_trace_cleanup, spdk_trace_create_tpoint_group_mask,
-        spdk_trace_init, spdk_trace_set_tpoints, SPDK_LOG_DEBUG, SPDK_LOG_INFO, SPDK_RPC_RUNTIME,
+        spdk_log_set_print_level, spdk_nvme_transport_available_by_name, spdk_pci_addr,
+        spdk_rpc_finish, spdk_rpc_initialize, spdk_rpc_set_state, spdk_subsystem_fini,
+        spdk_subsystem_init, spdk_thread_lib_fini, spdk_thread_send_critical_msg,
+        spdk_trace_cleanup, spdk_trace_create_tpoint_group_mask, spdk_trace_init,
+        spdk_trace_set_tpoints, SPDK_LOG_DEBUG, SPDK_LOG_INFO, SPDK_RPC_RUNTIME,
     },
     spdk_rs_log,
 };
@@ -40,7 +41,7 @@ use crate::{
         nic,
         nic::SIpAddr,
         reactor::{Reactor, ReactorState, Reactors},
-        Cores, MayastorFeatures, Mthread,
+        Cores, MayastorFeatures, Mthread, NvmfTargetInfo, TransportCaps,
     },
     eventing::{io_engine_events::io_engine_stop_event_meta, Event, EventWithMeta},
     grpc,
@@ -49,8 +50,8 @@ use crate::{
     logger::FmtSpan,
     persistent_store::PersistentStoreBuilder,
     subsys::{
-        self, config::opts::TARGET_CRDT_LEN, registration::registration_grpc::ApiVersion, Config,
-        PoolConfig, Registration,
+        self, config::opts::TARGET_CRDT_LEN, nvmf::transport::RDMA_TRANSPORT,
+        registration::registration_grpc::ApiVersion, Config, PoolConfig, Registration,
     },
 };
 
@@ -286,6 +287,11 @@ pub struct MayastorCliArgs {
     /// Enables RDMA between initiator and Mayastor Nvmf target.
     #[clap(long = "enable-rdma", env = "ENABLE_RDMA", value_parser = delay_compat)]
     pub rdma: bool,
+    /// Enable falling back to nvmf connect over tcp if this node is not rdma capable, {n}
+    /// even though the target is rdma capable. {n}
+    /// Otherwise, the connection fails.
+    #[clap(long, env = "NVME_CONNECT_FALLBACK", value_parser = delay_compat)]
+    pub nvme_connect_fallback: bool,
     /// Enables globally blob store cluster release on unmap.
     #[clap(long, env = "ENABLE_BS_CLUSTER_UNMAP", hide = true)]
     pub bs_cluster_unmap: bool,
@@ -433,6 +439,39 @@ fn delay_compat(s: &str) -> Result<bool, String> {
     }
 }
 
+/// The RDMA state of an io-engine which has been asked for RDMA.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct RdmaState {
+    /// Our nvmf target is listening over rdma, which means spdk found usable
+    /// rdma devices and managed to bind them.
+    target: bool,
+    /// Fall back to tcp when connecting to an rdma capable target from here,
+    /// rather than failing the connection, if we can't do rdma after all.
+    fallback: bool,
+}
+
+impl RdmaState {
+    /// Get the RDMA state of an io-engine which has yet to bring up its
+    /// target, with the given connect fallback.
+    fn new(fallback: bool) -> Self {
+        Self {
+            target: false,
+            fallback,
+        }
+    }
+
+    /// Check if our nvmf target is listening over rdma.
+    pub fn target(&self) -> bool {
+        self.target
+    }
+
+    /// Check if we may fall back to tcp when connecting to an rdma capable
+    /// target and we can't do rdma, rather than failing the connection.
+    pub fn fallback(&self) -> bool {
+        self.fallback
+    }
+}
+
 /// Mayastor features.
 impl MayastorFeatures {
     fn init_features() -> MayastorFeatures {
@@ -549,7 +588,12 @@ pub struct MayastorEnvironment {
     pub nexus_read_policy: nexus::NexusReadPolicy,
     developer_delay: bool,
     interrupt_mode: bool,
-    rdma: bool,
+    /// The RDMA state, set only if RDMA has been requested.
+    rdma: Option<RdmaState>,
+    /// Our nvmf target is listening over tcp.
+    tcp_target: bool,
+    /// The transport capabilities of the node we run on.
+    transport_caps: TransportCaps,
     bs_cluster_unmap: bool,
     pub pool_args: PoolCliArgs,
     pub nvme: NvmeCliArgs,
@@ -602,7 +646,9 @@ impl Default for MayastorEnvironment {
             nexus_read_policy: nexus::NexusReadPolicy::default(),
             developer_delay: false,
             interrupt_mode: false,
-            rdma: false,
+            rdma: None,
+            tcp_target: false,
+            transport_caps: TransportCaps::default(),
             bs_cluster_unmap: false,
             pool_args: PoolCliArgs::default(),
             traces: SpdkTracingArgs::default(),
@@ -709,6 +755,13 @@ struct SubsystemCtx {
     sender: futures::channel::oneshot::Sender<bool>,
 }
 
+// libibverbs, which spdk itself uses to enumerate the rdma devices, and which
+// `ibv_devinfo` reports from. It's already linked in for spdk's sake.
+extern "C" {
+    fn ibv_get_device_list(num_devices: *mut c_int) -> *mut *mut c_void;
+    fn ibv_free_device_list(list: *mut *mut c_void);
+}
+
 static MAYASTOR_FEATURES: OnceCell<MayastorFeatures> = OnceCell::new();
 
 static MAYASTOR_DEFAULT_ENV: OnceCell<parking_lot::Mutex<MayastorEnvironment>> = OnceCell::new();
@@ -749,7 +802,9 @@ impl MayastorEnvironment {
             skip_sig_handler: args.skip_sig_handler,
             developer_delay: args.developer_delay,
             interrupt_mode: args.interrupt_mode,
-            rdma: args.rdma,
+            rdma: args
+                .rdma
+                .then_some(RdmaState::new(args.nvme_connect_fallback)),
             bs_cluster_unmap: args.bs_cluster_unmap,
             enable_io_all_thrd_nexus_channels: args.enable_io_all_thrd_nexus_channels,
             nexus_read_policy: args.nexus_read_policy,
@@ -951,9 +1006,101 @@ impl MayastorEnvironment {
             .cloned()
     }
 
-    /// Check if RDMA needs to be enabled for Mayastor nvmf target.
-    pub fn rdma(&self) -> bool {
+    /// Get the RDMA state of the Mayastor nvmf target, set only if RDMA has
+    /// been requested for it, which says nothing about it being possible, see
+    /// [`Self::rdma_enabled`].
+    pub fn rdma(&self) -> Option<RdmaState> {
         self.rdma
+    }
+
+    /// Check if RDMA needs to be enabled for Mayastor nvmf target: it has been
+    /// requested and spdk has been built with rdma support.
+    /// Whether this host can actually do rdma is only known once we've tried, see [`Self::rdma_target`].
+    pub fn rdma_enabled(&self) -> bool {
+        self.rdma.is_some() && Self::rdma_transport_registered()
+    }
+
+    /// Check if our nvmf target is listening over rdma, which means spdk found
+    /// usable rdma devices and managed to bind them.
+    /// We also take this as proof that we can connect to remote targets over rdma.
+    /// # NOTE
+    /// This isn't strictly true as we may still be able to connect to remote targets even if
+    /// the nvmf target isn't listening over rdma, but it's a good enough proxy for now.
+    pub fn rdma_target(&self) -> bool {
+        self.rdma.is_some_and(|rdma| rdma.target())
+    }
+
+    /// Get the state of our nvmf target, to report to the control-plane.
+    pub fn nvmf_target_info() -> NvmfTargetInfo {
+        let env = Self::global_or_default();
+        NvmfTargetInfo {
+            interface: env.nvmf_tgt_interface.clone(),
+            // The listeners all share the target's address, they only differ
+            // in transport and port.
+            address: Self::get_nvmf_tgt_ip()
+                .map(|ip| ip.to_string())
+                .unwrap_or_default(),
+            // Tcp is always asked for, rdma only through --enable-rdma, and
+            // either is true only once the target has bound it.
+            tcp: Some(env.tcp_target),
+            rdma: env.rdma.map(|rdma| rdma.target()),
+        }
+    }
+
+    /// Record which transports our nvmf target is listening over.
+    pub(crate) fn set_nvmf_target(&mut self, tcp: bool, rdma: bool) {
+        self.tcp_target = tcp;
+        if let Some(state) = self.rdma.as_mut() {
+            state.target = rdma;
+        }
+    }
+
+    /// Get the transport capabilities of the node we run on, as detected
+    /// during start-up.
+    pub fn transport_caps() -> TransportCaps {
+        Self::global_or_default().transport_caps.clone()
+    }
+
+    /// Detects the node's transport capabilities, the same way the csi node
+    /// does so that both report the same thing.
+    fn detect_transport_caps() -> TransportCaps {
+        let caps = TransportCaps {
+            rdma_hca_present: Self::rdma_hca_present(),
+            nvme_rdma_module_loaded: std::fs::metadata("/sys/module/nvme_rdma").is_ok(),
+        };
+        if caps.rdma_hca_present && !caps.nvme_rdma_module_loaded {
+            warn!(
+                "This node has rdma hardware but the nvme_rdma kernel module is not loaded, \
+                so its initiator can't connect over rdma"
+            );
+        }
+        debug!("Node transport capabilities: {caps:?}");
+        caps
+    }
+
+    /// Checks if rdma hca hardware is present on this node, which is the same
+    /// thing `ibv_devinfo -l` reports, only asked straight to libibverbs.
+    fn rdma_hca_present() -> bool {
+        let mut devices: c_int = 0;
+        // Only enumerates the devices, it doesn't open them, so it can't
+        // upset the rdma_cm devices spdk opens later on.
+        let list = unsafe { ibv_get_device_list(&mut devices) };
+        if list.is_null() {
+            // Errno says why, but either way we have no hardware to use.
+            debug!("Failed to enumerate the rdma devices");
+            return false;
+        }
+        unsafe { ibv_free_device_list(list) };
+        devices > 0
+    }
+
+    /// Checks with spdk if the nvme(host side) rdma transport is registered,
+    /// which is only the case if spdk has been built with rdma support. The
+    /// nvme and nvmf rdma transports are built together, so this tells us
+    /// about both. The transports register themselves before main() runs, so
+    /// this can be called at any point during start-up.
+    fn rdma_transport_registered() -> bool {
+        unsafe { spdk_nvme_transport_available_by_name(RDMA_TRANSPORT.as_ptr()) }
     }
 
     /// Detects IP address for NVMF target by the interface specified in CLI
@@ -1151,6 +1298,17 @@ impl MayastorEnvironment {
         // setup the logger as soon as possible
         self.init_logger();
 
+        // rdma can't be used at all if spdk hasn't been built with it, no
+        // matter what has been requested.
+        if self.rdma.is_some() && !Self::rdma_transport_registered() {
+            warn!("RDMA was requested but spdk has not been built with rdma support");
+        }
+
+        // Detect what the node can do before the eal takes over its memory,
+        // as this shells out to ibv_devinfo.
+        self.transport_caps = Self::detect_transport_caps();
+        self = self.setup_static();
+
         if option_env!("ASAN_ENABLE").unwrap_or_default() == "1" {
             print_asan_env();
         }
@@ -1346,4 +1504,23 @@ fn print_asan_env() {
     print_compile_var!("CARGO_BUILD_TARGET");
     print_compile_var!("CARGO_PROFILE_DEV_PANIC");
     print_run_var("RUST_BACKTRACE");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The rdma transports must be registered with spdk, otherwise rdma can
+    /// never be used, no matter the platform.
+    #[test]
+    fn rdma_transport_registered() {
+        let tcp = CString::new("TCP").unwrap();
+        let bogus = CString::new("NOT_A_TRANSPORT").unwrap();
+
+        // sanity check the transport lookup itself.
+        assert!(unsafe { spdk_nvme_transport_available_by_name(tcp.as_ptr()) });
+        assert!(!unsafe { spdk_nvme_transport_available_by_name(bogus.as_ptr()) });
+
+        assert!(MayastorEnvironment::rdma_transport_registered());
+    }
 }

--- a/io-engine/src/core/env.rs
+++ b/io-engine/src/core/env.rs
@@ -302,7 +302,7 @@ pub struct MayastorCliArgs {
     /// round-robin over remote readers only when no local reader is
     /// healthy.
     #[clap(
-        long = "policy",
+        long,
         env = "NEXUS_READ_POLICY",
         default_value_t = nexus::NexusReadPolicy::RoundRobin
     )]

--- a/io-engine/src/core/mod.rs
+++ b/io-engine/src/core/mod.rs
@@ -21,8 +21,8 @@ pub use device_events::{
 };
 pub use device_monitor::{device_cmd_queue, device_monitor_loop, DeviceCommand};
 pub use env::{
-    mayastor_env_stop, MayastorCliArgs, MayastorEnvironment, NvmeCliArgs, PoolCliArgs, GLOBAL_RC,
-    SIG_RECEIVED,
+    mayastor_env_stop, MayastorCliArgs, MayastorEnvironment, NvmeCliArgs, PoolCliArgs, RdmaState,
+    GLOBAL_RC, SIG_RECEIVED,
 };
 pub use handle::{BdevHandle, UntypedBdevHandle};
 pub use io_device::IoDevice;
@@ -318,20 +318,23 @@ pub struct MayastorFeatures {
     pub logical_volume_manager: bool,
     /// When set to true, support for snapshot rebuild is enabled.
     pub snapshot_rebuild: bool,
-    /// When set to true, the io-engine instance supports RDMA transport.
+    /// When set to true, this io-engine can use the RDMA transport, which
+    /// says nothing about rdma being usable on this host, see
+    /// [`NvmfTargetInfo`].
     pub rdma_capable_io_engine: bool,
     /// Diskpool encryption capability.
     pub diskpool_encryption: bool,
     /// Nexus label versioning capability.
     pub nexus_label_version: u32,
 }
+
 impl MayastorFeatures {
     /// Check if LVM feature is enabled.
     pub fn lvm(&self) -> bool {
         self.logical_volume_manager
     }
 
-    /// Get nvmf target's rdma feature state.
+    /// Get this io-engine's rdma capability.
     pub fn rdma_capable_io_engine(&self) -> bool {
         self.rdma_capable_io_engine
     }
@@ -340,6 +343,34 @@ impl MayastorFeatures {
     pub fn nexus_label_version(&self) -> u32 {
         self.nexus_label_version
     }
+}
+
+/// The transport capabilities of the node we run on, to expose to the
+/// control-plane. Computed the same way as the csi node does, so that both
+/// report the same thing.
+#[derive(Debug, Default, Clone)]
+pub struct TransportCaps {
+    /// RDMA HCA hardware is present on this node.
+    pub rdma_hca_present: bool,
+    /// The nvme_rdma kernel module is loaded on this node. We don't use it
+    /// ourselves, as we do rdma from userspace, but the node's initiator
+    /// needs it to connect over rdma.
+    pub nvme_rdma_module_loaded: bool,
+}
+
+/// The state of our nvmf target, to expose to the control-plane. Unlike the
+/// features, this is not what we're capable of but what we ended up with.
+#[derive(Debug, Default, Clone)]
+pub struct NvmfTargetInfo {
+    /// The network interface the target listens on, if one was specified.
+    pub interface: Option<String>,
+    /// The address the target listens on.
+    pub address: String,
+    /// Whether the target is listening over tcp, unset if it wasn't asked to.
+    pub tcp: Option<bool>,
+    /// Whether the target is listening over rdma, which is what makes rdma
+    /// usable, unset if it wasn't asked to.
+    pub rdma: Option<bool>,
 }
 
 /// Bugfix information to expose to the control-plane.

--- a/io-engine/src/grpc/mod.rs
+++ b/io-engine/src/grpc/mod.rs
@@ -22,6 +22,7 @@ impl From<BdevError> for tonic::Status {
             BdevError::UriParseFailed { .. } => Status::invalid_argument(e.to_string()),
             BdevError::UriSchemeUnsupported { .. } => Status::invalid_argument(e.to_string()),
             BdevError::InvalidUri { .. } => Status::invalid_argument(e.to_string()),
+            BdevError::RdmaUnavailable { .. } => Status::failed_precondition(e.to_string()),
             BdevError::IntParamParseFailed { .. } => Status::invalid_argument(e.to_string()),
             BdevError::BoolParamParseFailed { .. } => Status::invalid_argument(e.to_string()),
             BdevError::UuidParamParseFailed { .. } => Status::invalid_argument(e.to_string()),

--- a/io-engine/src/grpc/v1/host.rs
+++ b/io-engine/src/grpc/v1/host.rs
@@ -1,6 +1,9 @@
 use crate::{
     bdev::{nexus, NvmeControllerState},
-    core::{BlockDeviceIoStats, CoreError, MayastorBugFixes, MayastorFeatures},
+    core::{
+        BlockDeviceIoStats, CoreError, MayastorBugFixes, MayastorEnvironment, MayastorFeatures,
+        NvmfTargetInfo, TransportCaps,
+    },
     grpc::{
         controller_grpc::{controller_stats, list_controllers, NvmeControllerInfo},
         rpc_submit, GrpcClientContext, GrpcResult, Serializer,
@@ -104,6 +107,27 @@ impl From<MayastorFeatures> for host_rpc::MayastorFeatures {
         }
     }
 }
+
+impl From<TransportCaps> for host_rpc::TransportCaps {
+    fn from(c: TransportCaps) -> Self {
+        Self {
+            rdma_hca_present: c.rdma_hca_present,
+            nvme_rdma_module_loaded: c.nvme_rdma_module_loaded,
+        }
+    }
+}
+
+impl From<NvmfTargetInfo> for host_rpc::NvmfTargetInfo {
+    fn from(t: NvmfTargetInfo) -> Self {
+        Self {
+            interface: t.interface,
+            address: t.address,
+            tcp: t.tcp,
+            rdma: t.rdma,
+        }
+    }
+}
+
 impl From<MayastorFeatures> for host_rpc::BackCompatMayastorFeatures {
     fn from(f: MayastorFeatures) -> Self {
         Self {
@@ -243,6 +267,8 @@ impl host_rpc::HostRpc for HostService {
                 features: Some(MayastorFeatures::get().into()),
                 bugfixes: Some(MayastorBugFixes::get().into()),
                 version: Some(raw_version_string()),
+                nvmf_target: Some(MayastorEnvironment::nvmf_target_info().into()),
+                transport_caps: Some(MayastorEnvironment::transport_caps().into()),
             }),
         };
 

--- a/io-engine/src/subsys/config/opts.rs
+++ b/io-engine/src/subsys/config/opts.rs
@@ -60,8 +60,14 @@ impl Default for NexusOpts {
         Self {
             nvmf_enable: true,
             nvmf_discovery_enable: true,
-            nvmf_nexus_port: NVMF_PORT_NEXUS,
-            nvmf_replica_port: NVMF_PORT_REPLICA,
+            nvmf_nexus_port: std::env::var("NVMF_PORT_NEXUS")
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(NVMF_PORT_NEXUS),
+            nvmf_replica_port: std::env::var("NVMF_PORT_REPLICA")
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(NVMF_PORT_REPLICA),
         }
     }
 }

--- a/io-engine/src/subsys/mod.rs
+++ b/io-engine/src/subsys/mod.rs
@@ -18,7 +18,7 @@ pub use registration::{registration_grpc::Registration, RegistrationSubsystem};
 use crate::subsys::nvmf::Nvmf;
 
 pub(super) mod config;
-mod nvmf;
+pub(crate) mod nvmf;
 /// Module for managing of the nvmx admin queues.
 pub mod nvmx;
 /// Module for registration of the data-plane with control-plane

--- a/io-engine/src/subsys/nvmf/mod.rs
+++ b/io-engine/src/subsys/nvmf/mod.rs
@@ -28,7 +28,7 @@ mod admin_cmd;
 mod poll_groups;
 mod subsystem;
 mod target;
-mod transport;
+pub(crate) mod transport;
 
 // wrapper around our NVMF subsystem used for registration
 pub struct Nvmf(pub(crate) *mut spdk_subsystem);

--- a/io-engine/src/subsys/nvmf/target.rs
+++ b/io-engine/src/subsys/nvmf/target.rs
@@ -167,7 +167,7 @@ impl Target {
     /// add the transport to the target
     fn add_transport(&self) {
         Reactors::master().send_future(async move {
-            let rdma = MayastorEnvironment::global_or_default().rdma();
+            let rdma = MayastorEnvironment::global_or_default().rdma_enabled();
             let ret = transport::create_and_add_transports(rdma).await;
             NVMF_TGT.with(|t| {
                 if ret.is_err() {
@@ -235,7 +235,7 @@ impl Target {
 
         if rc != 0 {
             return Err(Error::CreateTarget {
-                msg: "failed to back target".into(),
+                msg: "for the nexus".into(),
             });
         }
 
@@ -247,7 +247,7 @@ impl Target {
 
         if rc != 0 {
             return Err(Error::CreateTarget {
-                msg: "failed to front target".into(),
+                msg: "for the replica".into(),
             });
         }
         info!(
@@ -257,7 +257,7 @@ impl Target {
             trid_replica.trsvcid.as_str(),
         );
 
-        if MayastorEnvironment::global_or_default().rdma() {
+        if MayastorEnvironment::global_or_default().rdma_enabled() {
             // listen RDMA also.
             let _ = self
                 .listen_rdma()
@@ -266,12 +266,13 @@ impl Target {
                 })
                 .map_err(|e| {
                     warn!(
-                        "failed to listen rdma on address. err: {e}:\
-                        The target will however keep running with \
+                        "failed to listen rdma on address: {e}: the target will however keep running with \
                         only tcp listener, with performance expectations of tcp"
                     );
                 });
         }
+
+        MayastorEnvironment::global().set_nvmf_target(true, self.rdma);
 
         self.next_state();
         Ok(())
@@ -301,7 +302,7 @@ impl Target {
 
         if rc != 0 {
             return Err(Error::CreateTarget {
-                msg: "failed to back target".into(),
+                msg: "for the nexus".into(),
             });
         }
 
@@ -313,7 +314,7 @@ impl Target {
 
         if rc != 0 {
             return Err(Error::CreateTarget {
-                msg: "failed to front target".into(),
+                msg: "for the replica".into(),
             });
         }
         info!(
@@ -463,6 +464,8 @@ impl Target {
 
     /// start the shutdown of the target and subsystems
     pub(crate) fn start_shutdown(&mut self) {
+        // the target is going away, so nothing can be shared over it anymore.
+        MayastorEnvironment::global().set_nvmf_target(false, false);
         self.next_state = TargetState::ShutdownSubsystems;
         Reactors::master().send_future(async {
             NVMF_TGT.with(|tgt| {

--- a/io-engine/src/subsys/nvmf/transport.rs
+++ b/io-engine/src/subsys/nvmf/transport.rs
@@ -59,6 +59,9 @@ pub async fn create_and_add_transports(add_rdma: bool) -> Result<(), Error> {
     if add_rdma {
         info!("Adding RDMA transport for Mayastor Nvmf target");
         let mut opts = cfg.nvmf_tgt_conf.opts_rdma.into();
+        // Creating the transport is also how we find out if RDMA is at all
+        // possible here: spdk enumerates the rdma devices while doing so and
+        // fails if this host has none which it can use.
         let transport = unsafe { spdk_nvmf_transport_create(RDMA_TRANSPORT.as_ptr(), &mut opts) };
 
         let ret = transport.to_result(|_| Error::Transport {
@@ -69,9 +72,8 @@ pub async fn create_and_add_transports(add_rdma: bool) -> Result<(), Error> {
         if let Err(e) = ret {
             // todo: add event mechanism for Target and Nvmfsubsystem
             warn!(
-                "RDMA enablement failed {e}.\
-                The target will however keep running with only tcp, \
-                with performance expectations of tcp."
+                "RDMA enablement failed {e}. The target will however keep running with only tcp, \
+                with the performance expectations of tcp."
             );
             return Ok(());
         }
@@ -88,8 +90,14 @@ pub async fn create_and_add_transports(add_rdma: bool) -> Result<(), Error> {
             })
         };
 
-        let _result = r.await.ok();
-        debug!("Added RDMA nvmf transport");
+        match r.await.ok().and_then(|result| result.ok()) {
+            Some(_) => debug!("Added RDMA nvmf transport"),
+            None => warn!(
+                "Failed to add the RDMA transport to the nvmf target. \
+                The target will however keep running with only tcp, \
+                with the performance expectations of tcp."
+            ),
+        }
     }
 
     Ok(())

--- a/io-engine/src/subsys/registration/registration_grpc.rs
+++ b/io-engine/src/subsys/registration/registration_grpc.rs
@@ -1,6 +1,6 @@
 #![warn(missing_docs)]
 
-use crate::core::{MayastorBugFixes, MayastorFeatures};
+use crate::core::{MayastorBugFixes, MayastorEnvironment, MayastorFeatures};
 use futures::{select, FutureExt, StreamExt};
 use http::Uri;
 use io_engine_api::v1::registration::{
@@ -159,6 +159,8 @@ impl Registration {
             features: Some(MayastorFeatures::get().into()),
             bugfixes: Some(MayastorBugFixes::get().into()),
             version: Some(raw_version_string()),
+            nvmf_target: Some(MayastorEnvironment::nvmf_target_info().into()),
+            transport_caps: Some(MayastorEnvironment::transport_caps().into()),
         };
         self.client
             .register(tonic::Request::new(register))

--- a/io-engine/tests/nvmf.rs
+++ b/io-engine/tests/nvmf.rs
@@ -50,7 +50,10 @@ fn pool_name() -> String {
     "tpool".to_string()
 }
 
-pub async fn create_nexus(h: &mut RpcHandle, children: Vec<String>) {
+pub async fn create_nexus(
+    h: &mut RpcHandle,
+    children: Vec<String>,
+) -> Result<(), Box<dyn std::error::Error>> {
     h.nexus
         .create_nexus(CreateNexusRequest {
             name: nexus_name(),
@@ -65,8 +68,8 @@ pub async fn create_nexus(h: &mut RpcHandle, children: Vec<String>) {
             resv_type: None,
             preempt_policy: 0,
         })
-        .await
-        .unwrap();
+        .await?;
+    Ok(())
 }
 
 #[common::spdk_test]
@@ -240,7 +243,14 @@ async fn test_rdma_target() {
         .add_container_bin(
             "ms_0",
             Binary::from_dbg("io-engine")
-                .with_args(vec!["-l", "1,2", "--enable-rdma", "-T", iface.as_str()])
+                .with_args(vec!["-l", "1", "--enable-rdma", "-T", iface.as_str()])
+                .with_privileged(Some(true)),
+        )
+        .add_container_bin(
+            "ms_1",
+            Binary::from_dbg("io-engine")
+                .with_args(vec!["-l", "2"])
+                .with_args(vec!["--grpc-port", "10125"])
                 .with_privileged(Some(true)),
         )
         .with_clean(true)
@@ -265,7 +275,8 @@ async fn test_rdma_target() {
         .await
         .unwrap();
 
-    hdl.replica
+    let replica = hdl
+        .replica
         .create_replica(CreateReplicaRequest {
             name: repl_name(),
             uuid: repl_uuid(),
@@ -277,9 +288,24 @@ async fn test_rdma_target() {
         })
         .await
         .unwrap();
+    let replica = replica.into_inner();
+    println!("Replica Uri: {:?}", replica.uri);
+    let url = url::Url::parse(&replica.uri).unwrap();
+    assert!(
+        url.scheme() == "nvmf+rdma+tcp",
+        "unexpected scheme: {}",
+        url
+    );
 
-    let child0 = format!("bdev:///{}", repl_name());
-    create_nexus(&mut hdl, vec![child0.clone()]).await;
+    let host = url.host_str().unwrap();
+    let nqn = format!("{NVME_NQN_PREFIX}:{}", replica.name);
+    let conn_status = nvme_connect(host, &nqn, "rdma", true);
+    assert!(conn_status.success());
+    nvme_disconnect_nqn(&nqn);
+
+    create_nexus(&mut hdl, vec![replica.uri.clone()])
+        .await
+        .unwrap();
     let device_uri = hdl
         .nexus
         .publish_nexus(PublishNexusRequest {
@@ -302,8 +328,55 @@ async fn test_rdma_target() {
     let nqn = format!("{NVME_NQN_PREFIX}:{}", nexus_name());
     let conn_status = nvme_connect(host, &nqn, "rdma", true);
     assert!(conn_status.success());
-
     nvme_disconnect_nqn(&nqn);
+
+    // Test TCP is still working with the same containers, but using ms_1 which is not configured for RDMA.
+
+    let host = url.host_str().unwrap();
+    let nqn = format!("{NVME_NQN_PREFIX}:{}", replica.name);
+    let conn_status = nvme_connect(host, &nqn, "tcp", true);
+    assert!(conn_status.success());
+    nvme_disconnect_nqn(&nqn);
+
+    let mut hdl = conn.grpc_handle_ext("ms_1", 10125).await.unwrap();
+    println!("ms_1 grpc endpoint {:?}", hdl.endpoint);
+
+    create_nexus(&mut hdl, vec![replica.uri])
+        .await
+        .expect("Create Nexus with replica TCP");
+
+    let controllers = hdl
+        .host
+        .list_nvme_controllers(())
+        .await
+        .expect("List NVMe controllers");
+    // todo: change api to expose transport type?
+    println!("NVMe controllers: {controllers:?}");
+
+    let device_uri = hdl
+        .nexus
+        .publish_nexus(PublishNexusRequest {
+            uuid: nexus_uuid(),
+            key: "".to_string(),
+            share: ShareProtocolNexus::NexusNvmf as i32,
+            ..Default::default()
+        })
+        .await
+        .expect("Failed to publish nexus")
+        .into_inner()
+        .nexus
+        .unwrap()
+        .device_uri;
+
+    let url = url::Url::parse(device_uri.as_str()).unwrap();
+    assert!(url.scheme() == "nvmf");
+
+    let host = url.host_str().unwrap();
+    let nqn = format!("{NVME_NQN_PREFIX}:{}", nexus_name());
+    let conn_status = nvme_connect(host, &nqn, "tcp", true);
+    assert!(conn_status.success());
+    nvme_disconnect_nqn(&nqn);
+
     // Explicitly destroy this test's containers so that rxe device can be
     // deleted.
     test.down().await;

--- a/scripts/clean-cargo-tests.sh
+++ b/scripts/clean-cargo-tests.sh
@@ -62,7 +62,7 @@ done
 # Kill's processes running off the workspace cargo binary location
 ps aux | grep "$ROOT_DIR/target" | grep -v -e sudo -e grep | awk '{ print $2 }' | xargs -I% sudo kill -9 %
 
-sudo rm -rf /var/run/dpdk/*
+sudo find /var/run/dpdk -mindepth 1 -delete
 
 nix-sudo rm -rf "$back_dir" 2>/dev/null
 

--- a/shell.nix
+++ b/shell.nix
@@ -69,7 +69,7 @@ let
         # SRCDIR is needed by docker-compose files as it requires absolute paths
         export SRCDIR=`pwd`
 
-        export PATH="$PATH:$(pwd)/scripts/nix-sudo"
+        export PATH="$(pwd)/target/debug:$PATH:$(pwd)/scripts/nix-sudo"
 
         export IO_ENGINE_DIR="$RUST_TARGET_DEBUG"
 


### PR DESCRIPTION
First attempt to enable RDMA for both initiator and target, removes the hard coded TCP transport and re-uses similar approach to existing spdk code.