### PR TITLE
feat(gpt): add nexus label infra back

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -588,6 +588,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "build_const"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ae4235e6dac0694637c763029ecea1a2ec9e4e06ec2729bd21ba4d9c863eb7"
+
+[[package]]
 name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -861,6 +867,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e4c1eaa2012c47becbbad2ab175484c2a84d1185b566fb2cc5b8707343dfe58"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d663548de7f5cca343f1e0a48d14dcfb0e9eb4e079ec58883b7251539fa10aeb"
+dependencies = [
+ "build_const",
 ]
 
 [[package]]
@@ -2110,6 +2125,7 @@ dependencies = [
  "chrono",
  "clap",
  "colored_json",
+ "crc",
  "crossbeam",
  "derive_builder",
  "devinfo",

--- a/io-engine/Cargo.toml
+++ b/io-engine/Cargo.toml
@@ -76,6 +76,7 @@ tokio-stream = "0.1.16"
 either = "1.13.0"
 sha2 = "0.10.8"
 signal-hook = "0.3.17"
+crc = "1.8.1"
 
 chrono = { workspace = true }
 colored_json = { workspace = true }

--- a/io-engine/src/bdev/gpt/primitives.rs
+++ b/io-engine/src/bdev/gpt/primitives.rs
@@ -1,0 +1,1144 @@
+//! Generic GPT (GUID Partition Table) primitives.
+//!
+//! This module contains only the standards-based pieces of GPT handling —
+//! header, partition entry, protective MBR, label container, probing,
+//! serialisation and validation — with no knowledge of any particular
+//! partition layout. The nexus' versioned MayaMeta/MayaData layout is
+//! built on top of these primitives in [`super::label`].
+//!
+//! The on-disk format follows the UEFI specification:
+//! - LBA 0: protective MBR
+//! - LBA 1: primary GPT header
+//! - LBA 2..: primary partition table
+//! - last LBA: secondary GPT header (mirror of the primary)
+//! - just before the secondary header: secondary partition table
+
+use std::{
+    convert::From,
+    fmt,
+    io::{Cursor, Seek, SeekFrom},
+    ops::{Deref, DerefMut},
+    str::FromStr,
+};
+
+use crate::core::{BlockDeviceHandle, CoreError};
+
+use bincode::{deserialize_from, serialize, serialize_into, Error};
+use crc::{crc32, Hasher32};
+use serde::{
+    de::{Deserializer, SeqAccess, Unexpected, Visitor},
+    ser::{SerializeTuple, Serializer},
+    Deserialize, Serialize,
+};
+use snafu::{ResultExt, Snafu};
+use spdk_rs::{DmaBuf, DmaError};
+use uuid::{self, Uuid};
+
+/// The GPT label error type.
+#[derive(Debug, Snafu)]
+pub enum LabelError {
+    #[snafu(display("Serialization error: {source}"))]
+    SerializeError { source: Error },
+    #[snafu(display("Failed to allocate buffer for reading {part}: {source}"))]
+    ReadAlloc { source: DmaError, part: String },
+    #[snafu(display("Failed to allocate buffer for writing {what}: {source}"))]
+    WriteAlloc { source: DmaError, what: String },
+    #[snafu(display("Error reading {what}: {source}"))]
+    ReadError { source: CoreError, what: String },
+    #[snafu(display("Error writing {what}: {source}"))]
+    WriteError { source: CoreError, what: String },
+    #[snafu(display("Label is invalid: {source}"))]
+    InvalidLabel { source: ProbeError },
+    #[snafu(display("Failed to obtain BlockDeviceHandle: {source}"))]
+    HandleError { source: CoreError },
+    #[snafu(display(
+        "Device is too small to accommodate the requested partition layout: \
+         size = {num_blocks} x {block_size}"
+    ))]
+    DeviceTooSmall { num_blocks: u64, block_size: u64 },
+    #[snafu(display(
+        "Label is too large to fit on the device: dev-size = {dev_size}, label-size = {part_size}"
+    ))]
+    LabelTooLarge { dev_size: u64, part_size: u64 },
+    #[snafu(display("{source}"))]
+    SeekError { source: std::io::Error },
+}
+
+/// The GPT probe error type.
+#[derive(Debug, Snafu)]
+pub enum ProbeError {
+    #[snafu(display("Serialization error: {source}"))]
+    ChecksumSerializeError { source: Error },
+    #[snafu(display("Deserialization error: {source}"))]
+    DeserializeError { source: Error },
+    #[snafu(display("Incorrect MBR signature"))]
+    MbrSignature {},
+    #[snafu(display("Disk size in MBR does not match size in GPT header"))]
+    MbrSize {},
+    #[snafu(display("Incorrect GPT header signature"))]
+    GptSignature {},
+    #[snafu(display("Incorrect GPT header revision"))]
+    GptRevision {},
+    #[snafu(display("Incorrect GPT header size: actual={actual_size}, expected={expected_size}"))]
+    GptHeaderSize {
+        actual_size: u32,
+        expected_size: u32,
+    },
+    #[snafu(display("Incorrect GPT header checksum"))]
+    GptChecksum {},
+    #[snafu(display("Incorrect GPT partition table checksum"))]
+    PartitionTableChecksum {},
+    #[snafu(display("Disk GUIDs differ"))]
+    CompareDiskGuid {},
+    #[snafu(display("Disk sizes differ"))]
+    CompareDiskSize {},
+    #[snafu(display("GPT stored partition table checksums differ"))]
+    ComparePartitionTableChecksum {},
+    #[snafu(display("GPT partition table location is incorrect"))]
+    PartitionTableLocation {},
+    #[snafu(display("Missing partition: {name}"))]
+    MissingPartition { name: String },
+    #[snafu(display("Primary GPT header location is incorrect"))]
+    PrimaryLocation {},
+    #[snafu(display("Secondary GPT header location is incorrect"))]
+    SecondaryLocation {},
+    #[snafu(display("Location of first usable block is incorrect"))]
+    FirstUsableBlock {},
+    #[snafu(display("Location of last usable block is incorrect"))]
+    LastUsableBlock {},
+    #[snafu(display("Partition table exceeds maximum size"))]
+    PartitionTableSize {},
+    #[snafu(display("Insufficient space reserved for partition table"))]
+    PartitionTableSpace {},
+    #[snafu(display("Partition starts before first usable block"))]
+    PartitionStart {},
+    #[snafu(display("Partition ends after last usable block"))]
+    PartitionEnd {},
+    #[snafu(display("Partition has negative size"))]
+    NegativePartitionSize {},
+    #[snafu(display("GPT header locations are inconsistent"))]
+    CompareHeaderLocation {},
+    #[snafu(display("Number of partition table entries differ"))]
+    ComparePartitionEntryCount {},
+    #[snafu(display("Partition table entry sizes differ"))]
+    ComparePartitionEntrySize {},
+    #[snafu(display("Incorrect partition layout"))]
+    IncorrectPartitions {},
+    #[snafu(display("Label is invalid"))]
+    LabelRedundancy {},
+}
+
+impl From<ProbeError> for LabelError {
+    fn from(error: ProbeError) -> LabelError {
+        LabelError::InvalidLabel { source: error }
+    }
+}
+
+/// Based on RFC4122.
+#[derive(Debug, serde::Deserialize, PartialEq, Default, serde::Serialize, Clone, Copy)]
+pub struct GptGuid {
+    pub time_low: u32,
+    pub time_mid: u16,
+    pub time_high: u16,
+    pub node: [u8; 8],
+}
+
+impl From<Uuid> for GptGuid {
+    fn from(uuid: Uuid) -> GptGuid {
+        let fields = uuid.as_fields();
+        GptGuid {
+            time_low: fields.0,
+            time_mid: fields.1,
+            time_high: fields.2,
+            node: *fields.3,
+        }
+    }
+}
+
+impl From<GptGuid> for Uuid {
+    fn from(guid: GptGuid) -> Uuid {
+        Uuid::from_fields(guid.time_low, guid.time_mid, guid.time_high, &guid.node)
+    }
+}
+
+impl FromStr for GptGuid {
+    type Err = uuid::Error;
+
+    fn from_str(uuid: &str) -> Result<Self, Self::Err> {
+        Ok(GptGuid::from(Uuid::from_str(uuid)?))
+    }
+}
+
+impl fmt::Display for GptGuid {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", Uuid::from(*self))
+    }
+}
+
+impl GptGuid {
+    pub fn new_random() -> Self {
+        GptGuid::from(Uuid::new_v4())
+    }
+}
+
+/// The GPT header structure, as defined in the UEFI specification.
+#[derive(Debug, Deserialize, PartialEq, Default, Serialize, Copy, Clone)]
+pub struct GptHeader {
+    /// GPT signature (must be "EFI PART").
+    pub signature: [u8; 8],
+    /// 00 00 01 00 up til version 2.17
+    pub revision: [u8; 4],
+    /// GPT header size (92 bytes)
+    pub header_size: u32,
+    /// CRC32 of the header.
+    pub self_checksum: u32,
+    pub reserved: [u8; 4],
+    /// primary lba where the header
+    pub lba_self: u64,
+    /// alternative lba
+    pub lba_alt: u64,
+    /// first usable lba
+    pub lba_start: u64,
+    /// last usable lba
+    pub lba_end: u64,
+    /// 16 bytes representing the GUID of the GPT.
+    pub guid: GptGuid,
+    /// lba of where to find the partition table
+    pub lba_table: u64,
+    /// number of partitions, most tools set this to 128
+    pub num_entries: u32,
+    /// Size of element
+    pub entry_size: u32,
+    /// CRC32 checksum of the partition array.
+    pub table_crc: u32,
+}
+
+impl GptHeader {
+    /// The size of the partition table in bytes: 128 entries × 128 bytes each,
+    /// the minimum required by the UEFI specification.
+    pub const PARTITION_TABLE_SIZE: u64 = 128 * 128;
+    /// The byte offset of the first usable LBA (1 MiB). Aligning the first
+    /// usable sector to 1 MiB is the conventional default used by most GPT
+    /// tools (e.g. fdisk, gdisk) to ensure optimal I/O alignment on SSDs and
+    /// RAID arrays.
+    pub const DATA_OFFSET: u64 = 1024 * 1024;
+    /// The GPT header size in bytes, as defined by the UEFI specification.
+    /// The remainder of the first LBA (sector) following the header is reserved.
+    pub const HEADER_SIZE: u32 = 92;
+    /// The revision of the GPT header, as defined in the UEFI specification.
+    pub const HEADER_REVISION: [u8; 4] = [0x00, 0x00, 0x01, 0x00];
+    /// The signature of the GPT header, as defined in the UEFI specification.
+    pub const HEADER_SIGNATURE: [u8; 8] = [0x45, 0x46, 0x49, 0x20, 0x50, 0x41, 0x52, 0x54];
+
+    /// Converts a slice into a GPT header and verifies the validity of the data.
+    pub fn from_slice(slice: &[u8]) -> Result<GptHeader, ProbeError> {
+        let mut reader = Cursor::new(slice);
+
+        let mut header: GptHeader = deserialize_from(&mut reader).context(DeserializeSnafu)?;
+
+        if header.header_size != GptHeader::HEADER_SIZE {
+            return Err(ProbeError::GptHeaderSize {
+                actual_size: header.header_size,
+                expected_size: GptHeader::HEADER_SIZE,
+            });
+        }
+
+        if header.signature != GptHeader::HEADER_SIGNATURE {
+            return Err(ProbeError::GptSignature {});
+        }
+
+        if header.revision != GptHeader::HEADER_REVISION {
+            return Err(ProbeError::GptRevision {});
+        }
+
+        let checksum = header.self_checksum;
+
+        if checksum != header.checksum().context(ChecksumSerializeSnafu)? {
+            return Err(ProbeError::GptChecksum {});
+        }
+
+        Ok(header)
+    }
+
+    /// Checksums the header with the checksum field itself set to 0.
+    pub fn checksum(&mut self) -> Result<u32, Error> {
+        self.self_checksum = 0;
+        self.self_checksum = crc32::checksum_ieee(&serialize(&self)?);
+        Ok(self.self_checksum)
+    }
+
+    // Creates a new GPT header for a device with specified size.
+    pub fn new(guid: GptGuid, block_size: u64, num_blocks: u64) -> Self {
+        let partition_blocks = Aligned::get_blocks(GptHeader::PARTITION_TABLE_SIZE, block_size);
+
+        let data_start = Aligned::get_blocks(GptHeader::DATA_OFFSET, block_size);
+
+        GptHeader {
+            signature: GptHeader::HEADER_SIGNATURE,
+            revision: GptHeader::HEADER_REVISION,
+            header_size: GptHeader::HEADER_SIZE,
+            self_checksum: 0,
+            reserved: [0; 4],
+            lba_self: 1,
+            lba_alt: num_blocks - 1,
+            lba_start: data_start,
+            lba_end: num_blocks - partition_blocks - 2,
+            guid,
+            lba_table: 2,
+            num_entries: 128,
+            entry_size: 128,
+            table_crc: 0,
+        }
+    }
+
+    /// Derives the secondary GPT header from this (primary) header.
+    ///
+    /// The secondary header mirrors the primary: `lba_self`/`lba_alt` are
+    /// swapped so the secondary points to itself at the last LBA of the disk.
+    /// The secondary partition table is placed immediately after `lba_end`
+    /// (the last usable LBA), growing backwards toward the secondary header.
+    pub fn as_secondary(&self) -> Result<GptHeader, Error> {
+        let mut secondary = *self;
+        secondary.lba_self = self.lba_alt;
+        secondary.lba_alt = self.lba_self;
+        secondary.lba_table = self.lba_end + 1;
+        secondary.checksum()?;
+        Ok(secondary)
+    }
+
+    /// Derives the primary GPT header from this (secondary) header.
+    ///
+    /// This is the inverse of [`as_secondary`](Self::as_secondary): must be
+    /// called on a secondary header. `lba_self`/`lba_alt` are swapped so the
+    /// result points to LBA 1 (the primary header location), and the primary
+    /// partition table is placed at `lba_self + 1` (LBA 2, immediately after
+    /// the primary header).
+    pub fn as_primary(&self) -> Result<GptHeader, Error> {
+        let mut primary = *self;
+        primary.lba_self = self.lba_alt;
+        primary.lba_alt = self.lba_self;
+        primary.lba_table = self.lba_alt + 1;
+        primary.checksum()?;
+        Ok(primary)
+    }
+}
+
+// For arrays bigger than 32 elements, things start to get unimplemented
+// in terms of derive and what not. So we create our own "newtype" struct,
+// and tell serde how to use it during serializing/deserializing.
+#[derive(Debug, PartialEq, Default, Clone)]
+pub struct GptName {
+    pub name: String,
+}
+impl std::fmt::Display for GptName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.name)
+    }
+}
+
+struct GpEntryNameVisitor;
+
+impl<'a> Deserialize<'a> for GptName {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'a>,
+    {
+        deserializer.deserialize_tuple_struct("GptName", 36, GpEntryNameVisitor)
+    }
+}
+
+impl Serialize for GptName {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        // we can't use serialize_type_struct here as we want exactly 72 bytes
+        let mut s = serializer.serialize_tuple(36)?;
+        let mut out: Vec<u16> = vec![0; 36];
+        for (i, o) in self.name.encode_utf16().zip(out.iter_mut()) {
+            *o = i;
+        }
+
+        out.iter().for_each(|e| s.serialize_element(&e).unwrap());
+        s.end()
+    }
+}
+
+impl<'a> Visitor<'a> for GpEntryNameVisitor {
+    type Value = GptName;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("Invalid GPT partition name")
+    }
+
+    fn visit_seq<A>(self, mut seq: A) -> std::result::Result<GptName, A::Error>
+    where
+        A: SeqAccess<'a>,
+    {
+        let mut out = Vec::new();
+        let mut end = false;
+        loop {
+            match seq.next_element()? {
+                Some(0) => {
+                    end = true;
+                }
+                Some(e) if !end => out.push(e),
+                _ => break,
+            }
+        }
+
+        if end {
+            Ok(GptName::from(String::from_utf16_lossy(&out)))
+        } else {
+            Err(serde::de::Error::invalid_value(Unexpected::Seq, &self))
+        }
+    }
+}
+
+impl From<String> for GptName {
+    fn from(name: String) -> GptName {
+        GptName { name }
+    }
+}
+impl From<&str> for GptName {
+    fn from(name: &str) -> GptName {
+        GptName::from(String::from(name))
+    }
+}
+
+/// The GPT partition entry structure, as defined in the UEFI specification.
+#[derive(Debug, Default, PartialEq, Deserialize, Serialize, Clone)]
+pub struct GptEntry {
+    /// GUID type, some of them are assigned/reserved for example to Linux
+    pub ent_type: GptGuid,
+    /// entry GUID, can be anything typically random
+    pub ent_guid: GptGuid,
+    /// start lba for this entry
+    pub ent_start: u64,
+    /// end lba for this entry
+    pub ent_end: u64,
+    /// entry attributes, according to do the docs bit 0 MUST be zero
+    pub ent_attr: u64,
+    /// UTF-16 name of the partition entry,
+    /// DO NOT confuse this with filesystem labels!
+    pub ent_name: GptName,
+}
+
+impl GptEntry {
+    /// Converts a slice into a partition table.
+    pub fn from_slice(slice: &[u8], count: u32) -> Result<Vec<GptEntry>, ProbeError> {
+        let mut reader = Cursor::new(slice);
+        let mut partitions: Vec<GptEntry> = Vec::with_capacity(count as usize);
+        for _ in 0..count {
+            partitions.push(deserialize_from(&mut reader).context(DeserializeSnafu)?);
+        }
+        Ok(partitions)
+    }
+
+    /// Checks if the partition entry is unused, which is indicated by a zeroed GUID.
+    pub fn is_unused(&self) -> bool {
+        self.ent_guid == GptGuid::default()
+    }
+
+    /// Calculates the checksum over the partition table.
+    pub fn checksum(partitions: &[GptEntry], size: u32) -> Result<u32, Error> {
+        let mut digest = crc32::Digest::new(crc32::IEEE);
+        let count = partitions.len() as u32;
+        for entry in partitions {
+            digest.write(&serialize(entry)?);
+        }
+        if count < size {
+            let pad = serialize(&GptEntry::default())?;
+            for _ in count..size {
+                digest.write(&pad);
+            }
+        }
+        Ok(digest.sum32())
+    }
+}
+
+/// Although we don't use it, we must have a protective MBR to avoid systems
+/// to get confused about what's on the disk. Utils like sgdisk work fine
+/// without an MBR (but will warn) but as we want to be able to access the
+/// partitions with the nexus out of the data path, will create one here.
+///
+/// The struct should have a 440 byte code section here as well,
+/// however this is omitted to make serialisation a bit easier.
+#[derive(Copy, Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct Pmbr {
+    /// signature to uniquely ID the disk we do not use this
+    disk_signature: u32,
+    reserved: u16,
+    /// number of partition entries
+    pub(super) entries: [MbrEntry; 4],
+    /// must be set to [0x55, 0xaa]
+    signature: [u8; 2],
+}
+
+/// The MBR partition entry structure, as defined in the UEFI specification.
+#[derive(Copy, Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+pub struct MbrEntry {
+    /// attributes of this MBR partition we set these all to zero, which
+    /// includes the boot flag.
+    attributes: u8,
+    /// start in CHS format
+    chs_start: [u8; 3],
+    /// type of partition, in our case always 0xEE
+    ent_type: u8,
+    /// end of the partition
+    chs_last: [u8; 3],
+    /// lba start
+    lba_start: u32,
+    /// last sector of this partition
+    num_sectors: u32,
+}
+
+impl MbrEntry {
+    /// Set this MBR partition entry to represent a protective MBR partition of given size.
+    pub fn protect(&mut self, num_blocks: u64) {
+        self.attributes = 0x00; // NOT bootable
+        self.ent_type = 0xee; // protective MBR partition
+        self.chs_start = [0x00, 0x02, 0x00]; // CHS address 0/0/2
+        self.chs_last = [0xff, 0xff, 0xff]; // CHS address 1023/255/63
+
+        // The partition starts immediately after the MBR
+        self.lba_start = 1;
+
+        // The partition size must accurately reflect
+        // the disk size where possible.
+        if num_blocks > u32::MAX as u64 {
+            // If the size (in blocks) is too large to fit into 32 bits,
+            // then set the size to 0xffff_ffff
+            self.num_sectors = u32::MAX;
+        } else {
+            // Do not count the first block that contains the MBR
+            self.num_sectors = (num_blocks - 1) as u32;
+        }
+    }
+}
+
+impl Pmbr {
+    /// The signature of the protective MBR, as defined in the UEFI specification.
+    pub const PMBR_SIGNATURE: [u8; 2] = [0x55, 0xaa];
+
+    /// Converts a slice into a MBR and validates the signature.
+    pub fn from_slice(slice: &[u8]) -> Result<Pmbr, ProbeError> {
+        let mut reader = Cursor::new(slice);
+
+        let mbr: Pmbr = deserialize_from(&mut reader).context(DeserializeSnafu)?;
+
+        if mbr.signature != Pmbr::PMBR_SIGNATURE {
+            return Err(ProbeError::MbrSignature {});
+        }
+
+        Ok(mbr)
+    }
+}
+
+impl Default for Pmbr {
+    fn default() -> Self {
+        Pmbr {
+            disk_signature: 0,
+            reserved: 0,
+            entries: [MbrEntry::default(); 4],
+            signature: Pmbr::PMBR_SIGNATURE,
+        }
+    }
+}
+
+/// The status of the GPT labels on disk.
+#[derive(Clone, Copy, Debug, PartialEq, Serialize)]
+pub enum LabelStatus {
+    /// Both primary and secondary labels are synced with disk.
+    Both,
+    /// Only primary label is synced with disk.
+    Primary,
+    /// Only secondary label is synced with disk.
+    Secondary,
+    /// Neither primary or secondary labels are synced with disk.
+    Neither,
+}
+
+/// A standard GPT label: protective MBR, primary header, partition table
+/// and secondary header.
+///
+/// The container is layout-agnostic; consumers may attach any meaningful
+/// interpretation to the partitions via sibling modules (e.g.
+/// [`crate::bdev::nexus::nexus_label`] for the nexus' MayaMeta/MayaData
+/// layout).
+#[derive(Debug, PartialEq, Serialize, Clone)]
+pub struct GptLabel {
+    /// The status of the labels.
+    pub status: LabelStatus,
+    /// Block size of underlying device.
+    pub block_size: u64,
+    /// The protective MBR.
+    pub mbr: Pmbr,
+    /// The main GPT header.
+    pub primary: GptHeader,
+    /// Vector of GPT partition entries (only entries that actually define a
+    /// partition; padding entries are dropped).
+    pub partitions: Vec<GptEntry>,
+    /// The backup GPT header.
+    pub secondary: GptHeader,
+}
+
+impl GptLabel {
+    /// Build a new label from a freshly-constructed primary header and a
+    /// set of partition entries.
+    ///
+    /// Computes the partition-table CRC, the header self-CRC and derives
+    /// the secondary header from the primary. The protective MBR is
+    /// populated to match `num_blocks`.
+    pub fn new(
+        guid: GptGuid,
+        block_size: u64,
+        num_blocks: u64,
+        partitions: Vec<GptEntry>,
+    ) -> Result<GptLabel, LabelError> {
+        let mut pmbr = Pmbr::default();
+        pmbr.entries[0].protect(num_blocks);
+
+        let mut header = GptHeader::new(guid, block_size, num_blocks);
+        header.table_crc =
+            GptEntry::checksum(&partitions, header.num_entries).context(SerializeSnafu)?;
+        header.checksum().context(SerializeSnafu)?;
+        let secondary = header.as_secondary().context(SerializeSnafu)?;
+
+        Ok(GptLabel {
+            status: LabelStatus::Neither,
+            block_size,
+            mbr: pmbr,
+            primary: header,
+            partitions,
+            secondary,
+        })
+    }
+
+    /// Probe the disk for a [`GptLabel`].
+    pub async fn probe_label<T: GptDiskOps>(handle: &T) -> Result<GptLabel, LabelError> {
+        let GptDiskProps {
+            block_size,
+            num_blocks,
+        } = handle.props();
+
+        // Note that PMBR is 512B even on larger sector disks, but we must allocate block_size
+        // bytes to read it, as the underlying device may not support smaller reads.
+        let mut buf = handle.buffer_alloc(block_size).context(ReadAllocSnafu {
+            part: String::from("MBR"),
+        })?;
+        handle.read_at(0, &mut buf).await.context(ReadSnafu {
+            what: String::from("MBR"),
+        })?;
+        let mbr = GptLabel::read_mbr(&buf)?;
+
+        // GPT headers
+        let status: LabelStatus;
+        let primary: GptHeader;
+        let secondary: GptHeader;
+        let active: &GptHeader;
+
+        // Get primary GPT header.
+        handle
+            .read_at(block_size, &mut buf)
+            .await
+            .context(ReadSnafu {
+                what: String::from("primary GPT header"),
+            })?;
+        match GptLabel::read_primary_header(&buf, block_size, num_blocks) {
+            Ok(header) => {
+                primary = header;
+                active = &primary;
+                // Get secondary GPT header.
+                let offset = (num_blocks - 1) * block_size;
+                handle.read_at(offset, &mut buf).await.context(ReadSnafu {
+                    what: String::from("secondary GPT header"),
+                })?;
+                match GptLabel::read_secondary_header(&buf, block_size, num_blocks) {
+                    Ok(header) => {
+                        GptLabel::consistency_check(&primary, &header)?;
+                        // All good - primary and secondary GPT headers
+                        // are valid and consistent with each other.
+                        secondary = header;
+                        status = LabelStatus::Both;
+                    }
+                    Err(_) => {
+                        // Secondary GPT header is either not present
+                        // or invalid. Construct new secondary GPT header from primary.
+                        secondary = primary.as_secondary().context(SerializeSnafu)?;
+                        status = LabelStatus::Primary;
+                    }
+                }
+            }
+            Err(error) => {
+                // Primary GPT header is either not present or invalid.
+                // See if we can obtain a valid secondary GPT header.
+                let offset = (num_blocks - 1) * block_size;
+                handle.read_at(offset, &mut buf).await.context(ReadSnafu {
+                    what: String::from("secondary GPT header"),
+                })?;
+                match GptLabel::read_secondary_header(&buf, block_size, num_blocks) {
+                    Ok(header) => {
+                        secondary = header;
+                        active = &secondary;
+                        // Construct new primary GPT header from secondary.
+                        primary = secondary.as_primary().context(SerializeSnafu)?;
+                        status = LabelStatus::Secondary;
+                    }
+                    Err(_) => {
+                        // Neither primary or secondary GPT header is present or valid.
+                        return Err(LabelError::InvalidLabel { source: error });
+                    }
+                }
+            }
+        }
+
+        // The disk size recorded in protective MBR must be consistent with GPT header.
+        if mbr.entries[0].num_sectors != 0xffff_ffff
+            && u64::from(mbr.entries[0].num_sectors) != primary.lba_alt
+        {
+            return Err(LabelError::InvalidLabel {
+                source: ProbeError::MbrSize {},
+            });
+        }
+
+        // Partition table
+        let blocks = Aligned::get_blocks(
+            u64::from(active.entry_size * active.num_entries),
+            block_size,
+        );
+        let mut buf = handle
+            .buffer_alloc(blocks * block_size)
+            .context(ReadAllocSnafu {
+                part: String::from("partition table"),
+            })?;
+        let offset = active.lba_table * block_size;
+        handle.read_at(offset, &mut buf).await.context(ReadSnafu {
+            what: String::from("partition table"),
+        })?;
+        let mut partitions = GptLabel::read_partitions(&buf, active)?;
+
+        // There can be up to 128 partition entries stored on disk,
+        // even though most are not used. Retain only those entries
+        // that actually define partitions.
+        partitions.retain(|entry| entry.ent_start > 0 || entry.ent_end > 0);
+
+        Ok(GptLabel {
+            status,
+            block_size,
+            mbr,
+            primary,
+            partitions,
+            secondary,
+        })
+    }
+
+    /// Locate a partition by name.
+    pub fn partition(&self, name: &str) -> Option<&GptEntry> {
+        self.partitions
+            .iter()
+            .find(|entry| entry.ent_name.name == name)
+    }
+
+    /// Returns the offset (in bytes) of the specified partition.
+    pub fn partition_offset(&self, name: &str) -> Result<u64, ProbeError> {
+        match self.partition(name) {
+            Some(entry) => Ok(entry.ent_start * self.block_size),
+            None => Err(ProbeError::MissingPartition {
+                name: String::from(name),
+            }),
+        }
+    }
+
+    /// Returns the size (in bytes) of the specified partition.
+    ///
+    /// Per the UEFI spec, `ent_end` is the last LBA of the partition
+    /// (inclusive), so the block count is `ent_end - ent_start + 1`.
+    pub fn partition_size(&self, name: &str) -> Result<u64, ProbeError> {
+        match self.partition(name) {
+            Some(entry) => Ok((entry.ent_end - entry.ent_start + 1) * self.block_size),
+            None => Err(ProbeError::MissingPartition {
+                name: String::from(name),
+            }),
+        }
+    }
+}
+
+impl fmt::Display for GptLabel {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        writeln!(f, "GUID: {}", self.primary.guid)?;
+
+        writeln!(
+            f,
+            "Primary GPT header crc32: {:08x}",
+            self.primary.self_checksum
+        )?;
+        writeln!(f, "LBA primary GPT header: {}", self.primary.lba_self)?;
+        writeln!(f, "LBA primary partition table: {}", self.primary.lba_table)?;
+
+        writeln!(
+            f,
+            "Secondary GPT header crc32: {:08x}",
+            self.secondary.self_checksum
+        )?;
+        writeln!(f, "LBA secondary GPT header: {}", self.secondary.lba_self)?;
+        writeln!(
+            f,
+            "LBA secondary partition table: {}",
+            self.secondary.lba_table
+        )?;
+
+        writeln!(f, "Partition table crc32: {:08x}", self.primary.table_crc)?;
+        writeln!(f, "LBA first usable block: {}", self.primary.lba_start)?;
+        writeln!(f, "LBA last usable block: {}", self.primary.lba_end)?;
+
+        for (i, part) in self.partitions.iter().enumerate() {
+            writeln!(f, "  Partition {i}")?;
+            writeln!(f, "    GUID: {}", part.ent_guid)?;
+            writeln!(f, "    Type GUID: {}", part.ent_type)?;
+            writeln!(f, "    LBA start: {}", part.ent_start)?;
+            writeln!(f, "    LBA end: {}", part.ent_end)?;
+            writeln!(f, "    Name: {}", part.ent_name.name)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl GptLabel {
+    /// Construct a Pmbr from raw data.
+    fn read_mbr(buf: &impl GptBuffer) -> Result<Pmbr, ProbeError> {
+        Pmbr::from_slice(&buf.as_slice()[440..512])
+    }
+
+    /// Construct a GPT header from raw data.
+    fn read_header(buf: &impl GptBuffer) -> Result<GptHeader, ProbeError> {
+        GptHeader::from_slice(buf.as_slice())
+    }
+
+    /// Construct and validate primary GPT header.
+    fn read_primary_header(
+        buf: &impl GptBuffer,
+        block_size: u64,
+        num_blocks: u64,
+    ) -> Result<GptHeader, ProbeError> {
+        let header = GptLabel::read_header(buf)?;
+        GptLabel::validate_primary_header(&header, block_size, num_blocks)?;
+        Ok(header)
+    }
+
+    /// Construct and validate secondary GPT header.
+    fn read_secondary_header(
+        buf: &impl GptBuffer,
+        block_size: u64,
+        num_blocks: u64,
+    ) -> Result<GptHeader, ProbeError> {
+        let header = GptLabel::read_header(buf)?;
+        GptLabel::validate_secondary_header(&header, block_size, num_blocks)?;
+        Ok(header)
+    }
+
+    /// Construct and validate partition table.
+    fn read_partitions(
+        buf: &impl GptBuffer,
+        header: &GptHeader,
+    ) -> Result<Vec<GptEntry>, ProbeError> {
+        let partitions = GptEntry::from_slice(buf.as_slice(), header.num_entries)?;
+        GptLabel::validate_partitions(&partitions, header)?;
+        Ok(partitions)
+    }
+
+    /// Check that primary GPT header is valid and consistent.
+    pub fn validate_primary_header(
+        primary: &GptHeader,
+        block_size: u64,
+        num_blocks: u64,
+    ) -> Result<(), ProbeError> {
+        if primary.lba_self != 1 {
+            return Err(ProbeError::PrimaryLocation {});
+        }
+        if primary.lba_alt + 1 != num_blocks {
+            return Err(ProbeError::SecondaryLocation {});
+        }
+        if primary.lba_end >= primary.lba_alt {
+            return Err(ProbeError::LastUsableBlock {});
+        }
+        if primary.lba_table != primary.lba_self + 1 {
+            return Err(ProbeError::PartitionTableLocation {});
+        }
+        if (primary.num_entries * primary.entry_size) as u64 > GptHeader::PARTITION_TABLE_SIZE {
+            return Err(ProbeError::PartitionTableSize {});
+        }
+        if primary.lba_table + Aligned::get_blocks(GptHeader::PARTITION_TABLE_SIZE, block_size)
+            > primary.lba_start
+        {
+            return Err(ProbeError::PartitionTableSpace {});
+        }
+        Ok(())
+    }
+
+    /// Check that secondary GPT header is valid and consistent.
+    pub fn validate_secondary_header(
+        secondary: &GptHeader,
+        block_size: u64,
+        num_blocks: u64,
+    ) -> Result<(), ProbeError> {
+        if secondary.lba_alt != 1 {
+            return Err(ProbeError::PrimaryLocation {});
+        }
+        if secondary.lba_self + 1 != num_blocks {
+            return Err(ProbeError::SecondaryLocation {});
+        }
+        if secondary.lba_alt >= secondary.lba_start {
+            return Err(ProbeError::FirstUsableBlock {});
+        }
+        if secondary.lba_table != secondary.lba_end + 1 {
+            return Err(ProbeError::PartitionTableLocation {});
+        }
+        if (secondary.num_entries * secondary.entry_size) as u64 > GptHeader::PARTITION_TABLE_SIZE {
+            return Err(ProbeError::PartitionTableSize {});
+        }
+        if secondary.lba_table + Aligned::get_blocks(GptHeader::PARTITION_TABLE_SIZE, block_size)
+            > secondary.lba_self
+        {
+            return Err(ProbeError::PartitionTableSpace {});
+        }
+        Ok(())
+    }
+
+    /// Check that partition table entries are valid and consistent.
+    pub fn validate_partitions(
+        partitions: &[GptEntry],
+        header: &GptHeader,
+    ) -> Result<(), ProbeError> {
+        for entry in partitions {
+            if 0 < entry.ent_start && entry.ent_start < header.lba_start {
+                return Err(ProbeError::PartitionStart {});
+            }
+            if entry.ent_start > entry.ent_end {
+                return Err(ProbeError::NegativePartitionSize {});
+            }
+            if entry.ent_end > header.lba_end {
+                return Err(ProbeError::PartitionEnd {});
+            }
+        }
+        if header.table_crc
+            != GptEntry::checksum(partitions, header.num_entries).context(ChecksumSerializeSnafu)?
+        {
+            return Err(ProbeError::PartitionTableChecksum {});
+        }
+        Ok(())
+    }
+
+    /// Check that primary and secondary GPT headers are consistent with each other.
+    pub fn consistency_check(primary: &GptHeader, secondary: &GptHeader) -> Result<(), ProbeError> {
+        if primary.lba_self != secondary.lba_alt {
+            return Err(ProbeError::CompareHeaderLocation {});
+        }
+        if primary.lba_alt != secondary.lba_self {
+            return Err(ProbeError::CompareHeaderLocation {});
+        }
+        if primary.lba_start != secondary.lba_start {
+            return Err(ProbeError::FirstUsableBlock {});
+        }
+        if primary.lba_end != secondary.lba_end {
+            return Err(ProbeError::LastUsableBlock {});
+        }
+        if primary.guid != secondary.guid {
+            return Err(ProbeError::CompareDiskGuid {});
+        }
+        if primary.num_entries != secondary.num_entries {
+            return Err(ProbeError::ComparePartitionEntryCount {});
+        }
+        if primary.entry_size != secondary.entry_size {
+            return Err(ProbeError::ComparePartitionEntrySize {});
+        }
+        if primary.table_crc != secondary.table_crc {
+            return Err(ProbeError::ComparePartitionTableChecksum {});
+        }
+        Ok(())
+    }
+}
+
+/// Properties of the disk needed to probe and read GPT labels.
+#[derive(Clone, Copy)]
+pub struct GptDiskProps {
+    /// Logical block size of the underlying device.
+    pub block_size: u64,
+    /// Number of blocks on the underlying device.
+    pub num_blocks: u64,
+}
+
+/// Trait for disk operations needed to probe and read GPT labels.
+///
+/// Implementations decouple the GPT (de)serialisation code from any
+/// particular I/O backend (SPDK, plain files, etc.) so the label routines
+/// can be reused outside of the io-engine core.
+#[async_trait::async_trait(?Send)]
+pub trait GptDiskOps {
+    /// Backend-specific buffer type used for I/O.
+    type Buffer: GptBuffer;
+
+    /// Allocate an I/O buffer of `size` bytes suitable for use with
+    /// [`GptDiskOps::read_at`].
+    fn buffer_alloc(&self, size: u64) -> Result<Self::Buffer, DmaError>;
+    /// Return the geometry (block size, block count) of the underlying disk.
+    fn props(&self) -> GptDiskProps;
+    /// Read `buffer.len()` bytes starting at byte `offset` into `buffer`.
+    /// Returns the number of bytes read.
+    async fn read_at(&self, offset: u64, buffer: &mut Self::Buffer) -> Result<u64, CoreError>;
+}
+
+#[async_trait::async_trait(?Send)]
+impl GptDiskOps for Box<dyn BlockDeviceHandle> {
+    type Buffer = DmaBuf;
+
+    fn buffer_alloc(&self, size: u64) -> Result<Self::Buffer, DmaError> {
+        self.dma_malloc(size)
+    }
+    fn props(&self) -> GptDiskProps {
+        let bdev = self.get_device();
+        GptDiskProps {
+            block_size: bdev.block_len(),
+            num_blocks: bdev.num_blocks(),
+        }
+    }
+    async fn read_at(&self, offset: u64, buffer: &mut Self::Buffer) -> Result<u64, CoreError> {
+        self.read_at(offset, buffer).await
+    }
+}
+#[async_trait::async_trait(?Send)]
+impl GptDiskOps for dyn BlockDeviceHandle {
+    type Buffer = DmaBuf;
+
+    fn buffer_alloc(&self, size: u64) -> Result<Self::Buffer, DmaError> {
+        self.dma_malloc(size)
+    }
+    fn props(&self) -> GptDiskProps {
+        let bdev = self.get_device();
+        GptDiskProps {
+            block_size: bdev.block_len(),
+            num_blocks: bdev.num_blocks(),
+        }
+    }
+    async fn read_at(&self, offset: u64, buffer: &mut Self::Buffer) -> Result<u64, CoreError> {
+        #[allow(deprecated)]
+        self.read_at(offset, buffer).await
+    }
+}
+
+/// A trait to abstract over the buffer type used for reading/writing GPT data.
+pub trait GptBuffer {
+    /// View the buffer's contents as an immutable byte slice.
+    fn as_slice(&self) -> &[u8];
+    /// View the buffer's contents as a mutable byte slice.
+    fn as_mut_slice(&mut self) -> &mut [u8];
+}
+impl GptBuffer for DmaBuf {
+    fn as_slice(&self) -> &[u8] {
+        self.deref().as_slice()
+    }
+    fn as_mut_slice(&mut self) -> &mut [u8] {
+        self.deref_mut().as_mut_slice()
+    }
+}
+
+/// A structure to hold the raw label data and the offset at which it should be written to disk.
+pub struct LabelData<T: GptBuffer> {
+    /// Byte offset on the disk at which `buf` should be written.
+    pub offset: u64,
+    /// Serialised label data ready to be written verbatim to disk.
+    pub buf: T,
+}
+impl GptLabel {
+    /// Generate raw data for (primary) label ready to be written to disk.
+    pub fn primary_data<T: GptDiskOps + ?Sized>(
+        &self,
+        handle: &T,
+    ) -> Result<LabelData<T::Buffer>, LabelError> {
+        let mut buf = handle
+            .buffer_alloc(self.primary.lba_start * self.block_size)
+            .context(WriteAllocSnafu {
+                what: String::from("primary"),
+            })?;
+
+        let mut writer = Cursor::new(buf.as_mut_slice());
+
+        // Protective MBR
+        writer.seek(SeekFrom::Start(440)).context(SeekSnafu)?;
+        serialize_into(&mut writer, &self.mbr).context(SerializeSnafu)?;
+
+        // Primary GPT header
+        writer
+            .seek(SeekFrom::Start(self.primary.lba_self * self.block_size))
+            .context(SeekSnafu)?;
+        serialize_into(&mut writer, &self.primary).context(SerializeSnafu)?;
+
+        // Primary partition table
+        writer
+            .seek(SeekFrom::Start(self.primary.lba_table * self.block_size))
+            .context(SeekSnafu)?;
+        for entry in self.partitions.iter() {
+            serialize_into(&mut writer, &entry).context(SerializeSnafu)?;
+        }
+
+        Ok(LabelData { offset: 0, buf })
+    }
+
+    /// Generate raw data for (secondary) label ready to be written to disk.
+    pub fn secondary_data<T: GptDiskOps + ?Sized>(
+        &self,
+        handle: &T,
+    ) -> Result<LabelData<T::Buffer>, LabelError> {
+        let len_bytes = (self.secondary.lba_self - self.secondary.lba_table + 1) * self.block_size;
+        let mut buf = handle.buffer_alloc(len_bytes).context(WriteAllocSnafu {
+            what: String::from("secondary"),
+        })?;
+
+        let mut writer = Cursor::new(buf.as_mut_slice());
+
+        // Secondary partition table
+        for entry in self.partitions.iter() {
+            serialize_into(&mut writer, &entry).context(SerializeSnafu)?;
+        }
+
+        // Secondary GPT header
+        writer
+            .seek(SeekFrom::Start(
+                (self.secondary.lba_self - self.secondary.lba_table) * self.block_size,
+            ))
+            .context(SeekSnafu)?;
+        serialize_into(&mut writer, &self.secondary).context(SerializeSnafu)?;
+
+        let offset = self.secondary.lba_table * self.block_size;
+        Ok(LabelData { offset, buf })
+    }
+}
+
+/// A trait to calculate the number of blocks needed
+/// to represent a given size, aligned to a block size.
+pub trait Aligned {
+    /// Return the (appropriately aligned) number of blocks
+    /// representing this size.
+    fn get_blocks(size: Self, block_size: Self) -> Self;
+}
+
+impl Aligned for u32 {
+    fn get_blocks(size: u32, block_size: u32) -> u32 {
+        let blocks = size / block_size;
+        match size % block_size {
+            0 => blocks,
+            _ => blocks + 1,
+        }
+    }
+}
+
+impl Aligned for u64 {
+    fn get_blocks(size: u64, block_size: u64) -> u64 {
+        let blocks = size / block_size;
+        match size % block_size {
+            0 => blocks,
+            _ => blocks + 1,
+        }
+    }
+}

--- a/io-engine/src/bdev/gpt_labels.rs
+++ b/io-engine/src/bdev/gpt_labels.rs
@@ -1,0 +1,1012 @@
+//! GPT labeling for Nexus devices. The primary partition
+//! (/dev/x1) will be used for meta data during, rebuild. The second
+//! partition contains the file system.
+//!
+//! The nexus will adjust internal data structures to offset the IO to the
+//! right partition. put differently, when connecting to this device via
+//! NVMF or iSCSI it will show up as device with just one partition.
+//!
+//! When the nexus is removed from the data path and other initiations are
+//! used, the data is still accessible and thus removes us has a hard
+//! dependency in the data path.
+//!
+//! # Example:
+//!
+//! ```bash
+//! $ rm /code/disk1.img; truncate -s 1GiB /code/disk1.img
+//! $ mayastor-client nexus create $UUID 1GiB aio:////code/disk1.img?blk_size=512
+//! $ sgdisk -p /code/disk1.img
+//! Disk /code//disk1.img: 2097152 sectors, 1024.0 MiB
+//! Sector size (logical): 512 bytes
+//! Disk identifier (GUID): EAB49A2F-EFEA-45E6-9A1B-61FECE3426DD
+//! Partition table holds up to 128 entries
+//! Main partition table begins at sector 2 and ends at sector 33
+//! First usable sector is 2048, last usable sector is 2097118
+//! Partitions will be aligned on 2048-sector boundaries
+//! Total free space is 0 sectors (0 bytes)
+//!
+//! Number  Start (sector)    End (sector)  Size       Code  Name
+//!  1            2048           10239   4.0 MiB     FFFF  MayaMeta
+//!  2           10240         2097118   1019.0 MiB  FFFF  MayaData
+//! ```
+//!
+//! Notice how two partitions have been created when accessing the disk
+//! when shared by the nexus:
+//!
+//! ```bash
+//! $ mayastor-client nexus share $UUID
+//! "/dev/nbd0"
+//!
+//! TODO: also note how it complains about a MBR
+//!
+//! $ lsblk
+//! NAME    MAJ:MIN RM  SIZE RO TYPE MOUNTPOINT
+//! sda       8:0    0   50G  0 disk
+//! ├─sda1    8:1    0 41.5G  0 part /
+//! ├─sda2    8:2    0    7M  0 part [SWAP]
+//! └─sda3    8:3    0  511M  0 part /boot
+//! sr0      11:0    1 1024M  0 rom
+//! nbd0     43:0    0 1019M  0 disk
+//! nvme0n1 259:0    0  200G  0 disk /code
+//!
+//! The nbd0 zero device does not show the partitions when mounting
+//! it without the nexus in the data path, there would be two paritions
+//! ```
+
+use std::{cmp::min, convert::From, fmt, io::Cursor, str::FromStr};
+
+use serde::{Deserialize, Serialize};
+
+use crate::core::CoreError;
+use bincode::{deserialize_from, serialize, Error};
+use crc::{crc32, Hasher32};
+use serde::{
+    de::{Deserializer, SeqAccess, Unexpected, Visitor},
+    ser::{SerializeTuple, Serializer},
+};
+use snafu::{ResultExt, Snafu};
+use spdk_rs::DmaError;
+use uuid::{self, Uuid};
+
+/// The GPT label error type.
+#[derive(Debug, Snafu)]
+pub enum LabelError {
+    #[snafu(display("Serialization error: {source}"))]
+    SerializeError { source: Error },
+    #[snafu(display("Failed to allocate buffer for reading {part}: {source}"))]
+    ReadAlloc { source: DmaError, part: String },
+    #[snafu(display("Failed to allocate buffer for writing {what}: {source}"))]
+    WriteAlloc { source: DmaError, what: String },
+    #[snafu(display("Error reading {what}: {source}"))]
+    ReadError { source: CoreError, what: String },
+    #[snafu(display("Error writing {what}: {source}"))]
+    WriteError { source: CoreError, what: String },
+    #[snafu(display("Label is invalid: {source}"))]
+    InvalidLabel { source: ProbeError },
+    #[snafu(display("Failed to obtain BlockDeviceHandle: {source}"))]
+    HandleError { source: CoreError },
+    #[snafu(display(
+        "Device is too small to accommodate Metadata partition: size = {num_blocks} x {block_size}"
+    ))]
+    DeviceTooSmall { num_blocks: u64, block_size: u64 },
+    #[snafu(display(
+        "Label is too large to fit on the device: dev-size = {dev_size}, label-size = {part_size}"
+    ))]
+    LabelTooLarge { dev_size: u64, part_size: u64 },
+    #[snafu(display("Child data offsets differ"))]
+    DataOffsetMismatch,
+    #[snafu(display("Nexus has no children"))]
+    MissingChildren,
+    #[snafu(display("Error setting MetaDataIndex address: {error}"))]
+    IndexAddress { error: String },
+    #[snafu(display("{source}"))]
+    SeekError { source: std::io::Error },
+}
+
+/// The GPT probe error type.
+#[derive(Debug, Snafu)]
+pub enum ProbeError {
+    #[snafu(display("Serialization error: {source}"))]
+    ChecksumSerializeError { source: Error },
+    #[snafu(display("Deserialization error: {source}"))]
+    DeserializeError { source: Error },
+    #[snafu(display("Incorrect MBR signature"))]
+    MbrSignature {},
+    #[snafu(display("Disk size in MBR does not match size in GPT header"))]
+    MbrSize {},
+    #[snafu(display("Incorrect GPT header signature"))]
+    GptSignature {},
+    #[snafu(display("Incorrect GPT header revision"))]
+    GptRevision {},
+    #[snafu(display("Incorrect GPT header size: actual={actual_size}, expected={expected_size}"))]
+    GptHeaderSize {
+        actual_size: u32,
+        expected_size: u32,
+    },
+    #[snafu(display("Incorrect GPT header checksum"))]
+    GptChecksum {},
+    #[snafu(display("Incorrect GPT partition table checksum"))]
+    PartitionTableChecksum {},
+    #[snafu(display("Disk GUIDs differ"))]
+    CompareDiskGuid {},
+    #[snafu(display("Disk sizes differ"))]
+    CompareDiskSize {},
+    #[snafu(display("GPT stored partition table checksums differ"))]
+    ComparePartitionTableChecksum {},
+    #[snafu(display("GPT partition table location is incorrect"))]
+    PartitionTableLocation {},
+    #[snafu(display("Missing partition: {name}"))]
+    MissingPartition { name: String },
+    #[snafu(display("Primary GTP header location is incorrect"))]
+    PrimaryLocation {},
+    #[snafu(display("Secondary GTP header location is incorrect"))]
+    SecondaryLocation {},
+    #[snafu(display("Location of first usable block is incorrect"))]
+    FirstUsableBlock {},
+    #[snafu(display("Location of last usable block is incorrect"))]
+    LastUsableBlock {},
+    #[snafu(display("Partition table exceeds maximum size"))]
+    PartitionTableSize {},
+    #[snafu(display("Insufficient space reserved for partition table"))]
+    PartitionTableSpace {},
+    #[snafu(display("Partition starts before first usable block"))]
+    PartitionStart {},
+    #[snafu(display("Partition ends after last usable block"))]
+    PartitionEnd {},
+    #[snafu(display("Partition has negative size"))]
+    NegativePartitionSize {},
+    #[snafu(display("GPT header locations are inconsistent"))]
+    CompareHeaderLocation {},
+    #[snafu(display("Number of partition table entries differ"))]
+    ComparePartitionEntryCount {},
+    #[snafu(display("Partition table entry sizes differ"))]
+    ComparePartitionEntrySize {},
+    #[snafu(display("Incorrect partition layout"))]
+    IncorrectPartitions {},
+    #[snafu(display("Label is invalid"))]
+    LabelRedundancy {},
+}
+
+impl From<ProbeError> for LabelError {
+    fn from(error: ProbeError) -> LabelError {
+        LabelError::InvalidLabel { source: error }
+    }
+}
+
+/// Based on RFC4122.
+#[derive(Debug, serde::Deserialize, PartialEq, Default, serde::Serialize, Clone, Copy)]
+pub struct GptGuid {
+    pub time_low: u32,
+    pub time_mid: u16,
+    pub time_high: u16,
+    pub node: [u8; 8],
+}
+
+impl From<Uuid> for GptGuid {
+    fn from(uuid: Uuid) -> GptGuid {
+        let fields = uuid.as_fields();
+        GptGuid {
+            time_low: fields.0,
+            time_mid: fields.1,
+            time_high: fields.2,
+            node: *fields.3,
+        }
+    }
+}
+
+impl From<GptGuid> for Uuid {
+    fn from(guid: GptGuid) -> Uuid {
+        Uuid::from_fields(guid.time_low, guid.time_mid, guid.time_high, &guid.node)
+    }
+}
+
+impl FromStr for GptGuid {
+    type Err = uuid::Error;
+
+    fn from_str(uuid: &str) -> Result<Self, Self::Err> {
+        Ok(GptGuid::from(Uuid::from_str(uuid)?))
+    }
+}
+
+impl fmt::Display for GptGuid {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", Uuid::from(*self))
+    }
+}
+
+impl GptGuid {
+    pub fn new_random() -> Self {
+        GptGuid::from(Uuid::new_v4())
+    }
+}
+
+/// The GPT header structure, as defined in the UEFI specification.
+#[derive(Debug, Deserialize, PartialEq, Default, Serialize, Copy, Clone)]
+pub struct GptHeader {
+    /// GPT signature (must be "EFI PART").
+    pub signature: [u8; 8],
+    /// 00 00 01 00 up til version 2.17
+    pub revision: [u8; 4],
+    /// GPT header size (92 bytes)
+    pub header_size: u32,
+    /// CRC32 of the header.
+    pub self_checksum: u32,
+    pub reserved: [u8; 4],
+    /// primary lba where the header
+    pub lba_self: u64,
+    /// alternative lba
+    pub lba_alt: u64,
+    /// first usable lba
+    pub lba_start: u64,
+    /// last usable lba
+    pub lba_end: u64,
+    /// 16 bytes representing the GUID of the GPT.
+    pub guid: GptGuid,
+    /// lba of where to find the partition table
+    pub lba_table: u64,
+    /// number of partitions, most tools set this to 128
+    pub num_entries: u32,
+    /// Size of element
+    pub entry_size: u32,
+    /// CRC32 checksum of the partition array.
+    pub table_crc: u32,
+}
+
+impl GptHeader {
+    /// The size of the partition table in bytes.
+    pub const PARTITION_TABLE_SIZE: u64 = 128 * 128;
+    /// The offset of the partition table in bytes.
+    pub const DATA_OFFSET: u64 = 1024 * 1024;
+    /// The size of the GPT header in bytes.
+    pub const HEADER_SIZE: u32 = 92;
+    /// The revision of the GPT header, as defined in the UEFI specification.
+    pub const HEADER_REVISION: [u8; 4] = [0x00, 0x00, 0x01, 0x00];
+    /// The signature of the GPT header, as defined in the UEFI specification.
+    pub const HEADER_SIGNATURE: [u8; 8] = [0x45, 0x46, 0x49, 0x20, 0x50, 0x41, 0x52, 0x54];
+
+    /// Converts a slice into a GPT header and verifies the validity of the data.
+    pub fn from_slice(slice: &[u8]) -> Result<GptHeader, ProbeError> {
+        let mut reader = Cursor::new(slice);
+
+        let mut header: GptHeader = deserialize_from(&mut reader).context(DeserializeSnafu)?;
+
+        if header.header_size != GptHeader::HEADER_SIZE {
+            return Err(ProbeError::GptHeaderSize {
+                actual_size: header.header_size,
+                expected_size: GptHeader::HEADER_SIZE,
+            });
+        }
+
+        if header.signature != GptHeader::HEADER_SIGNATURE {
+            return Err(ProbeError::GptSignature {});
+        }
+
+        if header.revision != GptHeader::HEADER_REVISION {
+            return Err(ProbeError::GptRevision {});
+        }
+
+        let checksum = header.self_checksum;
+
+        if checksum != header.checksum().context(ChecksumSerializeSnafu)? {
+            return Err(ProbeError::GptChecksum {});
+        }
+
+        Ok(header)
+    }
+
+    /// Checksums the header with the checksum field itself set to 0.
+    pub fn checksum(&mut self) -> Result<u32, Error> {
+        self.self_checksum = 0;
+        self.self_checksum = crc32::checksum_ieee(&serialize(&self)?);
+        Ok(self.self_checksum)
+    }
+
+    // Creates a new GPT header for a device with specified size.
+    pub fn new(guid: GptGuid, block_size: u64, num_blocks: u64) -> Self {
+        let partition_blocks = Aligned::get_blocks(GptHeader::PARTITION_TABLE_SIZE, block_size);
+
+        let data_start = Aligned::get_blocks(GptHeader::DATA_OFFSET, block_size);
+
+        GptHeader {
+            signature: GptHeader::HEADER_SIGNATURE,
+            revision: GptHeader::HEADER_REVISION,
+            header_size: GptHeader::HEADER_SIZE,
+            self_checksum: 0,
+            reserved: [0; 4],
+            lba_self: 1,
+            lba_alt: num_blocks - 1,
+            lba_start: data_start,
+            lba_end: num_blocks - partition_blocks - 2,
+            guid,
+            lba_table: 2,
+            num_entries: 128,
+            entry_size: 128,
+            table_crc: 0,
+        }
+    }
+
+    /// Converts the header into a secondary GPT header.
+    pub fn as_secondary(&self) -> Result<GptHeader, Error> {
+        let mut secondary = *self;
+        secondary.lba_self = self.lba_alt;
+        secondary.lba_alt = self.lba_self;
+        secondary.lba_table = self.lba_end + 1;
+        secondary.checksum()?;
+        Ok(secondary)
+    }
+
+    /// Converts the header into a primary GPT header.
+    pub fn as_primary(&self) -> Result<GptHeader, Error> {
+        let mut primary = *self;
+        primary.lba_self = self.lba_alt;
+        primary.lba_alt = self.lba_self;
+        primary.lba_table = self.lba_alt + 1;
+        primary.checksum()?;
+        Ok(primary)
+    }
+}
+
+// For arrays bigger than 32 elements, things start to get unimplemented
+// in terms of derive and what not. So we create our own "newtype" struct,
+// and tell serde how to use it during serializing/deserializing.
+#[derive(Debug, PartialEq, Default, Clone)]
+pub struct GptName {
+    pub name: String,
+}
+impl std::fmt::Display for GptName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.name)
+    }
+}
+
+struct GpEntryNameVisitor;
+
+impl<'a> Deserialize<'a> for GptName {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'a>,
+    {
+        deserializer.deserialize_tuple_struct("GptName", 36, GpEntryNameVisitor)
+    }
+}
+
+impl Serialize for GptName {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        // we can't use serialize_type_struct here as we want exactly 72 bytes
+        let mut s = serializer.serialize_tuple(36)?;
+        let mut out: Vec<u16> = vec![0; 36];
+        for (i, o) in self.name.encode_utf16().zip(out.iter_mut()) {
+            *o = i;
+        }
+
+        out.iter().for_each(|e| s.serialize_element(&e).unwrap());
+        s.end()
+    }
+}
+
+impl<'a> Visitor<'a> for GpEntryNameVisitor {
+    type Value = GptName;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("Invalid GPT partition name")
+    }
+
+    fn visit_seq<A>(self, mut seq: A) -> std::result::Result<GptName, A::Error>
+    where
+        A: SeqAccess<'a>,
+    {
+        let mut out = Vec::new();
+        let mut end = false;
+        loop {
+            match seq.next_element()? {
+                Some(0) => {
+                    end = true;
+                }
+                Some(e) if !end => out.push(e),
+                _ => break,
+            }
+        }
+
+        if end {
+            Ok(GptName::from(String::from_utf16_lossy(&out)))
+        } else {
+            Err(serde::de::Error::invalid_value(Unexpected::Seq, &self))
+        }
+    }
+}
+
+impl From<String> for GptName {
+    fn from(name: String) -> GptName {
+        GptName { name }
+    }
+}
+impl From<&str> for GptName {
+    fn from(name: &str) -> GptName {
+        GptName::from(String::from(name))
+    }
+}
+
+/// The GPT partition entry structure, as defined in the UEFI specification.
+#[derive(Debug, Default, PartialEq, Deserialize, Serialize, Clone)]
+pub struct GptEntry {
+    /// GUID type, some of them are assigned/reserved for example to Linux
+    pub ent_type: GptGuid,
+    /// entry GUID, can be anything typically random
+    pub ent_guid: GptGuid,
+    /// start lba for this entry
+    pub ent_start: u64,
+    /// end lba for this entry
+    pub ent_end: u64,
+    /// entry attributes, according to do the docs bit 0 MUST be zero
+    pub ent_attr: u64,
+    /// UTF-16 name of the partition entry,
+    /// DO NOT confuse this with filesystem labels!
+    pub ent_name: GptName,
+}
+
+impl GptEntry {
+    /// Converts a slice into a partition table.
+    pub fn from_slice(slice: &[u8], count: u32) -> Result<Vec<GptEntry>, ProbeError> {
+        let mut reader = Cursor::new(slice);
+        let mut partitions: Vec<GptEntry> = Vec::with_capacity(count as usize);
+        for _ in 0..count {
+            partitions.push(deserialize_from(&mut reader).context(DeserializeSnafu)?);
+        }
+        Ok(partitions)
+    }
+
+    /// Checks if the partition entry is unused, which is indicated by a zeroed GUID.
+    pub fn is_unused(&self) -> bool {
+        self.ent_guid == GptGuid::default()
+    }
+
+    /// Calculates the checksum over the partition table.
+    pub fn checksum(partitions: &[GptEntry], size: u32) -> Result<u32, Error> {
+        let mut digest = crc32::Digest::new(crc32::IEEE);
+        let count = partitions.len() as u32;
+        for entry in partitions {
+            digest.write(&serialize(entry)?);
+        }
+        if count < size {
+            let pad = serialize(&GptEntry::default())?;
+            for _ in count..size {
+                digest.write(&pad);
+            }
+        }
+        Ok(digest.sum32())
+    }
+}
+
+/// Although we don't use it, we must have a protective MBR to avoid systems
+/// to get confused about what's on the disk. Utils like sgdisk work fine
+/// without an MBR (but will warn) but as we want to be able to access the
+/// partitions with the nexus out of the data path, will create one here.
+///
+/// The struct should have a 440 byte code section here as well,
+/// however this is omitted to make serialisation a bit easier.
+#[derive(Copy, Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct Pmbr {
+    /// signature to uniquely ID the disk we do not use this
+    disk_signature: u32,
+    reserved: u16,
+    /// number of partition entries
+    pub(super) entries: [MbrEntry; 4],
+    /// must be set to [0x55, 0xaa]
+    signature: [u8; 2],
+}
+
+/// The MBR partition entry structure, as defined in the UEFI specification.
+#[derive(Copy, Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+pub struct MbrEntry {
+    /// attributes of this MBR partition we set these all to zero, which
+    /// includes the boot flag.
+    attributes: u8,
+    /// start in CHS format
+    chs_start: [u8; 3],
+    /// type of partition, in our case always 0xEE
+    ent_type: u8,
+    /// end of the partition
+    chs_last: [u8; 3],
+    /// lba start
+    lba_start: u32,
+    /// last sector of this partition
+    num_sectors: u32,
+}
+
+impl MbrEntry {
+    /// Set this MBR partition entry to represent a protective MBR partition of given size.
+    pub fn protect(&mut self, num_blocks: u64) {
+        self.attributes = 0x00; // NOT bootable
+        self.ent_type = 0xee; // protective MBR partition
+        self.chs_start = [0x00, 0x02, 0x00]; // CHS address 0/0/2
+        self.chs_last = [0xff, 0xff, 0xff]; // CHS address 1023/255/63
+
+        // The partition starts immediately after the MBR
+        self.lba_start = 1;
+
+        // The partition size must accurately reflect
+        // the disk size where possible.
+        if num_blocks > u32::MAX as u64 {
+            // If the size (in blocks) is too large to fit into 32 bits,
+            // then set the size to 0xffff_ffff
+            self.num_sectors = u32::MAX;
+        } else {
+            // Do not count the first block that contains the MBR
+            self.num_sectors = (num_blocks - 1) as u32;
+        }
+    }
+}
+
+impl Pmbr {
+    /// The signature of the protective MBR, as defined in the UEFI specification.
+    pub const PMBR_SIGNATURE: [u8; 2] = [0x55, 0xaa];
+
+    /// Converts a slice into a MBR and validates the signature.
+    pub fn from_slice(slice: &[u8]) -> Result<Pmbr, ProbeError> {
+        let mut reader = Cursor::new(slice);
+
+        let mbr: Pmbr = deserialize_from(&mut reader).context(DeserializeSnafu)?;
+
+        if mbr.signature != Pmbr::PMBR_SIGNATURE {
+            return Err(ProbeError::MbrSignature {});
+        }
+
+        Ok(mbr)
+    }
+}
+
+impl Default for Pmbr {
+    fn default() -> Self {
+        Pmbr {
+            disk_signature: 0,
+            reserved: 0,
+            entries: [MbrEntry::default(); 4],
+            signature: Pmbr::PMBR_SIGNATURE,
+        }
+    }
+}
+
+/// The status of the GPT labels on disk.
+#[derive(Clone, Copy, Debug, PartialEq, Serialize)]
+pub enum LabelStatus {
+    /// Both primary and secondary labels are synced with disk.
+    Both,
+    /// Only primary label is synced with disk.
+    Primary,
+    /// Only secondary label is synced with disk.
+    Secondary,
+    /// Neither primary or secondary labels are synced with disk.
+    Neither,
+}
+
+/// The label is standard GPT label (such that you can use it without us in the data path).
+/// The only thing that is really specific to us is the ent_type [`GptGuid`]; if we see that
+/// attached to a partition, we assume the data in that partition is ours.
+/// In the data we will have more magic markers to confirm the assumption but this is step one.
+#[derive(Debug, PartialEq, Serialize, Clone)]
+pub struct GptLabel {
+    /// The status of the labels.
+    pub status: LabelStatus,
+    /// Block size of underlying device.
+    pub block_size: u64,
+    /// The protective MBR.
+    pub mbr: Pmbr,
+    /// The main GPT header.
+    pub primary: GptHeader,
+    /// Vector of GPT entries where the first element is considered to be ours.
+    pub partitions: Vec<GptEntry>,
+    /// The backup GPT header.
+    pub secondary: GptHeader,
+}
+
+impl GptLabel {
+    /// Partition Type GUID for our "MayaMeta" partition.
+    pub const METADATA_PARTITION_TYPE_ID: &'static str = "27663382-e5e6-11e9-81b4-ca5ca5ca5ca5";
+    /// Partition Type GUID for our "MayaData" partition.
+    pub const DATA_PARTITION_TYPE_ID: &'static str = "27663382-e5e6-11e9-81b4-ca5ca5ca5ca6";
+    /// Size of the "MayaMeta" partition.
+    pub const METADATA_PARTITION_SIZE: u64 = 4 * 1024 * 1024;
+
+    fn meta_guid() -> GptGuid {
+        GptGuid::from_str(GptLabel::METADATA_PARTITION_TYPE_ID)
+            .expect("to be a constant, so it should be valid")
+    }
+    fn meta_name() -> &'static str {
+        "MayaMeta"
+    }
+    fn data_guid() -> GptGuid {
+        GptGuid::from_str(GptLabel::DATA_PARTITION_TYPE_ID)
+            .expect("to be a constant, so it should be valid")
+    }
+    fn data_name() -> &'static str {
+        "MayaData"
+    }
+
+    /// Generate a new [`GptLabel`].
+    pub fn generate_label(
+        guid: GptGuid,
+        block_size: u64,
+        num_blocks: u64,
+        data_part_size: Option<u64>,
+    ) -> Result<GptLabel, LabelError> {
+        // (Protective) MBR
+        let mut pmbr = Pmbr::default();
+        pmbr.entries[0].protect(num_blocks);
+
+        // Primary GPT header
+        let mut header = GptHeader::new(guid, block_size, num_blocks);
+
+        let dev_size = block_size * num_blocks;
+
+        // Partition table
+        let partitions = GptLabel::create_partitions(
+            &header,
+            block_size,
+            dev_size,
+            data_part_size.unwrap_or(dev_size),
+        )?;
+
+        header.table_crc =
+            GptEntry::checksum(&partitions, header.num_entries).context(SerializeSnafu)?;
+        header.checksum().context(SerializeSnafu)?;
+
+        // Secondary GPT header
+        let secondary = header.as_secondary().context(SerializeSnafu)?;
+
+        Ok(GptLabel {
+            status: LabelStatus::Neither,
+            block_size,
+            mbr: pmbr,
+            primary: header,
+            partitions,
+            secondary,
+        })
+    }
+
+    /// Create partition table entries for the "MayaMeta" and "MayaData" partitions.
+    fn create_partitions(
+        header: &GptHeader,
+        block_size: u64,
+        dev_size: u64,
+        data_part_size: u64,
+    ) -> Result<Vec<GptEntry>, LabelError> {
+        let metadata_blocks = Aligned::get_blocks(GptLabel::METADATA_PARTITION_SIZE, block_size);
+
+        let data_start = header.lba_start + metadata_blocks;
+        if data_start > header.lba_end {
+            // Device is too small to accommodate Metadata partition
+            return Err(LabelError::DeviceTooSmall {
+                num_blocks: header.lba_alt + 1,
+                block_size,
+            });
+        }
+
+        if data_part_size > dev_size {
+            return Err(LabelError::LabelTooLarge {
+                dev_size,
+                part_size: data_part_size,
+            });
+        }
+
+        let data_blocks = Aligned::get_blocks(data_part_size, block_size);
+        Ok(vec![
+            GptEntry {
+                ent_type: Self::meta_guid(),
+                ent_guid: GptGuid::new_random(),
+                ent_start: header.lba_start,
+                ent_end: data_start - 1,
+                ent_attr: 0,
+                ent_name: Self::meta_name().into(),
+            },
+            GptEntry {
+                ent_type: Self::data_guid(),
+                ent_guid: header.guid,
+                ent_start: data_start,
+                //ent_end: round_1mib(min(data_start + data_blocks - 1, header.lba_end)) - 1,
+                ent_end: min(data_start + data_blocks - 1, header.lba_end),
+                ent_attr: 0,
+                ent_name: Self::data_name().into(),
+            },
+        ])
+    }
+
+    /// Check for the presence of "MayaMeta" and "MayaData" partitions.
+    pub fn check_partitions(label: &GptLabel) -> bool {
+        let metadata_start = Aligned::get_blocks(GptHeader::DATA_OFFSET, label.block_size);
+        if metadata_start != label.primary.lba_start {
+            return false;
+        }
+
+        let metadata_blocks =
+            Aligned::get_blocks(GptLabel::METADATA_PARTITION_SIZE, label.block_size);
+
+        let data_start = metadata_start + metadata_blocks;
+        if data_start > label.primary.lba_end {
+            return false;
+        }
+
+        match label.partition(Self::meta_name()) {
+            Some(entry) => {
+                if entry.ent_type != Self::meta_guid() {
+                    return false;
+                }
+                if entry.ent_start != metadata_start {
+                    return false;
+                }
+                if entry.ent_end != data_start - 1 {
+                    return false;
+                }
+            }
+            None => {
+                return false;
+            }
+        }
+
+        if let Some(entry) = label.partition(Self::data_name()) {
+            if entry.ent_type != Self::data_guid() {
+                return false;
+            }
+            if entry.ent_start == data_start {
+                return true;
+            }
+        }
+
+        false
+    }
+
+    /// Locate a partition by name.
+    pub(crate) fn partition(&self, name: &str) -> Option<&GptEntry> {
+        self.partitions
+            .iter()
+            .find(|entry| entry.ent_name.name == name)
+    }
+
+    /// Returns the offset (in bytes) of the specified partition.
+    pub fn partition_offset(&self, name: &str) -> Result<u64, ProbeError> {
+        match self.partition(name) {
+            Some(entry) => Ok(entry.ent_start * self.block_size),
+            None => Err(ProbeError::MissingPartition {
+                name: String::from(name),
+            }),
+        }
+    }
+
+    /// Returns the size (in bytes) of the specified partition.
+    pub fn partition_size(&self, name: &str) -> Result<u64, ProbeError> {
+        match self.partition(name) {
+            Some(entry) => Ok((entry.ent_end - entry.ent_start) * self.block_size),
+            None => Err(ProbeError::MissingPartition {
+                name: String::from(name),
+            }),
+        }
+    }
+}
+
+impl fmt::Display for GptLabel {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        writeln!(f, "GUID: {}", self.primary.guid)?;
+
+        writeln!(
+            f,
+            "Primary GPT header crc32: {:08x}",
+            self.primary.self_checksum
+        )?;
+        writeln!(f, "LBA primary GPT header: {}", self.primary.lba_self)?;
+        writeln!(f, "LBA primary partition table: {}", self.primary.lba_table)?;
+
+        writeln!(
+            f,
+            "Secondary GPT header crc32: {:08x}",
+            self.secondary.self_checksum
+        )?;
+        writeln!(f, "LBA secondary GPT header: {}", self.secondary.lba_self)?;
+        writeln!(
+            f,
+            "LBA secondary partition table: {}",
+            self.secondary.lba_table
+        )?;
+
+        writeln!(f, "Partition table crc32: {:08x}", self.primary.table_crc)?;
+        writeln!(f, "LBA first usable block: {}", self.primary.lba_start)?;
+        writeln!(f, "LBA last usable block: {}", self.primary.lba_end)?;
+
+        for (i, part) in self.partitions.iter().enumerate() {
+            writeln!(f, "  Partition {i}")?;
+            writeln!(f, "    GUID: {}", part.ent_guid)?;
+            writeln!(f, "    Type GUID: {}", part.ent_type)?;
+            writeln!(f, "    LBA start: {}", part.ent_start)?;
+            writeln!(f, "    LBA end: {}", part.ent_end)?;
+            writeln!(f, "    Name: {}", part.ent_name.name)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl GptLabel {
+    /// Construct a Pmbr from raw data.
+    #[allow(dead_code)]
+    fn read_mbr(buf: &[u8]) -> Result<Pmbr, ProbeError> {
+        Pmbr::from_slice(&buf[440..512])
+    }
+
+    /// Construct a GPT header from raw data.
+    #[allow(dead_code)]
+    fn read_header(buf: &[u8]) -> Result<GptHeader, ProbeError> {
+        GptHeader::from_slice(buf)
+    }
+
+    /// Construct and validate primary GPT header.
+    #[allow(dead_code)]
+    fn read_primary_header(
+        buf: &[u8],
+        block_size: u64,
+        num_blocks: u64,
+    ) -> Result<GptHeader, ProbeError> {
+        let header = GptLabel::read_header(buf)?;
+        GptLabel::validate_primary_header(&header, block_size, num_blocks)?;
+        Ok(header)
+    }
+
+    /// Construct and validate secondary GPT header.
+    #[allow(dead_code)]
+    fn read_secondary_header(
+        buf: &[u8],
+        block_size: u64,
+        num_blocks: u64,
+    ) -> Result<GptHeader, ProbeError> {
+        let header = GptLabel::read_header(buf)?;
+        GptLabel::validate_secondary_header(&header, block_size, num_blocks)?;
+        Ok(header)
+    }
+
+    /// Construct and validate partition table.
+    #[allow(dead_code)]
+    fn read_partitions(buf: &[u8], header: &GptHeader) -> Result<Vec<GptEntry>, ProbeError> {
+        let partitions = GptEntry::from_slice(buf, header.num_entries)?;
+        GptLabel::validate_partitions(&partitions, header)?;
+        Ok(partitions)
+    }
+
+    /// Check that primary GPT header is valid and consistent.
+    pub fn validate_primary_header(
+        primary: &GptHeader,
+        block_size: u64,
+        num_blocks: u64,
+    ) -> Result<(), ProbeError> {
+        if primary.lba_self != 1 {
+            return Err(ProbeError::PrimaryLocation {});
+        }
+        if primary.lba_alt + 1 != num_blocks {
+            return Err(ProbeError::SecondaryLocation {});
+        }
+        if primary.lba_end >= primary.lba_alt {
+            return Err(ProbeError::LastUsableBlock {});
+        }
+        if primary.lba_table != primary.lba_self + 1 {
+            return Err(ProbeError::PartitionTableLocation {});
+        }
+        if (primary.num_entries * primary.entry_size) as u64 > GptHeader::PARTITION_TABLE_SIZE {
+            return Err(ProbeError::PartitionTableSize {});
+        }
+        if primary.lba_table + Aligned::get_blocks(GptHeader::PARTITION_TABLE_SIZE, block_size)
+            > primary.lba_start
+        {
+            return Err(ProbeError::PartitionTableSpace {});
+        }
+        Ok(())
+    }
+
+    /// Check that secondary GPT header is valid and consistent.
+    pub fn validate_secondary_header(
+        secondary: &GptHeader,
+        block_size: u64,
+        num_blocks: u64,
+    ) -> Result<(), ProbeError> {
+        if secondary.lba_alt != 1 {
+            return Err(ProbeError::PrimaryLocation {});
+        }
+        if secondary.lba_self + 1 != num_blocks {
+            return Err(ProbeError::SecondaryLocation {});
+        }
+        if secondary.lba_alt >= secondary.lba_start {
+            return Err(ProbeError::FirstUsableBlock {});
+        }
+        if secondary.lba_table != secondary.lba_end + 1 {
+            return Err(ProbeError::PartitionTableLocation {});
+        }
+        if (secondary.num_entries * secondary.entry_size) as u64 > GptHeader::PARTITION_TABLE_SIZE {
+            return Err(ProbeError::PartitionTableSize {});
+        }
+        if secondary.lba_table + Aligned::get_blocks(GptHeader::PARTITION_TABLE_SIZE, block_size)
+            > secondary.lba_self
+        {
+            return Err(ProbeError::PartitionTableSpace {});
+        }
+        Ok(())
+    }
+
+    /// Check that partition table entries are valid and consistent.
+    pub fn validate_partitions(
+        partitions: &[GptEntry],
+        header: &GptHeader,
+    ) -> Result<(), ProbeError> {
+        for entry in partitions {
+            if 0 < entry.ent_start && entry.ent_start < header.lba_start {
+                return Err(ProbeError::PartitionStart {});
+            }
+            if entry.ent_start > entry.ent_end {
+                return Err(ProbeError::NegativePartitionSize {});
+            }
+            if entry.ent_end > header.lba_end {
+                return Err(ProbeError::PartitionEnd {});
+            }
+        }
+        if header.table_crc
+            != GptEntry::checksum(partitions, header.num_entries).context(ChecksumSerializeSnafu)?
+        {
+            return Err(ProbeError::PartitionTableChecksum {});
+        }
+        Ok(())
+    }
+
+    /// Check that primary and secondary GPT headers are consistent with each other.
+    pub fn consistency_check(primary: &GptHeader, secondary: &GptHeader) -> Result<(), ProbeError> {
+        if primary.lba_self != secondary.lba_alt {
+            return Err(ProbeError::CompareHeaderLocation {});
+        }
+        if primary.lba_alt != secondary.lba_self {
+            return Err(ProbeError::CompareHeaderLocation {});
+        }
+        if primary.lba_start != secondary.lba_start {
+            return Err(ProbeError::FirstUsableBlock {});
+        }
+        if primary.lba_end != secondary.lba_end {
+            return Err(ProbeError::LastUsableBlock {});
+        }
+        if primary.guid != secondary.guid {
+            return Err(ProbeError::CompareDiskGuid {});
+        }
+        if primary.num_entries != secondary.num_entries {
+            return Err(ProbeError::ComparePartitionEntryCount {});
+        }
+        if primary.entry_size != secondary.entry_size {
+            return Err(ProbeError::ComparePartitionEntrySize {});
+        }
+        if primary.table_crc != secondary.table_crc {
+            return Err(ProbeError::ComparePartitionTableChecksum {});
+        }
+        Ok(())
+    }
+}
+
+/// A trait to calculate the number of blocks needed
+/// to represent a given size, aligned to a block size.
+pub trait Aligned {
+    /// Return the (appropriately aligned) number of blocks
+    /// representing this size.
+    fn get_blocks(size: Self, block_size: Self) -> Self;
+}
+
+impl Aligned for u32 {
+    fn get_blocks(size: u32, block_size: u32) -> u32 {
+        let blocks = size / block_size;
+        match size % block_size {
+            0 => blocks,
+            _ => blocks + 1,
+        }
+    }
+}
+
+impl Aligned for u64 {
+    fn get_blocks(size: u64, block_size: u64) -> u64 {
+        let blocks = size / block_size;
+        match size % block_size {
+            0 => blocks,
+            _ => blocks + 1,
+        }
+    }
+}

--- a/io-engine/src/bdev/gpt_labels.rs
+++ b/io-engine/src/bdev/gpt_labels.rs
@@ -1,20 +1,17 @@
-//! GPT labeling for Nexus devices. The primary partition
-//! (/dev/x1) will be used for meta data during, rebuild. The second
-//! partition contains the file system.
+//! GPT labeling for Nexus devices. The primary partition (`MayaMeta`) is
+//! reserved for metadata used during rebuild. The second partition
+//! (`MayaData`) contains the file system data.
 //!
-//! The nexus will adjust internal data structures to offset the IO to the
-//! right partition. put differently, when connecting to this device via
-//! NVMF or iSCSI it will show up as device with just one partition.
-//!
-//! When the nexus is removed from the data path and other initiations are
-//! used, the data is still accessible and thus removes us has a hard
-//! dependency in the data path.
+//! The label written is a standard GPT label, so the partitions remain
+//! accessible even when the nexus is removed from the data path and the
+//! disks are accessed directly via NVMF/iSCSI or as local block devices.
+//! This removes the nexus as a hard dependency in the data path.
 //!
 //! # Example:
 //!
 //! ```bash
 //! $ rm /code/disk1.img; truncate -s 1GiB /code/disk1.img
-//! $ mayastor-client nexus create $UUID 1GiB aio:////code/disk1.img?blk_size=512
+//! $ io-engine-client nexus create $UUID 1GiB aio:////code/disk1.img?blk_size=512
 //! $ sgdisk -p /code/disk1.img
 //! Disk /code//disk1.img: 2097152 sectors, 1024.0 MiB
 //! Sector size (logical): 512 bytes
@@ -30,14 +27,12 @@
 //!  2           10240         2097118   1019.0 MiB  FFFF  MayaData
 //! ```
 //!
-//! Notice how two partitions have been created when accessing the disk
-//! when shared by the nexus:
+//! When the device is shared by the nexus the partitions are not exposed
+//! to the initiator (the nexus presents a single partition view):
 //!
 //! ```bash
-//! $ mayastor-client nexus share $UUID
+//! $ io-engine-client nexus share $UUID
 //! "/dev/nbd0"
-//!
-//! TODO: also note how it complains about a MBR
 //!
 //! $ lsblk
 //! NAME    MAJ:MIN RM  SIZE RO TYPE MOUNTPOINT
@@ -48,24 +43,31 @@
 //! sr0      11:0    1 1024M  0 rom
 //! nbd0     43:0    0 1019M  0 disk
 //! nvme0n1 259:0    0  200G  0 disk /code
-//!
-//! The nbd0 zero device does not show the partitions when mounting
-//! it without the nexus in the data path, there would be two paritions
 //! ```
+//!
+//! When mounted without the nexus in the data path the two partitions
+//! become visible to the initiator.
 
-use std::{cmp::min, convert::From, fmt, io::Cursor, str::FromStr};
+use std::{
+    cmp::min,
+    convert::From,
+    fmt,
+    io::{Cursor, Seek, SeekFrom},
+    ops::{Deref, DerefMut},
+    str::FromStr,
+};
 
-use serde::{Deserialize, Serialize};
+use crate::core::{BlockDeviceHandle, CoreError};
 
-use crate::core::CoreError;
-use bincode::{deserialize_from, serialize, Error};
+use bincode::{deserialize_from, serialize, serialize_into, Error};
 use crc::{crc32, Hasher32};
 use serde::{
     de::{Deserializer, SeqAccess, Unexpected, Visitor},
     ser::{SerializeTuple, Serializer},
+    Deserialize, Serialize,
 };
 use snafu::{ResultExt, Snafu};
-use spdk_rs::DmaError;
+use spdk_rs::{DmaBuf, DmaError};
 use uuid::{self, Uuid};
 
 /// The GPT label error type.
@@ -137,9 +139,9 @@ pub enum ProbeError {
     PartitionTableLocation {},
     #[snafu(display("Missing partition: {name}"))]
     MissingPartition { name: String },
-    #[snafu(display("Primary GTP header location is incorrect"))]
+    #[snafu(display("Primary GPT header location is incorrect"))]
     PrimaryLocation {},
-    #[snafu(display("Secondary GTP header location is incorrect"))]
+    #[snafu(display("Secondary GPT header location is incorrect"))]
     SecondaryLocation {},
     #[snafu(display("Location of first usable block is incorrect"))]
     FirstUsableBlock {},
@@ -253,11 +255,16 @@ pub struct GptHeader {
 }
 
 impl GptHeader {
-    /// The size of the partition table in bytes.
+    /// The size of the partition table in bytes: 128 entries × 128 bytes each,
+    /// the minimum required by the UEFI specification.
     pub const PARTITION_TABLE_SIZE: u64 = 128 * 128;
-    /// The offset of the partition table in bytes.
+    /// The byte offset of the first usable LBA (1 MiB). Aligning the first
+    /// usable sector to 1 MiB is the conventional default used by most GPT
+    /// tools (e.g. fdisk, gdisk) to ensure optimal I/O alignment on SSDs and
+    /// RAID arrays.
     pub const DATA_OFFSET: u64 = 1024 * 1024;
-    /// The size of the GPT header in bytes.
+    /// The GPT header size in bytes, as defined by the UEFI specification.
+    /// The remainder of the first LBA (sector) following the header is reserved.
     pub const HEADER_SIZE: u32 = 92;
     /// The revision of the GPT header, as defined in the UEFI specification.
     pub const HEADER_REVISION: [u8; 4] = [0x00, 0x00, 0x01, 0x00];
@@ -325,7 +332,12 @@ impl GptHeader {
         }
     }
 
-    /// Converts the header into a secondary GPT header.
+    /// Derives the secondary GPT header from this (primary) header.
+    ///
+    /// The secondary header mirrors the primary: `lba_self`/`lba_alt` are
+    /// swapped so the secondary points to itself at the last LBA of the disk.
+    /// The secondary partition table is placed immediately after `lba_end`
+    /// (the last usable LBA), growing backwards toward the secondary header.
     pub fn as_secondary(&self) -> Result<GptHeader, Error> {
         let mut secondary = *self;
         secondary.lba_self = self.lba_alt;
@@ -335,7 +347,13 @@ impl GptHeader {
         Ok(secondary)
     }
 
-    /// Converts the header into a primary GPT header.
+    /// Derives the primary GPT header from this (secondary) header.
+    ///
+    /// This is the inverse of [`as_secondary`](Self::as_secondary): must be
+    /// called on a secondary header. `lba_self`/`lba_alt` are swapped so the
+    /// result points to LBA 1 (the primary header location), and the primary
+    /// partition table is placed at `lba_self + 1` (LBA 2, immediately after
+    /// the primary header).
     pub fn as_primary(&self) -> Result<GptHeader, Error> {
         let mut primary = *self;
         primary.lba_self = self.lba_alt;
@@ -666,6 +684,124 @@ impl GptLabel {
         })
     }
 
+    /// Probe the disk for a [`GptLabel`].
+    pub async fn probe_label<T: GptDiskOps>(handle: &T) -> Result<GptLabel, LabelError> {
+        let GptDiskProps {
+            block_size,
+            num_blocks,
+        } = handle.props();
+
+        // Note that PMBR is 512B even on larger sector disks, but we must allocate block_size
+        // bytes to read it, as the underlying device may not support smaller reads.
+        let mut buf = handle.buffer_alloc(block_size).context(ReadAllocSnafu {
+            part: String::from("MBR"),
+        })?;
+        handle.read_at(0, &mut buf).await.context(ReadSnafu {
+            what: String::from("MBR"),
+        })?;
+        let mbr = GptLabel::read_mbr(&buf)?;
+
+        // GPT headers
+        let status: LabelStatus;
+        let primary: GptHeader;
+        let secondary: GptHeader;
+        let active: &GptHeader;
+
+        // Get primary GPT header.
+        handle
+            .read_at(block_size, &mut buf)
+            .await
+            .context(ReadSnafu {
+                what: String::from("primary GPT header"),
+            })?;
+        match GptLabel::read_primary_header(&buf, block_size, num_blocks) {
+            Ok(header) => {
+                primary = header;
+                active = &primary;
+                // Get secondary GPT header.
+                let offset = (num_blocks - 1) * block_size;
+                handle.read_at(offset, &mut buf).await.context(ReadSnafu {
+                    what: String::from("secondary GPT header"),
+                })?;
+                match GptLabel::read_secondary_header(&buf, block_size, num_blocks) {
+                    Ok(header) => {
+                        GptLabel::consistency_check(&primary, &header)?;
+                        // All good - primary and secondary GPT headers
+                        // are valid and consistent with each other.
+                        secondary = header;
+                        status = LabelStatus::Both;
+                    }
+                    Err(_) => {
+                        // Secondary GPT header is either not present
+                        // or invalid. Construct new secondary GPT header from primary.
+                        secondary = primary.as_secondary().context(SerializeSnafu)?;
+                        status = LabelStatus::Primary;
+                    }
+                }
+            }
+            Err(error) => {
+                // Primary GPT header is either not present or invalid.
+                // See if we can obtain a valid secondary GPT header.
+                let offset = (num_blocks - 1) * block_size;
+                handle.read_at(offset, &mut buf).await.context(ReadSnafu {
+                    what: String::from("secondary GPT header"),
+                })?;
+                match GptLabel::read_secondary_header(&buf, block_size, num_blocks) {
+                    Ok(header) => {
+                        secondary = header;
+                        active = &secondary;
+                        // Construct new primary GPT header from secondary.
+                        primary = secondary.as_primary().context(SerializeSnafu)?;
+                        status = LabelStatus::Secondary;
+                    }
+                    Err(_) => {
+                        // Neither primary or secondary GPT header is present or valid.
+                        return Err(LabelError::InvalidLabel { source: error });
+                    }
+                }
+            }
+        }
+
+        // The disk size recorded in protective MBR must be consistent with GPT header.
+        if mbr.entries[0].num_sectors != 0xffff_ffff
+            && u64::from(mbr.entries[0].num_sectors) != primary.lba_alt
+        {
+            return Err(LabelError::InvalidLabel {
+                source: ProbeError::MbrSize {},
+            });
+        }
+
+        // Partition table
+        let blocks = Aligned::get_blocks(
+            u64::from(active.entry_size * active.num_entries),
+            block_size,
+        );
+        let mut buf = handle
+            .buffer_alloc(blocks * block_size)
+            .context(ReadAllocSnafu {
+                part: String::from("partition table"),
+            })?;
+        let offset = active.lba_table * block_size;
+        handle.read_at(offset, &mut buf).await.context(ReadSnafu {
+            what: String::from("partition table"),
+        })?;
+        let mut partitions = GptLabel::read_partitions(&buf, active)?;
+
+        // There can be up to 128 partition entries stored on disk,
+        // even though most are not used. Retain only those entries
+        // that actually define partitions.
+        partitions.retain(|entry| entry.ent_start > 0 || entry.ent_end > 0);
+
+        Ok(GptLabel {
+            status,
+            block_size,
+            mbr,
+            primary,
+            partitions,
+            secondary,
+        })
+    }
+
     /// Create partition table entries for the "MayaMeta" and "MayaData" partitions.
     fn create_partitions(
         header: &GptHeader,
@@ -775,9 +911,12 @@ impl GptLabel {
     }
 
     /// Returns the size (in bytes) of the specified partition.
+    ///
+    /// Per the UEFI spec, `ent_end` is the last LBA of the partition
+    /// (inclusive), so the block count is `ent_end - ent_start + 1`.
     pub fn partition_size(&self, name: &str) -> Result<u64, ProbeError> {
         match self.partition(name) {
-            Some(entry) => Ok((entry.ent_end - entry.ent_start) * self.block_size),
+            Some(entry) => Ok((entry.ent_end - entry.ent_start + 1) * self.block_size),
             None => Err(ProbeError::MissingPartition {
                 name: String::from(name),
             }),
@@ -828,21 +967,18 @@ impl fmt::Display for GptLabel {
 
 impl GptLabel {
     /// Construct a Pmbr from raw data.
-    #[allow(dead_code)]
-    fn read_mbr(buf: &[u8]) -> Result<Pmbr, ProbeError> {
-        Pmbr::from_slice(&buf[440..512])
+    fn read_mbr(buf: &impl GptBuffer) -> Result<Pmbr, ProbeError> {
+        Pmbr::from_slice(&buf.as_slice()[440..512])
     }
 
     /// Construct a GPT header from raw data.
-    #[allow(dead_code)]
-    fn read_header(buf: &[u8]) -> Result<GptHeader, ProbeError> {
-        GptHeader::from_slice(buf)
+    fn read_header(buf: &impl GptBuffer) -> Result<GptHeader, ProbeError> {
+        GptHeader::from_slice(buf.as_slice())
     }
 
     /// Construct and validate primary GPT header.
-    #[allow(dead_code)]
     fn read_primary_header(
-        buf: &[u8],
+        buf: &impl GptBuffer,
         block_size: u64,
         num_blocks: u64,
     ) -> Result<GptHeader, ProbeError> {
@@ -852,9 +988,8 @@ impl GptLabel {
     }
 
     /// Construct and validate secondary GPT header.
-    #[allow(dead_code)]
     fn read_secondary_header(
-        buf: &[u8],
+        buf: &impl GptBuffer,
         block_size: u64,
         num_blocks: u64,
     ) -> Result<GptHeader, ProbeError> {
@@ -864,9 +999,11 @@ impl GptLabel {
     }
 
     /// Construct and validate partition table.
-    #[allow(dead_code)]
-    fn read_partitions(buf: &[u8], header: &GptHeader) -> Result<Vec<GptEntry>, ProbeError> {
-        let partitions = GptEntry::from_slice(buf, header.num_entries)?;
+    fn read_partitions(
+        buf: &impl GptBuffer,
+        header: &GptHeader,
+    ) -> Result<Vec<GptEntry>, ProbeError> {
+        let partitions = GptEntry::from_slice(buf.as_slice(), header.num_entries)?;
         GptLabel::validate_partitions(&partitions, header)?;
         Ok(partitions)
     }
@@ -980,6 +1117,161 @@ impl GptLabel {
             return Err(ProbeError::ComparePartitionTableChecksum {});
         }
         Ok(())
+    }
+}
+
+/// Properties of the disk needed to probe and read GPT labels.
+#[derive(Clone, Copy)]
+pub struct GptDiskProps {
+    /// Logical block size of the underlying device.
+    pub block_size: u64,
+    /// Number of blocks on the underlying device.
+    pub num_blocks: u64,
+}
+
+/// Trait for disk operations needed to probe and read GPT labels.
+///
+/// Implementations decouple the GPT (de)serialisation code from any
+/// particular I/O backend (SPDK, plain files, etc.) so the label routines
+/// can be reused outside of the io-engine core.
+#[async_trait::async_trait(?Send)]
+pub trait GptDiskOps {
+    /// Backend-specific buffer type used for I/O.
+    type Buffer: GptBuffer;
+
+    /// Allocate an I/O buffer of `size` bytes suitable for use with
+    /// [`GptDiskOps::read_at`].
+    fn buffer_alloc(&self, size: u64) -> Result<Self::Buffer, DmaError>;
+    /// Return the geometry (block size, block count) of the underlying disk.
+    fn props(&self) -> GptDiskProps;
+    /// Read `buffer.len()` bytes starting at byte `offset` into `buffer`.
+    /// Returns the number of bytes read.
+    async fn read_at(&self, offset: u64, buffer: &mut Self::Buffer) -> Result<u64, CoreError>;
+}
+
+#[async_trait::async_trait(?Send)]
+impl GptDiskOps for Box<dyn BlockDeviceHandle> {
+    type Buffer = DmaBuf;
+
+    fn buffer_alloc(&self, size: u64) -> Result<Self::Buffer, DmaError> {
+        self.dma_malloc(size)
+    }
+    fn props(&self) -> GptDiskProps {
+        let bdev = self.get_device();
+        GptDiskProps {
+            block_size: bdev.block_len(),
+            num_blocks: bdev.num_blocks(),
+        }
+    }
+    async fn read_at(&self, offset: u64, buffer: &mut Self::Buffer) -> Result<u64, CoreError> {
+        self.read_at(offset, buffer).await
+    }
+}
+#[async_trait::async_trait(?Send)]
+impl GptDiskOps for dyn BlockDeviceHandle {
+    type Buffer = DmaBuf;
+
+    fn buffer_alloc(&self, size: u64) -> Result<Self::Buffer, DmaError> {
+        self.dma_malloc(size)
+    }
+    fn props(&self) -> GptDiskProps {
+        let bdev = self.get_device();
+        GptDiskProps {
+            block_size: bdev.block_len(),
+            num_blocks: bdev.num_blocks(),
+        }
+    }
+    async fn read_at(&self, offset: u64, buffer: &mut Self::Buffer) -> Result<u64, CoreError> {
+        #[allow(deprecated)]
+        self.read_at(offset, buffer).await
+    }
+}
+
+/// A trait to abstract over the buffer type used for reading/writing GPT data.
+pub trait GptBuffer {
+    /// View the buffer's contents as an immutable byte slice.
+    fn as_slice(&self) -> &[u8];
+    /// View the buffer's contents as a mutable byte slice.
+    fn as_mut_slice(&mut self) -> &mut [u8];
+}
+impl GptBuffer for DmaBuf {
+    fn as_slice(&self) -> &[u8] {
+        self.deref().as_slice()
+    }
+    fn as_mut_slice(&mut self) -> &mut [u8] {
+        self.deref_mut().as_mut_slice()
+    }
+}
+
+/// A structure to hold the raw label data and the offset at which it should be written to disk.
+pub struct LabelData<T: GptBuffer> {
+    /// Byte offset on the disk at which `buf` should be written.
+    pub offset: u64,
+    /// Serialised label data ready to be written verbatim to disk.
+    pub buf: T,
+}
+impl GptLabel {
+    /// Generate raw data for (primary) label ready to be written to disk.
+    pub fn primary_data<T: GptDiskOps + ?Sized>(
+        &self,
+        handle: &T,
+    ) -> Result<LabelData<T::Buffer>, LabelError> {
+        let mut buf = handle
+            .buffer_alloc(self.primary.lba_start * self.block_size)
+            .context(WriteAllocSnafu {
+                what: String::from("primary"),
+            })?;
+
+        let mut writer = Cursor::new(buf.as_mut_slice());
+
+        // Protective MBR
+        writer.seek(SeekFrom::Start(440)).context(SeekSnafu)?;
+        serialize_into(&mut writer, &self.mbr).context(SerializeSnafu)?;
+
+        // Primary GPT header
+        writer
+            .seek(SeekFrom::Start(self.primary.lba_self * self.block_size))
+            .context(SeekSnafu)?;
+        serialize_into(&mut writer, &self.primary).context(SerializeSnafu)?;
+
+        // Primary partition table
+        writer
+            .seek(SeekFrom::Start(self.primary.lba_table * self.block_size))
+            .context(SeekSnafu)?;
+        for entry in self.partitions.iter() {
+            serialize_into(&mut writer, &entry).context(SerializeSnafu)?;
+        }
+
+        Ok(LabelData { offset: 0, buf })
+    }
+
+    /// Generate raw data for (secondary) label ready to be written to disk.
+    pub fn secondary_data<T: GptDiskOps + ?Sized>(
+        &self,
+        handle: &T,
+    ) -> Result<LabelData<T::Buffer>, LabelError> {
+        let len_bytes = (self.secondary.lba_self - self.secondary.lba_table + 1) * self.block_size;
+        let mut buf = handle.buffer_alloc(len_bytes).context(WriteAllocSnafu {
+            what: String::from("secondary"),
+        })?;
+
+        let mut writer = Cursor::new(buf.as_mut_slice());
+
+        // Secondary partition table
+        for entry in self.partitions.iter() {
+            serialize_into(&mut writer, &entry).context(SerializeSnafu)?;
+        }
+
+        // Secondary GPT header
+        writer
+            .seek(SeekFrom::Start(
+                (self.secondary.lba_self - self.secondary.lba_table) * self.block_size,
+            ))
+            .context(SeekSnafu)?;
+        serialize_into(&mut writer, &self.secondary).context(SerializeSnafu)?;
+
+        let offset = self.secondary.lba_table * self.block_size;
+        Ok(LabelData { offset, buf })
     }
 }
 

--- a/io-engine/src/bdev/mod.rs
+++ b/io-engine/src/bdev/mod.rs
@@ -14,7 +14,6 @@ pub use io_engine_api::v1::pool::{ProbeError, ProbeErrorCode};
 pub mod crypto;
 pub(crate) mod device;
 mod ftl;
-pub mod gpt_labels;
 mod loopback;
 mod lvs;
 mod malloc;

--- a/io-engine/src/bdev/mod.rs
+++ b/io-engine/src/bdev/mod.rs
@@ -14,6 +14,7 @@ pub use io_engine_api::v1::pool::{ProbeError, ProbeErrorCode};
 pub mod crypto;
 pub(crate) mod device;
 mod ftl;
+pub mod gpt_labels;
 mod loopback;
 mod lvs;
 mod malloc;

--- a/io-engine/src/bdev/nexus/nexus_child.rs
+++ b/io-engine/src/bdev/nexus/nexus_child.rs
@@ -316,7 +316,7 @@ pub struct NexusChild<'c> {
     ///
     /// TODO: we don't rename this field due to possible issues with
     /// TODO: child serialized state.
-    name: String,
+    pub(crate) name: String,
     /// Underlying block device.
     #[serde(skip_serializing)]
     device: Option<Box<dyn BlockDevice>>,

--- a/io-engine/src/bin/gpt.rs
+++ b/io-engine/src/bin/gpt.rs
@@ -1,6 +1,6 @@
 use clap::Parser;
-use io_engine::gpt_labels::{
-    GptBuffer, GptDiskOps, GptDiskProps, GptGuid, GptLabel, LabelError, ProbeError,
+use io_engine::gpt::{
+    GptBuffer, GptDiskOps, GptDiskProps, GptGuid, LabelError, ProbeError, VersionedLabel, V1,
 };
 use snafu::{ResultExt, Snafu};
 use std::{
@@ -95,14 +95,13 @@ fn write(cli_args: &CliArgs) -> Result<(), Error> {
         "978D2F99-AA7C-4F24-AE22-1BF99137D7B1",
     )?);
     let mut gpt_disk = GptDisk::new(false, true, cli_args)?;
-    let props = gpt_disk.props();
 
     // Create new disk label.
-    let label = GptLabel::generate_label(guid, props.block_size, props.num_blocks, None)?;
+    let label = V1::generate(guid, gpt_disk.props())?;
     println!("{label}");
 
-    let primary = label.primary_data(&gpt_disk)?;
-    let secondary = label.secondary_data(&gpt_disk)?;
+    let primary = label.gpt.primary_data(&gpt_disk)?;
+    let secondary = label.gpt.secondary_data(&gpt_disk)?;
 
     gpt_disk.write_at(&primary.buf, primary.offset)?;
     gpt_disk.write_at(&secondary.buf, secondary.offset)?;
@@ -114,10 +113,10 @@ fn write(cli_args: &CliArgs) -> Result<(), Error> {
 async fn read(cli_args: &CliArgs) -> Result<(), Error> {
     let gpt_disk = GptDisk::new(true, false, cli_args)?;
 
-    let label = gpt_disk.probe_label().await?;
+    let label = VersionedLabel::probe(&gpt_disk).await?;
     println!("{label}");
 
-    if !GptLabel::check_partitions(&label) {
+    if !label.check() {
         todo!("resync the label with the partitions");
     }
 
@@ -189,9 +188,6 @@ impl GptDisk {
         self.file.write_all_at(buf, offset).context(WriteSnafu)?;
         Ok(())
     }
-    async fn probe_label(&self) -> Result<GptLabel, LabelError> {
-        GptLabel::probe_label(self).await
-    }
 }
 
 /// In-memory I/O buffer satisfying [`GptBuffer`] for file-based disk access.
@@ -209,7 +205,7 @@ impl DerefMut for FileBuffer {
 }
 
 #[async_trait::async_trait(?Send)]
-impl io_engine::gpt_labels::GptDiskOps for GptDisk {
+impl io_engine::gpt::GptDiskOps for GptDisk {
     type Buffer = FileBuffer;
 
     fn buffer_alloc(&self, size: u64) -> Result<Self::Buffer, spdk_rs::DmaError> {

--- a/io-engine/src/bin/gpt.rs
+++ b/io-engine/src/bin/gpt.rs
@@ -1,0 +1,253 @@
+use clap::Parser;
+use io_engine::gpt_labels::{
+    GptBuffer, GptDiskOps, GptDiskProps, GptGuid, GptLabel, LabelError, ProbeError,
+};
+use snafu::{ResultExt, Snafu};
+use std::{
+    ops::{Deref, DerefMut},
+    os::unix::fs::{FileExt, FileTypeExt},
+};
+use version_info::{package_description, version_info_string};
+
+#[derive(Debug, Clone, Parser)]
+#[clap(name = package_description!(), version = version_info_string!())]
+struct CliArgs {
+    /// The disk uri to use.
+    /// Run as sudo if this is a real block device.
+    #[clap(short, long)]
+    disk_uri: url::Url,
+
+    /// Command.
+    #[clap(subcommand)]
+    command: Command,
+}
+
+#[derive(clap::Subcommand, Debug, Clone)]
+enum Command {
+    /// Read and display the GPT label from the disk.
+    Read,
+    /// Write a new GPT label to the disk, overwriting any existing label.
+    Write,
+}
+
+#[derive(Debug, Snafu)]
+enum Error {
+    #[snafu(display("{source}"))]
+    Label { source: LabelError },
+    #[snafu(display("{source}"))]
+    Probe { source: ProbeError },
+    #[snafu(display("No filepath in disk-uri"))]
+    InvalidUri,
+    #[snafu(display("Failed to open disk: {source}"))]
+    OpenDisk { source: std::io::Error },
+    #[snafu(display("Failed to write to disk: {source}"))]
+    Write { source: std::io::Error },
+    #[snafu(display("Failed to read {path}: {source}"))]
+    ReadFile {
+        path: String,
+        source: std::io::Error,
+    },
+    #[snafu(display("Failed to parse int from sysfs {path} = {value}: {source}"))]
+    ParseSysfs {
+        path: String,
+        value: String,
+        source: std::num::ParseIntError,
+    },
+    #[snafu(display("Failed to read disk metadata: {source}"))]
+    DiskMeta { source: std::io::Error },
+    #[snafu(display("Disk not in /dev/"))]
+    DiskDev,
+    #[snafu(display("{source}"))]
+    InvalidUuid { source: uuid::Error },
+}
+impl From<uuid::Error> for Error {
+    fn from(source: uuid::Error) -> Self {
+        Self::InvalidUuid { source }
+    }
+}
+impl From<LabelError> for Error {
+    fn from(source: LabelError) -> Self {
+        Self::Label { source }
+    }
+}
+impl From<ProbeError> for Error {
+    fn from(source: ProbeError) -> Self {
+        Self::Probe { source }
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), String> {
+    let cli_args = CliArgs::parse();
+
+    match &cli_args.command {
+        Command::Write => write(&cli_args),
+        Command::Read => read(&cli_args).await,
+    }
+    .map_err(|e| format!("{e}"))
+}
+
+/// Creates a fresh GPT label on the disk and writes both the primary (LBA 1)
+/// and secondary (last LBA) headers along with their partition tables.
+fn write(cli_args: &CliArgs) -> Result<(), Error> {
+    // Fixed GUID used as the disk identifier for CLI testing.
+    let guid = GptGuid::from(uuid::Uuid::parse_str(
+        "978D2F99-AA7C-4F24-AE22-1BF99137D7B1",
+    )?);
+    let mut gpt_disk = GptDisk::new(false, true, cli_args)?;
+    let props = gpt_disk.props();
+
+    // Create new disk label.
+    let label = GptLabel::generate_label(guid, props.block_size, props.num_blocks, None)?;
+    println!("{label}");
+
+    let primary = label.primary_data(&gpt_disk)?;
+    let secondary = label.secondary_data(&gpt_disk)?;
+
+    gpt_disk.write_at(&primary.buf, primary.offset)?;
+    gpt_disk.write_at(&secondary.buf, secondary.offset)?;
+
+    Ok(())
+}
+
+/// Probes the disk for an existing GPT label and prints it to stdout.
+async fn read(cli_args: &CliArgs) -> Result<(), Error> {
+    let gpt_disk = GptDisk::new(true, false, cli_args)?;
+
+    let label = gpt_disk.probe_label().await?;
+    println!("{label}");
+
+    if !GptLabel::check_partitions(&label) {
+        todo!("resync the label with the partitions");
+    }
+
+    Ok(())
+}
+
+/// Wraps a disk file or block device for GPT label read/write operations.
+struct GptDisk {
+    file: std::fs::File,
+    props: GptDiskProps,
+}
+impl GptDisk {
+    /// Opens the disk at the path given in `cli_args.disk_uri`.
+    /// `read`/`write` control the file open flags.
+    fn new(read: bool, write: bool, cli_args: &CliArgs) -> Result<Self, Error> {
+        let disk = cli_args
+            .disk_uri
+            .to_file_path()
+            .map_err(|_| Error::InvalidUri)?;
+        let disk = disk.to_string_lossy().to_string();
+
+        let file = std::fs::File::options()
+            .read(read)
+            .write(write)
+            .open(&disk)
+            .context(OpenDiskSnafu)?;
+        let props = Self::disk_props(&disk, &file)?;
+        Ok(Self { file, props })
+    }
+    /// Determines block size and block count. For block devices these are read
+    /// from sysfs (`/sys/block/<dev>/queue/logical_block_size` and `size`).
+    /// For regular files a 512-byte block size is assumed.
+    fn disk_props(disk: &str, file: &std::fs::File) -> Result<GptDiskProps, Error> {
+        let metadata = file.metadata().context(DiskMetaSnafu)?;
+        let file_len = metadata.len();
+
+        let block_size;
+        let num_blocks;
+        if metadata.file_type().is_block_device() {
+            let dev = disk.strip_prefix("/dev/").ok_or(Error::DiskDev)?;
+            block_size = Self::read_block_sysfs(dev, "queue/logical_block_size")?;
+            // sysfs `size` is always reported in 512-byte sectors, regardless of
+            // the device's logical block size; convert into logical blocks.
+            let sysfs_sectors = Self::read_block_sysfs(dev, "size")?;
+            num_blocks = sysfs_sectors * 512 / block_size;
+        } else {
+            block_size = 512;
+            num_blocks = file_len / block_size;
+        }
+        Ok(GptDiskProps {
+            block_size,
+            num_blocks,
+        })
+    }
+    fn read_block_sysfs(dev: &str, attr: &str) -> Result<u64, Error> {
+        let path = format!("/sys/block/{dev}/{attr}");
+        let value = std::fs::read_to_string(&path).map_err(|source| Error::ReadFile {
+            path: path.clone(),
+            source,
+        })?;
+        value.trim().parse().map_err(|source| Error::ParseSysfs {
+            path,
+            value,
+            source,
+        })
+    }
+    /// Writes `buf` to the disk at the given byte `offset`.
+    fn write_at(&mut self, buf: &[u8], offset: u64) -> Result<(), Error> {
+        self.file.write_all_at(buf, offset).context(WriteSnafu)?;
+        Ok(())
+    }
+    async fn probe_label(&self) -> Result<GptLabel, LabelError> {
+        GptLabel::probe_label(self).await
+    }
+}
+
+/// In-memory I/O buffer satisfying [`GptBuffer`] for file-based disk access.
+struct FileBuffer(Vec<u8>);
+impl Deref for FileBuffer {
+    type Target = [u8];
+    fn deref(&self) -> &Self::Target {
+        self.0.as_slice()
+    }
+}
+impl DerefMut for FileBuffer {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.0.as_mut_slice()
+    }
+}
+
+#[async_trait::async_trait(?Send)]
+impl io_engine::gpt_labels::GptDiskOps for GptDisk {
+    type Buffer = FileBuffer;
+
+    fn buffer_alloc(&self, size: u64) -> Result<Self::Buffer, spdk_rs::DmaError> {
+        Ok(FileBuffer(vec![0; size as usize]))
+    }
+    fn props(&self) -> GptDiskProps {
+        self.props
+    }
+    async fn read_at(
+        &self,
+        offset: u64,
+        buffer: &mut Self::Buffer,
+    ) -> Result<u64, io_engine::core::CoreError> {
+        let len = buffer.0.len() as u64;
+        // todo: refactor DmaError&CoreError out of this interface so we can
+        // propagate this io::Error directly instead of stuffing it into a
+        // generic CoreError variant.
+        self.file
+            .read_exact_at(&mut buffer.0, offset)
+            .map_err(|e| {
+                let errno = e
+                    .raw_os_error()
+                    .map(nix::errno::Errno::from_raw)
+                    .unwrap_or(nix::errno::Errno::EIO);
+                io_engine::core::CoreError::ReadDispatch {
+                    source: errno,
+                    offset,
+                    len,
+                }
+            })?;
+        Ok(len)
+    }
+}
+impl GptBuffer for FileBuffer {
+    fn as_slice(&self) -> &[u8] {
+        self.0.as_slice()
+    }
+    fn as_mut_slice(&mut self) -> &mut [u8] {
+        self.0.as_mut_slice()
+    }
+}

--- a/io-engine/src/core/gpt/label.rs
+++ b/io-engine/src/core/gpt/label.rs
@@ -1,0 +1,107 @@
+//! Versioned GPT label: a [`GptLabel`] tagged with a layout version.
+//!
+//! The underlying label is a standard GPT label so the partitions remain
+//! accessible even when read directly via NVMF/iSCSI or as local block
+//! devices.
+//!
+//! Each version owns its layout in its own module (see [`super::v1`]).
+//! Versions implement [`LabelVariant`] for detection/validation and
+//! expose their own `generate` constructor — there is no generic
+//! generator here because each version's parameters differ.
+
+use super::{
+    primitives::{GptDiskOps, GptLabel, LabelError, ProbeError},
+    v1::V1,
+};
+
+/// Behaviour each label version must provide.
+///
+/// Kept deliberately small so it doesn't leak how many partitions a
+/// layout has, what they are called or how they are addressed; those
+/// details are private to each variant's implementation.
+pub trait LabelVariant {
+    /// Return `true` if `label`'s partition table matches the signature
+    /// of this variant (typically by inspecting partition type GUIDs).
+    fn detect(&self, label: &GptLabel) -> bool;
+
+    /// Verify that `label` matches this variant's expected layout
+    /// (offsets, sizes, names, etc.).
+    fn check(&self, label: &GptLabel) -> bool;
+}
+
+/// Version of the on-disk label layout.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LabelVersion {
+    /// First (and currently the only) layout. See [`super::v1`].
+    V1,
+}
+
+impl std::fmt::Display for LabelVersion {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Self::V1 => write!(f, "v1"),
+        }
+    }
+}
+
+impl LabelVersion {
+    /// All known versions, in any order. Used by [`Self::detect`] to walk
+    /// the list when probing an existing label.
+    const ALL: &'static [LabelVersion] = &[LabelVersion::V1];
+
+    /// Return the [`LabelVariant`] backing this version.
+    pub fn variant(self) -> &'static dyn LabelVariant {
+        match self {
+            Self::V1 => &V1::INSTANCE,
+        }
+    }
+
+    /// Identify which label version, if any, wrote the partition table in
+    /// `label`. Each variant decides what counts as a match. Returns
+    /// `None` when no version recognises the layout.
+    pub fn detect(label: &GptLabel) -> Option<Self> {
+        Self::ALL
+            .iter()
+            .copied()
+            .find(|v| v.variant().detect(label))
+    }
+}
+
+/// A versioned on-disk label: a [`GptLabel`] paired with the
+/// [`LabelVersion`] that produced it.
+///
+/// Construct via a version-specific generator (e.g. [`V1::generate`]) or
+/// by probing an existing disk with [`Self::probe`].
+#[derive(Debug, Clone)]
+pub struct VersionedLabel {
+    /// Layout version this label was written with.
+    pub version: LabelVersion,
+    /// The underlying GPT label.
+    pub gpt: GptLabel,
+}
+
+impl VersionedLabel {
+    /// Probe the disk for a versioned label. Fails with
+    /// [`ProbeError::IncorrectPartitions`] if a valid GPT is present but
+    /// doesn't match any known layout version.
+    pub async fn probe<T: GptDiskOps>(handle: &T) -> Result<VersionedLabel, LabelError> {
+        let gpt = GptLabel::probe_label(handle).await?;
+        let version = LabelVersion::detect(&gpt).ok_or(LabelError::InvalidLabel {
+            source: ProbeError::IncorrectPartitions {},
+        })?;
+        Ok(VersionedLabel { version, gpt })
+    }
+
+    /// Verify the partition layout matches the recorded version.
+    pub fn check(&self) -> bool {
+        self.version.variant().check(&self.gpt)
+    }
+}
+
+impl std::fmt::Display for VersionedLabel {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        writeln!(f, "Version: {}", self.version)?;
+        writeln!(f, "{}", self.gpt)?;
+        Ok(())
+    }
+}

--- a/io-engine/src/core/gpt/mod.rs
+++ b/io-engine/src/core/gpt/mod.rs
@@ -1,0 +1,19 @@
+//! GPT (GUID Partition Table) handling.
+//!
+//! - [`primitives`] — standards-based GPT primitives (headers, partition
+//!   entries, protective MBR, label container, probing, serialisation,
+//!   validation), with no knowledge of any particular partition layout.
+//! - [`label`] — versioned on-disk label: a [`VersionedLabel`] built on
+//!   top of [`primitives::GptLabel`] with a [`LabelVariant`] per version.
+//! - Per-version layout modules ([`v1`], ...) implement [`LabelVariant`].
+
+pub mod label;
+pub mod primitives;
+pub mod v1;
+
+pub use label::{LabelVariant, LabelVersion, VersionedLabel};
+pub use primitives::{
+    Aligned, GptBuffer, GptDiskOps, GptDiskProps, GptEntry, GptGuid, GptHeader, GptLabel, GptName,
+    LabelData, LabelError, LabelStatus, MbrEntry, Pmbr, ProbeError,
+};
+pub use v1::V1;

--- a/io-engine/src/core/gpt/primitives.rs
+++ b/io-engine/src/core/gpt/primitives.rs
@@ -1,0 +1,1179 @@
+//! Generic GPT (GUID Partition Table) primitives.
+//!
+//! This module contains only the standards-based pieces of GPT handling —
+//! header, partition entry, protective MBR, label container, probing,
+//! serialisation and validation — with no knowledge of any particular
+//! partition layout. The versioned MayaMeta/MayaData layout is
+//! built on top of these primitives in [`super::label`].
+//!
+//! The on-disk format follows the UEFI specification, ie:
+//! +---------------------------------------------------------------+
+//! |                        LBA 0 (512 B)                          |
+//! |                     Protective MBR (PMBR)                     |
+//! |        - MBR signature                                        |
+//! |        - One partition entry of type 0xEE covering disk       |
+//! +---------------------------------------------------------------+
+//! |                        LBA 1 (512 B)                          |
+//! |                     Primary GPT Header                        |
+//! |   "EFI PART" signature | Disk GUID | CRC32 | Table location   |
+//! +---------------------------------------------------------------+
+//! |                  LBA 2 ... LBA 33 (or more)                   |
+//! |                 GPT Partition Entry Array                     |
+//! |   [Entry 0] Partition Type GUID | Unique GUID | LBAs | Name   |
+//! |   [Entry 1] ...                                               |
+//! |   Typically 128 entries × 128 bytes each                      |
+//! +---------------------------------------------------------------+
+//! |                                                               |
+//! |                     Usable Disk Space                         |
+//! |                 (Defined by GPT Header)                       |
+//! |                                                               |
+//! |   +-------------------------------------------------------+   |
+//! |   | EFI System Partition (ESP)                            |   |
+//! |   | FAT32, ~100–300 MB                                    |   |
+//! |   |   /EFI/BOOT/BOOTX64.EFI                               |   |
+//! |   |   /EFI/<vendor>/...                                   |   |
+//! |   +-------------------------------------------------------+   |
+//! |                                                               |
+//! |   +-------------------------------------------------------+   |
+//! |   | Microsoft Reserved Partition (MSR) (Windows only)     |   |
+//! |   | ~16 MB, no filesystem                                 |   |
+//! |   +-------------------------------------------------------+   |
+//! |                                                               |
+//! |   +-------------------------------------------------------+   |
+//! |   | OS Partition (NTFS/ext4/etc.)                         |   |
+//! |   +-------------------------------------------------------+   |
+//! |                                                               |
+//! |   +-------------------------------------------------------+   |
+//! |   | Recovery / OEM / Vendor Partitions                    |   |
+//! |   +-------------------------------------------------------+   |
+//! |                                                               |
+//! +---------------------------------------------------------------+
+//! |            Backup GPT Partition Entry Array (N-32...)         |
+//! +---------------------------------------------------------------+
+//! |                     Backup GPT Header (Last LBA)              |
+//! +---------------------------------------------------------------+
+
+use std::{
+    convert::From,
+    fmt,
+    io::{Cursor, Seek, SeekFrom},
+    ops::{Deref, DerefMut},
+    str::FromStr,
+};
+
+use crate::core::{BlockDeviceHandle, CoreError};
+
+use bincode::{deserialize_from, serialize, serialize_into, Error};
+use crc::{crc32, Hasher32};
+use serde::{
+    de::{Deserializer, SeqAccess, Unexpected, Visitor},
+    ser::{SerializeTuple, Serializer},
+    Deserialize, Serialize,
+};
+use snafu::{ResultExt, Snafu};
+use spdk_rs::{DmaBuf, DmaError};
+use uuid::{self, Uuid};
+
+/// The GPT label error type.
+#[derive(Debug, Snafu)]
+pub enum LabelError {
+    #[snafu(display("Serialization error: {source}"))]
+    SerializeError { source: Error },
+    #[snafu(display("Failed to allocate buffer for reading {part}: {source}"))]
+    ReadAlloc { source: DmaError, part: String },
+    #[snafu(display("Failed to allocate buffer for writing {what}: {source}"))]
+    WriteAlloc { source: DmaError, what: String },
+    #[snafu(display("Error reading {what}: {source}"))]
+    ReadError { source: CoreError, what: String },
+    #[snafu(display("Error writing {what}: {source}"))]
+    WriteError { source: CoreError, what: String },
+    #[snafu(display("Label is invalid: {source}"))]
+    InvalidLabel { source: ProbeError },
+    #[snafu(display("Failed to obtain BlockDeviceHandle: {source}"))]
+    HandleError { source: CoreError },
+    #[snafu(display(
+        "Device is too small to accommodate the requested partition layout: \
+         size = {num_blocks} x {block_size}"
+    ))]
+    DeviceTooSmall { num_blocks: u64, block_size: u64 },
+    #[snafu(display("{source}"))]
+    SeekError { source: std::io::Error },
+}
+
+/// The GPT probe error type.
+#[derive(Debug, Snafu)]
+pub enum ProbeError {
+    #[snafu(display("Serialization error: {source}"))]
+    ChecksumSerializeError { source: Error },
+    #[snafu(display("Deserialization error: {source}"))]
+    DeserializeError { source: Error },
+    #[snafu(display("Incorrect MBR signature"))]
+    MbrSignature {},
+    #[snafu(display("Disk size in MBR does not match size in GPT header"))]
+    MbrSize {},
+    #[snafu(display("Incorrect GPT header signature"))]
+    GptSignature {},
+    #[snafu(display("Incorrect GPT header revision"))]
+    GptRevision {},
+    #[snafu(display("Incorrect GPT header size: actual={actual_size}, expected={expected_size}"))]
+    GptHeaderSize {
+        actual_size: u32,
+        expected_size: u32,
+    },
+    #[snafu(display("Incorrect GPT header checksum"))]
+    GptChecksum {},
+    #[snafu(display("Incorrect GPT partition table checksum"))]
+    PartitionTableChecksum {},
+    #[snafu(display("Disk GUIDs differ"))]
+    CompareDiskGuid {},
+    #[snafu(display("Disk sizes differ"))]
+    CompareDiskSize {},
+    #[snafu(display("GPT stored partition table checksums differ"))]
+    ComparePartitionTableChecksum {},
+    #[snafu(display("GPT partition table location is incorrect"))]
+    PartitionTableLocation {},
+    #[snafu(display("Missing partition: {name}"))]
+    MissingPartition { name: String },
+    #[snafu(display("Primary GPT header location is incorrect"))]
+    PrimaryLocation {},
+    #[snafu(display("Secondary GPT header location is incorrect"))]
+    SecondaryLocation {},
+    #[snafu(display("Location of first usable block is incorrect"))]
+    FirstUsableBlock {},
+    #[snafu(display("Location of last usable block is incorrect"))]
+    LastUsableBlock {},
+    #[snafu(display("Partition table exceeds maximum size"))]
+    PartitionTableSize {},
+    #[snafu(display("Insufficient space reserved for partition table"))]
+    PartitionTableSpace {},
+    #[snafu(display("Partition starts before first usable block"))]
+    PartitionStart {},
+    #[snafu(display("Partition ends after last usable block"))]
+    PartitionEnd {},
+    #[snafu(display("Partition has negative size"))]
+    NegativePartitionSize {},
+    #[snafu(display("GPT header locations are inconsistent"))]
+    CompareHeaderLocation {},
+    #[snafu(display("Number of partition table entries differ"))]
+    ComparePartitionEntryCount {},
+    #[snafu(display("Partition table entry sizes differ"))]
+    ComparePartitionEntrySize {},
+    #[snafu(display("Incorrect partition layout"))]
+    IncorrectPartitions {},
+    #[snafu(display("Label is invalid"))]
+    LabelRedundancy {},
+}
+
+impl From<ProbeError> for LabelError {
+    fn from(error: ProbeError) -> LabelError {
+        LabelError::InvalidLabel { source: error }
+    }
+}
+
+/// Based on RFC4122.
+#[derive(Debug, serde::Deserialize, PartialEq, Default, serde::Serialize, Clone, Copy)]
+pub struct GptGuid {
+    pub time_low: u32,
+    pub time_mid: u16,
+    pub time_high: u16,
+    pub node: [u8; 8],
+}
+
+impl From<Uuid> for GptGuid {
+    fn from(uuid: Uuid) -> GptGuid {
+        let fields = uuid.as_fields();
+        GptGuid {
+            time_low: fields.0,
+            time_mid: fields.1,
+            time_high: fields.2,
+            node: *fields.3,
+        }
+    }
+}
+
+impl From<GptGuid> for Uuid {
+    fn from(guid: GptGuid) -> Uuid {
+        Uuid::from_fields(guid.time_low, guid.time_mid, guid.time_high, &guid.node)
+    }
+}
+
+impl FromStr for GptGuid {
+    type Err = uuid::Error;
+
+    fn from_str(uuid: &str) -> Result<Self, Self::Err> {
+        Ok(GptGuid::from(Uuid::from_str(uuid)?))
+    }
+}
+
+impl fmt::Display for GptGuid {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", Uuid::from(*self))
+    }
+}
+
+impl GptGuid {
+    pub fn new_random() -> Self {
+        GptGuid::from(Uuid::new_v4())
+    }
+}
+
+/// The GPT header structure, as defined in the UEFI specification.
+#[derive(Debug, Deserialize, PartialEq, Default, Serialize, Copy, Clone)]
+pub struct GptHeader {
+    /// GPT signature (must be "EFI PART").
+    pub signature: [u8; 8],
+    /// 00 00 01 00 up til version 2.17.
+    pub revision: [u8; 4],
+    /// GPT header size (92 bytes).
+    pub header_size: u32,
+    /// CRC32 of the header.
+    pub self_checksum: u32,
+    pub reserved: [u8; 4],
+    /// Primary lba where the header.
+    pub lba_self: u64,
+    /// Alternative lba.
+    pub lba_alt: u64,
+    /// First usable lba.
+    pub lba_start: u64,
+    /// Last usable lba.
+    pub lba_end: u64,
+    /// 16 bytes representing the GUID of the GPT.
+    pub guid: GptGuid,
+    /// Lba of where to find the partition table.
+    pub lba_table: u64,
+    /// Number of partitions, most tools set this to 128.
+    pub num_entries: u32,
+    /// Size of element.
+    pub entry_size: u32,
+    /// CRC32 checksum of the partition array.
+    pub table_crc: u32,
+}
+
+impl GptHeader {
+    /// The size of the partition table in bytes: 128 entries × 128 bytes each,
+    /// the minimum required by the UEFI specification.
+    pub const PARTITION_TABLE_SIZE: u64 = 128 * 128;
+    /// The byte offset of the first usable LBA (1 MiB). Aligning the first
+    /// usable sector to 1 MiB is the conventional default used by most GPT
+    /// tools (e.g. fdisk, gdisk) to ensure optimal I/O alignment on SSDs and
+    /// RAID arrays.
+    pub const DATA_OFFSET: u64 = 1024 * 1024;
+    /// The GPT header size in bytes, as defined by the UEFI specification.
+    /// The remainder of the first LBA (sector) following the header is reserved.
+    pub const HEADER_SIZE: u32 = 92;
+    /// The revision of the GPT header, as defined in the UEFI specification.
+    pub const HEADER_REVISION: [u8; 4] = [0x00, 0x00, 0x01, 0x00];
+    /// The signature of the GPT header, as defined in the UEFI specification.
+    pub const HEADER_SIGNATURE: [u8; 8] = [0x45, 0x46, 0x49, 0x20, 0x50, 0x41, 0x52, 0x54];
+
+    /// Converts a slice into a GPT header and verifies the validity of the data.
+    pub fn from_slice(slice: &[u8]) -> Result<GptHeader, ProbeError> {
+        let mut reader = Cursor::new(slice);
+
+        let mut header: GptHeader = deserialize_from(&mut reader).context(DeserializeSnafu)?;
+
+        if header.header_size != GptHeader::HEADER_SIZE {
+            return Err(ProbeError::GptHeaderSize {
+                actual_size: header.header_size,
+                expected_size: GptHeader::HEADER_SIZE,
+            });
+        }
+
+        if header.signature != GptHeader::HEADER_SIGNATURE {
+            return Err(ProbeError::GptSignature {});
+        }
+
+        if header.revision != GptHeader::HEADER_REVISION {
+            return Err(ProbeError::GptRevision {});
+        }
+
+        let checksum = header.self_checksum;
+
+        if checksum != header.checksum().context(ChecksumSerializeSnafu)? {
+            return Err(ProbeError::GptChecksum {});
+        }
+
+        Ok(header)
+    }
+
+    /// Checksums the header with the checksum field itself set to 0.
+    pub fn checksum(&mut self) -> Result<u32, Error> {
+        self.self_checksum = 0;
+        self.self_checksum = crc32::checksum_ieee(&serialize(&self)?);
+        Ok(self.self_checksum)
+    }
+
+    // Creates a new GPT header for a device with specified size.
+    pub fn new(guid: GptGuid, block_size: u64, num_blocks: u64) -> Self {
+        let partition_blocks = Aligned::get_blocks(GptHeader::PARTITION_TABLE_SIZE, block_size);
+
+        let data_start = Aligned::get_blocks(GptHeader::DATA_OFFSET, block_size);
+
+        GptHeader {
+            signature: GptHeader::HEADER_SIGNATURE,
+            revision: GptHeader::HEADER_REVISION,
+            header_size: GptHeader::HEADER_SIZE,
+            self_checksum: 0,
+            reserved: [0; 4],
+            lba_self: 1,
+            lba_alt: num_blocks - 1,
+            lba_start: data_start,
+            lba_end: num_blocks - partition_blocks - 2,
+            guid,
+            lba_table: 2,
+            num_entries: 128,
+            entry_size: 128,
+            table_crc: 0,
+        }
+    }
+
+    /// Derives the secondary GPT header from this (primary) header.
+    ///
+    /// The secondary header mirrors the primary: `lba_self`/`lba_alt` are
+    /// swapped so the secondary points to itself at the last LBA of the disk.
+    /// The secondary partition table is placed immediately after `lba_end`
+    /// (the last usable LBA), growing backwards toward the secondary header.
+    pub fn as_secondary(&self) -> Result<GptHeader, Error> {
+        let mut secondary = *self;
+        secondary.lba_self = self.lba_alt;
+        secondary.lba_alt = self.lba_self;
+        secondary.lba_table = self.lba_end + 1;
+        secondary.checksum()?;
+        Ok(secondary)
+    }
+
+    /// Derives the primary GPT header from this (secondary) header.
+    ///
+    /// This is the inverse of [`as_secondary`](Self::as_secondary): must be
+    /// called on a secondary header. `lba_self`/`lba_alt` are swapped so the
+    /// result points to LBA 1 (the primary header location), and the primary
+    /// partition table is placed at `lba_self + 1` (LBA 2, immediately after
+    /// the primary header).
+    pub fn as_primary(&self) -> Result<GptHeader, Error> {
+        let mut primary = *self;
+        primary.lba_self = self.lba_alt;
+        primary.lba_alt = self.lba_self;
+        primary.lba_table = self.lba_alt + 1;
+        primary.checksum()?;
+        Ok(primary)
+    }
+}
+
+// For arrays bigger than 32 elements, things start to get unimplemented
+// in terms of derive and what not. So we create our own "newtype" struct,
+// and tell serde how to use it during serializing/deserializing.
+#[derive(Debug, PartialEq, Default, Clone)]
+pub struct GptName {
+    pub name: String,
+}
+impl std::fmt::Display for GptName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.name)
+    }
+}
+
+struct GpEntryNameVisitor;
+
+impl<'a> Deserialize<'a> for GptName {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'a>,
+    {
+        deserializer.deserialize_tuple_struct("GptName", 36, GpEntryNameVisitor)
+    }
+}
+
+impl Serialize for GptName {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        // we can't use serialize_type_struct here as we want exactly 72 bytes
+        let mut s = serializer.serialize_tuple(36)?;
+        let mut out: Vec<u16> = vec![0; 36];
+        for (i, o) in self.name.encode_utf16().zip(out.iter_mut()) {
+            *o = i;
+        }
+
+        out.iter().for_each(|e| s.serialize_element(&e).unwrap());
+        s.end()
+    }
+}
+
+impl<'a> Visitor<'a> for GpEntryNameVisitor {
+    type Value = GptName;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("Invalid GPT partition name")
+    }
+
+    fn visit_seq<A>(self, mut seq: A) -> std::result::Result<GptName, A::Error>
+    where
+        A: SeqAccess<'a>,
+    {
+        let mut out = Vec::new();
+        let mut end = false;
+        loop {
+            match seq.next_element()? {
+                Some(0) => {
+                    end = true;
+                }
+                Some(e) if !end => out.push(e),
+                _ => break,
+            }
+        }
+
+        if end {
+            Ok(GptName::from(String::from_utf16_lossy(&out)))
+        } else {
+            Err(serde::de::Error::invalid_value(Unexpected::Seq, &self))
+        }
+    }
+}
+
+impl From<String> for GptName {
+    fn from(name: String) -> GptName {
+        GptName { name }
+    }
+}
+impl From<&str> for GptName {
+    fn from(name: &str) -> GptName {
+        GptName::from(String::from(name))
+    }
+}
+
+/// The GPT partition entry structure, as defined in the UEFI specification.
+#[derive(Debug, Default, PartialEq, Deserialize, Serialize, Clone)]
+pub struct GptEntry {
+    /// GUID type, some of them are assigned/reserved for example to Linux.
+    pub ent_type: GptGuid,
+    /// Entry GUID, can be anything typically random.
+    pub ent_guid: GptGuid,
+    /// Start lba for this entry.
+    pub ent_start: u64,
+    /// End lba for this entry.
+    pub ent_end: u64,
+    /// Entry attributes, according to do the docs bit 0 MUST be zero.
+    pub ent_attr: u64,
+    /// UTF-16 name of the partition entry,
+    /// DO NOT confuse this with filesystem labels!
+    pub ent_name: GptName,
+}
+
+impl GptEntry {
+    /// Converts a slice into a partition table.
+    pub fn from_slice(slice: &[u8], count: u32) -> Result<Vec<GptEntry>, ProbeError> {
+        let mut reader = Cursor::new(slice);
+        let mut partitions: Vec<GptEntry> = Vec::with_capacity(count as usize);
+        for _ in 0..count {
+            partitions.push(deserialize_from(&mut reader).context(DeserializeSnafu)?);
+        }
+        Ok(partitions)
+    }
+
+    /// Checks if the partition entry is unused, which is indicated by a zeroed GUID.
+    pub fn is_unused(&self) -> bool {
+        self.ent_guid == GptGuid::default()
+    }
+
+    /// Calculates the checksum over the partition table.
+    pub fn checksum(partitions: &[GptEntry], size: u32) -> Result<u32, Error> {
+        let mut digest = crc32::Digest::new(crc32::IEEE);
+        let count = partitions.len() as u32;
+        for entry in partitions {
+            digest.write(&serialize(entry)?);
+        }
+        if count < size {
+            let pad = serialize(&GptEntry::default())?;
+            for _ in count..size {
+                digest.write(&pad);
+            }
+        }
+        Ok(digest.sum32())
+    }
+}
+
+/// Although we don't use it, we must have a protective MBR to avoid systems
+/// to get confused about what's on the disk. Utils like sgdisk work fine
+/// without an MBR (but will warn) but as we want to be able to access the
+/// partitions out of the data path, will create one here.
+///
+/// The struct should have a 440 byte code section here as well,
+/// however this is omitted to make serialisation a bit easier.
+#[derive(Copy, Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct Pmbr {
+    /// Signature to uniquely ID the disk - we do not use this.
+    disk_signature: u32,
+    reserved: u16,
+    /// Number of partition entries.
+    pub(super) entries: [MbrEntry; 4],
+    /// Must be set to [0x55, 0xaa].
+    signature: [u8; 2],
+}
+
+/// The MBR partition entry structure, as defined in the UEFI specification.
+#[derive(Copy, Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+pub struct MbrEntry {
+    /// Attributes of this MBR partition we set these all to zero, which
+    /// includes the boot flag.
+    attributes: u8,
+    /// Start in CHS format.
+    chs_start: [u8; 3],
+    /// Type of partition, in our case always 0xEE.
+    ent_type: u8,
+    /// End of the partition.
+    chs_last: [u8; 3],
+    /// Lba start.
+    lba_start: u32,
+    /// Last sector of this partition.
+    num_sectors: u32,
+}
+
+impl MbrEntry {
+    /// Set this MBR partition entry to represent a protective MBR partition of given size.
+    pub fn protect(&mut self, num_blocks: u64) {
+        self.attributes = 0x00; // NOT bootable
+        self.ent_type = 0xee; // protective MBR partition
+        self.chs_start = [0x00, 0x02, 0x00]; // CHS address 0/0/2
+        self.chs_last = [0xff, 0xff, 0xff]; // CHS address 1023/255/63
+
+        // The partition starts immediately after the MBR
+        self.lba_start = 1;
+
+        // The partition size must accurately reflect
+        // the disk size where possible.
+        if num_blocks > u32::MAX as u64 {
+            // If the size (in blocks) is too large to fit into 32 bits,
+            // then set the size to 0xffff_ffff
+            self.num_sectors = u32::MAX;
+        } else {
+            // Do not count the first block that contains the MBR
+            self.num_sectors = (num_blocks - 1) as u32;
+        }
+    }
+}
+
+impl Pmbr {
+    /// The signature of the protective MBR, as defined in the UEFI specification.
+    pub const PMBR_SIGNATURE: [u8; 2] = [0x55, 0xaa];
+
+    /// Converts a slice into a MBR and validates the signature.
+    pub fn from_slice(slice: &[u8]) -> Result<Pmbr, ProbeError> {
+        let mut reader = Cursor::new(slice);
+
+        let mbr: Pmbr = deserialize_from(&mut reader).context(DeserializeSnafu)?;
+
+        if mbr.signature != Pmbr::PMBR_SIGNATURE {
+            return Err(ProbeError::MbrSignature {});
+        }
+
+        Ok(mbr)
+    }
+}
+
+impl Default for Pmbr {
+    fn default() -> Self {
+        Pmbr {
+            disk_signature: 0,
+            reserved: 0,
+            entries: [MbrEntry::default(); 4],
+            signature: Pmbr::PMBR_SIGNATURE,
+        }
+    }
+}
+
+/// The status of the GPT labels on disk.
+#[derive(Clone, Copy, Debug, PartialEq, Serialize)]
+pub enum LabelStatus {
+    /// Both primary and secondary labels are synced with disk.
+    Both,
+    /// Only primary label is synced with disk.
+    Primary,
+    /// Only secondary label is synced with disk.
+    Secondary,
+    /// Neither primary or secondary labels are synced with disk.
+    Neither,
+}
+
+/// A standard GPT label: protective MBR, primary header, partition table
+/// and secondary header.
+///
+/// The container is layout-agnostic; consumers may attach any meaningful
+/// interpretation to the partitions via sibling modules (e.g.
+/// [`super::label`] for the versioned MayaMeta/MayaData layout).
+#[derive(Debug, PartialEq, Serialize, Clone)]
+pub struct GptLabel {
+    /// The status of the labels.
+    pub status: LabelStatus,
+    /// Block size of underlying device.
+    pub block_size: u64,
+    /// The protective MBR.
+    pub mbr: Pmbr,
+    /// The main GPT header.
+    pub primary: GptHeader,
+    /// Vector of GPT partition entries (only entries that actually define a
+    /// partition; padding entries are dropped).
+    pub partitions: Vec<GptEntry>,
+    /// The backup GPT header.
+    pub secondary: GptHeader,
+}
+
+impl GptLabel {
+    /// Build a new label from a freshly-constructed primary header and a
+    /// set of partition entries.
+    ///
+    /// Computes the partition-table CRC, the header self-CRC and derives
+    /// the secondary header from the primary. The protective MBR is
+    /// populated to match `num_blocks`.
+    pub fn new(
+        guid: GptGuid,
+        block_size: u64,
+        num_blocks: u64,
+        partitions: Vec<GptEntry>,
+    ) -> Result<GptLabel, LabelError> {
+        let mut pmbr = Pmbr::default();
+        pmbr.entries[0].protect(num_blocks);
+
+        let mut header = GptHeader::new(guid, block_size, num_blocks);
+        header.table_crc =
+            GptEntry::checksum(&partitions, header.num_entries).context(SerializeSnafu)?;
+        header.checksum().context(SerializeSnafu)?;
+        let secondary = header.as_secondary().context(SerializeSnafu)?;
+
+        Ok(GptLabel {
+            status: LabelStatus::Neither,
+            block_size,
+            mbr: pmbr,
+            primary: header,
+            partitions,
+            secondary,
+        })
+    }
+
+    /// Probe the disk for a [`GptLabel`].
+    pub async fn probe_label<T: GptDiskOps>(handle: &T) -> Result<GptLabel, LabelError> {
+        let GptDiskProps {
+            block_size,
+            num_blocks,
+        } = handle.props();
+
+        // Note that PMBR is 512B even on larger sector disks, but we must allocate block_size
+        // bytes to read it, as the underlying device may not support smaller reads.
+        let mut buf = handle.buffer_alloc(block_size).context(ReadAllocSnafu {
+            part: String::from("MBR"),
+        })?;
+        handle.read_at(0, &mut buf).await.context(ReadSnafu {
+            what: String::from("MBR"),
+        })?;
+        let mbr = GptLabel::read_mbr(&buf)?;
+
+        // GPT headers
+        let status: LabelStatus;
+        let primary: GptHeader;
+        let secondary: GptHeader;
+        let active: &GptHeader;
+
+        // Get primary GPT header.
+        handle
+            .read_at(block_size, &mut buf)
+            .await
+            .context(ReadSnafu {
+                what: String::from("primary GPT header"),
+            })?;
+        match GptLabel::read_primary_header(&buf, block_size, num_blocks) {
+            Ok(header) => {
+                primary = header;
+                active = &primary;
+                // Get secondary GPT header.
+                let offset = (num_blocks - 1) * block_size;
+                handle.read_at(offset, &mut buf).await.context(ReadSnafu {
+                    what: String::from("secondary GPT header"),
+                })?;
+                match GptLabel::read_secondary_header(&buf, block_size, num_blocks) {
+                    Ok(header) => {
+                        GptLabel::consistency_check(&primary, &header)?;
+                        // All good - primary and secondary GPT headers
+                        // are valid and consistent with each other.
+                        secondary = header;
+                        status = LabelStatus::Both;
+                    }
+                    Err(_) => {
+                        // Secondary GPT header is either not present
+                        // or invalid. Construct new secondary GPT header from primary.
+                        secondary = primary.as_secondary().context(SerializeSnafu)?;
+                        status = LabelStatus::Primary;
+                    }
+                }
+            }
+            Err(error) => {
+                // Primary GPT header is either not present or invalid.
+                // See if we can obtain a valid secondary GPT header.
+                let offset = (num_blocks - 1) * block_size;
+                handle.read_at(offset, &mut buf).await.context(ReadSnafu {
+                    what: String::from("secondary GPT header"),
+                })?;
+                match GptLabel::read_secondary_header(&buf, block_size, num_blocks) {
+                    Ok(header) => {
+                        secondary = header;
+                        active = &secondary;
+                        // Construct new primary GPT header from secondary.
+                        primary = secondary.as_primary().context(SerializeSnafu)?;
+                        status = LabelStatus::Secondary;
+                    }
+                    Err(_) => {
+                        // Neither primary or secondary GPT header is present or valid.
+                        return Err(LabelError::InvalidLabel { source: error });
+                    }
+                }
+            }
+        }
+
+        // The disk size recorded in protective MBR must be consistent with GPT header.
+        if mbr.entries[0].num_sectors != 0xffff_ffff
+            && u64::from(mbr.entries[0].num_sectors) != primary.lba_alt
+        {
+            return Err(LabelError::InvalidLabel {
+                source: ProbeError::MbrSize {},
+            });
+        }
+
+        // Partition table
+        let blocks = Aligned::get_blocks(
+            u64::from(active.entry_size * active.num_entries),
+            block_size,
+        );
+        let mut buf = handle
+            .buffer_alloc(blocks * block_size)
+            .context(ReadAllocSnafu {
+                part: String::from("partition table"),
+            })?;
+        let offset = active.lba_table * block_size;
+        handle.read_at(offset, &mut buf).await.context(ReadSnafu {
+            what: String::from("partition table"),
+        })?;
+        let mut partitions = GptLabel::read_partitions(&buf, active)?;
+
+        // There can be up to 128 partition entries stored on disk,
+        // even though most are not used. Retain only those entries
+        // that actually define partitions.
+        partitions.retain(|entry| entry.ent_start > 0 || entry.ent_end > 0);
+
+        Ok(GptLabel {
+            status,
+            block_size,
+            mbr,
+            primary,
+            partitions,
+            secondary,
+        })
+    }
+
+    /// Locate a partition by name.
+    pub fn partition(&self, name: &str) -> Option<&GptEntry> {
+        self.partitions
+            .iter()
+            .find(|entry| entry.ent_name.name == name)
+    }
+
+    /// Returns the offset (in bytes) of the specified partition.
+    pub fn partition_offset(&self, name: &str) -> Result<u64, ProbeError> {
+        match self.partition(name) {
+            Some(entry) => Ok(entry.ent_start * self.block_size),
+            None => Err(ProbeError::MissingPartition {
+                name: String::from(name),
+            }),
+        }
+    }
+
+    /// Returns the size (in bytes) of the specified partition.
+    ///
+    /// Per the UEFI spec, `ent_end` is the last LBA of the partition
+    /// (inclusive), so the block count is `ent_end - ent_start + 1`.
+    pub fn partition_size(&self, name: &str) -> Result<u64, ProbeError> {
+        match self.partition(name) {
+            Some(entry) => Ok((entry.ent_end - entry.ent_start + 1) * self.block_size),
+            None => Err(ProbeError::MissingPartition {
+                name: String::from(name),
+            }),
+        }
+    }
+}
+
+impl fmt::Display for GptLabel {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        writeln!(f, "GUID: {}", self.primary.guid)?;
+
+        writeln!(
+            f,
+            "Primary GPT header crc32: {:08x}",
+            self.primary.self_checksum
+        )?;
+        writeln!(f, "LBA primary GPT header: {}", self.primary.lba_self)?;
+        writeln!(f, "LBA primary partition table: {}", self.primary.lba_table)?;
+
+        writeln!(
+            f,
+            "Secondary GPT header crc32: {:08x}",
+            self.secondary.self_checksum
+        )?;
+        writeln!(f, "LBA secondary GPT header: {}", self.secondary.lba_self)?;
+        writeln!(
+            f,
+            "LBA secondary partition table: {}",
+            self.secondary.lba_table
+        )?;
+
+        writeln!(f, "Partition table crc32: {:08x}", self.primary.table_crc)?;
+        writeln!(f, "LBA first usable block: {}", self.primary.lba_start)?;
+        writeln!(f, "LBA last usable block: {}", self.primary.lba_end)?;
+
+        for (i, part) in self.partitions.iter().enumerate() {
+            writeln!(f, "  Partition {i}")?;
+            writeln!(f, "    GUID: {}", part.ent_guid)?;
+            writeln!(f, "    Type GUID: {}", part.ent_type)?;
+            writeln!(f, "    LBA start: {}", part.ent_start)?;
+            writeln!(f, "    LBA end: {}", part.ent_end)?;
+            writeln!(f, "    Name: {}", part.ent_name.name)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl GptLabel {
+    /// Construct a Pmbr from raw data.
+    fn read_mbr(buf: &impl GptBuffer) -> Result<Pmbr, ProbeError> {
+        Pmbr::from_slice(&buf.as_slice()[440..512])
+    }
+
+    /// Construct a GPT header from raw data.
+    fn read_header(buf: &impl GptBuffer) -> Result<GptHeader, ProbeError> {
+        GptHeader::from_slice(buf.as_slice())
+    }
+
+    /// Construct and validate primary GPT header.
+    fn read_primary_header(
+        buf: &impl GptBuffer,
+        block_size: u64,
+        num_blocks: u64,
+    ) -> Result<GptHeader, ProbeError> {
+        let header = GptLabel::read_header(buf)?;
+        GptLabel::validate_primary_header(&header, block_size, num_blocks)?;
+        Ok(header)
+    }
+
+    /// Construct and validate secondary GPT header.
+    fn read_secondary_header(
+        buf: &impl GptBuffer,
+        block_size: u64,
+        num_blocks: u64,
+    ) -> Result<GptHeader, ProbeError> {
+        let header = GptLabel::read_header(buf)?;
+        GptLabel::validate_secondary_header(&header, block_size, num_blocks)?;
+        Ok(header)
+    }
+
+    /// Construct and validate partition table.
+    fn read_partitions(
+        buf: &impl GptBuffer,
+        header: &GptHeader,
+    ) -> Result<Vec<GptEntry>, ProbeError> {
+        let partitions = GptEntry::from_slice(buf.as_slice(), header.num_entries)?;
+        GptLabel::validate_partitions(&partitions, header)?;
+        Ok(partitions)
+    }
+
+    /// Check that primary GPT header is valid and consistent.
+    pub fn validate_primary_header(
+        primary: &GptHeader,
+        block_size: u64,
+        num_blocks: u64,
+    ) -> Result<(), ProbeError> {
+        if primary.lba_self != 1 {
+            return Err(ProbeError::PrimaryLocation {});
+        }
+        if primary.lba_alt + 1 != num_blocks {
+            return Err(ProbeError::SecondaryLocation {});
+        }
+        if primary.lba_end >= primary.lba_alt {
+            return Err(ProbeError::LastUsableBlock {});
+        }
+        if primary.lba_table != primary.lba_self + 1 {
+            return Err(ProbeError::PartitionTableLocation {});
+        }
+        if (primary.num_entries * primary.entry_size) as u64 > GptHeader::PARTITION_TABLE_SIZE {
+            return Err(ProbeError::PartitionTableSize {});
+        }
+        if primary.lba_table + Aligned::get_blocks(GptHeader::PARTITION_TABLE_SIZE, block_size)
+            > primary.lba_start
+        {
+            return Err(ProbeError::PartitionTableSpace {});
+        }
+        Ok(())
+    }
+
+    /// Check that secondary GPT header is valid and consistent.
+    pub fn validate_secondary_header(
+        secondary: &GptHeader,
+        block_size: u64,
+        num_blocks: u64,
+    ) -> Result<(), ProbeError> {
+        if secondary.lba_alt != 1 {
+            return Err(ProbeError::PrimaryLocation {});
+        }
+        if secondary.lba_self + 1 != num_blocks {
+            return Err(ProbeError::SecondaryLocation {});
+        }
+        if secondary.lba_alt >= secondary.lba_start {
+            return Err(ProbeError::FirstUsableBlock {});
+        }
+        if secondary.lba_table != secondary.lba_end + 1 {
+            return Err(ProbeError::PartitionTableLocation {});
+        }
+        if (secondary.num_entries * secondary.entry_size) as u64 > GptHeader::PARTITION_TABLE_SIZE {
+            return Err(ProbeError::PartitionTableSize {});
+        }
+        if secondary.lba_table + Aligned::get_blocks(GptHeader::PARTITION_TABLE_SIZE, block_size)
+            > secondary.lba_self
+        {
+            return Err(ProbeError::PartitionTableSpace {});
+        }
+        Ok(())
+    }
+
+    /// Check that partition table entries are valid and consistent.
+    pub fn validate_partitions(
+        partitions: &[GptEntry],
+        header: &GptHeader,
+    ) -> Result<(), ProbeError> {
+        for entry in partitions {
+            if 0 < entry.ent_start && entry.ent_start < header.lba_start {
+                return Err(ProbeError::PartitionStart {});
+            }
+            if entry.ent_start > entry.ent_end {
+                return Err(ProbeError::NegativePartitionSize {});
+            }
+            if entry.ent_end > header.lba_end {
+                return Err(ProbeError::PartitionEnd {});
+            }
+        }
+        if header.table_crc
+            != GptEntry::checksum(partitions, header.num_entries).context(ChecksumSerializeSnafu)?
+        {
+            return Err(ProbeError::PartitionTableChecksum {});
+        }
+        Ok(())
+    }
+
+    /// Check that primary and secondary GPT headers are consistent with each other.
+    pub fn consistency_check(primary: &GptHeader, secondary: &GptHeader) -> Result<(), ProbeError> {
+        if primary.lba_self != secondary.lba_alt {
+            return Err(ProbeError::CompareHeaderLocation {});
+        }
+        if primary.lba_alt != secondary.lba_self {
+            return Err(ProbeError::CompareHeaderLocation {});
+        }
+        if primary.lba_start != secondary.lba_start {
+            return Err(ProbeError::FirstUsableBlock {});
+        }
+        if primary.lba_end != secondary.lba_end {
+            return Err(ProbeError::LastUsableBlock {});
+        }
+        if primary.guid != secondary.guid {
+            return Err(ProbeError::CompareDiskGuid {});
+        }
+        if primary.num_entries != secondary.num_entries {
+            return Err(ProbeError::ComparePartitionEntryCount {});
+        }
+        if primary.entry_size != secondary.entry_size {
+            return Err(ProbeError::ComparePartitionEntrySize {});
+        }
+        if primary.table_crc != secondary.table_crc {
+            return Err(ProbeError::ComparePartitionTableChecksum {});
+        }
+        Ok(())
+    }
+}
+
+/// Properties of the disk needed to probe and read GPT labels.
+#[derive(Debug, Clone, Copy)]
+pub struct GptDiskProps {
+    /// Logical block size of the underlying device.
+    pub block_size: u64,
+    /// Number of blocks on the underlying device.
+    pub num_blocks: u64,
+}
+
+/// Trait for disk operations needed to probe and read GPT labels.
+///
+/// Implementations decouple the GPT (de)serialisation code from any
+/// particular I/O backend (SPDK, plain files, etc.) so the label routines
+/// can be reused outside of the io-engine core.
+#[async_trait::async_trait(?Send)]
+pub trait GptDiskOps {
+    /// Backend-specific buffer type used for I/O.
+    type Buffer: GptBuffer;
+
+    /// Allocate an I/O buffer of `size` bytes suitable for use with
+    /// [`GptDiskOps::read_at`].
+    fn buffer_alloc(&self, size: u64) -> Result<Self::Buffer, DmaError>;
+    /// Return the geometry (block size, block count) of the underlying disk.
+    fn props(&self) -> GptDiskProps;
+    /// Read `buffer.len()` bytes starting at byte `offset` into `buffer`.
+    /// Returns the number of bytes read.
+    async fn read_at(&self, offset: u64, buffer: &mut Self::Buffer) -> Result<u64, CoreError>;
+}
+
+#[async_trait::async_trait(?Send)]
+impl GptDiskOps for Box<dyn BlockDeviceHandle> {
+    type Buffer = DmaBuf;
+
+    fn buffer_alloc(&self, size: u64) -> Result<Self::Buffer, DmaError> {
+        self.dma_malloc(size)
+    }
+    fn props(&self) -> GptDiskProps {
+        let bdev = self.get_device();
+        GptDiskProps {
+            block_size: bdev.block_len(),
+            num_blocks: bdev.num_blocks(),
+        }
+    }
+    async fn read_at(&self, offset: u64, buffer: &mut Self::Buffer) -> Result<u64, CoreError> {
+        self.read_at(offset, buffer).await
+    }
+}
+#[async_trait::async_trait(?Send)]
+impl GptDiskOps for dyn BlockDeviceHandle {
+    type Buffer = DmaBuf;
+
+    fn buffer_alloc(&self, size: u64) -> Result<Self::Buffer, DmaError> {
+        self.dma_malloc(size)
+    }
+    fn props(&self) -> GptDiskProps {
+        let bdev = self.get_device();
+        GptDiskProps {
+            block_size: bdev.block_len(),
+            num_blocks: bdev.num_blocks(),
+        }
+    }
+    async fn read_at(&self, offset: u64, buffer: &mut Self::Buffer) -> Result<u64, CoreError> {
+        #[allow(deprecated)]
+        self.read_at(offset, buffer).await
+    }
+}
+
+/// A trait to abstract over the buffer type used for reading/writing GPT data.
+pub trait GptBuffer {
+    /// View the buffer's contents as an immutable byte slice.
+    fn as_slice(&self) -> &[u8];
+    /// View the buffer's contents as a mutable byte slice.
+    fn as_mut_slice(&mut self) -> &mut [u8];
+}
+impl GptBuffer for DmaBuf {
+    fn as_slice(&self) -> &[u8] {
+        self.deref().as_slice()
+    }
+    fn as_mut_slice(&mut self) -> &mut [u8] {
+        self.deref_mut().as_mut_slice()
+    }
+}
+
+/// A structure to hold the raw label data and the offset at which it should be written to disk.
+pub struct LabelData<T: GptBuffer> {
+    /// Byte offset on the disk at which `buf` should be written.
+    pub offset: u64,
+    /// Serialised label data ready to be written verbatim to disk.
+    pub buf: T,
+}
+impl GptLabel {
+    /// Generate raw data for (primary) label ready to be written to disk.
+    pub fn primary_data<T: GptDiskOps + ?Sized>(
+        &self,
+        handle: &T,
+    ) -> Result<LabelData<T::Buffer>, LabelError> {
+        let mut buf = handle
+            .buffer_alloc(self.primary.lba_start * self.block_size)
+            .context(WriteAllocSnafu {
+                what: String::from("primary"),
+            })?;
+
+        let mut writer = Cursor::new(buf.as_mut_slice());
+
+        // Protective MBR
+        writer.seek(SeekFrom::Start(440)).context(SeekSnafu)?;
+        serialize_into(&mut writer, &self.mbr).context(SerializeSnafu)?;
+
+        // Primary GPT header
+        writer
+            .seek(SeekFrom::Start(self.primary.lba_self * self.block_size))
+            .context(SeekSnafu)?;
+        serialize_into(&mut writer, &self.primary).context(SerializeSnafu)?;
+
+        // Primary partition table
+        writer
+            .seek(SeekFrom::Start(self.primary.lba_table * self.block_size))
+            .context(SeekSnafu)?;
+        for entry in self.partitions.iter() {
+            serialize_into(&mut writer, &entry).context(SerializeSnafu)?;
+        }
+
+        Ok(LabelData { offset: 0, buf })
+    }
+
+    /// Generate raw data for (secondary) label ready to be written to disk.
+    pub fn secondary_data<T: GptDiskOps + ?Sized>(
+        &self,
+        handle: &T,
+    ) -> Result<LabelData<T::Buffer>, LabelError> {
+        let len_bytes = (self.secondary.lba_self - self.secondary.lba_table + 1) * self.block_size;
+        let mut buf = handle.buffer_alloc(len_bytes).context(WriteAllocSnafu {
+            what: String::from("secondary"),
+        })?;
+
+        let mut writer = Cursor::new(buf.as_mut_slice());
+
+        // Secondary partition table
+        for entry in self.partitions.iter() {
+            serialize_into(&mut writer, &entry).context(SerializeSnafu)?;
+        }
+
+        // Secondary GPT header
+        writer
+            .seek(SeekFrom::Start(
+                (self.secondary.lba_self - self.secondary.lba_table) * self.block_size,
+            ))
+            .context(SeekSnafu)?;
+        serialize_into(&mut writer, &self.secondary).context(SerializeSnafu)?;
+
+        let offset = self.secondary.lba_table * self.block_size;
+        Ok(LabelData { offset, buf })
+    }
+}
+
+/// A trait to calculate the number of blocks needed
+/// to represent a given size, aligned to a block size.
+pub trait Aligned {
+    /// Return the (appropriately aligned) number of blocks
+    /// representing this size.
+    fn get_blocks(size: Self, block_size: Self) -> Self;
+}
+
+impl Aligned for u32 {
+    fn get_blocks(size: u32, block_size: u32) -> u32 {
+        let blocks = size / block_size;
+        match size % block_size {
+            0 => blocks,
+            _ => blocks + 1,
+        }
+    }
+}
+
+impl Aligned for u64 {
+    fn get_blocks(size: u64, block_size: u64) -> u64 {
+        let blocks = size / block_size;
+        match size % block_size {
+            0 => blocks,
+            _ => blocks + 1,
+        }
+    }
+}

--- a/io-engine/src/core/gpt/v1.rs
+++ b/io-engine/src/core/gpt/v1.rs
@@ -1,0 +1,139 @@
+//! V1 of the on-disk label layout.
+//!
+//! Layout:
+//! - `MayaMeta`: 4 MiB metadata partition at the GPT default first usable
+//!   LBA (1 MiB aligned).
+//! - `MayaData`: data partition immediately following `MayaMeta`, sized to
+//!   the requested data size or the remainder of the device.
+
+use std::str::FromStr;
+
+use super::{
+    label::{LabelVariant, LabelVersion, VersionedLabel},
+    primitives::{Aligned, GptDiskProps, GptEntry, GptGuid, GptHeader, GptLabel, LabelError},
+};
+
+/// V1 layout marker. Zero-sized; used as a singleton via [`V1::INSTANCE`].
+pub struct V1;
+
+impl V1 {
+    /// Partition Type GUID for the `MayaMeta` partition.
+    pub const META_TYPE_GUID: &'static str = "27663382-e5e6-11e9-81b4-ca5ca5ca5ca5";
+    /// Partition Type GUID for the `MayaData` partition.
+    pub const DATA_TYPE_GUID: &'static str = "27663382-e5e6-11e9-81b4-ca5ca5ca5ca6";
+    /// GPT partition name for the metadata partition.
+    pub const META_NAME: &'static str = "MayaMeta";
+    /// GPT partition name for the data partition.
+    pub const DATA_NAME: &'static str = "MayaData";
+    /// Size (in bytes) of the metadata partition.
+    pub const META_SIZE: u64 = 4 * 1024 * 1024;
+
+    /// Singleton used by [`super::label::LabelVersion::variant`].
+    pub const INSTANCE: V1 = V1;
+
+    fn meta_type_guid() -> GptGuid {
+        GptGuid::from_str(Self::META_TYPE_GUID).expect("constant GUID must be valid")
+    }
+
+    fn data_type_guid() -> GptGuid {
+        GptGuid::from_str(Self::DATA_TYPE_GUID).expect("constant GUID must be valid")
+    }
+
+    /// Generate a fresh V1 label. The data partition fills the
+    /// remainder of the device after the metadata partition.
+    pub fn generate(guid: GptGuid, disk: GptDiskProps) -> Result<VersionedLabel, LabelError> {
+        // Transient header gives us a `lba_start`/`lba_end` to place
+        // partitions; the canonical header is built inside `GptLabel::new`.
+        let header = GptHeader::new(guid, disk.block_size, disk.num_blocks);
+        let partitions = Self::build_partitions(&header, disk.block_size)?;
+        let gpt = GptLabel::new(guid, disk.block_size, disk.num_blocks, partitions)?;
+        Ok(VersionedLabel {
+            version: LabelVersion::V1,
+            gpt,
+        })
+    }
+
+    fn build_partitions(header: &GptHeader, block_size: u64) -> Result<Vec<GptEntry>, LabelError> {
+        let metadata_blocks = Aligned::get_blocks(Self::META_SIZE, block_size);
+
+        let data_start = header.lba_start + metadata_blocks;
+        if data_start > header.lba_end {
+            return Err(LabelError::DeviceTooSmall {
+                num_blocks: header.lba_alt + 1,
+                block_size,
+            });
+        }
+
+        Ok(vec![
+            GptEntry {
+                ent_type: Self::meta_type_guid(),
+                ent_guid: GptGuid::new_random(),
+                ent_start: header.lba_start,
+                ent_end: data_start - 1,
+                ent_attr: 0,
+                ent_name: Self::META_NAME.into(),
+            },
+            GptEntry {
+                ent_type: Self::data_type_guid(),
+                ent_guid: header.guid,
+                ent_start: data_start,
+                ent_end: header.lba_end,
+                ent_attr: 0,
+                ent_name: Self::DATA_NAME.into(),
+            },
+        ])
+    }
+}
+
+impl LabelVariant for V1 {
+    fn detect(&self, label: &GptLabel) -> bool {
+        label
+            .partition(Self::META_NAME)
+            .map(|e| e.ent_type == Self::meta_type_guid())
+            .unwrap_or(false)
+            && label
+                .partition(Self::DATA_NAME)
+                .map(|e| e.ent_type == Self::data_type_guid())
+                .unwrap_or(false)
+    }
+
+    fn check(&self, label: &GptLabel) -> bool {
+        let block_size = label.block_size;
+
+        let metadata_start = Aligned::get_blocks(GptHeader::DATA_OFFSET, block_size);
+        if metadata_start != label.primary.lba_start {
+            return false;
+        }
+
+        let metadata_blocks = Aligned::get_blocks(Self::META_SIZE, block_size);
+        let data_start = metadata_start + metadata_blocks;
+        if data_start > label.primary.lba_end {
+            return false;
+        }
+
+        match label.partition(Self::META_NAME) {
+            Some(entry) => {
+                if entry.ent_type != Self::meta_type_guid() {
+                    return false;
+                }
+                if entry.ent_start != metadata_start {
+                    return false;
+                }
+                if entry.ent_end != data_start - 1 {
+                    return false;
+                }
+            }
+            None => return false,
+        }
+
+        if let Some(entry) = label.partition(Self::DATA_NAME) {
+            if entry.ent_type != Self::data_type_guid() {
+                return false;
+            }
+            if entry.ent_start == data_start {
+                return true;
+            }
+        }
+        false
+    }
+}

--- a/io-engine/src/core/mod.rs
+++ b/io-engine/src/core/mod.rs
@@ -59,6 +59,7 @@ mod device_monitor;
 pub mod diagnostics;
 mod env;
 pub mod fault_injection;
+pub mod gpt;
 mod handle;
 mod io_device;
 pub mod io_driver;

--- a/io-engine/src/lib.rs
+++ b/io-engine/src/lib.rs
@@ -56,4 +56,4 @@ pub extern "C" fn cps_init() {
     bdev::null_ng::register();
 }
 
-pub use bdev::gpt_labels;
+pub use core::gpt;

--- a/io-engine/src/lib.rs
+++ b/io-engine/src/lib.rs
@@ -55,3 +55,5 @@ pub extern "C" fn cps_init() {
     bdev::nexus::register_module(true);
     bdev::null_ng::register();
 }
+
+pub use bdev::gpt_labels;


### PR DESCRIPTION
    refactor(gpt): move to core and split into versioned layout modules
    
    Split the GPT module (moved from bdev/gpt* to core/gpt/) into
    generic primitives, a versioned label (VersionedLabel + LabelVariant)
    and a per-version layout (v1).
    
    Public types renamed to be layout- neutral (VersionedLabel, LabelVersion,
    LabelData).
    Construction now goes through the version itself:
    V1::generate(guid, GptDiskProps).
    
---

    feat(gpt): add simply binary to write/read
    
    Adds simply binary to read and write the nexus gpt.
    It makes use of the added gpt ops interface.
    This allows is to reuse the gpt code whilst not running
    in spdk at all!
    
---

    refactor(gpt): add gpt ops interface
    
    Add a generic ops interface, allowing us to reuse the gpt code even
    outside of the io-engine core.
    Adds implementation with the existing BlockDeviceHandle.
    Note that we could make the BlockDeviceHandle the generic interface,
    but at the moment that is too coupled to spdk itself.
    
---

    feat(gpt): add nexus label infra back
    
    Add parts of the nexus gpt label infra back.
    This will be useful for testing the upcoming changes to the alignment and
    the offset of the data partition.
    Also, we do plan on eventually bringing back the index back.

