### PR TITLE
ci: skip ublk based tests on 6.17.0 oracle kernels

### DIFF
--- a/io-engine/tests/lvs_pool.rs
+++ b/io-engine/tests/lvs_pool.rs
@@ -1109,10 +1109,12 @@ impl TestHotRmGuard {
         let script = r#"
         set -euo pipefail
         modprobe ublk_drv
-        if [ "$(uname -r)" = "6.17.0-1016-oracle" ]; then
-          echo "ublk_drv bug Oops in ublk_init_queues" >&2
-          exit 2
-        fi
+        case "$(uname -r)" in
+            6.17.0-*-oracle)
+                echo "ublk_drv bug Oops in ublk_init_queues" >&2
+                exit 2
+            ;;
+        esac
         o=$(ublk add -t loop -f $1)
         echo $o | head -n 1 | awk '{print $3}' | tr -d ':'
     "#;
@@ -1134,7 +1136,7 @@ impl TestHotRmGuard {
                 }
             }
         } else if result.0 == 2 && result.2.contains("ublk_drv bug Oops in ublk_init_queues") {
-            eprint!(" skipped because UBLK kernel module has a bug: https://github.com/actions/runner-images/issues/14175");
+            eprint!(" skipped because UBLK kernel module has a bug: https://github.com/actions/runner-images/issues/14175 ");
             return None;
         }
         assert_eq!(result.0, 0, "Failed to setup ublk device: {result:#?}");


### PR DESCRIPTION
The existing skip was targetting a specific patch version, but now that CI is using a new patch it's again failing and getting stuck.

Let's instead skip on all 6.17.0 from oracle