### PR TITLE
refactor: don't reuse clean shutdown for nexus share/unshare

### DIFF
--- a/io-engine/src/bdev/nexus/nexus_bdev.rs
+++ b/io-engine/src/bdev/nexus/nexus_bdev.rs
@@ -802,9 +802,8 @@ impl<'n> Nexus<'n> {
         };
 
         // Persist the fact that the nexus is now successfully open.
-        // `PersistOp::Create` records the initial clean-while-unshared state,
-        // which then gets flipped on share/unshare to maintain the invariant
-        // `clean_shutdown <=> currently unshared`.
+        // `PersistOp::Create` records the initial unshared state, which then
+        // gets transitioned via `PersistOp::SetShared` on share/unshare.
         // We have to do this before setting the nexus to open so that
         // nexus list does not return this nexus until it is persisted.
         if let Err(e) = nex.persist(PersistOp::Create).await {
@@ -834,8 +833,8 @@ impl<'n> Nexus<'n> {
     pub async fn destroy_ext(mut self: Pin<&mut Self>, sigterm: bool) -> Result<(), Error> {
         info!("{:?}: destroying nexus...", self);
 
-        // Destroy already issues `PersistOp::Shutdown` below (which sets
-        // `clean_shutdown = true`), so skip the redundant persist here.
+        // Destroy already issues `PersistOp::Shutdown` below (which persists
+        // shutdown markers), so skip the redundant persist here.
         self.as_mut().unshare_nexus_internal(false).await?;
 
         // wait for all rebuild jobs to be cancelled before proceeding with the

--- a/io-engine/src/bdev/nexus/nexus_persistence.rs
+++ b/io-engine/src/bdev/nexus/nexus_persistence.rs
@@ -44,6 +44,11 @@ pub struct NexusInfo {
     pub do_self_shutdown: bool,
     /// Information about children.
     pub children: Vec<ChildInfo>,
+    /// Is the nexus target currently shared/active?
+    /// This tracks whether front-end I/O may be in flight.
+    /// If the nexus is unshared, no front-end I/O can be in flight, and we may
+    /// assume that the replicas are in-sync.
+    pub shared: bool,
 }
 pub struct NexusInfoTxn<'a> {
     key_info: &'a mut PersistentNexusInfo,
@@ -82,13 +87,11 @@ pub(crate) enum PersistOp<'a> {
     },
     /// Save the clean shutdown variable.
     Shutdown,
-    /// Explicitly set the clean shutdown flag while the nexus is alive.
-    /// This is used to track the invariant `clean_shutdown <=> currently
-    /// unshared`: while no I/O can possibly flow (unshared), the children
-    /// cannot get dirty, so a crash from that state is equivalent to a clean
-    /// shutdown. Set to `true` on nexus create and on unshare, set to `false`
-    /// when the nexus transitions to shared and I/O becomes possible.
-    SetCleanShutdown { clean: bool },
+    /// Explicitly set whether the nexus is shared while it is alive.
+    /// This is used to persist whether I/O can potentially flow through the
+    /// nexus (shared) or not (unshared) without implying that the nexus was
+    /// shut down.
+    SetShared { shared: bool },
 }
 
 impl std::fmt::Debug for PersistOp<'_> {
@@ -104,8 +107,8 @@ impl std::fmt::Debug for PersistOp<'_> {
                 child_uri, healthy, ..
             } => write!(f, "UpdateChildCond: {child_uri}: {healthy}"),
             PersistOp::Shutdown => write!(f, "Shutdown"),
-            PersistOp::SetCleanShutdown { clean } => {
-                write!(f, "SetCleanShutdown: {clean}")
+            PersistOp::SetShared { shared } => {
+                write!(f, "SetShared: {shared}")
             }
         }
     }
@@ -156,11 +159,11 @@ impl<'n> Nexus<'n> {
                         reason: "only child is unhealthy".to_string(),
                     });
                 }
+                nexus_info.clean_shutdown = false;
                 // A freshly created nexus is intrinsically unshared: no
