### PR TITLE
Nexus Label V2 - implement requested size constraint

### DIFF
--- a/io-engine/src/bdev/nexus/nexus_bdev.rs
+++ b/io-engine/src/bdev/nexus/nexus_bdev.rs
@@ -221,6 +221,8 @@ pub struct Nexus<'n> {
     /// be larger. The actual Nexus size will be calculated based on the
     /// capabilities of the underlying child devices.
     req_size: u64,
+    /// The size of the nexus bdev must match the requested size exactly.
+    req_size_exact: bool,
     /// Vector of nexus children.
     pub(super) children: Vec<NexusChild<'n>>,
     /// NVMe parameters
@@ -348,9 +350,11 @@ impl BdevStater for Nexus<'_> {
 impl<'n> Nexus<'n> {
     /// create a new nexus instance with optionally directly attaching
     /// children to it.
+    #[allow(clippy::too_many_arguments)]
     fn new(
         name: &str,
         size: u64,
+        size_exact: bool,
         bdev_uuid: Option<&str>,
         nexus_uuid: Option<uuid::Uuid>,
         nvme_params: NexusNvmeParams,
@@ -365,6 +369,7 @@ impl<'n> Nexus<'n> {
             data_ent_offset: 0,
             label_version,
             req_size: size,
+            req_size_exact: size_exact,
             nexus_target: None,
             nvme_params,
             has_io_device: false,
@@ -522,6 +527,11 @@ impl<'n> Nexus<'n> {
     /// TODO
     pub fn req_size(&self) -> u64 {
         self.req_size
+    }
+
+    /// The requested size of the Nexus in blocks.
+    pub fn req_size_blks(&self) -> u64 {
+        self.req_size / self.block_len()
     }
 
     /// Returns the actual size of the Nexus instance, in bytes.
@@ -734,6 +744,15 @@ impl<'n> Nexus<'n> {
             }
         }
         let size_blks = end_blk - start_blk + 1;
+        let req_size_blks = self.req_size() / blk_size;
+
+        if self.req_size_exact && req_size_blks != size_blks {
+            return Err(Error::NexusSizeUnmatched {
+                name,
+                requested: self.req_size(),
+                got: size_blks * blk_size,
+            });
+        }
 
         unsafe {
             self.as_mut().set_data_ent_offset(start_blk);
@@ -1414,13 +1433,14 @@ pub async fn nexus_create(
     uuid: Option<&str>,
     children: &[String],
 ) -> Result<(), Error> {
-    nexus_create_ext(name, size, uuid, children, LabelVersion::V1).await
+    nexus_create_ext(name, size, false, uuid, children, LabelVersion::V1).await
 }
 
 /// Same as [`nexus_create`] but allows specifying the label version to use for the nexus.
 pub async fn nexus_create_ext(
     name: &str,
     size: u64,
+    size_exact: bool,
     uuid: Option<&str>,
     children: &[String],
     label_version: LabelVersion,
@@ -1428,6 +1448,7 @@ pub async fn nexus_create_ext(
     nexus_create_internal(
         name,
         size,
+        size_exact,
         uuid,
         None,
         NexusNvmeParams::default(),
@@ -1443,9 +1464,11 @@ pub async fn nexus_create_ext(
 /// resv_key: NVMe reservation key for children
 /// label_version: on-disk label layout version used to compute partition
 /// offsets on the child devices.
+#[allow(clippy::too_many_arguments)]
 pub async fn nexus_create_v2(
     name: &str,
     size: u64,
+    size_exact: bool,
     uuid: &str,
     nvme_params: NexusNvmeParams,
     children: &[String],
@@ -1489,6 +1512,7 @@ pub async fn nexus_create_v2(
             nexus_create_internal(
                 name,
                 size,
+                size_exact,
                 Some(bdev_uuid.as_str()),
                 Some(nexus_uuid),
                 nvme_params,
@@ -1502,6 +1526,7 @@ pub async fn nexus_create_v2(
             nexus_create_internal(
                 name,
                 size,
+                size_exact,
                 Some(uuid),
                 None,
                 nvme_params,
@@ -1518,6 +1543,7 @@ pub async fn nexus_create_v2(
 async fn nexus_create_internal(
     name: &str,
     size: u64,
+    size_exact: bool,
     bdev_uuid: Option<&str>,
     nexus_uuid: Option<Uuid>,
     nvme_params: NexusNvmeParams,
@@ -1555,6 +1581,7 @@ async fn nexus_create_internal(
     let mut nexus_bdev = Nexus::new(
         name,
         size,
+        size_exact,
         bdev_uuid,
         nexus_uuid,
         nvme_params,

--- a/io-engine/src/bdev/nexus/nexus_bdev_error.rs
+++ b/io-engine/src/bdev/nexus/nexus_bdev_error.rs
@@ -163,6 +163,12 @@ pub enum Error {
     UpdateShareProperties { source: CoreError, name: String },
     #[snafu(display("failed to save nexus state {name}, {source}"))]
     SaveStateFailed { source: StoreError, name: String },
+    #[snafu(display("Nexus {name} requested {requested}B but got {got}B"))]
+    NexusSizeUnmatched {
+        name: String,
+        requested: u64,
+        got: u64,
+    },
 }
 
 impl From<NvmfError> for Error {
@@ -226,6 +232,7 @@ impl From<Error> for tonic::Status {
             Error::SubsysNvmf { .. } => Status::internal(e.to_string()),
             Error::UpdateShareProperties { .. } => Status::internal(e.to_string()),
             Error::SaveStateFailed { .. } => Status::data_loss(e.to_string()),
+            Error::NexusSizeUnmatched { .. } => Status::invalid_argument(e.to_string()),
         };
         status
             .metadata_mut()
@@ -295,7 +302,7 @@ impl ToErrno for Error {
             | Error::NoRebuildSource { .. } => Errno::EFAULT,
 
             // This is something we'll have to handle better
-            Error::MixedBlockSizes { .. } => Errno::EINVAL,
+            Error::MixedBlockSizes { .. } | Error::NexusSizeUnmatched { .. } => Errno::EINVAL,
         }
     }
 }

--- a/io-engine/src/bin/io-engine-client/v1/nexus_cli.rs
+++ b/io-engine/src/bin/io-engine-client/v1/nexus_cli.rs
@@ -55,6 +55,23 @@ enum NvmeAnaState {
     Inaccessible,
 }
 
+/// Nexus on-disk label version
+#[derive(Debug, Default, Clone, clap::ValueEnum)]
+enum NexusLabelVersion {
+    #[default]
+    V1,
+    V2,
+}
+
+impl From<NexusLabelVersion> for v1::nexus::NexusLabelVersion {
+    fn from(v: NexusLabelVersion) -> Self {
+        match v {
+            NexusLabelVersion::V1 => v1::nexus::NexusLabelVersion::LabelV1,
+            NexusLabelVersion::V2 => v1::nexus::NexusLabelVersion::LabelV2,
+        }
+    }
+}
+
 #[derive(Debug, Args)]
 #[command(subcommand_required = true, arg_required_else_help = true)]
 pub struct NexusArgs {
@@ -122,6 +139,12 @@ struct CreateArgs {
     /// key used to persist the NexusInfo structure
     #[arg(long = "nexus-info-key", default_value = "")]
     nexus_info_key: String,
+    /// The nexus on-disk label version.
+    #[arg(long)]
+    label_version: Option<NexusLabelVersion>,
+    /// Disable requested-size enforcement.
+    #[arg(long)]
+    required_size: Option<bool>,
 }
 
 #[derive(Debug, Args)]
@@ -224,24 +247,43 @@ async fn nexus_create(mut ctx: Context, args: CreateArgs) -> crate::Result<()> {
 
     let resv_type = args.resv_type.map(|t| NvmeReservation::from(t) as i32);
 
-    let response = ctx
-        .v1
-        .nexus
-        .create_nexus(v1::nexus::CreateNexusRequest {
-            name,
-            uuid: uuid.clone(),
-            size: args.size.as_u64(),
-            min_cntl_id: args.min_cntlid,
-            max_cntl_id: args.max_cntlid,
-            resv_key: args.resv_key,
-            preempt_key: args.preempt_key,
-            children: args.children.iter().map(|u| u.to_string()).collect(),
-            nexus_info_key: args.nexus_info_key,
-            resv_type,
-            preempt_policy: 0,
+    let create_request = v1::nexus::CreateNexusRequest {
+        name,
+        uuid: uuid.clone(),
+        size: args.size.as_u64(),
+        min_cntl_id: args.min_cntlid,
+        max_cntl_id: args.max_cntlid,
+        resv_key: args.resv_key,
+        preempt_key: args.preempt_key,
+        children: args.children.iter().map(|u| u.to_string()).collect(),
+        nexus_info_key: args.nexus_info_key,
+        resv_type,
+        preempt_policy: 0,
+    };
+
+    let label_version = args.label_version.unwrap_or(NexusLabelVersion::V2);
+    let required_size = args.required_size.unwrap_or(true);
+
+    let api = &mut ctx.v1.nexus;
+    let response = match api
+        .create_nexus_v2(v1::nexus::CreateNexusV2Request {
+            v1: Some(create_request.clone()),
+            label_version: v1::nexus::NexusLabelVersion::from(label_version) as i32,
+            required_size,
         })
         .await
-        .context(GrpcStatus)?;
+    {
+        Ok(response) => response,
+        Err(status) if status.code() == Code::Unimplemented => {
+            api.create_nexus(create_request).await.context(GrpcStatus)?
+        }
+        Err(status) => {
+            return Err(crate::ClientError::GrpcStatus {
+                source: status,
+                backtrace: None,
+            });
+        }
+    };
 
     match ctx.output {
         OutputFormat::Json => {
@@ -255,7 +297,7 @@ async fn nexus_create(mut ctx: Context, args: CreateArgs) -> crate::Result<()> {
             let val = &response.get_ref().nexus.as_ref().unwrap().uuid;
             println!("{val}");
         }
-    };
+    }
 
     Ok(())
 }

--- a/io-engine/src/core/gpt/maya.rs
+++ b/io-engine/src/core/gpt/maya.rs
@@ -19,6 +19,17 @@ use super::{
     primitives::{Aligned, GptDiskProps, GptEntry, GptGuid, GptHeader, GptLabel, LabelError},
 };
 
+fn align_down(value: u64, align: u64) -> u64 {
+    value - value % align
+}
+
+fn align_up(value: u64, align: u64) -> u64 {
+    match value % align {
+        0 => value,
+        rem => value.saturating_add(align - rem),
+    }
+}
+
 /// Partition Type GUID for the `MayaMeta` partition.
 pub const META_TYPE_GUID: &str = "27663382-e5e6-11e9-81b4-ca5ca5ca5ca5";
 /// Partition Type GUID for the `MayaData` partition.
@@ -43,8 +54,12 @@ pub trait Layout {
     /// Alignment (in bytes) of the data partition length. A value `<=`
     /// the device block size means no extra alignment beyond the block.
     /// When larger, the data length is rounded down to a multiple of
-    /// this value, leaving a trailing void in the last usable region.
+    /// this value.
     const DATA_ALIGN_SIZE: u64;
+    /// Size (in bytes) of a fixed trailing void reserved between the
+    /// end of the data partition and the last usable block. Zero means
+    /// no reservation (data may extend up to `last_usable`).
+    const TRAILING_VOID_SIZE: u64;
     /// Which [`LabelVersion`] this layout represents.
     const VERSION: LabelVersion;
 }
@@ -85,21 +100,40 @@ fn data_extent<L: Layout>(
         return Err(too_small());
     }
 
-    let max_blocks = last_usable - data_start + 1;
-    let req_blocks = Aligned::get_blocks(req_size, block_size);
-    let clamped = min(req_blocks, max_blocks);
-
-    // Round the length down to the version's data alignment (no-op for
-    // V1 and any version whose alignment fits in a single block).
-    let data_blocks = if L::DATA_ALIGN_SIZE > 0 {
-        let cluster_blocks = Aligned::get_blocks(L::DATA_ALIGN_SIZE, block_size);
-        clamped & !(cluster_blocks - 1)
+    // Reserve a fixed trailing void (if any) from the end of the device.
+    let trailing_blocks = Aligned::get_blocks(L::TRAILING_VOID_SIZE, block_size);
+    let usable_end = if trailing_blocks > 0 {
+        if trailing_blocks + data_start >= num_blocks {
+            return Err(too_small());
+        }
+        // usable_end is the last block *before* the void starts.
+        let void_start = num_blocks - trailing_blocks;
+        void_start - 1
     } else {
-        clamped
+        last_usable
     };
 
+    let max_blocks = usable_end - data_start + 1;
+    let req_blocks = Aligned::get_blocks(req_size, block_size);
+
+    // Round available capacity down to fit, but round requested size up to
+    // satisfy the version's data alignment.
+    let data_blocks = if L::DATA_ALIGN_SIZE > 0 {
+        let cluster_blocks = Aligned::get_blocks(L::DATA_ALIGN_SIZE, block_size);
+        min(
+            align_up(req_blocks, cluster_blocks),
+            align_down(max_blocks, cluster_blocks),
+        )
+    } else {
+        min(req_blocks, max_blocks)
+    };
+
+    if data_blocks == 0 {
+        return Err(too_small());
+    }
+
     let data_end = data_start + data_blocks - 1;
-    if data_end > last_usable || data_end < data_start {
+    if data_end > usable_end || data_end < data_start {
         return Err(too_small());
     }
 
@@ -207,6 +241,7 @@ pub mod v1 {
         const META_SIZE: u64 = 4 * 1024 * 1024;
         const DATA_START_OFFSET: u64 = 5 * 1024 * 1024;
         const DATA_ALIGN_SIZE: u64 = 0;
+        const TRAILING_VOID_SIZE: u64 = 0;
         const VERSION: LabelVersion = LabelVersion::V1;
     }
 
@@ -331,41 +366,41 @@ pub mod v1 {
 
 /// V2 of the on-disk label layout.
 ///
-/// 3 MiB metadata partition, data aligned to a 4 MiB cluster boundary with
-/// a trailing 4 MiB void reserved (never allocated on a default cluster).
+/// 3 MiB metadata partition, data aligned down to a 1 MiB boundary with a
+/// fixed 4 MiB trailing void reserved before the end of the device.
 ///
 /// The metadata size is reduced to 3 MiB so that the data partition starts
-/// at a 4 MiB offset, aligning user data to the default cluster size. The
-/// last 4 MiB are reserved as a void so the data length is also a multiple
-/// of 4 MiB; this isn't fully foolproof for larger cluster sizes, but those
-/// can be addressed in a future version bump. Replacing 4 MiB with the
-/// actual cluster size will also require changing the wipe of the first
-/// 8 MiB when replicas are created to ensure typical fs data is cleared.
+/// at a 4 MiB offset, aligning user data to the default cluster size. A
+/// fixed 4 MiB region is always reserved between the end of the data
+/// partition and the last usable block; the data length itself is only
+/// required to be a multiple of 1 MiB (and is therefore not necessarily a
+/// multiple of 4 MiB).
 ///
 /// Device layout:
 ///
 /// ```text
-/// 0     ───── reserved for protective MBR
-/// 1     ───── reserved for primary GPT header
-/// 2     ──┐
-///         ├── reserved for GPT entries
-/// 33    ──┘
-/// 34    ──┐
-///         ├── unused
-/// 2047  ──┘
-/// 2048  ──┐
-///         ├── 3M reserved for metadata
-/// 8191  ──┘
+/// 0        ───── reserved for protective MBR
+/// 1        ───── reserved for primary GPT header
+/// 2        ──┐
+///            ├── reserved for GPT entries
+/// 33       ──┘
+/// 34       ──┐
+///            ├── unused
+/// 2047     ──┘
+/// 2048     ──┐
+///            ├── 3 MiB reserved for metadata
+/// 8191     ──┘
 /// 8192     ────┐
-///              ├── available for user data (this is what the nexus bdev exposes)
+///              ├── available for user data, 1 MiB aligned length
+///              │   (this is what the nexus bdev exposes)
 /// N-4MiB-1 ────┘
 /// N-4MiB   ──┐
-///            ├── void to ensure user data is a multiple of 4 MiB (matches default cluster size)
+///            ├── fixed 4 MiB void reserved before end of device
 /// N-34     ──┘
-/// N-33  ──┐
-///         ├── reserved for the copy of GPT entries
-/// N-2   ──┘
-/// N-1   ───── last device block, reserved for secondary GPT header
+/// N-33     ──┐
+///            ├── reserved for the copy of GPT entries
+/// N-2      ──┘
+/// N-1      ───── last device block, reserved for secondary GPT header
 /// ```
 pub mod v2 {
     use super::*;
@@ -376,7 +411,8 @@ pub mod v2 {
     impl Layout for V2 {
         const META_SIZE: u64 = 3 * 1024 * 1024;
         const DATA_START_OFFSET: u64 = 4 * 1024 * 1024;
-        const DATA_ALIGN_SIZE: u64 = 4 * 1024 * 1024;
+        const DATA_ALIGN_SIZE: u64 = 1024 * 1024;
+        const TRAILING_VOID_SIZE: u64 = 4 * 1024 * 1024;
         const VERSION: LabelVersion = LabelVersion::V2;
     }
 
@@ -405,81 +441,95 @@ pub mod v2 {
             Aligned::get_blocks(V2::DATA_ALIGN_SIZE, block_size)
         }
 
+        fn trailing_void_blks(block_size: u64) -> u64 {
+            Aligned::get_blocks(V2::TRAILING_VOID_SIZE, block_size)
+        }
+
         #[test]
         fn data_extents() {
             // 12 MiB device / 512 = 24_576 blocks
             let num_blocks = 24_576;
             let block_size = 512;
-            let aligned_end = DATA_START_BLKS + data_align_blks(block_size) - 1;
+            let void = trailing_void_blks(block_size);
 
             // pretend we want a size larger than the device so we fill it
             let extent = data_extent::<V2>(u64::MAX, num_blocks, block_size).unwrap();
             assert_eq!(extent.start, DATA_START_BLKS);
-            assert_eq!(extent.end, aligned_end);
+            // fills up to `num_blocks - 4 MiB - 1`
+            let max_blocks = num_blocks - void - DATA_START_BLKS;
+            let aligned_blocks = max_blocks & !(data_align_blks(block_size) - 1);
+            assert_eq!(extent.end, DATA_START_BLKS + aligned_blocks - 1);
             assert!(extent.is_multiple_of(V2::DATA_ALIGN_SIZE / block_size));
+            // exactly 4 MiB reserved before the end of the device
+            assert_eq!(num_blocks - 1 - extent.end, void);
+            // 12 MiB - 4 MiB meta/offset - 4 MiB void = 4 MiB usable
+            let size_bytes = (extent.end - extent.start + 1) * block_size;
+            assert_eq!(size_bytes, 4 * 1024 * 1024);
 
-            // request size with same size as device, should clamp+align to same result
-            let extent =
-                data_extent::<V2>(num_blocks * block_size, num_blocks, block_size).unwrap();
+            // 5 MiB request on a 12 MiB device -> clamped to 4 MiB
+            let extent = data_extent::<V2>(5 * 1024 * 1024, num_blocks, block_size).unwrap();
             assert_eq!(extent.start, DATA_START_BLKS);
-            assert_eq!(extent.end, aligned_end);
-            assert!(extent.is_multiple_of(V2::DATA_ALIGN_SIZE / block_size));
+            let size_bytes = (extent.end - extent.start + 1) * block_size;
+            assert_eq!(size_bytes, 4 * 1024 * 1024);
+            assert_eq!(num_blocks - 1 - extent.end, void);
 
-            // request size smaller size than device, still aligns down to one cluster
-            let extent =
-                data_extent::<V2>((num_blocks - 1) * block_size, num_blocks, block_size).unwrap();
+            // request 3 MiB on a 12 MiB device: fits exactly (3 MiB is 1 MiB aligned)
+            let extent = data_extent::<V2>(3 * 1024 * 1024, num_blocks, block_size).unwrap();
             assert_eq!(extent.start, DATA_START_BLKS);
-            assert_eq!(extent.end, aligned_end);
-            assert!(extent.is_multiple_of(V2::DATA_ALIGN_SIZE / block_size));
-
-            // request that wouldn't quite fill last_usable: still aligns down to one cluster
-            let extent = data_extent::<V2>(
-                (24_541 - DATA_START_BLKS + 1) * block_size,
-                num_blocks,
-                block_size,
-            )
-            .unwrap();
-            assert_eq!(extent.start, DATA_START_BLKS);
-            assert_eq!(extent.end, aligned_end);
-
-            // smallest viable V2 device: needs at least one full 4 MiB cluster of
-            // data, i.e. last_usable >= data_start + cluster - 1.
-            // num_blocks = gpt_reserved + meta_end + 1 + cluster
-            let gpt_reserved_blks =
-                Aligned::get_blocks(GptHeader::PARTITION_TABLE_SIZE, block_size) + 1;
             assert_eq!(
-                data_extent::<V2>(
-                    u64::MAX,
-                    gpt_reserved_blks + META_END_BLKS + 1 + data_align_blks(block_size),
-                    block_size,
-                )
-                .unwrap(),
+                extent.end,
+                DATA_START_BLKS + (3 * 1024 * 1024) / block_size - 1
+            );
+            assert!(extent.is_multiple_of(V2::DATA_ALIGN_SIZE / block_size));
+
+            // request 3.5 MiB on a 12 MiB device: aligned up to 4 MiB
+            let extent =
+                data_extent::<V2>(3 * 1024 * 1024 + 512 * 1024, num_blocks, block_size).unwrap();
+            assert_eq!(extent.start, DATA_START_BLKS);
+            assert_eq!(
+                extent.end,
+                DATA_START_BLKS + (4 * 1024 * 1024) / block_size - 1
+            );
+            let size_bytes = (extent.end - extent.start + 1) * block_size;
+            assert_eq!(size_bytes, 4 * 1024 * 1024);
+
+            // Smallest viable V2 device: 1 MiB of data plus the 4 MiB void.
+            let min_num_blocks = DATA_START_BLKS + data_align_blks(block_size) + void;
+            assert_eq!(
+                data_extent::<V2>(u64::MAX, min_num_blocks, block_size).unwrap(),
                 DataExtent {
                     start: DATA_START_BLKS,
-                    end: aligned_end,
+                    end: DATA_START_BLKS + data_align_blks(block_size) - 1,
                 }
             );
 
-            // one block short of fitting a full cluster -> too small
+            // one block short -> too small
             assert!(matches!(
-                data_extent::<V2>(
-                    u64::MAX,
-                    gpt_reserved_blks + META_END_BLKS + data_align_blks(block_size),
-                    block_size,
-                ),
+                data_extent::<V2>(u64::MAX, min_num_blocks - 1, block_size),
                 Err(LabelError::DeviceTooSmall { .. })
             ));
 
-            // 13 MiB device / 512 = 26_624 blocks
-            let num_blocks = 26_624;
-            let block_size = 512;
-            let aligned_end = DATA_START_BLKS + data_align_blks(block_size) - 1;
-
-            // pretend we want a size larger than the device so we fill it
+            // A 13 MiB device reserves 4 MiB from the actual end, leaving 5 MiB of data.
+            let num_blocks = (13 * 1024 * 1024) / block_size;
             let extent = data_extent::<V2>(u64::MAX, num_blocks, block_size).unwrap();
-            assert_eq!(extent.start, DATA_START_BLKS);
-            assert_eq!(extent.end, aligned_end + data_align_blks(block_size));
-            assert!(extent.is_multiple_of(V2::DATA_ALIGN_SIZE / block_size));
+            let size_bytes = (extent.end - extent.start + 1) * block_size;
+            assert_eq!(size_bytes, 5 * 1024 * 1024);
+            assert!(
+                size_bytes % (1024 * 1024) == 0,
+                "size must be 1 MiB aligned"
+            );
+            assert!(
+                size_bytes % (4 * 1024 * 1024) != 0,
+                "size must not be a multiple of 4 MiB for a 13 MiB device"
+            );
+            assert_eq!(num_blocks - 1 - extent.end, void);
+
+            // A 15 MiB device reserves 4 MiB from the actual end, leaving 7 MiB of data.
+            let num_blocks = (15 * 1024 * 1024) / block_size;
+            let extent = data_extent::<V2>(u64::MAX, num_blocks, block_size).unwrap();
+            let size_bytes = (extent.end - extent.start + 1) * block_size;
+            assert_eq!(size_bytes, 7 * 1024 * 1024);
+            assert_eq!(num_blocks - 1 - extent.end, void);
         }
 
         #[test]
@@ -499,8 +549,15 @@ pub mod v2 {
 
             let data = label.gpt.partition(DATA_NAME).unwrap();
             assert_eq!(data.ent_start, 8192);
+            // usable_end = 262_144 - 8192 - 1 = 253_951. max = 245_760 = 120 MiB,
+            // already 1 MiB aligned. data_end = 253_951.
             assert_eq!(data.ent_end, 253_951);
             assert!(data.is_multiple_of(V2::DATA_ALIGN_SIZE / disk.block_size));
+            // exactly 4 MiB reserved before the end of the device
+            assert_eq!(
+                disk.num_blocks - 1 - data.ent_end,
+                4 * 1024 * 1024 / disk.block_size
+            );
 
             assert!(label.check());
             assert_eq!(LabelVersion::detect(&label.gpt), Some(LabelVersion::V2));
@@ -520,8 +577,14 @@ pub mod v2 {
 
             let data = label.gpt.partition(DATA_NAME).unwrap();
             assert_eq!(data.ent_start, 1024);
+            // usable_end = 262_144 - 1024 - 1 = 261_119. max = 260_096 = 1016 MiB,
+            // already 1 MiB aligned. data_end = 261_119.
             assert_eq!(data.ent_end, 261_119);
             assert!(data.is_multiple_of(V2::DATA_ALIGN_SIZE / disk.block_size));
+            assert_eq!(
+                disk.num_blocks - 1 - data.ent_end,
+                4 * 1024 * 1024 / disk.block_size
+            );
 
             assert!(label.check());
             assert_eq!(LabelVersion::detect(&label.gpt), Some(LabelVersion::V2));

--- a/io-engine/src/grpc/v0/mayastor_grpc.rs
+++ b/io-engine/src/grpc/v0/mayastor_grpc.rs
@@ -1004,6 +1004,7 @@ impl mayastor_server::Mayastor for MayastorSvc {
                 nexus::nexus_create_v2(
                     &args.name,
                     args.size,
+                    false,
                     &args.uuid,
                     nexus::NexusNvmeParams {
                         min_cntlid: args.min_cntl_id as u16,

--- a/io-engine/src/grpc/v1/nexus.rs
+++ b/io-engine/src/grpc/v1/nexus.rs
@@ -120,6 +120,7 @@ impl NexusService {
 
     async fn create_nexus(
         args: CreateNexusRequest,
+        size_exact: bool,
         label_version: LabelVersion,
     ) -> GrpcResult<CreateNexusResponse> {
         trace!("{:?}", args);
@@ -150,6 +151,7 @@ impl NexusService {
             nexus::nexus_create_v2(
                 &args.name,
                 args.size,
+                size_exact,
                 &args.uuid,
                 nexus::NexusNvmeParams {
                     min_cntlid: args.min_cntl_id as u16,
@@ -461,13 +463,14 @@ impl NexusRpc for NexusService {
         let version = NexusLabelVersion::try_from(args.label_version).unwrap_or_default();
         let label_version = label_version_from_proto(version)
             .ok_or_else(|| Status::invalid_argument("unsupported label version"))?;
+        let size_exact = args.required_size;
         let args = args.v1.ok_or(Status::invalid_argument("missing v1"))?;
 
         self.serialized(
             ctx,
             args.uuid.clone(),
             false,
-            Self::create_nexus(args, label_version),
+            Self::create_nexus(args, size_exact, label_version),
         )
         .await
     }
@@ -484,7 +487,7 @@ impl NexusRpc for NexusService {
             ctx,
             args.uuid.clone(),
             false,
-            Self::create_nexus(args, LabelVersion::V1),
+            Self::create_nexus(args, false, LabelVersion::V1),
         )
         .await
     }

--- a/io-engine/src/grpc/v1/nexus.rs
+++ b/io-engine/src/grpc/v1/nexus.rs
@@ -463,7 +463,7 @@ impl NexusRpc for NexusService {
         let version = NexusLabelVersion::try_from(args.label_version).unwrap_or_default();
         let label_version = label_version_from_proto(version)
             .ok_or_else(|| Status::invalid_argument("unsupported label version"))?;
-        let size_exact = args.required_size;
+        let size_exact = args.required_size && label_version != LabelVersion::V1;
         let args = args.v1.ok_or(Status::invalid_argument("missing v1"))?;
 
         self.serialized(

--- a/io-engine/tests/nexus_io.rs
+++ b/io-engine/tests/nexus_io.rs
@@ -368,6 +368,7 @@ async fn nexus_io_resv_acquire() {
             nexus_create_v2(
                 NXNAME,
                 32 * 1024 * 1024,
+                false,
                 NEXUS_UUID,
                 nvme_params,
                 &[format!("nvmf://{ip0}:8420/{HOSTNQN}:{REPL_UUID}")],
@@ -564,6 +565,7 @@ async fn nexus_io_resv_preempt() {
             nexus_create_v2(
                 NXNAME,
                 32 * 1024 * 1024,
+                false,
                 NEXUS_UUID,
                 nvme_params,
                 &[format!("nvmf://{ip0}:8420/{HOSTNQN}:{REPL_UUID}")],
@@ -835,6 +837,7 @@ async fn nexus_io_resv_preempt_tabled() {
                     nexus_create_v2(
                         NXNAME,
                         32 * 1024 * 1024,
+                        false,
                         NEXUS_UUID,
                         nvme_params,
                         &[format!("nvmf://{ip0}:8420/{HOSTNQN}:{REPL_UUID}")],

--- a/io-engine/tests/nexus_size.rs
+++ b/io-engine/tests/nexus_size.rs
@@ -16,7 +16,12 @@ async fn create_nexus(
 ) -> Result<(), io_engine::bdev::nexus::Error> {
     let children = vec![format!("malloc:///m0?size={}B", child_size)];
 
-    nexus_create_ext("nexus", size, None, &children, label).await
+    let size_exact = match label {
+        LabelVersion::V1 => false,
+        LabelVersion::V2 => true,
+    };
+
+    nexus_create_ext("nexus", size, size_exact, None, &children, label).await
 }
 
 static MS: OnceCell<MayastorTest> = OnceCell::new();
@@ -51,32 +56,56 @@ async fn nexus_bdev_size() {
             let size = 13 * mb;
             let child_size = 13 * mb;
             let label = LabelVersion::V2;
+
+            create_nexus(size, child_size, label)
+                .await
+                .expect_err("Can't create nexus with the same size as the child");
+
+            let size = 6 * mb;
+            create_nexus(size, child_size, label)
+                .await
+                .expect_err("Not enough space for the nexus data area in the child");
+
+            let size = 5 * mb;
             create_nexus(size, child_size, label).await.unwrap();
             let nexus = nexus_lookup_mut("nexus").unwrap();
             assert_eq!(nexus.block_len(), ss);
             assert_eq!(nexus.req_size(), size);
-            let bdev_size = last_usable(child_size) - label.data_start_blks(ss);
-            let f4mb_blks = 4 * mb / ss;
-            assert_eq!(
-                nexus.as_ref().num_blocks(),
-                align_down(bdev_size, f4mb_blks)
-            );
+            assert_eq!(nexus.size_in_bytes(), size);
+            assert_eq!(nexus.as_ref().num_blocks(), size / ss);
             nexus.destroy().await.unwrap();
 
-            let size = 17 * mb;
+            let size = 7 * mb;
+            let child_size = 14 * mb;
+            create_nexus(size, child_size, label)
+                .await
+                .expect_err("Not enough space for the nexus data area in the child");
+
+            let size = 7 * mb;
+            let child_size = 15 * mb;
+            create_nexus(size, child_size, label).await.unwrap();
+            let nexus = nexus_lookup_mut("nexus").unwrap();
+            assert_eq!(nexus.block_len(), ss);
+            assert_eq!(nexus.req_size(), size);
+            assert_eq!(nexus.size_in_bytes(), size);
+            assert_eq!(nexus.as_ref().num_blocks(), size / ss);
+            nexus.destroy().await.unwrap();
+
+            let size = 5 * mb;
+            let child_size = 12 * mb;
+            create_nexus(size, child_size, label)
+                .await
+                .expect_err("Not enough space for the nexus data area in the child");
+
+            let size = 8 * mb;
             let child_size = 17 * mb;
             let label = LabelVersion::V2;
             create_nexus(size, child_size, label).await.unwrap();
             let nexus = nexus_lookup_mut("nexus").unwrap();
             assert_eq!(nexus.block_len(), ss);
             assert_eq!(nexus.req_size(), size);
-            let bdev_size = last_usable(child_size) - label.data_start_blks(ss);
-            let f4mb_blks = 4 * mb / ss;
-            println!("bdev_size: {}", nexus.as_ref().num_blocks());
-            assert_eq!(
-                nexus.as_ref().num_blocks(),
-                align_down(bdev_size, f4mb_blks)
-            );
+            assert_eq!(nexus.size_in_bytes(), size);
+            assert_eq!(nexus.as_ref().num_blocks(), size / ss);
             nexus.destroy().await.unwrap();
 
             let size = 12 * mb;
@@ -86,18 +115,18 @@ async fn nexus_bdev_size() {
             let nexus = nexus_lookup_mut("nexus").unwrap();
             assert_eq!(nexus.block_len(), ss);
             assert_eq!(nexus.req_size(), size);
-            let bdev_size = last_usable(child_size) - label.data_start_blks(ss);
-            let f4mb_blks = 4 * mb / ss;
-            println!("bdev_size: {}", nexus.as_ref().num_blocks());
-            assert_eq!(
-                nexus.as_ref().num_blocks(),
-                align_down(bdev_size, f4mb_blks)
-            );
+            assert_eq!(nexus.size_in_bytes(), size);
+            assert_eq!(nexus.as_ref().num_blocks(), size / ss);
+            nexus.destroy().await.unwrap();
+
+            let size = 5 * mb;
+            let child_size = 16 * mb;
+            let label = LabelVersion::V2;
+            create_nexus(size, child_size, label).await.unwrap();
+            let nexus = nexus_lookup_mut("nexus").unwrap();
+            assert_eq!(nexus.num_blocks(), size / ss);
+            assert_eq!(nexus.size_in_bytes(), size);
             nexus.destroy().await.unwrap();
         })
         .await;
-}
-
-fn align_down(value: u64, align: u64) -> u64 {
-    value & !(align - 1)
 }


### PR DESCRIPTION

    refactor(cli): support specifying label version and size required
    
    Allows for us to use the new api whilst keeping the existing one
    in-place for back-compat.
    
---

    feat: add request size constraint enforcement
    
    Ensure the nexus bdev size matches the exact request size when
    the caller specifies this to be the case.
    
---

    refactor(label/v2): ensure size aligned to 1MiB with 4MiB void
    
    Goes back to the original scope, as otherwise rounding to 4MiB multiple
    to the size again leads to size inconsistency.
