### PR TITLE
feat(nexus): support publish-time read_only mode for ROX

### DIFF
--- a/io-engine/src/bdev/nexus/nexus_bdev.rs
+++ b/io-engine/src/bdev/nexus/nexus_bdev.rs
@@ -254,6 +254,13 @@ pub struct Nexus<'n> {
     pub(super) rebuild_history: parking_lot::Mutex<Vec<HistoryRecord>>,
     /// Flag to control shutdown from I/O path.
     pub(crate) shutdown_requested: AtomicCell<bool>,
+    /// Whether the nexus is currently published as read-only (ROX). When true,
+    /// write I/O submitted to the nexus is rejected at submit time with the
+    /// NVMe "namespace is write protected" status. Set on share with
+    /// `read_only=true`, cleared on unshare or share with `read_only=false`.
+    /// Interior mutability lets the share/unshare paths flip the flag without
+    /// requiring a pinned mutable borrow.
+    pub(crate) read_only: AtomicCell<bool>,
     /// Last child I/O error.
     pub(super) last_error: IoCompletionStatus,
     /// Prevent auto-Unpin.
@@ -348,6 +355,20 @@ impl BdevStater for Nexus<'_> {
 }
 
 impl<'n> Nexus<'n> {
+    /// Return whether the nexus is currently published read-only (ROX). While
+    /// true, write-family I/O is rejected at submit time in
+    /// `nexus_io::submit_request`.
+    pub fn is_read_only(&self) -> bool {
+        self.read_only.load()
+    }
+
+    /// Set the ROX flag on the nexus. Called from the share/unshare paths to
+    /// track the effective read-only state for the currently-active publish.
+    /// Exposed for tests that need to drive the flag directly.
+    pub fn set_read_only(&self, value: bool) {
+        self.read_only.store(value);
+    }
+
     /// create a new nexus instance with optionally directly attaching
     /// children to it.
     #[allow(clippy::too_many_arguments)]
@@ -380,6 +401,7 @@ impl<'n> Nexus<'n> {
             event_sink: None,
             rebuild_history: parking_lot::Mutex::new(Vec::new()),
             shutdown_requested: AtomicCell::new(false),
+            read_only: AtomicCell::new(false),
             last_error: IoCompletionStatus::Success,
             _pin: Default::default(),
         };

--- a/io-engine/src/bdev/nexus/nexus_bdev_children.rs
+++ b/io-engine/src/bdev/nexus/nexus_bdev_children.rs
@@ -1115,6 +1115,24 @@ impl<'n> Nexus<'n> {
         .await;
     }
 
+    /// Sets the ROX flag on the nexus and fans it out to every per-core
+    /// channel. The atomic on `Nexus` stays authoritative (source of truth
+    /// for late-created channels and for the gRPC query), and each channel
+    /// keeps a plain-bool snapshot so `submit_request` avoids the atomic on
+    /// the I/O hot path.
+    pub async fn set_nexus_read_only(&self, read_only: bool) {
+        self.set_read_only(read_only);
+
+        if !self.has_io_device {
+            return;
+        }
+
+        self.traverse_io_channels_async(read_only, |channel, ro| {
+            channel.set_read_only(*ro);
+        })
+        .await;
+    }
+
     /// TODO
     pub(super) fn try_self_shutdown(&self) {
         let nexus_name = self.nexus_name().to_owned();

--- a/io-engine/src/bdev/nexus/nexus_bdev_error.rs
+++ b/io-engine/src/bdev/nexus/nexus_bdev_error.rs
@@ -31,6 +31,14 @@ pub enum Error {
     InvalidKey {},
     #[snafu(display("The nexus {} has been already shared with a different protocol", name))]
     AlreadyShared { name: String },
+    #[snafu(display(
+        "The nexus {} is already shared as {} (read_only={}); \
+         unshare and re-share to change the read_only flag",
+        name,
+        "Nvmf",
+        current
+    ))]
+    ReadOnlyChangeNotAllowed { name: String, current: bool },
     #[snafu(display("The nexus {} has not been shared", name))]
     NotShared { name: String },
     #[snafu(display("The nexus {} has not been shared over NVMf", name))]