-                // initiator can connect and no I/O can dirty the children
-                // until `share_ext` runs. Record the clean state up front so
-                // that a crash from here is not treated as a dirty shutdown.
-                nexus_info.clean_shutdown = true;
+                // initiator can connect and no front-end I/O can flow until
+                // `share_ext` runs. Record this up front.
+                nexus_info.shared = false;
             }
             PersistOp::AddChild { child_uri, healthy } => {
                 // Add the state of a new child. This should only be called
@@ -190,7 +193,7 @@ impl<'n> Nexus<'n> {
             PersistOp::Update { child_uri, healthy } => {
                 let uuid = NexusChild::uuid(child_uri).expect("Failed to get child UUID.");
                 // Only update the state of the child that has changed. Do not
-                // update the other children or "clean shutdown" information.
+                // update the other children or nexus state markers.
                 // This should only be called on a child state change.
                 nexus_info.children.iter_mut().for_each(|c| {
                     if c.uuid == uuid {
@@ -248,16 +251,16 @@ impl<'n> Nexus<'n> {
                 }
             }
             PersistOp::Shutdown => {
-                // Only update the clean shutdown variable. Do not update the
-                // child state information.
+                // Update only shutdown-related markers. Do not update child
+                // state information.
                 // This should only be called when destroying a nexus.
                 nexus_info.clean_shutdown = true;
             }
-            PersistOp::SetCleanShutdown { clean } => {
-                // Only update the clean shutdown variable. This is used by
-                // share/unshare/create transitions to track whether the nexus
-                // is currently in a state where I/O can dirty the children.
-                nexus_info.clean_shutdown = *clean;
+            PersistOp::SetShared { shared } => {
+                // Only update the shared marker. This is used by
+                // share/unshare/create transitions to track whether front-end
+                // I/O can currently flow through the nexus.
+                nexus_info.shared = *shared;
             }
         }
 

--- a/io-engine/src/bdev/nexus/nexus_share.rs
+++ b/io-engine/src/bdev/nexus/nexus_share.rs
@@ -42,14 +42,11 @@ impl Share for Nexus<'_> {
             Some(Protocol::Off) | None => {
                 info!("{:?}: sharing NVMF target...", self);
 
-                // Persist `clean_shutdown = false` before the share goes
-                // live, so that a crash from here cannot leave the nexus
-                // marked clean while an initiator could be connecting and
-                // dirtying children. Lives here (rather than in `share_ext`)
-                // so the same guarantee holds for any direct caller of the
-                // trait method.
+                // Persist `shared = true` before the share goes live, so a
+                // crash from here cannot leave the nexus persisted as
+                // unshared while initiators may already be writing data.
                 self.as_mut()
-                    .persist(PersistOp::SetCleanShutdown { clean: false })
+                    .persist(PersistOp::SetShared { shared: true })
                     .await?;
 
                 let name = self.name.clone();
@@ -179,12 +176,11 @@ impl<'n> Nexus<'n> {
             // right now Off is mapped to Nbd, will clean up the Nbd related
             // code once we refactor the rust tests that use nbd.
             Protocol::Off => {
-                // Persist `clean_shutdown = false` before the NBD share goes
-                // live. The NVMe-oF path persists the same flag inside
-                // `Share::share_nvmf`, so each protocol owns its own
-                // transition guarantee.
+                // Persist `shared = true` before the NBD share goes live. The NVMe-oF
+                // path persists the same transition inside `Share::share_nvmf`,
+                // so each protocol owns its own transition guarantee.
                 self.as_mut()
-                    .persist(PersistOp::SetCleanShutdown { clean: false })
+                    .persist(PersistOp::SetShared { shared: true })
                     .await?;
 
                 let disk = NbdDisk::create(&self.name)
@@ -219,8 +215,7 @@ impl<'n> Nexus<'n> {
         }
     }
 
-    /// Unshare the nexus target and persist the now-clean state so a crash
-    /// from here behaves like a graceful shutdown.
+    /// Unshare the nexus target and persist the now-unshared state.
     pub async fn unshare_nexus(mut self: Pin<&mut Self>) -> Result<(), Error> {
         self.as_mut().unshare_nexus_internal(true).await
     }
@@ -228,7 +223,7 @@ impl<'n> Nexus<'n> {
     /// Inner unshare path shared by the public `unshare_nexus` and the
     /// destroy path. `persist_clean` controls whether the now-unshared state
     /// is recorded; destroy passes `false` because `PersistOp::Shutdown`
-    /// issued shortly afterwards already flips `clean_shutdown` to `true`.
+    /// issued shortly afterwards persists shutdown markers directly.
     pub(super) async fn unshare_nexus_internal(
         mut self: Pin<&mut Self>,
         persist_clean: bool,
@@ -251,23 +246,23 @@ impl<'n> Nexus<'n> {
 
         if persist_clean {
             // Double-check the `NvmfSubsystem` is really gone before marking
-            // the children clean. A racing resume can re-start a stopped
+            // the nexus as unshared. A racing resume can re-start a stopped
             // subsystem and leave the unshare looking successful on the way
-            // out; if it is still around, the children could still be
-            // touched, so leave `clean_shutdown` as-is and let the existing
-            // crash-recovery path handle it on next start.
+            // out; if it is still around, front-end I/O can still be
+            // possible, so leave the persisted shared marker as-is and let
+            // the existing crash-recovery path handle it on next start.
             if NvmfSubsystem::nqn_lookup(&self.name).is_some() {
                 warn!(
                     "{self:?}: NvmfSubsystem still present after unshare, \
-                    skipping clean-shutdown persist (subsystem resume race)"
+                    skipping set-shared persist (subsystem resume race)"
                 );
             } else if let Err(e) = self
                 .as_mut()
-                .persist(PersistOp::SetCleanShutdown { clean: true })
+                .persist(PersistOp::SetShared { shared: false })
                 .await
             {
                 warn!(
-                    "{self:?}: failed to persist clean_shutdown after unshare \
+                    "{self:?}: failed to persist shared after unshare \
                     (best-effort, falling back to existing crash-recovery \
                     behaviour on next start): {e}"
                 );

--- a/io-engine/tests/persistence.rs
+++ b/io-engine/tests/persistence.rs
@@ -5,6 +5,7 @@ use common::compose::{
             AddChildNexusRequest, BdevShareRequest, BdevUri, Child, ChildState, CreateNexusRequest,
             CreateReply, DestroyNexusRequest, Nexus, NexusState, Null, PublishNexusRequest,
             RebuildStateRequest, RemoveChildNexusRequest, ShareProtocolNexus,
+            UnpublishNexusRequest,
         },
         GrpcConnect, RpcHandle,
     },
@@ -29,10 +30,15 @@ static CHILD1_UUID: &str = "d61b2fdf-1be8-457a-a481-70a42d0a2223";
 static CHILD2_UUID: &str = "094ae8c6-46aa-4139-b4f2-550d39645db3";
 static CHILD3_UUID: &str = "ae09c08f-8909-4024-a9ae-c21a2a0596b9";
 
+async fn etcd_nexus_info(etcd: &mut Client, nexus_uuid: &str) -> NexusInfo {
+    let response = etcd.get(nexus_uuid, None).await.expect("No entry found");
+    let value = response.kvs().first().unwrap().value();
+    serde_json::from_slice::<NexusInfo>(value).unwrap()
+}
+
 /// This test checks that when an unexpected restart occurs, all persisted info
-/// remains unchanged. The nexus is never shared here, so `clean_shutdown`
-/// stays `true` throughout: an unshared nexus cannot accept I/O and is
-/// therefore clean by construction.
+/// remains unchanged. The nexus is never shared here, so the persisted
+/// `shared` marker stays `false` throughout.
 #[tokio::test]
 async fn persist_unexpected_restart() {
     let test = start_infrastructure("persist_unexpected_restart").await;
@@ -52,13 +58,12 @@ async fn persist_unexpected_restart() {
     // Retrieve the nexus info from the store.
 
     let mut etcd = Client::connect([ETCD_ENDPOINT], None).await.unwrap();
-    let response = etcd.get(nexus_uuid, None).await.expect("No entry found");
-    let value = response.kvs().first().unwrap().value();
-    let nexus_info: NexusInfo = serde_json::from_slice(value).unwrap();
+    let nexus_info = etcd_nexus_info(&mut etcd, nexus_uuid).await;
 
     // Check the persisted nexus info is correct.
 
-    assert!(nexus_info.clean_shutdown);
+    assert!(!nexus_info.clean_shutdown);
+    assert!(!nexus_info.shared);
 
     let child = child_info(&nexus_info, &uuid(&child1));
     assert!(child.healthy);
@@ -66,18 +71,55 @@ async fn persist_unexpected_restart() {
     let child = child_info(&nexus_info, &uuid(&child2));
     assert!(child.healthy);
 
+    publish_nexus(ms1, nexus_uuid).await;
+    let nexus_info = etcd_nexus_info(&mut etcd, nexus_uuid).await;
+    assert!(!nexus_info.clean_shutdown);
+    assert!(nexus_info.shared);
+    unpublish_nexus(ms1, nexus_uuid).await;
+    let nexus_info = etcd_nexus_info(&mut etcd, nexus_uuid).await;
+    assert!(!nexus_info.clean_shutdown);
+    assert!(!nexus_info.shared);
+    publish_nexus(ms1, nexus_uuid).await;
+    let nexus_info = etcd_nexus_info(&mut etcd, nexus_uuid).await;
+    assert!(!nexus_info.clean_shutdown);
+    assert!(nexus_info.shared);
+
     // Restart the container where the nexus lives.
     test.restart("ms1")
         .await
         .expect("Failed to restart container.");
 
-    let response = etcd.get(nexus_uuid, None).await.expect("No entry found");
-    let value = response.kvs().first().unwrap().value();
-    let nexus_info: NexusInfo = serde_json::from_slice(value).unwrap();
+    let nexus_info = etcd_nexus_info(&mut etcd, nexus_uuid).await;
 
     // Check the persisted nexus info changed to reflect clean shutdown.
 
     assert!(nexus_info.clean_shutdown);
+    assert!(nexus_info.shared);
+
+    let child = child_info(&nexus_info, &uuid(&child1));
+    assert!(child.healthy);
+
+    let child = child_info(&nexus_info, &uuid(&child2));
+    assert!(child.healthy);
+
+    let ms1 = &mut grpc.grpc_handle("ms1").await.unwrap();
+    create_nexus(ms1, nexus_uuid, vec![child1.clone(), child2.clone()]).await;
+    let nexus_info = etcd_nexus_info(&mut etcd, nexus_uuid).await;
+    assert!(!nexus_info.clean_shutdown);
+    assert!(!nexus_info.shared);
+
+    publish_nexus(ms1, nexus_uuid).await;
+    let nexus_info = etcd_nexus_info(&mut etcd, nexus_uuid).await;
+    assert!(!nexus_info.clean_shutdown);
+    assert!(nexus_info.shared);
+
+    // Kill the container to simulate a crash
+    test.kill("ms1").await.expect("Failed to kill container.");
+    test.start("ms1").await.expect("Failed to start container.");
+
+    let nexus_info = etcd_nexus_info(&mut etcd, nexus_uuid).await;
+    assert!(!nexus_info.clean_shutdown);
+    assert!(nexus_info.shared);
 
     let child = child_info(&nexus_info, &uuid(&child1));
     assert!(child.healthy);
@@ -107,13 +149,12 @@ async fn persist_clean_shutdown() {
     // Retrieve the nexus info from the store.
 
     let mut etcd = Client::connect([ETCD_ENDPOINT], None).await.unwrap();
-    let response = etcd.get(nexus_uuid, None).await.expect("No entry found");
-    let value = response.kvs().first().unwrap().value();
-    let nexus_info: NexusInfo = serde_json::from_slice(value).unwrap();
+    let nexus_info = etcd_nexus_info(&mut etcd, nexus_uuid).await;
 
     // Check the persisted nexus info is correct.
 
-    assert!(nexus_info.clean_shutdown);
+    assert!(!nexus_info.clean_shutdown);
+    assert!(!nexus_info.shared);
 
     let child = child_info(&nexus_info, &uuid(&child1));
     assert!(child.healthy);
@@ -121,15 +162,13 @@ async fn persist_clean_shutdown() {
     let child = child_info(&nexus_info, &uuid(&child2));
     assert!(child.healthy);
 
-    // Publish the nexus so the share path flips clean_shutdown to false;
-    // this lets the subsequent destroy meaningfully validate the
-    // false -> true transition driven by `PersistOp::Shutdown`.
+    // Publish the nexus so the share path persists `shared = true` before
+    // destroy; this exercises the share/unshare state transition path.
     publish_nexus(ms1, nexus_uuid).await;
 
-    let response = etcd.get(nexus_uuid, None).await.expect("No entry found");
-    let value = response.kvs().first().unwrap().value();
-    let nexus_info: NexusInfo = serde_json::from_slice(value).unwrap();
+    let nexus_info = etcd_nexus_info(&mut etcd, nexus_uuid).await;
     assert!(!nexus_info.clean_shutdown);
+    assert!(nexus_info.shared);
 
     // Destroy the nexus
     ms1.mayastor
@@ -139,13 +178,12 @@ async fn persist_clean_shutdown() {
         .await
         .expect("Failed to destroy nexus");
 
-    let response = etcd.get(nexus_uuid, None).await.expect("No entry found");
-    let value = response.kvs().first().unwrap().value();
-    let nexus_info: NexusInfo = serde_json::from_slice(value).unwrap();
+    let nexus_info = etcd_nexus_info(&mut etcd, nexus_uuid).await;
 
     // Check the persisted nexus info is correct.
 
     assert!(nexus_info.clean_shutdown);
+    assert!(nexus_info.shared);
 
     let child = child_info(&nexus_info, &uuid(&child1));
     assert!(child.healthy);
@@ -232,10 +270,9 @@ async fn persist_io_failure() {
     // Use etcd-client to check the persisted entry.
 
     let mut etcd = Client::connect([ETCD_ENDPOINT], None).await.unwrap();
-    let response = etcd.get(nexus_uuid, None).await.expect("No entry found");
-    let value = response.kvs().first().unwrap().value();
-    let nexus_info: NexusInfo = serde_json::from_slice(value).unwrap();
+    let nexus_info = etcd_nexus_info(&mut etcd, nexus_uuid).await;
     assert!(!nexus_info.clean_shutdown);
+    assert!(nexus_info.shared);
 
     // Expect child1 to be healthy.
     let child = child_info(&nexus_info, &uuid(&child1));
@@ -260,9 +297,7 @@ async fn persist_io_failure() {
         ChildState::ChildDegraded as i32
     );
 
-    let response = etcd.get(nexus_uuid, None).await.expect("No entry found");
-    let value = response.kvs().first().unwrap().value();
-    let nexus_info: NexusInfo = serde_json::from_slice(value).unwrap();
+    let nexus_info = etcd_nexus_info(&mut etcd, nexus_uuid).await;
     let child = child_info(&nexus_info, &uuid(&child3));
     assert!(!child.healthy);
 
@@ -298,18 +333,14 @@ async fn persist_io_failure() {
         ChildState::ChildOnline as i32
     );
 
-    let response = etcd.get(nexus_uuid, None).await.expect("No entry found");
-    let value = response.kvs().first().unwrap().value();
-    let nexus_info: NexusInfo = serde_json::from_slice(value).unwrap();
+    let nexus_info = etcd_nexus_info(&mut etcd, nexus_uuid).await;
     let child = child_info(&nexus_info, &uuid(&child3));
     assert!(child.healthy);
 
     // Remove child3 and verify that it is unhealthy
     remove_child_nexus(ms1, nexus_uuid, &child3).await;
 
-    let response = etcd.get(nexus_uuid, None).await.expect("No entry found");
-    let value = response.kvs().first().unwrap().value();
-    let nexus_info: NexusInfo = serde_json::from_slice(value).unwrap();
+    let nexus_info = etcd_nexus_info(&mut etcd, nexus_uuid).await;
     // Since child3 is removed, it shouldn't be in the persisted entry as well.
     no_child_info(&nexus_info, &uuid(&child3));
 }
@@ -447,6 +478,15 @@ async fn publish_nexus(hdl: &mut RpcHandle, uuid: &str) -> String {
         .expect("Failed to publish nexus")
         .into_inner()
         .device_uri
+}
+/// Unpublish a nexus with the given UUID.
+async fn unpublish_nexus(hdl: &mut RpcHandle, uuid: &str) {
+    hdl.mayastor
+        .unpublish_nexus(UnpublishNexusRequest {
+            uuid: uuid.to_string(),
+        })
+        .await
+        .expect("Failed to unpublish nexus");
 }
 
 /// Creates and shares a bdev over NVMf and returns the share uri.


### PR DESCRIPTION
In previous change we had modified the clean shutdown, keeping it as true in case the nexus was not shared.
This is a breaking change which affects existing control-plane and e2e tests.

Instead here we add a new shared flag which we can use without modifying the existing flags.

The control-plane will then also have to be changed to take this flag into account when determining the replica health.