### PR TITLE
fix(core): restore reactor affinity after cpuset updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2105,6 +2105,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "533e68a5842e734946fe159fb03fc9bbbb254f590dd0d8ad321ae5ff7beca2c1"
+dependencies = [
+ "bitflags 2.6.0",
+ "futures-util",
+ "inotify-sys",
+ "libc",
+ "tokio",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2144,6 +2166,7 @@ dependencies = [
  "hex",
  "http",
  "humantime",
+ "inotify",
  "io-engine-api",
  "io-engine-tests",
  "io-uring",

--- a/io-engine/Cargo.toml
+++ b/io-engine/Cargo.toml
@@ -77,6 +77,7 @@ either = "1.13.0"
 sha2 = "0.10.8"
 signal-hook = "0.3.17"
 crc = "1.8.1"
+inotify = "0.11"
 
 chrono = { workspace = true }
 colored_json = { workspace = true }

--- a/io-engine/src/core/affinity.rs
+++ b/io-engine/src/core/affinity.rs
@@ -1,0 +1,143 @@
+use std::{
+    path::Path,
+    time::{Duration, Instant},
+};
+
+use inotify::{EventMask, Inotify, WatchMask};
+
+use crate::core::{runtime, Mthread, Reactors};
+
+const CPUSET_FILE: &str = "/var/lib/kubelet/cpu_manager_state";
+
+/// Starts the CPUManager cpuset monitoring thread.
+///
+/// The monitor watches the kubelet `cpu_manager_state` file for
+/// cpuset updates and restores reactor and runtime thread affinity
+/// when Kubernetes CPUManager changes the effective cpuset.
+pub fn start_monitor() {
+    if std::env::var("KUBERNETES_SERVICE_HOST").is_err() {
+        return;
+    }
+    runtime::spawn_blocking(run);
+}
+
+fn run() {
+    let mut inotify = match Inotify::init() {
+        Ok(inotify) => inotify,
+        Err(error) => {
+            tracing::error!(
+                ?error,
+                "failed to initialize CPUManager affinity monitor; affinity restoration disabled"
+            );
+            return;
+        }
+    };
+
+    loop {
+        if !Path::new(CPUSET_FILE).exists() {
+            tracing::warn!("{CPUSET_FILE} does not exist, waiting...");
+            std::thread::sleep(std::time::Duration::from_secs(1));
+            continue;
+        }
+
+        if let Err(error) = inotify.watches().add(
+            CPUSET_FILE,
+            WatchMask::ATTRIB | WatchMask::MODIFY | WatchMask::CLOSE_WRITE | WatchMask::DELETE_SELF,
+        ) {
+            tracing::warn!(?error, "failed to watch {CPUSET_FILE}, retrying");
+            std::thread::sleep(std::time::Duration::from_secs(1));
+            continue;
+        }
+
+        tracing::trace!("watching {CPUSET_FILE}");
+
+        let mut buffer = [0u8; 4096];
+        let mut recreate_watch = false;
+
+        while !recreate_watch {
+            match inotify.read_events_blocking(&mut buffer) {
+                Ok(events) => {
+                    let mut changed = false;
+
+                    for event in events {
+                        tracing::trace!("event {:?}", event.mask);
+
+                        if event.mask.contains(EventMask::ATTRIB)
+                            || event.mask.contains(EventMask::MODIFY)
+                            || event.mask.contains(EventMask::CLOSE_WRITE)
+                        {
+                            changed = true;
+                        }
+
+                        if event.mask.contains(EventMask::DELETE_SELF)
+                            || event.mask.contains(EventMask::IGNORED)
+                        {
+                            recreate_watch = true;
+                        }
+                    }
+
+                    if changed {
+                        reconcile();
+                    }
+                }
+                Err(error) => {
+                    tracing::warn!(?error, "cpu_manager_state monitor failed, recreating watch");
+                    recreate_watch = true;
+                }
+            }
+        }
+
+        tracing::debug!(
+            "inotify watch lost (DELETE_SELF/IGNORED), recreating watch on new cpuset file"
+        );
+
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+}
+
+/// Upper bound on how long [`reconcile`] waits for kubelet to apply the cgroup
+/// cpuset after a `cpu_manager_state` event.
+///
+/// kubelet writes `cpu_manager_state` (which triggers this reconcile) as soon
+/// as a Guaranteed pod is admitted/removed, but it applies the container's
+/// cgroup cpuset asynchronously, on its CPUManager reconcile period (default
+/// 5s). Measured apply latencies on the target cluster were ~5s (grow) and
+/// ~7-9s (shrink), so we must keep watching well past that; otherwise we miss
+/// the apply and leave the baseline stale, which then mis-triggers the next
+/// event. This is only a ceiling -- reconcile breaks the moment the change is
+/// observed, so it normally returns in ~5-9s and only approaches this bound if
+/// the apply never arrives (in which case we fall back to the current
+/// baseline).
+const RECONCILE_SETTLE_WINDOW: Duration = Duration::from_secs(20);
+/// Interval between cpuset re-checks within [`RECONCILE_SETTLE_WINDOW`].
+const RECONCILE_SETTLE_INTERVAL: Duration = Duration::from_millis(500);
+
+fn reconcile() {
+    tracing::debug!("Detected cpuset update, restoring affinity");
+
+    // Wait for kubelet to actually apply the cgroup cpuset before restoring
+    // affinity. kubelet writes cpu_manager_state (our trigger) up to its
+    // CPUManager reconcile period (~5s) *before* it applies the container cgroup
+    // cpuset, so poll refresh until it reports the cpuset changed -- then stop
+    // early. If nothing changes within the settle window (a same-value
+    // re-assert or a spurious event), stop anyway. Either way, fall through.
+    let start = Instant::now();
+    loop {
+        if Mthread::refresh_base_cpuset() {
+            break;
+        }
+        if start.elapsed() >= RECONCILE_SETTLE_WINDOW {
+            break;
+        }
+        std::thread::sleep(RECONCILE_SETTLE_INTERVAL);
+    }
+
+    // Applying the cgroup cpuset resets our threads' affinities (the kernel
+    // re-pins every task in the cgroup to the new mask), so restore them once,
+    // per event, using the current baseline -- the new cpuset if it changed,
+    // the old one otherwise.
+    for reactor in Reactors::iter() {
+        reactor.reapply_affinity();
+    }
+    runtime::reapply_workers_unaffinity();
+}

--- a/io-engine/src/core/env.rs
+++ b/io-engine/src/core/env.rs
@@ -1143,6 +1143,13 @@ impl MayastorEnvironment {
         // setup the logger as soon as possible
         self.init_logger();
 
+        // Snapshot the process's baseline CPU affinity (the container cgroup
+        // cpuset) before any reactor pins itself to a single core. This is the
+        // seed used to place off-reactor worker threads; capturing it here,
+        // on the still-unpinned main thread, is what keeps those workers off
+        // the reactor cores. See spdk_rs::Thread::capture_base_cpuset.
+        Mthread::capture_base_cpuset();
+
         if option_env!("ASAN_ENABLE").unwrap_or_default() == "1" {
             print_asan_env();
         }
@@ -1221,6 +1228,10 @@ impl MayastorEnvironment {
 
             assert!(receiver.await.unwrap());
         });
+
+        info!("Affinity monitoring started!");
+
+        crate::core::start_affinity_monitor();
 
         // load any pools that need to be created
         if let Some(config) = pool_config {

--- a/io-engine/src/core/mod.rs
+++ b/io-engine/src/core/mod.rs
@@ -51,6 +51,7 @@ pub use snapshot::{
 
 use spdk_rs::libspdk::SPDK_NVME_SC_CAPACITY_EXCEEDED;
 
+mod affinity;
 mod bdev;
 mod block_device;
 mod descriptor;
@@ -75,6 +76,8 @@ pub mod snapshot;
 pub(crate) mod thread;
 pub(crate) mod wiper;
 mod work_queue;
+
+pub use affinity::start_monitor as start_affinity_monitor;
 
 /// Obtain the full error chain
 pub trait VerboseError {

--- a/io-engine/src/core/reactor.rs
+++ b/io-engine/src/core/reactor.rs
@@ -37,6 +37,7 @@ use std::{
     os::{fd::RawFd, raw::c_void},
     pin::Pin,
     slice::Iter,
+    sync::atomic::{AtomicU64, Ordering},
     time::Duration,
 };
 
@@ -120,7 +121,7 @@ pub struct Reactor {
     /// represents the state of the reactor
     flags: Cell<ReactorState>,
     /// Unique identifier of the thread on which reactor is running.
-    tid: Cell<u64>,
+    tid: AtomicU64,
     /// sender and Receiver for sending futures across cores without going
     /// through FFI
     sx: Sender<Pin<Box<dyn Future<Output = ()> + 'static>>>,
@@ -363,7 +364,7 @@ impl Reactor {
             lcore: core,
             developer_delay,
             flags: Cell::new(ReactorState::Init),
-            tid: Cell::new(0),
+            tid: AtomicU64::new(0),
             sx,
             rx,
             interrupt_enabled,
@@ -547,13 +548,13 @@ impl Reactor {
 
     /// Returns system identifier of the thread this reactor is running on.
     pub fn tid(&self) -> u64 {
-        self.tid.get()
+        self.tid.load(Ordering::Relaxed)
     }
 
     /// poll this reactor to complete any work that is pending
     pub fn poll_reactor(&self) {
         // Initialize TID for this reactor.
-        self.tid.set(gettid());
+        self.tid.store(gettid(), Ordering::Relaxed);
 
         // If interrupt mode is enabled, enter it immediately. The
         // reactor will block in fd_group_wait() until events arrive,
@@ -931,6 +932,30 @@ impl Reactor {
             })
         } else {
             Ok(r)
+        }
+    }
+
+    pub fn reapply_affinity(&self) {
+        let tid = self.tid();
+
+        if tid == 0 {
+            return;
+        }
+
+        unsafe {
+            let mut set: libc::cpu_set_t = std::mem::zeroed();
+
+            libc::CPU_SET(self.core() as usize, &mut set);
+
+            let rc = libc::sched_setaffinity(
+                tid as libc::pid_t,
+                std::mem::size_of::<libc::cpu_set_t>(),
+                &set,
+            );
+
+            if rc != 0 {
+                tracing::warn!("Failed to repin reactor core={} tid={}", self.core(), tid);
+            }
         }
     }
 

--- a/io-engine/src/core/runtime.rs
+++ b/io-engine/src/core/runtime.rs
@@ -3,13 +3,15 @@
 //! runtime to do whatever it needs to do. The tokio threads are
 //! unaffinitized such that they do not run on any of our reactors.
 
+use super::Mthread;
 use crate::core::Reactor;
 use futures::{channel::oneshot, Future};
 use once_cell::sync::Lazy;
+use parking_lot::Mutex;
+use std::collections::HashSet;
 use tokio::task::JoinHandle;
-
-use super::Mthread;
-
+static UNAFFINITIZED_WORKERS: Lazy<Mutex<HashSet<libc::pid_t>>> =
+    Lazy::new(|| Mutex::new(HashSet::new()));
 /// spawn a future on the tokio runtime.
 pub fn spawn(f: impl Future<Output = ()> + Send + 'static) {
     RUNTIME.spawn(f);
@@ -46,6 +48,14 @@ where
     RUNTIME.spawn_blocking(f)
 }
 
+pub fn reapply_workers_unaffinity() {
+    let tids = UNAFFINITIZED_WORKERS.lock().clone();
+
+    for tid in tids {
+        Mthread::unaffinitize_tid(tid);
+    }
+}
+
 pub struct Runtime {
     rt: tokio::runtime::Runtime,
 }
@@ -53,9 +63,15 @@ pub struct Runtime {
 static RUNTIME: Lazy<Runtime> = Lazy::new(|| {
     let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
-        .worker_threads(5)
-        .max_blocking_threads(6)
-        .on_thread_start(Mthread::unaffinitize)
+        .worker_threads(6)
+        .max_blocking_threads(7)
+        .on_thread_start(|| {
+            let tid = unsafe { libc::syscall(libc::SYS_gettid) as libc::pid_t };
+
+            UNAFFINITIZED_WORKERS.lock().insert(tid);
+
+            Mthread::unaffinitize();
+        })
         .build()
         .unwrap();
 


### PR DESCRIPTION
Kubernetes CPU Manager running with cpuManagerPolicy=static may rewrite container cpusets when Guaranteed pods are admitted or removed.

When cpuset.cpus.effective is updated, the kernel resets task affinity masks for threads in the cgroup. This causes Mayastor reactor threads to lose their CPU pinning and Tokio worker threads to lose their unaffinitized CPU mask.

Add a cpuset monitor that watches for cpuset updates and automatically restores reactor affinity. Tokio worker TIDs are tracked so worker unaffinity can also be re-applied, preserving separation between reactor and runtime threads.

This improves support for deployments using:
- cpuManagerPolicy=static
- isolcpus
- KubeVirt dedicated CPUs

Fixes silent affinity loss after Guaranteed pod
admission/removal events.



fix(io-engine): update reactor repinning handling



refactor(affinity): run cpuset monitor on runtime blocking pool

Run the cpuset affinity monitor via runtime::spawn_blocking() instead of creating a dedicated std::thread.

This allows the monitor thread to participate in the existing thread unaffinity restoration mechanism and avoids maintaining a separate unmanaged thread.



fix(io-engine): re-pin reactors on CPUManager cpuset updates

Monitor kubelet cpu_manager_state and re-pin reactor threads when CPUManager updates the node cpuset allocation.

Handle cpu_manager_state inode replacement by re-establishing the inotify watch after DELETE_SELF and IGNORED events to ensure subsequent CPUManager updates are detected.