### PR TITLE
extend clear error api to allow selective reset

### DIFF
--- a/io-engine/src/bin/io-engine-client/v1/pool_cli.rs
+++ b/io-engine/src/bin/io-engine-client/v1/pool_cli.rs
@@ -37,7 +37,6 @@ enum PoolCommands {
     /// List storage pools
     List(ListArgs),
     /// Clears errors from the storage pool
-    #[command(name = "clear-errors")]
     ClearErrors(ClearErrorsArgs),
     /// Probes storage pool
     Probe(ProbeArgs),
@@ -134,6 +133,9 @@ struct ClearErrorsArgs {
     disk: Vec<String>,
     #[arg(short = 'u', long)]
     uuid: Option<Uuid>,
+    /// Specify which errors to clear, if not all errors will be cleared.
+    #[arg(long = "clear")]
+    clear_arg: Option<ClearErrors>,
 }
 
 #[derive(Debug, Args)]
@@ -287,6 +289,25 @@ impl From<PoolType> for v1rpc::pool::PoolType {
         match value {
             PoolType::Lvs => Self::Lvs,
             PoolType::Lvm => Self::Lvm,
+        }
+    }
+}
+
+#[derive(Debug, Clone, clap::ValueEnum)]
+pub(super) enum ClearErrors {
+    /// Clear io error and stall transition counts from the pool.
+    All,
+    /// Clear only I/O errors from the pool.
+    IoErrors,
+    /// Clear only I/O stall transitions from the pool.
+    IoStallTransitions,
+}
+impl From<ClearErrors> for v1rpc::pool::ClearErrors {
+    fn from(value: ClearErrors) -> Self {
+        match value {
+            ClearErrors::All => Self::ClearAll,
+            ClearErrors::IoErrors => Self::ClearIoErrors,
+            ClearErrors::IoStallTransitions => Self::ClearIoStallTransitions,
         }
     }
 }
@@ -563,6 +584,10 @@ async fn clear_errors(mut ctx: Context, args: ClearErrorsArgs) -> crate::Result<
     let name = args.name;
     let uuid = args.uuid.map(|u| u.to_string());
     let disks = args.disk;
+    let clear = args
+        .clear_arg
+        .map(|c| v1rpc::pool::ClearErrors::from(c) as i32)
+        .unwrap_or_default();
 
     let response = ctx
         .v1
@@ -571,7 +596,7 @@ async fn clear_errors(mut ctx: Context, args: ClearErrorsArgs) -> crate::Result<
             name: name.clone(),
             uuid,
             disks,
-            clear: 0,
+            clear,
         })
         .await
         .context(GrpcStatus)?;

--- a/io-engine/src/grpc/v1/pool.rs
+++ b/io-engine/src/grpc/v1/pool.rs
@@ -448,8 +448,15 @@ impl PoolGrpc {
         self.pool.grow().await?;
         Ok(())
     }
