### PR TITLE
fix(nexus/grpc): add read_only field to v1 struct literals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1341,6 +1341,8 @@ dependencies = [
  "bytes",
  "chrono",
  "futures",
+ "pbjson",
+ "pbjson-build",
  "prost",
  "prost-extend",
  "serde",
@@ -2875,6 +2877,28 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "pbjson"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e6349fa080353f4a597daffd05cb81572a9c031a6d4fff7e504947496fcc68"
+dependencies = [
+ "base64 0.21.5",
+ "serde",
+]
+
+[[package]]
+name = "pbjson-build"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6eea3058763d6e656105d1403cb04e0a41b7bbac6362d413e7c33be0c32279c9"
+dependencies = [
+ "heck",
+ "itertools 0.13.0",
+ "prost",
+ "prost-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,8 @@ prost = "0.13.2"
 prost-derive = "0.13.3"
 bytes = "1.11.1"
 prost-build = "0.13.3"
+pbjson = "0.7.0"
+pbjson-build = "0.7.0"
 
 udev = "0.9.1"
 bindgen = "0.70.1"

--- a/io-engine/src/bin/io-engine-client/v1/nexus_cli.rs
+++ b/io-engine/src/bin/io-engine-client/v1/nexus_cli.rs
@@ -482,6 +482,7 @@ async fn nexus_publish(mut ctx: Context, args: PublishArgs) -> crate::Result<()>
             key,
             share: protocol,
             allowed_hosts,
+            read_only: None,
         })
         .await
         .context(GrpcStatus)?;

--- a/io-engine/src/grpc/v1/nexus.rs
+++ b/io-engine/src/grpc/v1/nexus.rs
@@ -418,6 +418,9 @@ impl<'n> nexus::Nexus<'n> {
             allowed_hosts: self.allowed_hosts(),
             label_version: Some(label_version_to_proto(self.label_version) as i32),
             bdev_size: Some(self.size_in_bytes()),
+            // ROX support in the io-engine is not yet wired; report `None` for now,
+            // consumers will populate this once the publish-time `read_only` flag lands.
+            read_only: None,
         }
     }
 }


### PR DESCRIPTION
Bumps utils/dependencies to include openebs/mayastor-dependencies#162 which adds an `optional bool read_only` field to both the v1 `Nexus` proto message and `PublishNexusRequest`. Two sites in the io-engine construct these as struct literals without `..Default::default()`, so bumping the submodule alone breaks the build with `E0063: missing field read_only`.

Add the field explicitly as `None` at both sites:

  - `io-engine/src/grpc/v1/nexus.rs:403`: the `Nexus { ... }` response literal in `into_grpc()`
  - `io-engine/src/bin/io-engine-client/v1/nexus_cli.rs:480`: the `PublishNexusRequest { ... }` in the CLI publish path

The io-engine doesn't know how to track ROX state yet, so `None` is the honest default until the consumer PR lands and populates them from actual state.

Also adds `pbjson`/`pbjson-build` to the workspace dependency table because the newer `events-api` inside the bumped submodule needs them. This includes the same submodule bump and `pbjson` workspace deps as openebs/mayastor#2031, plus the missing struct literal fixes that were blocking #2031's CI.

Refs: openebs/mayastor-dependencies#162
Refs: openebs/mayastor#2031

cc @abhilashshetty04 @rohan2794 @tiagolobocastro