### PR TITLE
refactor(gpt): add gpt ops interface

### DIFF
--- a/io-engine/src/bdev/gpt_labels.rs
+++ b/io-engine/src/bdev/gpt_labels.rs
@@ -53,19 +53,26 @@
 //! it without the nexus in the data path, there would be two paritions
 //! ```
 
-use std::{cmp::min, convert::From, fmt, io::Cursor, str::FromStr};
+use std::{
+    cmp::min,
+    convert::From,
+    fmt,
+    io::{Cursor, Seek, SeekFrom},
+    ops::{Deref, DerefMut},
+    str::FromStr,
+};
 
-use serde::{Deserialize, Serialize};
+use crate::core::{BlockDeviceHandle, CoreError};
 
-use crate::core::CoreError;
-use bincode::{deserialize_from, serialize, Error};
+use bincode::{deserialize_from, serialize, serialize_into, Error};
 use crc::{crc32, Hasher32};
 use serde::{
     de::{Deserializer, SeqAccess, Unexpected, Visitor},
     ser::{SerializeTuple, Serializer},
+    Deserialize, Serialize,
 };
 use snafu::{ResultExt, Snafu};
-use spdk_rs::DmaError;
+use spdk_rs::{DmaBuf, DmaError};
 use uuid::{self, Uuid};
 
 /// The GPT label error type.
@@ -666,6 +673,124 @@ impl GptLabel {
         })
     }
 