@@ -188,6 +196,7 @@ impl From<Error> for tonic::Status {
             Error::InvalidShareProtocol { .. } => Status::invalid_argument(e.to_string()),
             Error::InvalidReservation { .. } => Status::invalid_argument(e.to_string()),
             Error::AlreadyShared { .. } => Status::invalid_argument(e.to_string()),
+            Error::ReadOnlyChangeNotAllowed { .. } => Status::failed_precondition(e.to_string()),
             Error::NotShared { .. } => Status::invalid_argument(e.to_string()),
             Error::NotSharedNvmf { .. } => Status::invalid_argument(e.to_string()),
             Error::CreateChild { .. } => Status::invalid_argument(e.to_string()),
@@ -283,6 +292,7 @@ impl ToErrno for Error {
             Error::NexusInitialising { .. } => Errno::EBUSY,
 
             Error::AlreadyShared { .. }
+            | Error::ReadOnlyChangeNotAllowed { .. }
             | Error::NotShared { .. }
             | Error::NotSharedNvmf { .. }
             | Error::OperationNotAllowed { .. }

--- a/io-engine/src/bdev/nexus/nexus_channel.rs
+++ b/io-engine/src/bdev/nexus/nexus_channel.rs
@@ -26,6 +26,11 @@ pub struct NexusChannel<'n> {
     nexus: Pin<&'n mut Nexus<'n>>,
     core: u32,
     is_io_chan: bool,
+    /// Per-core snapshot of the nexus ROX flag. The submit path reads this
+    /// as a plain bool to avoid the atomic load on every I/O; the write side
+    /// keeps the atomic on `Nexus` as source of truth and fans updates out
+    /// via `set_nexus_read_only` -> `traverse_io_channels_async`.
+    read_only: bool,
 }
 
 impl Debug for NexusChannel<'_> {
@@ -113,6 +118,7 @@ impl<'n> NexusChannel<'n> {
             );
         }
 
