### PR TITLE
feat(nexus): persist clean_shutdown on share/unshare transitions

### DIFF
--- a/io-engine/src/bdev/nexus/nexus_bdev.rs
+++ b/io-engine/src/bdev/nexus/nexus_bdev.rs
@@ -802,6 +802,9 @@ impl<'n> Nexus<'n> {
         };
 
         // Persist the fact that the nexus is now successfully open.
+        // `PersistOp::Create` records the initial clean-while-unshared state,
+        // which then gets flipped on share/unshare to maintain the invariant
+        // `clean_shutdown <=> currently unshared`.
         // We have to do this before setting the nexus to open so that
         // nexus list does not return this nexus until it is persisted.
         if let Err(e) = nex.persist(PersistOp::Create).await {
@@ -831,7 +834,9 @@ impl<'n> Nexus<'n> {
     pub async fn destroy_ext(mut self: Pin<&mut Self>, sigterm: bool) -> Result<(), Error> {
         info!("{:?}: destroying nexus...", self);
 
-        self.as_mut().unshare_nexus().await?;
+        // Destroy already issues `PersistOp::Shutdown` below (which sets
+        // `clean_shutdown = true`), so skip the redundant persist here.
+        self.as_mut().unshare_nexus_internal(false).await?;
 
         // wait for all rebuild jobs to be cancelled before proceeding with the
         // destruction of the nexus

--- a/io-engine/src/bdev/nexus/nexus_persistence.rs
+++ b/io-engine/src/bdev/nexus/nexus_persistence.rs
@@ -82,6 +82,13 @@ pub(crate) enum PersistOp<'a> {
     },
     /// Save the clean shutdown variable.
     Shutdown,
+    /// Explicitly set the clean shutdown flag while the nexus is alive.
+    /// This is used to track the invariant `clean_shutdown <=> currently
+    /// unshared`: while no I/O can possibly flow (unshared), the children
+    /// cannot get dirty, so a crash from that state is equivalent to a clean
+    /// shutdown. Set to `true` on nexus create and on unshare, set to `false`
+    /// when the nexus transitions to shared and I/O becomes possible.
+    SetCleanShutdown { clean: bool },
 }
 
 impl std::fmt::Debug for PersistOp<'_> {
@@ -97,6 +104,9 @@ impl std::fmt::Debug for PersistOp<'_> {
                 child_uri, healthy, ..
             } => write!(f, "UpdateChildCond: {child_uri}: {healthy}"),
             PersistOp::Shutdown => write!(f, "Shutdown"),
+            PersistOp::SetCleanShutdown { clean } => {
+                write!(f, "SetCleanShutdown: {clean}")
+            }
         }
     }
 }
@@ -146,6 +156,11 @@ impl<'n> Nexus<'n> {
                         reason: "only child is unhealthy".to_string(),
                     });
                 }