+    /// Probe the disk for a [`GptLabel`].
+    pub async fn probe_label<T: GptDiskOps>(handle: &T) -> Result<GptLabel, LabelError> {
+        let GptDiskProps {
+            block_size,
+            num_blocks,
+        } = handle.props();
+
+        // Note that PMBR is 512B even on larger sector disks, but we must allocate block_size
+        // bytes to read it, as the underlying device may not support smaller reads.
+        let mut buf = handle.buffer_alloc(block_size).context(ReadAllocSnafu {
+            part: String::from("MBR"),
+        })?;
+        handle.read_at(0, &mut buf).await.context(ReadSnafu {
+            what: String::from("MBR"),
+        })?;
+        let mbr = GptLabel::read_mbr(&buf)?;
+
+        // GPT headers
+        let status: LabelStatus;
+        let primary: GptHeader;
+        let secondary: GptHeader;
+        let active: &GptHeader;
+
+        // Get primary GPT header.
+        handle
+            .read_at(block_size, &mut buf)
+            .await
+            .context(ReadSnafu {
+                what: String::from("primary GPT header"),
+            })?;
+        match GptLabel::read_primary_header(&buf, block_size, num_blocks) {
+            Ok(header) => {
+                primary = header;
+                active = &primary;
+                // Get secondary GPT header.
+                let offset = (num_blocks - 1) * block_size;
+                handle.read_at(offset, &mut buf).await.context(ReadSnafu {
+                    what: String::from("secondary GPT header"),
+                })?;
+                match GptLabel::read_secondary_header(&buf, block_size, num_blocks) {
+                    Ok(header) => {
+                        GptLabel::consistency_check(&primary, &header)?;
+                        // All good - primary and secondary GPT headers
+                        // are valid and consistent with each other.
+                        secondary = header;
+                        status = LabelStatus::Both;
+                    }
+                    Err(_) => {
+                        // Secondary GPT header is either not present
+                        // or invalid. Construct new secondary GPT header from primary.
+                        secondary = primary.as_secondary().context(SerializeSnafu)?;
+                        status = LabelStatus::Primary;
+                    }
+                }
+            }
+            Err(error) => {
+                // Primary GPT header is either not present or invalid.
+                // See if we can obtain a valid secondary GPT header.
+                let offset = (num_blocks - 1) * block_size;
+                handle.read_at(offset, &mut buf).await.context(ReadSnafu {
+                    what: String::from("secondary GPT header"),
+                })?;
+                match GptLabel::read_secondary_header(&buf, block_size, num_blocks) {
+                    Ok(header) => {
+                        secondary = header;
+                        active = &secondary;
+                        // Construct new primary GPT header from secondary.
+                        primary = secondary.as_primary().context(SerializeSnafu)?;
+                        status = LabelStatus::Secondary;
+                    }
+                    Err(_) => {
+                        // Neither primary or secondary GPT header is present or valid.
+                        return Err(LabelError::InvalidLabel { source: error });
+                    }
+                }
+            }
+        }
+
+        // The disk size recorded in protective MBR must be consistent with GPT header.
+        if mbr.entries[0].num_sectors != 0xffff_ffff
+            && u64::from(mbr.entries[0].num_sectors) != primary.lba_alt
+        {
+            return Err(LabelError::InvalidLabel {
+                source: ProbeError::MbrSize {},
+            });
+        }
+
+        // Partition table
+        let blocks = Aligned::get_blocks(
+            u64::from(active.entry_size * active.num_entries),
+            block_size,
+        );
+        let mut buf = handle
+            .buffer_alloc(blocks * block_size)
+            .context(ReadAllocSnafu {
+                part: String::from("partition table"),
+            })?;
+        let offset = active.lba_table * block_size;
+        handle.read_at(offset, &mut buf).await.context(ReadSnafu {
+            what: String::from("partition table"),
+        })?;
+        let mut partitions = GptLabel::read_partitions(&buf, active)?;
+
+        // There can be up to 128 partition entries stored on disk,
+        // even though most are not used. Retain only those entries
+        // that actually define partitions.
+        partitions.retain(|entry| entry.ent_start > 0 || entry.ent_end > 0);
+
+        Ok(GptLabel {
+            status,
+            block_size,
+            mbr,
+            primary,
+            partitions,
+            secondary,
+        })
+    }
+
     /// Create partition table entries for the "MayaMeta" and "MayaData" partitions.
     fn create_partitions(
         header: &GptHeader,
@@ -828,21 +953,18 @@ impl fmt::Display for GptLabel {
 
 impl GptLabel {
     /// Construct a Pmbr from raw data.
-    #[allow(dead_code)]
-    fn read_mbr(buf: &[u8]) -> Result<Pmbr, ProbeError> {
-        Pmbr::from_slice(&buf[440..512])
+    fn read_mbr(buf: &impl GptBuffer) -> Result<Pmbr, ProbeError> {
+        Pmbr::from_slice(&buf.as_slice()[440..512])
     }
 
     /// Construct a GPT header from raw data.
-    #[allow(dead_code)]
-    fn read_header(buf: &[u8]) -> Result<GptHeader, ProbeError> {
-        GptHeader::from_slice(buf)
+    fn read_header(buf: &impl GptBuffer) -> Result<GptHeader, ProbeError> {
+        GptHeader::from_slice(buf.as_slice())
     }
 
     /// Construct and validate primary GPT header.
-    #[allow(dead_code)]
     fn read_primary_header(
-        buf: &[u8],
+        buf: &impl GptBuffer,
         block_size: u64,
         num_blocks: u64,
     ) -> Result<GptHeader, ProbeError> {
@@ -852,9 +974,8 @@ impl GptLabel {
     }
 
     /// Construct and validate secondary GPT header.
-    #[allow(dead_code)]
     fn read_secondary_header(
-        buf: &[u8],
+        buf: &impl GptBuffer,
         block_size: u64,
         num_blocks: u64,
     ) -> Result<GptHeader, ProbeError> {
@@ -864,9 +985,11 @@ impl GptLabel {
     }
 
     /// Construct and validate partition table.
-    #[allow(dead_code)]
-    fn read_partitions(buf: &[u8], header: &GptHeader) -> Result<Vec<GptEntry>, ProbeError> {
-        let partitions = GptEntry::from_slice(buf, header.num_entries)?;
+    fn read_partitions(
+        buf: &impl GptBuffer,
+        header: &GptHeader,
+    ) -> Result<Vec<GptEntry>, ProbeError> {
+        let partitions = GptEntry::from_slice(buf.as_slice(), header.num_entries)?;
         GptLabel::validate_partitions(&partitions, header)?;
         Ok(partitions)
     }
@@ -980,6 +1103,147 @@ impl GptLabel {
             return Err(ProbeError::ComparePartitionTableChecksum {});
         }
         Ok(())
+    }
+}
+
+/// Properties of the disk needed to probe and read GPT labels.
+#[derive(Clone, Copy)]
+pub struct GptDiskProps {
+    /// Logical block size of the underlying device.
+    pub block_size: u64,
+    /// Number of blocks on the underlying device.
+    pub num_blocks: u64,
+}
+
+/// Trait for disk operations needed to probe and read GPT labels.
+#[async_trait::async_trait(?Send)]
+pub trait GptDiskOps {
+    type Buffer: GptBuffer;
+
+    fn buffer_alloc(&self, size: u64) -> Result<Self::Buffer, DmaError>;
+    fn props(&self) -> GptDiskProps;
+    async fn read_at(&self, offset: u64, buffer: &mut Self::Buffer) -> Result<u64, CoreError>;
+}
+
+#[async_trait::async_trait(?Send)]
+impl GptDiskOps for Box<dyn BlockDeviceHandle> {
+    type Buffer = DmaBuf;
+
+    fn buffer_alloc(&self, size: u64) -> Result<Self::Buffer, DmaError> {
+        self.dma_malloc(size)
+    }
+    fn props(&self) -> GptDiskProps {
+        let bdev = self.get_device();
+        GptDiskProps {
+            block_size: bdev.block_len(),
+            num_blocks: bdev.num_blocks(),
+        }
+    }
+    async fn read_at(&self, offset: u64, buffer: &mut Self::Buffer) -> Result<u64, CoreError> {
+        self.read_at(offset, buffer).await
+    }
+}
+#[async_trait::async_trait(?Send)]
+impl GptDiskOps for dyn BlockDeviceHandle {
+    type Buffer = DmaBuf;
+
+    fn buffer_alloc(&self, size: u64) -> Result<Self::Buffer, DmaError> {
+        self.dma_malloc(size)
+    }
+    fn props(&self) -> GptDiskProps {
+        let bdev = self.get_device();
+        GptDiskProps {
+            block_size: bdev.block_len(),
+            num_blocks: bdev.num_blocks(),
+        }
+    }
+    async fn read_at(&self, offset: u64, buffer: &mut Self::Buffer) -> Result<u64, CoreError> {
+        #[allow(deprecated)]
+        self.read_at(offset, buffer).await
+    }
+}
+
+/// A trait to abstract over the buffer type used for reading/writing GPT data.
+pub trait GptBuffer {
+    fn as_slice(&self) -> &[u8];
+    fn as_mut_slice(&mut self) -> &mut [u8];
+}
+impl GptBuffer for DmaBuf {
+    fn as_slice(&self) -> &[u8] {
+        self.deref().as_slice()
+    }
+    fn as_mut_slice(&mut self) -> &mut [u8] {
+        self.deref_mut().as_mut_slice()
+    }
+}
+
+/// A structure to hold the raw label data and the offset at which it should be written to disk.
+pub struct LabelDataX<T: GptBuffer> {
+    pub offset: u64,
+    pub buf: T,
+}
+impl GptLabel {
+    /// Generate raw data for (primary) label ready to be written to disk.
+    pub fn primary_data<T: GptDiskOps + ?Sized>(
+        &self,
+        handle: &T,
+    ) -> Result<LabelDataX<T::Buffer>, LabelError> {
+        let mut buf = handle
+            .buffer_alloc(self.primary.lba_start * self.block_size)
+            .context(WriteAllocSnafu {
+                what: String::from("primary"),
+            })?;
+
+        let mut writer = Cursor::new(buf.as_mut_slice());
+
+        // Protective MBR
+        writer.seek(SeekFrom::Start(440)).context(SeekSnafu)?;
+        serialize_into(&mut writer, &self.mbr).context(SerializeSnafu)?;
+
+        // Primary GPT header
+        writer
+            .seek(SeekFrom::Start(self.primary.lba_self * self.block_size))
+            .context(SeekSnafu)?;
+        serialize_into(&mut writer, &self.primary).context(SerializeSnafu)?;
+
+        // Primary partition table
+        writer
+            .seek(SeekFrom::Start(self.primary.lba_table * self.block_size))
+            .context(SeekSnafu)?;
+        for entry in self.partitions.iter() {
+            serialize_into(&mut writer, &entry).context(SerializeSnafu)?;
+        }
+
+        Ok(LabelDataX { offset: 0, buf })
+    }
+
+    /// Generate raw data for (secondary) label ready to be written to disk.
+    pub fn secondary_data<T: GptDiskOps + ?Sized>(
+        &self,
+        handle: &T,
+    ) -> Result<LabelDataX<T::Buffer>, LabelError> {
+        let len_bytes = (self.secondary.lba_self - self.secondary.lba_table + 1) * self.block_size;
+        let mut buf = handle.buffer_alloc(len_bytes).context(WriteAllocSnafu {
+            what: String::from("secondary"),
+        })?;
+
+        let mut writer = Cursor::new(buf.as_mut_slice());
+
+        // Secondary partition table
+        for entry in self.partitions.iter() {
+            serialize_into(&mut writer, &entry).context(SerializeSnafu)?;
+        }
+
+        // Secondary GPT header
+        writer
+            .seek(SeekFrom::Start(
+                (self.secondary.lba_self - self.secondary.lba_table) * self.block_size,
+            ))
+            .context(SeekSnafu)?;
+        serialize_into(&mut writer, &self.secondary).context(SerializeSnafu)?;
+
+        let offset = self.secondary.lba_table * self.block_size;
+        Ok(LabelDataX { offset, buf })
     }
 }
 

--- a/io-engine/src/bin/gpt.rs
+++ b/io-engine/src/bin/gpt.rs
@@ -1,0 +1,236 @@
+use clap::Parser;
+use io_engine::gpt_labels::{
+    GptBuffer, GptDiskOps, GptDiskProps, GptGuid, GptLabel, LabelError, ProbeError,
+};
+use snafu::{ResultExt, Snafu};
+use std::{
+    ops::{Deref, DerefMut},
+    os::unix::fs::{FileExt, FileTypeExt},
+};
+use version_info::{package_description, version_info_string};
+
+#[derive(Debug, Clone, Parser)]
+#[clap(name = package_description!(), version = version_info_string!())]
+struct CliArgs {
+    /// The disk uri to use.
+    /// Run as sudo if this is a real block device.
+    #[clap(short, long)]
+    disk_uri: url::Url,
+
+    /// Command.
+    #[clap(subcommand)]
+    command: Command,
+}
+
+#[derive(clap::Subcommand, Debug, Clone)]
+enum Command {
+    /// Read and display the GPT label from the disk.
+    Read,
+    /// Write a new GPT label to the disk, overwriting any existing label.
+    Write,
+}
+
+#[derive(Debug, Snafu)]
+enum Error {
+    #[snafu(display("{source}"))]
+    Label { source: LabelError },
+    #[snafu(display("{source}"))]
+    Probe { source: ProbeError },
+    #[snafu(display("No filepath in disk-uri"))]
+    InvalidUri,
+    #[snafu(display("Failed to open disk: {source}"))]
+    OpenDisk { source: std::io::Error },
+    #[snafu(display("Failed to write to disk: {source}"))]
+    Write { source: std::io::Error },
+    #[snafu(display("Failed to read {path}: {source}"))]
+    ReadFile {
+        path: String,
+        source: std::io::Error,
+    },
+    #[snafu(display("Failed to parse int from sysfs {path} = {value}: {source}"))]
+    ParseSysfs {
+        path: String,
+        value: String,
+        source: std::num::ParseIntError,
+    },
+    #[snafu(display("Failed to read disk metadata: {source}"))]
+    DiskMeta { source: std::io::Error },
+    #[snafu(display("Disk not in /dev/"))]
+    DiskDev,
+    #[snafu(display("{source}"))]
+    InvalidUuid { source: uuid::Error },
+}
+impl From<uuid::Error> for Error {
+    fn from(source: uuid::Error) -> Self {
+        Self::InvalidUuid { source }
+    }
+}
+impl From<LabelError> for Error {
+    fn from(source: LabelError) -> Self {
+        Self::Label { source }
+    }
+}
+impl From<ProbeError> for Error {
+    fn from(source: ProbeError) -> Self {
+        Self::Probe { source }
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), String> {
+    let cli_args = CliArgs::parse();
+
+    match &cli_args.command {
+        Command::Write => write(&cli_args),
+        Command::Read => read(&cli_args).await,
+    }
+    .map_err(|e| format!("{e}"))
+}
+
+/// Creates a fresh GPT label on the disk and writes both the primary (LBA 1)
+/// and secondary (last LBA) headers along with their partition tables.
+fn write(cli_args: &CliArgs) -> Result<(), Error> {
+    // Fixed GUID used as the disk identifier for CLI testing.
+    let guid = GptGuid::from(uuid::Uuid::parse_str(
+        "978D2F99-AA7C-4F24-AE22-1BF99137D7B1",
+    )?);
+    let mut gpt_disk = GptDisk::new(false, true, cli_args)?;
+    let props = gpt_disk.props();
+
+    // Create new disk label.
+    let label = GptLabel::generate_label(guid, props.block_size, props.num_blocks, None)?;
+    println!("{label}");
+
+    let primary = label.primary_data(&gpt_disk)?;
+    let secondary = label.secondary_data(&gpt_disk)?;
+
+    gpt_disk.write_at(&primary.buf, primary.offset)?;
+    gpt_disk.write_at(&secondary.buf, secondary.offset)?;
+
+    Ok(())
+}
+
+/// Probes the disk for an existing GPT label and prints it to stdout.
+async fn read(cli_args: &CliArgs) -> Result<(), Error> {
+    let gpt_disk = GptDisk::new(true, false, cli_args)?;
+
+    let label = gpt_disk.probe_label().await?;
+    println!("{label}");
+
+    if !GptLabel::check_partitions(&label) {
+        todo!("resync the label with the partitions");
+    }
+
+    Ok(())
+}
+
+/// Wraps a disk file or block device for GPT label read/write operations.
+struct GptDisk {
+    file: std::fs::File,
+    props: GptDiskProps,
+}
+impl GptDisk {
+    /// Opens the disk at the path given in `cli_args.disk_uri`.
+    /// `read`/`write` control the file open flags.
+    fn new(read: bool, write: bool, cli_args: &CliArgs) -> Result<Self, Error> {
+        let disk = cli_args
+            .disk_uri
+            .to_file_path()
+            .map_err(|_| Error::InvalidUri)?;
+        let disk = disk.to_string_lossy().to_string();
+
+        let file = std::fs::File::options()
+            .read(read)
+            .write(write)
+            .open(&disk)
+            .context(OpenDiskSnafu)?;
+        let props = Self::disk_props(&disk, &file)?;
+        Ok(Self { file, props })
+    }
+    /// Determines block size and block count. For block devices these are read
+    /// from sysfs (`/sys/block/<dev>/queue/logical_block_size` and `size`).
+    /// For regular files a 512-byte block size is assumed.
+    fn disk_props(disk: &str, file: &std::fs::File) -> Result<GptDiskProps, Error> {
+        let metadata = file.metadata().context(DiskMetaSnafu)?;
+        let file_len = metadata.len();
+
+        let block_size;
+        let num_blocks;
+        if metadata.file_type().is_block_device() {
+            let dev = disk.strip_prefix("/dev/").ok_or(Error::DiskDev)?;
+            block_size = Self::read_block_sysfs(dev, "queue/logical_block_size")?;
+            num_blocks = Self::read_block_sysfs(dev, "size")?;
+        } else {
+            block_size = 512;
+            num_blocks = file_len / block_size;
+        }
+        Ok(GptDiskProps {
+            block_size,
+            num_blocks,
+        })
+    }
+    fn read_block_sysfs(dev: &str, attr: &str) -> Result<u64, Error> {
+        let path = format!("/sys/block/{dev}/{attr}");
+        let value = std::fs::read_to_string(&path).map_err(|source| Error::ReadFile {
+            path: path.clone(),
+            source,
+        })?;
+        value.trim().parse().map_err(|source| Error::ParseSysfs {
+            path,
+            value,
+            source,
+        })
+    }
+    /// Writes `buf` to the disk at the given byte `offset`.
+    fn write_at(&mut self, buf: &[u8], offset: u64) -> Result<(), Error> {
+        self.file.write_all_at(buf, offset).context(WriteSnafu)?;
+        Ok(())
+    }
+    async fn probe_label(&self) -> Result<GptLabel, LabelError> {
+        GptLabel::probe_label(self).await
+    }
+}
+
+/// In-memory I/O buffer satisfying [`GptBuffer`] for file-based disk access.
+struct FileBuffer(Vec<u8>);
+impl Deref for FileBuffer {
+    type Target = [u8];
+    fn deref(&self) -> &Self::Target {
+        self.0.as_slice()
+    }
+}
+impl DerefMut for FileBuffer {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.0.as_mut_slice()
+    }
+}
+
+#[async_trait::async_trait(?Send)]
+impl io_engine::gpt_labels::GptDiskOps for GptDisk {
+    type Buffer = FileBuffer;
+
+    fn buffer_alloc(&self, size: u64) -> Result<Self::Buffer, spdk_rs::DmaError> {
+        Ok(FileBuffer(vec![0; size as usize]))
+    }
+    fn props(&self) -> GptDiskProps {
+        self.props
+    }
+    async fn read_at(
+        &self,
+        offset: u64,
+        buffer: &mut Self::Buffer,
+    ) -> Result<u64, io_engine::core::CoreError> {
+        let len = buffer.0.len() as u64;
+        // todo: refactor DmaError&CoreError out of this interface.
+        self.file.read_exact_at(&mut buffer.0, offset).unwrap();
+        Ok(len)
+    }
+}
+impl GptBuffer for FileBuffer {
+    fn as_slice(&self) -> &[u8] {
+        self.0.as_slice()
+    }
+    fn as_mut_slice(&mut self) -> &mut [u8] {
+        self.0.as_mut_slice()
+    }
+}


### PR DESCRIPTION
Add a generic ops interface, allowing us to reuse the gpt code even outside of the io-engine core.
Adds implementation with the existing BlockDeviceHandle. Note that we could make the BlockDeviceHandle the generic interface, but at the moment that is too coupled to spdk itself.