### PR TITLE
fix: tackle various CI flaky tests

### DIFF
--- a/.github/workflows/bdd.yml
+++ b/.github/workflows/bdd.yml
@@ -62,6 +62,11 @@ jobs:
           # Check if nvme config is valid, otherwise apply it
           sudo ./scripts/nvme-conf.sh --check --apply --overwrite
 
+      - name: Configure Docker logging driver
+        run: |
+          echo '{"log-driver": "journald"}' | sudo tee /etc/docker/daemon.json
+          sudo systemctl restart docker
+
       - name: Setup VENV
         run: nix-shell --run "./test/python/setup.sh"
 

--- a/.github/workflows/bdd.yml
+++ b/.github/workflows/bdd.yml
@@ -94,6 +94,7 @@ jobs:
           path: ./ci-report/ci-report.tar.gz
 
       - name: Check Coredumps
+        if: always()
         run: sudo ./scripts/check-coredumps.sh --since "${TEST_START_DATE}"
 
       - name: Cleanup

--- a/.github/workflows/unit-int.yml
+++ b/.github/workflows/unit-int.yml
@@ -63,6 +63,11 @@ jobs:
           # Check if nvme config is valid, otherwise apply it
           sudo ./scripts/nvme-conf.sh --check --apply --overwrite
 
+      - name: Configure Docker logging driver
+        run: |
+          echo '{"log-driver": "journald"}' | sudo tee /etc/docker/daemon.json
+          sudo systemctl restart docker
+
       - name: Run Rust Tests
         run: |
           echo "TEST_START_DATE=$(date +"%Y-%m-%d %H:%M:%S")" >> $GITHUB_ENV

--- a/.github/workflows/unit-int.yml
+++ b/.github/workflows/unit-int.yml
@@ -69,6 +69,7 @@ jobs:
           nix-shell --run "./scripts/cargo-test.sh"
 
       - name: Check Coredumps
+        if: always()
         run: sudo ./scripts/check-coredumps.sh --since "${TEST_START_DATE}"
 
       - name: Cleanup
@@ -109,6 +110,7 @@ jobs:
           path: ./ci-report/ci-report.tar.gz
 
       - name: Check Coredumps
+        if: always()
         run: sudo ./scripts/check-coredumps.sh --since "${TEST_START_DATE}"
 
       - name: Cleanup

--- a/io-engine/src/bdev/device.rs
+++ b/io-engine/src/bdev/device.rs
@@ -4,7 +4,12 @@
 use async_trait::async_trait;
 use nix::errno::Errno;
 use once_cell::sync::{Lazy, OnceCell};