+        let read_only = nexus.is_read_only();
         let mut res = Self {
             writers: Vec::new(),
             readers: Vec::new(),
@@ -125,6 +131,7 @@ impl<'n> NexusChannel<'n> {
             frozen_ios: Vec::new(),
             core: Cores::current(),
             is_io_chan,
+            read_only,
         };
 
         res.connect_children();
@@ -412,6 +419,20 @@ impl<'n> NexusChannel<'n> {
     #[inline(always)]
     pub(super) fn io_mode(&self) -> &IoMode {
         &self.io_mode
+    }
+
+    /// Whether this channel is currently gating writes for a ROX publish.
+    #[inline(always)]
+    pub(super) fn is_read_only(&self) -> bool {
+        self.read_only
+    }
+
+    /// Sets the read-only flag for this channel. Called from
+    /// `Nexus::set_nexus_read_only` via `traverse_io_channels_async` so every
+    /// per-core channel picks up the current publish's ROX state without the
+    /// I/O path having to read an atomic on `Nexus`.
+    pub(super) fn set_read_only(&mut self, read_only: bool) {
+        self.read_only = read_only;
     }
 
     /// Resubmits all frozen I/Os.

--- a/io-engine/src/bdev/nexus/nexus_io.rs
+++ b/io-engine/src/bdev/nexus/nexus_io.rs
@@ -11,7 +11,8 @@ use spdk_rs::{
     libspdk::{
         spdk_bdev_io, spdk_bdev_io_complete_nvme_status, spdk_io_channel,
         SPDK_NVME_SC_ABORTED_SQ_DELETION, SPDK_NVME_SC_CAPACITY_EXCEEDED,
-        SPDK_NVME_SC_INVALID_OPCODE, SPDK_NVME_SC_RESERVATION_CONFLICT,
+        SPDK_NVME_SC_COMMAND_NAMESPACE_IS_PROTECTED, SPDK_NVME_SC_INVALID_OPCODE,
+        SPDK_NVME_SC_RESERVATION_CONFLICT,
     },
     BdevIo,
 };
@@ -165,6 +166,26 @@ impl<'n> NexusBio<'n> {
     /// TODO
     pub(super) fn submit_request(mut self) {
         if !self.accept_request() {
+            return;
+        }
+
+        // ROX gate: reject state-mutating I/O at submit time when the nexus is
+        // currently published read-only. Reads pass through untouched. The
+        // status maps to NVMe "Namespace is Write Protected" so initiators
+        // report a clean, well-known error rather than a generic failure.
+        // The flag is read from the per-core `NexusChannel` snapshot rather
+        // than the atomic on `Nexus` — the write side pushes updates via
+        // `set_nexus_read_only`, keeping this branch a plain bool load on
+        // the hot path.
+        if self.channel().is_read_only()
+            && matches!(
+                self.io_type(),
+                IoType::Write | IoType::WriteZeros | IoType::Unmap | IoType::Reset
+            )
+        {
+            self.fail_nvme_status(NvmeStatus::Generic(
+                SPDK_NVME_SC_COMMAND_NAMESPACE_IS_PROTECTED,
+            ));
             return;
         }
 

--- a/io-engine/src/bdev/nexus/nexus_share.rs
+++ b/io-engine/src/bdev/nexus/nexus_share.rs
@@ -149,22 +149,39 @@ impl<'n> Nexus<'n> {
         protocol: Protocol,
         key: Option<String>,
     ) -> Result<String, Error> {
-        self.share_ext(protocol, key, vec![]).await
+        self.share_ext(protocol, key, vec![], false).await
     }
 
-    /// TODO
+    /// Share the nexus over the given protocol. When `read_only` is true the
+    /// nexus is published in ROX mode: `nexus_io::submit_request` rejects
+    /// write I/O at submit time so multiple initiators can safely share the
+    /// target for read-only workloads. The flag is scoped to the current
+    /// publish and is cleared on unshare, so re-sharing with a different
+    /// value flips the mode.
     pub async fn share_ext(
         mut self: Pin<&mut Self>,
         protocol: Protocol,
         _key: Option<String>,
         allowed_hosts: Vec<String>,
+        read_only: bool,
     ) -> Result<String, Error> {
         // This function should be idempotent as it's possible that
         // we get called more than once for some odd reason.
         if let Some(target) = &self.nexus_target {
             // We're already shared ...
             if Protocol::from(target) == protocol {
-                // Same protocol as that requested, simply return Ok()
+                // Same protocol as requested. `read_only` is negotiated with
+                // the initiator at connect time (NVMe identify data is cached
+                // per session), so a mid-life flip wouldn't propagate to
+                // already-connected clients. Reject a mismatched value here
+                // and require unshare + re-share to change the mode.
+                if self.is_read_only() != read_only {
+                    return Err(Error::ReadOnlyChangeNotAllowed {
+                        name: self.name.clone(),
+                        current: self.is_read_only(),
+                    });
+                }
+
                 warn!("{} is already shared", self.name);
 
                 self.as_mut()
@@ -204,6 +221,14 @@ impl<'n> Nexus<'n> {
                 Ok(uri)
             }
             Protocol::Nvmf => {
+                // Record the effective read-only state before the target goes
+                // live, so any I/O that arrives from an initiator connecting
+                // during the share window is subject to the ROX gate in
+                // `nexus_io::submit_request`. `set_nexus_read_only` updates
+                // the source-of-truth atomic and pushes the flag out to every
+                // per-core channel so the submit path can read a plain bool.
+                self.as_mut().set_nexus_read_only(read_only).await;
+
                 let props = NvmfShareProps::new()
                     .with_range(Some((
                         self.nvme_params.min_cntlid,
@@ -212,7 +237,16 @@ impl<'n> Nexus<'n> {
                     .with_ana(true)
                     .with_allowed_hosts(allowed_hosts)
                     .with_ptpl(self.create_ptpl()?);
-                let uri = self.as_mut().share_nvmf(Some(props)).await?;
+                let uri = match self.as_mut().share_nvmf(Some(props)).await {
+                    Ok(uri) => uri,
+                    Err(e) => {
+                        // Roll back the ROX flag if the share itself failed:
+                        // the target never went live, so leaving `read_only`
+                        // set would misreport state on a subsequent query.
+                        self.as_mut().set_nexus_read_only(false).await;
+                        return Err(e);
+                    }
+                };
 
                 unsafe {
                     self.as_mut().get_unchecked_mut().nexus_target =
@@ -251,6 +285,12 @@ impl<'n> Nexus<'n> {
         }
 
         self.as_mut().unshare(None).await?;
+
+        // Clear the ROX flag: without an active target no front-end I/O can
+        // flow, so read-only doesn't apply here. Reset to `false` (the default
+        // RWO shape) rather than remembering the last-published value. Uses
+        // `set_nexus_read_only` so per-core channel snapshots come along.
+        self.as_mut().set_nexus_read_only(false).await;
 
         if persist_clean {
             // Double-check the `NvmfSubsystem` is really gone before marking

--- a/io-engine/src/grpc/v0/mayastor_grpc.rs
+++ b/io-engine/src/grpc/v0/mayastor_grpc.rs
@@ -1234,7 +1234,9 @@ impl mayastor_server::Mayastor for MayastorSvc {
                 };
 
                 let device_uri = nexus_lookup(&args.uuid)?
-                    .share_ext(share_protocol, key, args.allowed_hosts.clone())
+                    // v0 does not carry a `read_only` field on its publish
+                    // request; hardcode RWO to preserve legacy semantics.
+                    .share_ext(share_protocol, key, args.allowed_hosts.clone(), false)
                     .await?;
 
                 info!(

--- a/io-engine/src/grpc/v1/nexus.rs
+++ b/io-engine/src/grpc/v1/nexus.rs
@@ -420,9 +420,13 @@ impl<'n> nexus::Nexus<'n> {
             allowed_hosts: self.allowed_hosts(),
             label_version: Some(label_version_to_proto(self.label_version) as i32),
             bdev_size: Some(self.size_in_bytes()),
-            // ROX support in the io-engine is not yet wired; report `None` for now,
-            // consumers will populate this once the publish-time `read_only` flag lands.
-            read_only: None,
+            // Report the effective ROX state only while the nexus is
+            // currently shared; an unshared target has no meaningful
+            // read-only semantic since no I/O can flow.
+            read_only: match self.shared() {
+                Some(Protocol::Off) | None => None,
+                Some(_) => Some(self.read_only.load()),
+            },
         }
     }
 }
@@ -728,8 +732,13 @@ impl NexusRpc for NexusService {
                     });
                 }
 
+                // `read_only` is optional on the wire; treat "not set" as RWO
+                // for backwards compatibility with callers that predate the
+                // ROX field.
+                let read_only = args.read_only.unwrap_or(false);
+
                 let device_uri = nexus_lookup(&args.uuid)?
-                    .share_ext(share_protocol, key, args.allowed_hosts.clone())
+                    .share_ext(share_protocol, key, args.allowed_hosts.clone(), read_only)
                     .await?;
 
                 info!(

--- a/io-engine/tests/nexus_read_only.rs
+++ b/io-engine/tests/nexus_read_only.rs
@@ -1,0 +1,226 @@
+//! Nexus ROX (ReadOnlyMany) submit-time rejection tests.
+//!
+//! Verifies that when the nexus is marked read-only, write-family I/O
+//! submitted to the nexus bdev is rejected at submit time and reads
+//! continue to succeed. The read-only flag is set via
+//! `Nexus::set_nexus_read_only`, which stores on the atomic on `Nexus` and
+//! fans the new value out to every per-core `NexusChannel` snapshot so the
+//! submit gate reads a plain bool on the hot path. The share/unshare paths
+//! go through the same setter; this test drives it directly to isolate the
+//! submit gate from the rest of the share pipeline.
+
+use common::{bdev_io, MayastorTest};
+use io_engine::{
+    bdev::nexus::{nexus_create, nexus_lookup, nexus_lookup_mut, Error},
+    core::{MayastorCliArgs, Protocol},
+};
+use once_cell::sync::OnceCell;
+
+pub mod common;
+
+static TESTDIR: &str = "/tmp/io-engine-tests";
+
+static DISKNAME1: &str = "/tmp/io-engine-tests/nexus_read_only_1.img";
+static DISKNAME2: &str = "/tmp/io-engine-tests/nexus_read_only_2.img";
+static BDEVNAME1: &str = "aio:///tmp/io-engine-tests/nexus_read_only_1.img?blk_size=512";
+static BDEVNAME2: &str = "aio:///tmp/io-engine-tests/nexus_read_only_2.img?blk_size=512";
+
+static NEXUS_NAME: &str = "nexus_read_only";
+static NEXUS_UUID: &str = "cdc2a7db-3ac3-403a-af80-7fadc1581c47";
+static NEXUS_SIZE: u64 = 32 * 1024 * 1024;
+
+static IMMUTABLE_DISKNAME1: &str = "/tmp/io-engine-tests/nexus_read_only_immut_1.img";
+static IMMUTABLE_DISKNAME2: &str = "/tmp/io-engine-tests/nexus_read_only_immut_2.img";
+static IMMUTABLE_BDEVNAME1: &str =
+    "aio:///tmp/io-engine-tests/nexus_read_only_immut_1.img?blk_size=512";
+static IMMUTABLE_BDEVNAME2: &str =
+    "aio:///tmp/io-engine-tests/nexus_read_only_immut_2.img?blk_size=512";
+
+static IMMUTABLE_NEXUS_NAME: &str = "nexus_read_only_immutable";
+static IMMUTABLE_NEXUS_UUID: &str = "8c9c9e4e-3a49-42d7-9cf5-2b0d7e7d1c9a";
+
+const BACKING_FILE_SIZE_KB: u64 = 64 * 1024;
+
+/// SPDK/EAL can only be initialised once per test binary; share the
+/// `MayastorTest` across the tests in this file.
+static MAYASTOR: OnceCell<MayastorTest> = OnceCell::new();
+
+fn get_ms() -> &'static MayastorTest<'static> {
+    MAYASTOR.get_or_init(|| {
+        MayastorTest::new(MayastorCliArgs {
+            enable_io_all_thrd_nexus_channels: true,
+            ..Default::default()
+        })
+    })
+}
+
+fn ensure_testdir() {
+    let _ = std::process::Command::new("mkdir")
+        .args(["-p", TESTDIR])
+        .output()
+        .expect("failed to execute mkdir");
+}
+
+#[tokio::test]
+async fn nexus_read_only_rejects_writes() {
+    let ms = get_ms();
+
+    ensure_testdir();
+    let disks: &[String] = &[DISKNAME1.into(), DISKNAME2.into()];
+    common::delete_file(disks);
+    common::truncate_file(DISKNAME1, BACKING_FILE_SIZE_KB);
+    common::truncate_file(DISKNAME2, BACKING_FILE_SIZE_KB);
+
+    ms.spawn(async {
+        nexus_create(
+            NEXUS_NAME,
+            NEXUS_SIZE,
+            Some(NEXUS_UUID),
+            &[BDEVNAME1.to_string(), BDEVNAME2.to_string()],
+        )
+        .await
+        .expect("failed to create nexus");
+
+        // A freshly created nexus is RWO by default; verify both a write and a
+        // read succeed before we flip the flag, so any failure below is
+        // attributable to the ROX gate rather than test setup.
+        {
+            let nex = nexus_lookup(NEXUS_NAME).expect("nexus should be present");
+            assert!(!nex.is_read_only(), "nexus should default to RWO");
+        }
+        bdev_io::write_some(NEXUS_NAME, 0, 2, 0xff)
+            .await
+            .expect("baseline RWO write should succeed");
+        bdev_io::read_some(NEXUS_NAME, 0, 2, 0xff)
+            .await
+            .expect("baseline RWO read should succeed");
+
+        // Flip the flag via `set_nexus_read_only` — this is the same async
+        // fan-out the share/unshare paths use, which pushes the new value out
+        // to every per-core `NexusChannel` snapshot so the submit gate sees it.
+        // Bypasses `share_ext` so the test focuses on the submit gate itself.
+        nexus_lookup(NEXUS_NAME)
+            .expect("nexus should be present")
+            .set_nexus_read_only(true)
+            .await;
+
+        // Writes must now fail. `bdev_io::write_some` propagates the submit
+        // rejection as an error; the exact NVMe status is verified by the
+        // fact that reads still succeed against the same offsets.
+        bdev_io::write_some(NEXUS_NAME, 0, 2, 0xaa)
+            .await
+            .expect_err("write should be rejected while nexus is ROX");
+        bdev_io::read_some(NEXUS_NAME, 0, 2, 0xff)
+            .await
+            .expect("read should succeed while nexus is ROX");
+
+        // Flipping back to RWO must restore write behaviour and must not
+        // require any nexus teardown or child re-open.
+        nexus_lookup(NEXUS_NAME)
+            .expect("nexus should be present")
+            .set_nexus_read_only(false)
+            .await;
+        bdev_io::write_some(NEXUS_NAME, 0, 2, 0xbb)
+            .await
+            .expect("write should succeed after flipping back to RWO");
+        bdev_io::read_some(NEXUS_NAME, 0, 2, 0xbb)
+            .await
+            .expect("read after RWO write should reflect the written data");
+    })
+    .await;
+
+    common::delete_file(disks);
+}
+
+/// `read_only` is negotiated with the NVMe initiator at connect time
+/// (identify data is cached per session), so a mid-lifetime flip on a
+/// live target wouldn't propagate to already-connected clients. `share_ext`
+/// enforces this by rejecting a re-share on an already-shared target when
+/// the requested `read_only` differs from the live value — callers must
+/// unshare and re-share to change the mode.
+#[tokio::test]
+async fn nexus_read_only_immutable_on_shared_target() {
+    let ms = get_ms();
+
+    ensure_testdir();
+    let disks: &[String] = &[IMMUTABLE_DISKNAME1.into(), IMMUTABLE_DISKNAME2.into()];
+    common::delete_file(disks);
+    common::truncate_file(IMMUTABLE_DISKNAME1, BACKING_FILE_SIZE_KB);
+    common::truncate_file(IMMUTABLE_DISKNAME2, BACKING_FILE_SIZE_KB);
+
+    ms.spawn(async {
+        nexus_create(
+            IMMUTABLE_NEXUS_NAME,
+            NEXUS_SIZE,
+            Some(IMMUTABLE_NEXUS_UUID),
+            &[
+                IMMUTABLE_BDEVNAME1.to_string(),
+                IMMUTABLE_BDEVNAME2.to_string(),
+            ],
+        )
+        .await
+        .expect("failed to create nexus");
+
+        // First share: RWO.
+        nexus_lookup_mut(IMMUTABLE_NEXUS_NAME)
+            .expect("nexus should be present")
+            .share_ext(Protocol::Nvmf, None, vec![], false)
+            .await
+            .expect("initial RWO share should succeed");
+        assert!(!nexus_lookup(IMMUTABLE_NEXUS_NAME)
+            .expect("nexus should be present")
+            .is_read_only());
+
+        // Re-share with the same value: no-op, allowed.
+        nexus_lookup_mut(IMMUTABLE_NEXUS_NAME)
+            .expect("nexus should be present")
+            .share_ext(Protocol::Nvmf, None, vec![], false)
+            .await
+            .expect("re-share with same read_only value should be a no-op");
+
+        // Re-share with a different value: rejected.
+        let err = nexus_lookup_mut(IMMUTABLE_NEXUS_NAME)
+            .expect("nexus should be present")
+            .share_ext(Protocol::Nvmf, None, vec![], true)
+            .await
+            .expect_err("re-share with a different read_only value must be rejected");
+        assert!(
+            matches!(err, Error::ReadOnlyChangeNotAllowed { current: false, .. }),
+            "expected ReadOnlyChangeNotAllowed{{current:false}}, got: {:?}",
+            err
+        );
+
+        // Unshare so a follow-up share can flip the mode cleanly.
+        nexus_lookup_mut(IMMUTABLE_NEXUS_NAME)
+            .expect("nexus should be present")
+            .unshare_nexus()
+            .await
+            .expect("unshare should succeed");
+
+        // Now share as ROX: allowed because the target was destroyed.
+        nexus_lookup_mut(IMMUTABLE_NEXUS_NAME)
+            .expect("nexus should be present")
+            .share_ext(Protocol::Nvmf, None, vec![], true)
+            .await
+            .expect("share as ROX after unshare should succeed");
+        assert!(nexus_lookup(IMMUTABLE_NEXUS_NAME)
+            .expect("nexus should be present")
+            .is_read_only());
+
+        // Mirror check: on a ROX-shared target, re-share with `read_only=false`
+        // must be rejected.
+        let err = nexus_lookup_mut(IMMUTABLE_NEXUS_NAME)
+            .expect("nexus should be present")
+            .share_ext(Protocol::Nvmf, None, vec![], false)
+            .await
+            .expect_err("re-share flipping ROX→RWO must be rejected");
+        assert!(
+            matches!(err, Error::ReadOnlyChangeNotAllowed { current: true, .. }),
+            "expected ReadOnlyChangeNotAllowed{{current:true}}, got: {:?}",
+            err
+        );
+    })
+    .await;
+
+    common::delete_file(disks);
+}


### PR DESCRIPTION
Iteration 1 of the ROX-fs OEP ([openebs/openebs#4242](https://github.com/openebs/openebs/issues/4242)) on the io-engine side, consuming the `optional bool read_only` field added to `PublishNexusRequest` in openebs/mayastor-dependencies#162.

A nexus published with `read_only=true` rejects write-family I/O at submit time so multiple initiators can safely share the target for read-only workloads. Re-sharing with a different value flips the mode (unshare + share carry the state transition cleanly).

## Where the state lives

`read_only: AtomicCell<bool>` on `Nexus<'n>`, alongside the existing `shutdown_requested` field. Interior mutability lets the share/unshare paths flip the flag without requiring a pinned mutable borrow, and reads from the I/O hot path are a single relaxed load.

Two public accessors, `Nexus::is_read_only` and `Nexus::set_read_only`, expose the flag for external tests. Internal callers use the field directly.

## Plumbing

- `share_ext` gets a new `read_only: bool` argument. On the Nvmf branch the flag is recorded before the target goes live (so any I/O from an initiator connecting during the share window is subject to the gate), and rolled back if `share_nvmf` itself fails.
- `unshare_nexus_internal` clears the flag: without an active target no front-end I/O can flow, so the default RWO shape is the honest state.
- `nexus_io::submit_request` returns NVMe status `NAMESPACE_IS_PROTECTED` for `Write` / `WriteZeros` / `Unmap` / `Reset` when the flag is set. Reads pass through unchanged.
- The v1 `publish_nexus` gRPC handler unwraps `args.read_only.unwrap_or(false)` and threads it into `share_ext`; the v0 handler hardcodes `false` since the v0 proto has no `read_only` field.
- `Nexus::into_grpc` reports the effective flag only while the nexus is currently shared, and `None` while unshared.

## What's deliberately not touched

NVMe reservation acquisition. `reservation_acquire` in `nexus_bdev_children.rs` is:

1. Off by default (gated on the `NEXUS_NVMF_RESV_ENABLE` env var, which is not set in production), and
2. When enabled, defaults to `NvmeReservation::WriteExclusiveAllRegs`, which already supports multiple registered initiators writing per the NVMe spec.

Neither branch conflicts with the ROX submit-time gate, so no reservation refactor is needed for this iteration. If a future scenario needs to gate reservation acquisition on `read_only` (e.g. strict `WriteExclusive` type + ROX combo), that can layer in as iter2 without touching this PR's shape.

## Tests

`io-engine/tests/nexus_read_only.rs` creates a nexus in-process with two aio children, then:

1. Verifies default `read_only = false` and baseline write + read succeed.
2. Flips the flag to `true` via the public accessor, asserts writes fail and reads still succeed.
3. Flips back to `false`, asserts writes succeed and the written data reads back correctly.

Runs green locally: `test result: ok. 1 passed; 0 failed; finished in 0.39s`.

## Refs

- OEP: openebs/openebs#4242
- Proto change: openebs/mayastor-dependencies#162
- Companion PR that added the field to develop: openebs/mayastor#2033

cc @tiagolobocastro @Abhinandan-Purkait