### PR TITLE
fix: handle nexus info transaction

### DIFF
--- a/io-engine/src/bdev/nexus/nexus_persistence.rs
+++ b/io-engine/src/bdev/nexus/nexus_persistence.rs
@@ -48,7 +48,15 @@ pub struct NexusInfo {
     /// This tracks whether front-end I/O may be in flight.
     /// If the nexus is unshared, no front-end I/O can be in flight, and we may
     /// assume that the replicas are in-sync.
-    pub shared: bool,
+    #[serde(default)]
+    pub shared: Option<bool>,
+}
+impl NexusInfo {
+    /// Returns whether the nexus is currently shared.
+    /// If the value is not set, it defaults to true.
+    pub fn shared(&self) -> bool {
+        self.shared.unwrap_or(true)
+    }
 }
 pub struct NexusInfoTxn<'a> {
     key_info: &'a mut PersistentNexusInfo,
@@ -163,7 +171,7 @@ impl<'n> Nexus<'n> {
                 // A freshly created nexus is intrinsically unshared: no
                 // initiator can connect and no front-end I/O can flow until
                 // `share_ext` runs. Record this up front.
-                nexus_info.shared = false;
+                nexus_info.shared = Some(false);
             }
             PersistOp::AddChild { child_uri, healthy } => {
                 // Add the state of a new child. This should only be called
@@ -260,7 +268,7 @@ impl<'n> Nexus<'n> {
                 // Only update the shared marker. This is used by
                 // share/unshare/create transitions to track whether front-end
                 // I/O can currently flow through the nexus.
-                nexus_info.shared = *shared;
+                nexus_info.shared = Some(*shared);
             }
         }
 

--- a/io-engine/tests/persistence.rs
+++ b/io-engine/tests/persistence.rs
@@ -63,7 +63,7 @@ async fn persist_unexpected_restart() {
     // Check the persisted nexus info is correct.
 
     assert!(!nexus_info.clean_shutdown);
-    assert!(!nexus_info.shared);
+    assert!(!nexus_info.shared());
 
     let child = child_info(&nexus_info, &uuid(&child1));
     assert!(child.healthy);
@@ -74,15 +74,15 @@ async fn persist_unexpected_restart() {
     publish_nexus(ms1, nexus_uuid).await;
     let nexus_info = etcd_nexus_info(&mut etcd, nexus_uuid).await;
     assert!(!nexus_info.clean_shutdown);
-    assert!(nexus_info.shared);
+    assert!(nexus_info.shared());
     unpublish_nexus(ms1, nexus_uuid).await;
     let nexus_info = etcd_nexus_info(&mut etcd, nexus_uuid).await;
     assert!(!nexus_info.clean_shutdown);
-    assert!(!nexus_info.shared);
+    assert!(!nexus_info.shared());
     publish_nexus(ms1, nexus_uuid).await;
     let nexus_info = etcd_nexus_info(&mut etcd, nexus_uuid).await;
     assert!(!nexus_info.clean_shutdown);
-    assert!(nexus_info.shared);
+    assert!(nexus_info.shared());
 
     // Restart the container where the nexus lives.
     test.restart("ms1")
@@ -94,7 +94,7 @@ async fn persist_unexpected_restart() {
     // Check the persisted nexus info changed to reflect clean shutdown.
 
     assert!(nexus_info.clean_shutdown);
-    assert!(nexus_info.shared);
+    assert!(nexus_info.shared());
 
     let child = child_info(&nexus_info, &uuid(&child1));
     assert!(child.healthy);
@@ -106,12 +106,12 @@ async fn persist_unexpected_restart() {
     create_nexus(ms1, nexus_uuid, vec![child1.clone(), child2.clone()]).await;
     let nexus_info = etcd_nexus_info(&mut etcd, nexus_uuid).await;
     assert!(!nexus_info.clean_shutdown);
-    assert!(!nexus_info.shared);
+    assert!(!nexus_info.shared());
 
     publish_nexus(ms1, nexus_uuid).await;
     let nexus_info = etcd_nexus_info(&mut etcd, nexus_uuid).await;
     assert!(!nexus_info.clean_shutdown);
-    assert!(nexus_info.shared);
+    assert!(nexus_info.shared());
 
     // Kill the container to simulate a crash
     test.kill("ms1").await.expect("Failed to kill container.");
@@ -119,7 +119,7 @@ async fn persist_unexpected_restart() {
 
     let nexus_info = etcd_nexus_info(&mut etcd, nexus_uuid).await;
     assert!(!nexus_info.clean_shutdown);
-    assert!(nexus_info.shared);
+    assert!(nexus_info.shared());
 
     let child = child_info(&nexus_info, &uuid(&child1));
     assert!(child.healthy);
@@ -154,7 +154,7 @@ async fn persist_clean_shutdown() {
     // Check the persisted nexus info is correct.
 
     assert!(!nexus_info.clean_shutdown);
-    assert!(!nexus_info.shared);
+    assert!(!nexus_info.shared());
 
     let child = child_info(&nexus_info, &uuid(&child1));
     assert!(child.healthy);
@@ -168,7 +168,7 @@ async fn persist_clean_shutdown() {
 
     let nexus_info = etcd_nexus_info(&mut etcd, nexus_uuid).await;
     assert!(!nexus_info.clean_shutdown);
-    assert!(nexus_info.shared);
+    assert!(nexus_info.shared());
 
     // Destroy the nexus
     ms1.mayastor
@@ -183,7 +183,7 @@ async fn persist_clean_shutdown() {
     // Check the persisted nexus info is correct.
 
     assert!(nexus_info.clean_shutdown);
-    assert!(nexus_info.shared);
+    assert!(nexus_info.shared());
 
     let child = child_info(&nexus_info, &uuid(&child1));
     assert!(child.healthy);
@@ -272,7 +272,7 @@ async fn persist_io_failure() {
     let mut etcd = Client::connect([ETCD_ENDPOINT], None).await.unwrap();
     let nexus_info = etcd_nexus_info(&mut etcd, nexus_uuid).await;
     assert!(!nexus_info.clean_shutdown);
-    assert!(nexus_info.shared);
+    assert!(nexus_info.shared());
 
     // Expect child1 to be healthy.
     let child = child_info(&nexus_info, &uuid(&child1));


### PR DESCRIPTION
On transaction updates, we actually load the existing value and compare it to the in-memory.

This is not fully covered in the data-plane tests today, and was only caught on control-plane tests.

Since we load it, we now have to ensure we can load older values where shared did not exist.

todo: add transaction tests here