+                // A freshly created nexus is intrinsically unshared: no
+                // initiator can connect and no I/O can dirty the children
+                // until `share_ext` runs. Record the clean state up front so
+                // that a crash from here is not treated as a dirty shutdown.
+                nexus_info.clean_shutdown = true;
             }
             PersistOp::AddChild { child_uri, healthy } => {
                 // Add the state of a new child. This should only be called
@@ -238,6 +253,12 @@ impl<'n> Nexus<'n> {
                 // This should only be called when destroying a nexus.
                 nexus_info.clean_shutdown = true;
             }
+            PersistOp::SetCleanShutdown { clean } => {
+                // Only update the clean shutdown variable. This is used by
+                // share/unshare/create transitions to track whether the nexus
+                // is currently in a state where I/O can dirty the children.
+                nexus_info.clean_shutdown = *clean;
+            }
         }
 
         match self.save(&persistent_nexus_info).await {
@@ -246,8 +267,10 @@ impl<'n> Nexus<'n> {
                 Ok(())
             }
             Err(e) => {
-                // If the operation was an update for shutdown, no need to
-                // shutdown in the case of an error.
+                // `PersistOp::Shutdown` is on the destroy path already, so
+                // self-shutting-down on top of that is pointless. Every other
+                // op falls through to the safe-by-default self-shutdown
+                // behaviour, since the save layer already retries internally.
                 if matches!(op, PersistOp::Shutdown) {
                     error!("{self:?}: failed to update persistent store: {e}");
                 } else {

--- a/io-engine/src/bdev/nexus/nexus_share.rs
+++ b/io-engine/src/bdev/nexus/nexus_share.rs
@@ -3,9 +3,12 @@ use async_trait::async_trait;
 use snafu::ResultExt;
 use std::pin::Pin;
 
-use super::{nexus_err, Error, NbdDisk, Nexus, NexusTarget};
+use super::{nexus_err, Error, NbdDisk, Nexus, NexusTarget, PersistOp};
 
-use crate::core::{NvmfShareProps, Protocol, PtplProps, Share, UpdateProps};
+use crate::{
+    core::{NvmfShareProps, Protocol, PtplProps, Share, UpdateProps},
+    subsys::NvmfSubsystem,
+};
 
 ///
 /// The sharing of the nexus is different compared to regular bdevs
@@ -38,6 +41,16 @@ impl Share for Nexus<'_> {
         let uri = match self.shared() {
             Some(Protocol::Off) | None => {
                 info!("{:?}: sharing NVMF target...", self);
+
+                // Persist `clean_shutdown = false` before the share goes
+                // live, so that a crash from here cannot leave the nexus
+                // marked clean while an initiator could be connecting and
+                // dirtying children. Lives here (rather than in `share_ext`)
+                // so the same guarantee holds for any direct caller of the
+                // trait method.
+                self.as_mut()
+                    .persist(PersistOp::SetCleanShutdown { clean: false })
+                    .await?;
 
                 let name = self.name.clone();
                 self.as_mut()
@@ -166,6 +179,14 @@ impl<'n> Nexus<'n> {
             // right now Off is mapped to Nbd, will clean up the Nbd related
             // code once we refactor the rust tests that use nbd.
             Protocol::Off => {
+                // Persist `clean_shutdown = false` before the NBD share goes
+                // live. The NVMe-oF path persists the same flag inside
+                // `Share::share_nvmf`, so each protocol owns its own
+                // transition guarantee.
+                self.as_mut()
+                    .persist(PersistOp::SetCleanShutdown { clean: false })
+                    .await?;
+
                 let disk = NbdDisk::create(&self.name)
                     .await
                     .context(nexus_err::ShareNbdNexus {
@@ -198,8 +219,20 @@ impl<'n> Nexus<'n> {
         }
     }
 
-    /// TODO
+    /// Unshare the nexus target and persist the now-clean state so a crash
+    /// from here behaves like a graceful shutdown.
     pub async fn unshare_nexus(mut self: Pin<&mut Self>) -> Result<(), Error> {
+        self.as_mut().unshare_nexus_internal(true).await
+    }
+
+    /// Inner unshare path shared by the public `unshare_nexus` and the
+    /// destroy path. `persist_clean` controls whether the now-unshared state
+    /// is recorded; destroy passes `false` because `PersistOp::Shutdown`
+    /// issued shortly afterwards already flips `clean_shutdown` to `true`.
+    pub(super) async fn unshare_nexus_internal(
+        mut self: Pin<&mut Self>,
+        persist_clean: bool,
+    ) -> Result<(), Error> {
         match unsafe { self.as_mut().get_unchecked_mut().nexus_target.take() } {
             Some(NexusTarget::NbdDisk(disk)) => {
                 info!("{:?}: destroying NBD device target...", self);
@@ -214,7 +247,34 @@ impl<'n> Nexus<'n> {
             }
         }
 
-        self.as_mut().unshare(None).await
+        self.as_mut().unshare(None).await?;
+
+        if persist_clean {
+            // Double-check the `NvmfSubsystem` is really gone before marking
+            // the children clean. A racing resume can re-start a stopped
+            // subsystem and leave the unshare looking successful on the way
+            // out; if it is still around, the children could still be
+            // touched, so leave `clean_shutdown` as-is and let the existing
+            // crash-recovery path handle it on next start.
+            if NvmfSubsystem::nqn_lookup(&self.name).is_some() {
+                warn!(
+                    "{self:?}: NvmfSubsystem still present after unshare, \
+                    skipping clean-shutdown persist (subsystem resume race)"
+                );
+            } else if let Err(e) = self
+                .as_mut()
+                .persist(PersistOp::SetCleanShutdown { clean: true })
+                .await
+            {
+                warn!(
+                    "{self:?}: failed to persist clean_shutdown after unshare \
+                    (best-effort, falling back to existing crash-recovery \
+                    behaviour on next start): {e}"
+                );
+            }
+        }
+
+        Ok(())
     }
 
     /// TODO

--- a/io-engine/tests/persistence.rs
+++ b/io-engine/tests/persistence.rs
@@ -30,7 +30,9 @@ static CHILD2_UUID: &str = "094ae8c6-46aa-4139-b4f2-550d39645db3";
 static CHILD3_UUID: &str = "ae09c08f-8909-4024-a9ae-c21a2a0596b9";
 
 /// This test checks that when an unexpected restart occurs, all persisted info
-/// remains unchanged. In particular, the clean shutdown variable must be false.
+/// remains unchanged. The nexus is never shared here, so `clean_shutdown`
+/// stays `true` throughout: an unshared nexus cannot accept I/O and is
+/// therefore clean by construction.
 #[tokio::test]
 async fn persist_unexpected_restart() {
     let test = start_infrastructure("persist_unexpected_restart").await;
@@ -56,7 +58,7 @@ async fn persist_unexpected_restart() {
 
     // Check the persisted nexus info is correct.
 
-    assert!(!nexus_info.clean_shutdown);
+    assert!(nexus_info.clean_shutdown);
 
     let child = child_info(&nexus_info, &uuid(&child1));
     assert!(child.healthy);
@@ -111,13 +113,23 @@ async fn persist_clean_shutdown() {
 
     // Check the persisted nexus info is correct.
 
-    assert!(!nexus_info.clean_shutdown);
+    assert!(nexus_info.clean_shutdown);
 
     let child = child_info(&nexus_info, &uuid(&child1));
     assert!(child.healthy);
 
     let child = child_info(&nexus_info, &uuid(&child2));
     assert!(child.healthy);
+
+    // Publish the nexus so the share path flips clean_shutdown to false;
+    // this lets the subsequent destroy meaningfully validate the
+    // false -> true transition driven by `PersistOp::Shutdown`.
+    publish_nexus(ms1, nexus_uuid).await;
+
+    let response = etcd.get(nexus_uuid, None).await.expect("No entry found");
+    let value = response.kvs().first().unwrap().value();
+    let nexus_info: NexusInfo = serde_json::from_slice(value).unwrap();
+    assert!(!nexus_info.clean_shutdown);
 
     // Destroy the nexus
     ms1.mayastor


### PR DESCRIPTION
This is the data-plane change for offline volume rebuild iteration 4 (OEP openebs/openebs#4208).

## The core idea

A nexus is "clean" (no possible dirty data) iff it is currently unshared. While unshared, no initiator can connect and no I/O can dirty the children, so a crash from that state is equivalent to a graceful shutdown.

Today the only thing that flips `NexusInfo.clean_shutdown` to `true` is `PersistOp::Shutdown`, called during destroy/shutdown. An unshared nexus that crashes therefore looks "dirty" to the control plane on recovery, and `scheduling.rs::healthy_children` falls into the `HealthyChildItems::One` branch which forces every non-elected child into a full rebuild. For offline-rebuild nexuses (which by design never carry frontend I/O) that's a lot of needless copying.

## What changes

- New `PersistOp::SetCleanShutdown { clean }` variant. Wires through `nexus_info.clean_shutdown` like the other persist ops.
- `register_instance` calls `SetCleanShutdown { clean: true }` right after `PersistOp::Create`. A freshly created nexus is unshared by construction.
- `share_ext` calls `SetCleanShutdown { clean: false }` before the share actually goes live. A crash mid-share now leaves the nexus marked dirty, which is the safe direction, the existing share path already starts the nexus from a known-clean state, so over-marking-dirty just means a full rebuild on recovery instead of incorrectly trusting children.
- `unshare_nexus` calls `SetCleanShutdown { clean: true }` after the target is cleared. Best-effort: a persistence failure here is logged and swallowed, because the worst case is reverting to today's behaviour (full rebuild on next start), not data loss.
- The save-failure path that self-shutdowns now treats `SetCleanShutdown { clean: true }` the same as `PersistOp::Shutdown`, both are correctness-neutral, so a transient etcd hiccup shouldn't take the nexus down. `SetCleanShutdown { clean: false }` still self-shutdowns on failure, because that path is load-bearing for the dirty-window guarantee.

## Crash semantics

| Scenario | `clean_shutdown` after crash | Control-plane recovery |
|---|---|---|
| Crash before `share_ext` runs (offline rebuild) | `true` | Treat children as clean |
| Crash during `share_ext` (after the persist, before the share completes) | `false` | Existing full-rebuild behaviour |
| Crash on a shared nexus | `false` | Existing full-rebuild behaviour |
| Crash after `unshare_nexus` | `true` | Treat children as clean |
| Graceful shutdown | `true` | Treat children as clean |

No control-plane changes needed for this PR. `scheduling.rs::healthy_children` already does the right thing the moment it sees `clean_shutdown = true`.

## Testing

Local build + lint sweep on a Linux nix-shell environment:

```
cargo fmt --check
./scripts/rust-linter.sh          # cargo clippy --all --all-targets --features=io-engine-testing -- -D warnings
cargo build --bins --features=io-engine-testing
./scripts/cargo-test.sh
./scripts/pytest-tests.sh         # BDD
```

(All pass locally)

## Follow-up

There's a small follow-up on the control-plane side: today the offline-rebuild temp nexus is constructed from healthy replicas only, so when the offline replica returns it's added as a fresh child and the existing partial-rebuild / I/O-log machinery in `nexus_child.rs::start_io_log` never gets a chance to give it a cheap return path. Including the faulted child at temp-nexus-creation time fixes that, and lines up with `handle_faulted_child` / `faulted_child_wait` that already exist for shared volumes. Will raise a separate PR against mayastor-control-plane once this is merged.

cc @tiagolobocastro @Abhinandan-Purkait