-use std::{collections::HashMap, convert::TryFrom, os::raw::c_void, rc::Rc, sync::Mutex};
+use std::{
+    collections::HashMap,
+    convert::TryFrom,
+    os::raw::c_void,
+    sync::{Arc, Mutex},
+};
 
 use spdk_rs::{
     libspdk::{
@@ -131,11 +136,11 @@ impl BlockDevice for SpdkBlockDevice {
 
 /// Wrapper around native SPDK block device descriptor, which mimics target SPDK
 /// descriptor as an abstract BlockDeviceDescriptor instance.
-struct SpdkBlockDeviceDescriptor(Rc<UntypedDescriptorGuard>);
+struct SpdkBlockDeviceDescriptor(Arc<UntypedDescriptorGuard>);
 
 impl From<UntypedDescriptorGuard> for SpdkBlockDeviceDescriptor {
     fn from(descr: UntypedDescriptorGuard) -> Self {
-        Self(Rc::new(descr))
+        Self(Arc::new(descr))
     }
 }
 
@@ -176,10 +181,10 @@ struct SpdkBlockDeviceHandle {
     handle: UntypedBdevHandle,
 }
 
-impl TryFrom<Rc<UntypedDescriptorGuard>> for SpdkBlockDeviceHandle {
+impl TryFrom<Arc<UntypedDescriptorGuard>> for SpdkBlockDeviceHandle {
     type Error = CoreError;
 
-    fn try_from(desc: Rc<UntypedDescriptorGuard>) -> Result<Self, Self::Error> {
+    fn try_from(desc: Arc<UntypedDescriptorGuard>) -> Result<Self, Self::Error> {
         let handle = BdevHandle::try_from(desc)?;
         Ok(SpdkBlockDeviceHandle::from(handle))
     }

--- a/io-engine/src/core/descriptor.rs
+++ b/io-engine/src/core/descriptor.rs
@@ -15,6 +15,11 @@ use crate::{
 /// When this structure is dropped, the descriptor is closed.
 pub struct DescriptorGuard<T: BdevOps>(BdevDesc<T>, Option<Thread>);
 
+// Safety: BdevDesc<T> is already Sync.
+// The Thread field is only accessed through &mut self (Drop) or as a
+// read-only borrow (&self in Debug), so concurrent shared references are safe.
+unsafe impl<T: BdevOps> Sync for DescriptorGuard<T> {}
+
 pub type UntypedDescriptorGuard = DescriptorGuard<()>;
 
 impl<T: BdevOps> Deref for DescriptorGuard<T> {

--- a/io-engine/src/core/handle.rs
+++ b/io-engine/src/core/handle.rs
@@ -4,7 +4,7 @@ use nix::errno::Errno;
 use std::{
     convert::TryFrom,
     fmt::{Debug, Error, Formatter},
-    rc::Rc,
+    sync::Arc,
 };
 
 use spdk_rs::{
@@ -30,7 +30,7 @@ pub struct BdevHandle<T: BdevOps> {
     /// dropped before we close the descriptor
     channel: IoChannelGuard<T::ChannelData>,
     /// TODO
-    desc: Rc<DescriptorGuard<T>>,
+    desc: Arc<DescriptorGuard<T>>,
 }
 
 pub type UntypedBdevHandle = BdevHandle<()>;
@@ -43,7 +43,7 @@ impl<T: BdevOps> BdevHandle<T> {
             if claim && !desc.claim() {
                 return Err(CoreError::BdevNotFound { name: name.into() });
             }
-            return BdevHandle::try_from(Rc::new(desc));
+            return BdevHandle::try_from(Arc::new(desc));
         }
 
         Err(CoreError::BdevNotFound { name: name.into() })
@@ -52,7 +52,7 @@ impl<T: BdevOps> BdevHandle<T> {
     /// Opens a new bdev handle given a bdev.
     pub fn open_with_bdev(bdev: &Bdev<T>, read_write: bool) -> Result<BdevHandle<T>, CoreError> {
         let desc = bdev.open(read_write)?;
-        BdevHandle::try_from(Rc::new(desc))
+        BdevHandle::try_from(Arc::new(desc))
     }
 
     /// Closes the BdevHandle.
@@ -306,14 +306,14 @@ impl<T: BdevOps> TryFrom<DescriptorGuard<T>> for BdevHandle<T> {
     type Error = CoreError;
 
     fn try_from(desc: DescriptorGuard<T>) -> Result<Self, Self::Error> {
-        Self::try_from(Rc::new(desc))
+        Self::try_from(Arc::new(desc))
     }
 }
 
-impl<T: BdevOps> TryFrom<Rc<DescriptorGuard<T>>> for BdevHandle<T> {
+impl<T: BdevOps> TryFrom<Arc<DescriptorGuard<T>>> for BdevHandle<T> {
     type Error = CoreError;
 
-    fn try_from(desc: Rc<DescriptorGuard<T>>) -> Result<Self, Self::Error> {
+    fn try_from(desc: Arc<DescriptorGuard<T>>) -> Result<Self, Self::Error> {
         if let Ok(channel) = desc.io_channel() {
             return Ok(Self { channel, desc });
         }

--- a/io-engine/tests/lvs_pool.rs
+++ b/io-engine/tests/lvs_pool.rs
@@ -17,7 +17,10 @@ use io_engine_api::v1::pool::{
     Pool, PoolAlert, PoolAlertStatus, PoolAlerts, PoolErrors, PoolState,
 };
 use once_cell::sync::OnceCell;
-use std::{pin::Pin, time::Duration};
+use std::{
+    pin::Pin,
+    time::{Duration, Instant},
+};
 
 pub mod common;
 
@@ -863,11 +866,26 @@ async fn stall_test(vg: io_engine::lvm::VolumeGroup, bdev: StallBdev) {
         let state = lvol.dm_resume().await.unwrap();
         assert_eq!(state, DmState::Active);
 
+        // Wait for the LVS reset + superblock read to complete
+        // vbdev_lvs_bs_bdev_reset() must drain before new I/Os succeed.
+        let deadline = Instant::now() + Duration::from_secs(1);
+        loop {
+            let (_, errors, _) = ms
+                .spawn(async move { pool_info(&Lvs::lookup(pool_n).unwrap()).await })
+                .await;
+            if !errors.io_stalled {
+                break;
+            }
+            assert!(Instant::now() < deadline, "pool did not recover from stall");
+            sleep(Duration::from_millis(50)).await;
+        }
+
         // Backend device is active, I/Os should now complete inline here...
         let result = ms
             .spawn(async move { common::bdev_io::write_some(repl, 8192, 1, 0xbb).await })
             .await;
-        assert!(result.is_ok(), "I/O: {:?}", result);
+        assert!(result.is_ok(), "{} - I/O: {:?}", repl, result);
+
         // Original stalled I/Os should also have completed!
         for (i, r) in io_completions.into_iter().enumerate() {
             let result = r.await.unwrap();


### PR DESCRIPTION
    ci: add container logs to journalctl
    
    This will help diagnosing in case of failure.
    
---

    ci: check for coredumps even on failures

---

    fix: revert back to arc descriptor guard
    
    When a previous fix added the Thread it changed the descriptor guard
    to be protected by Rc.
    This turned out not to be sound because this guard is actually shared
    across the reactors which may run on different cores!
    
    For now we add the Arc back and we mark the guard as Sync, since the
    thread is only used via Drop and should not be freed by SPDK whilst
    we still have the guard anyway.
    
    todo: we should get the thread from the descriptor itself, rather than
    keep another copy of it.
    Also to consider creating separate guards in the various cores, rather
    than reusing the same one?
    
---

    test: wait until stall clears before IO
    
    vbdev_lvs_bs_bdev_reset() must drain before new I/Os succeed, so there's
    a race between dmsetup resume and trying to send new I/Os.
    Instead we now wait until the stall is cleared.
