### PR TITLE
refactor: use version_info_string macro

### DIFF
--- a/io-engine/examples/lvs-eval/main.rs
+++ b/io-engine/examples/lvs-eval/main.rs
@@ -1,7 +1,7 @@
 mod display;
 
 use clap::Parser;
-use version_info::{package_description, version_info_str};
+use version_info::{package_description, version_info_string};
 
 use io_engine_tests::MayastorTest;
 
@@ -17,7 +17,7 @@ use io_engine::{
 #[clap(
     name = package_description!(),
     about = "LVS Evaluation",
-    version = version_info_str!(),
+    version = version_info_string!(),
 )]
 pub struct CliArgs {
     pub disk: String,

--- a/io-engine/src/bin/initiator.rs
+++ b/io-engine/src/bin/initiator.rs
@@ -11,7 +11,7 @@ use chrono::Utc;
 use clap::{Parser, Subcommand};
 use tracing::{error, info, warn};
 use uuid::Uuid;
-use version_info::version_info_str;
+use version_info::version_info_string;
 
 use io_engine::{
     bdev::{device_create, device_open},
@@ -160,7 +160,7 @@ async fn connect(uri: &url::Url) -> Result<()> {
 #[derive(Debug, Parser)]
 #[command(
     name = "Test initiator for nexus replica",
-    version = version_info_str!(),
+    version = version_info_string!(),
     about = "Connect, read or write a block to a nexus replica using its URI"
 )]
 struct Args {

--- a/io-engine/src/bin/io-engine-client/v0/mod.rs
+++ b/io-engine/src/bin/io-engine-client/v0/mod.rs
@@ -16,12 +16,12 @@ pub(crate) use crate::GrpcStatus;
 use clap::{Parser, Subcommand};
 use context::{OutputFormat, Units};
 use snafu::ResultExt;
-use version_info::version_info_str;
+use version_info::version_info_string;
 
 #[derive(Parser, Debug)]
 #[command(
     name = "Mayastor CLI V0",
-    version = version_info_str!(),
+    version = version_info_string!(),
     about = "CLI utility for Mayastor"
 )]
 struct Opts {

--- a/io-engine/src/bin/io-engine-client/v1/mod.rs
+++ b/io-engine/src/bin/io-engine-client/v1/mod.rs
@@ -19,12 +19,12 @@ pub(crate) use crate::GrpcStatus;
 use clap::{Parser, Subcommand};
 use context::{OutputFormat, Units};
 use snafu::ResultExt;
-use version_info::version_info_str;
+use version_info::version_info_string;
 
 #[derive(Parser, Debug)]
 #[command(
     name = "Mayastor CLI V1",
-    version = version_info_str!(),
+    version = version_info_string!(),
     about = "CLI utility for Mayastor"
 )]
 struct Opts {

--- a/io-engine/src/bin/jsonrpc.rs
+++ b/io-engine/src/bin/jsonrpc.rs
@@ -10,13 +10,13 @@ extern crate serde_json;
 
 use clap::Parser;
 use jsonrpc::call;
-use version_info::{package_description, version_info_str};
+use version_info::{package_description, version_info_string};
 
 /// TODO
 #[derive(Debug, Parser)]
 #[clap(
     name = package_description!(),
-    version = version_info_str!(),
+    version = version_info_string!(),
     about = "Mayastor json-rpc client",
 )]
 struct Opt {

--- a/io-engine/src/bin/nvmet.rs
+++ b/io-engine/src/bin/nvmet.rs
@@ -17,7 +17,7 @@ use io_engine::{
     core::{MayastorCliArgs, MayastorEnvironment, Mthread, Reactors, Share},
     grpc, logger,
 };
-use version_info::version_info_str;
+use version_info::version_info_string;
 
 io_engine::CPS_INIT!();
 
@@ -57,7 +57,7 @@ fn start_tokio_runtime(args: &MayastorCliArgs) {
 #[derive(Debug, Parser)]
 #[command(
     name = "NVMeT CLI",
-    version = version_info_str!(),
+    version = version_info_string!(),
     about = "NVMe test utility to quickly create a nexus over existing nvme targets"
 )]
 struct Args {

--- a/io-engine/src/bin/uring-support.rs
+++ b/io-engine/src/bin/uring-support.rs
@@ -1,12 +1,12 @@
 use clap::Parser;
 use io_engine::bdev::util::uring;
-use version_info::version_info_str;
+use version_info::version_info_string;
 
 /// Determines io_uring support.
 #[derive(Debug, Parser)]
 #[command(
     name = "Detect io_uring support",
-    version = version_info_str!(),
+    version = version_info_string!(),
     author = "Jonathan Teh <jonathan.teh@mayadata.io>",
     about = "Determines io_uring support"
 )]

--- a/io-engine/src/core/env.rs
+++ b/io-engine/src/core/env.rs
@@ -19,7 +19,7 @@ use http::Uri;
 use once_cell::sync::{Lazy, OnceCell};
 use snafu::Snafu;
 use tokio::runtime::Builder;
-use version_info::{package_description, version_info_str};
+use version_info::{package_description, version_info_string};
 
 use spdk_rs::{
     libspdk::{
@@ -130,7 +130,7 @@ fn parse_grpc_ip(src: &str) -> Result<SIpAddr, String> {
 #[clap(
     name = package_description!(),
     about = "Containerized Attached Storage (CAS) for k8s",
-    version = version_info_str!(),
+    version = version_info_string!(),
 )]
 pub struct MayastorCliArgs {
     #[clap(short = 'g', long = "grpc-endpoint")]


### PR DESCRIPTION
Since clap now supports an owned string, use it so we can remove the leaked version.