-    async fn clear_errors(&self) -> Result<(), tonic::Status> {
-        self.pool.reset_errors().await?;
+    async fn clear_errors(&self, clear: ClearErrors) -> Result<(), tonic::Status> {
+        match clear {
+            ClearErrors::ClearAll => {
+                self.pool.reset_errors().await?;
+                self.pool.reset_stall_transitions().await?;
+            }
+            ClearErrors::ClearIoErrors => self.pool.reset_errors().await?,
+            ClearErrors::ClearIoStallTransitions => self.pool.reset_stall_transitions().await?,
+        }
         Ok(())
     }
     /// Access the `PoolOps` from this wrapper.
@@ -923,8 +930,14 @@ impl PoolRpc for PoolService {
             async move {
                 crate::spdk_submit!(async move {
                     info!("{:?}", request.get_ref());
+                    let req = request.get_ref();
+                    let clear_error =
+                        ClearErrors::try_from(req.clear).map_err(|_| LvsError::Invalid {
+                            source: BsError::InvalidArgument {},
+                            msg: format!("invalid clear arg provided: {}", req.clear),
+                        })?;
                     let pool = GrpcPoolFactory::finder(request.into_inner()).await?;
-                    pool.clear_errors().await?;
+                    pool.clear_errors(clear_error).await?;
                     Ok(Pool::async_from(pool.as_ops()).await)
                 })
             },

--- a/io-engine/src/lvm/error.rs
+++ b/io-engine/src/lvm/error.rs
@@ -60,6 +60,10 @@ pub enum Error {
     SnapshotNotSup {},
     #[snafu(display("Pool expansion is not currently supported for LVM volumes"))]
     GrowNotSup {},
+    #[snafu(display("Reset error is not currently supported for LVM volumes"))]
+    ResetErrNotSup {},
+    #[snafu(display("Reset stall transition is not currently supported for LVM volumes"))]
+    ResetStallTransitionNotSup {},
     #[snafu(display("{error}"))]
     Internal { error: String },
 }
@@ -98,6 +102,8 @@ impl ToErrno for Error {
             Error::Exists { .. } => Errno::EEXIST,
             Error::SnapshotNotSup { .. } => Errno::ENOTSUP,
             Error::GrowNotSup { .. } => Errno::ENOTSUP,
+            Error::ResetErrNotSup { .. } => Errno::ENOTSUP,
+            Error::ResetStallTransitionNotSup { .. } => Errno::ENOTSUP,
             Error::Internal { .. } => Errno::EPIPE,
         }
     }

--- a/io-engine/src/lvm/mod.rs
+++ b/io-engine/src/lvm/mod.rs
@@ -137,7 +137,11 @@ impl PoolOps for VolumeGroup {
     }
 
     async fn reset_errors(&self) -> Result<(), crate::pool_backend::Error> {
-        Err(Error::GrowNotSup {}.into())
+        Err(Error::ResetErrNotSup {}.into())
+    }
+
+    async fn reset_stall_transitions(&self) -> Result<(), crate::pool_backend::Error> {
+        Err(Error::ResetStallTransitionNotSup {}.into())
     }
 }
 

--- a/io-engine/src/lvs/mod.rs
+++ b/io-engine/src/lvs/mod.rs
@@ -8,6 +8,7 @@ use crate::{
         Error, FindPoolArgs, IPoolFactory, IPoolProps, ListPoolArgs, PoolArgs, PoolBackend,
         PoolMetadataInfo, PoolOps, ReplicaArgs,
     },
+    pool_information::pool_info_read,
     replica_backend::{
         FindReplicaArgs, IReplicaFactory, ListCloneArgs, ListReplicaArgs, ListSnapshotArgs,
         ReplicaOps, SnapshotOps,
@@ -172,6 +173,15 @@ impl PoolOps for Lvs {
             .map_err(|errno| crate::pool_backend::Error::Gen {
                 source: crate::pool_backend::GenericError::StatsReset { errno },
             })?;
+        Ok(())
+    }
+
+    async fn reset_stall_transitions(&self) -> Result<(), crate::pool_backend::Error> {
+        let cache = pool_info_read();
+        if let Some(pool_lock) = cache.get(self.name()) {
+            let mut pool_mut = pool_lock.write();
+            pool_mut.clear();
+        }
         Ok(())
     }
 }

--- a/io-engine/src/pool_backend.rs
+++ b/io-engine/src/pool_backend.rs
@@ -174,6 +174,9 @@ pub trait PoolOps: IPoolProps + BdevStater<Stats = BdevStats> + std::fmt::Debug 
 
     /// Reset the error stats of the pool disks.
     async fn reset_errors(&self) -> Result<(), Error>;
+
+    /// Reset stall transitions for the pool.
+    async fn reset_stall_transitions(&self) -> Result<(), Error>;
 }
 
 /// Interface for a pool factory which can be used for various

--- a/io-engine/src/pool_information.rs
+++ b/io-engine/src/pool_information.rs
@@ -28,6 +28,10 @@ impl PoolInfo {
     pub fn get(id: &str) -> Option<parking_lot::MappedRwLockReadGuard<'static, RwLock<PoolInfo>>> {
         pool_info(id)
     }
+    /// Clears the transition timestamps for the pool.
+    pub fn clear(&mut self) {
+        self.transition_timestamps.clear();
+    }
 }
 
 /// Returns write lock of the hashmap.


### PR DESCRIPTION
With this change user can selectively clear Pool Io errors (io-errors), IO stall transitions (io-stall-transitions) or both (all). 