### PR TITLE
fix: don't detach devices on submission error

### DIFF
--- a/.github/workflows/bdd.yml
+++ b/.github/workflows/bdd.yml
@@ -105,7 +105,7 @@ jobs:
       - name: Cleanup
         if: always()
         run: nix-shell --run "./scripts/pytest-tests.sh --clean-all-exit"
-# debugging
+      # debugging
       # - name: Setup tmate session
       #   if: ${{ failure() }}
       #   timeout-minutes: 240

--- a/.github/workflows/unit-int.yml
+++ b/.github/workflows/unit-int.yml
@@ -84,10 +84,11 @@ jobs:
       - name: Run JS Grpc Tests
         run: |
           echo "TEST_START_DATE=$(date +"%Y-%m-%d %H:%M:%S")" >> $GITHUB_ENV
+          echo "JS_GRPC=1" >> $GITHUB_ENV
           nix-shell --run "./scripts/grpc-test.sh"
 
       - name: Create JS Report
-        if: always()
+        if: always() && env.JS_GRPC == '1'
         run: |
           mkdir -p ci-report/js
           for file in *-xunit-report.xml; do
@@ -97,7 +98,7 @@ jobs:
           done
 
       - name: Test Report
-        if: always()
+        if: always() && env.JS_GRPC == '1'
         uses: pmeier/pytest-results-action@main
         with:
           path: 'ci-report/js/*-xunit-report.xml'
@@ -105,9 +106,9 @@ jobs:
           display-options: a
           fail-on-empty: true
           title: Test results
+
       - run: nix-shell --run "./scripts/ci-report.sh"
         if: failure() || cancelled()
-
       - uses: actions/upload-artifact@v7
         if: failure() || cancelled()
         with:
@@ -121,7 +122,7 @@ jobs:
       - name: Cleanup
         if: always()
         run: nix-shell --run "./scripts/clean-cargo-tests.sh"
-# debugging
+      # debugging
       # - name: Setup tmate session
       #   if: ${{ failure() }}
       #   timeout-minutes: 240

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,5 @@ ansible-hosts
 /rust-toolchain.toml
 /test/python/reports
 /ci-report/
+/local-fio-0-verify.state
+/test/python/local-job-fs-0-verify.state

--- a/io-engine/src/bdev/nexus/nexus_bdev_children.rs
+++ b/io-engine/src/bdev/nexus/nexus_bdev_children.rs
@@ -1103,6 +1103,18 @@ impl<'n> Nexus<'n> {
         debug!("{self:?}: set I/O mode to {mode:?}: done");
     }
 
+    /// Defrost all normal I/O channels of the nexus.
+    pub(crate) async fn defrost_normal(&self) {
+        if !self.has_io_device {
+            return;
+        }
+
+        self.traverse_io_channels_async((), |channel, _| {
+            channel.defrost();
+        })
+        .await;
+    }
+
     /// TODO
     pub(super) fn try_self_shutdown(&self) {
         let nexus_name = self.nexus_name().to_owned();

--- a/io-engine/src/bdev/nexus/nexus_channel.rs
+++ b/io-engine/src/bdev/nexus/nexus_channel.rs
@@ -389,7 +389,14 @@ impl<'n> NexusChannel<'n> {
         self.io_mode = io_mode;
         debug!("{self:?}: setting I/O mode to {io_mode:?}");
         if matches!(self.io_mode, IoMode::Normal) {
-            self.resubmit_frozen();
+            self.resubmit_frozen(true);
+        }
+    }
+
+    /// Defrosts I/Os from a normal channel.
+    pub(super) fn defrost(&mut self) {
+        if matches!(self.io_mode, IoMode::Normal) {
+            self.resubmit_frozen(false);
         }
     }
 
@@ -399,7 +406,10 @@ impl<'n> NexusChannel<'n> {
     }
 
     /// Resubmits all frozen I/Os.
-    fn resubmit_frozen(&mut self) {
+    fn resubmit_frozen(&mut self, log_always: bool) {
+        if !log_always && self.frozen_ios.is_empty() {
+            return;
+        }
         debug!(
             "{self:?}: resubmitting {n} frozen I/Os ...",
             n = self.frozen_ios.len()
@@ -424,10 +434,29 @@ impl<'n> NexusChannel<'n> {
         });
     }
 
+    /// Set the given device as the first writer in the list of writers for this channel.
+    pub(super) fn set_dev_wr_head(&mut self, dev: &str) {
+        self.writers.sort_by(|a, b| {
+            if a.get_device().device_name() == dev {
+                std::cmp::Ordering::Less
+            } else if b.get_device().device_name() == dev {
+                std::cmp::Ordering::Greater
+            } else {
+                std::cmp::Ordering::Equal
+            }
+        });
+    }
+
     /// Freezes submission of the given Nexus I/O.
     pub(super) fn freeze_io_submission(&mut self, io: NexusBio<'n>) {
         trace!("{io:?}: freezing I/O");
-        self.frozen_ios.push(io)
+        self.frozen_ios.push(io);
+    }
+
+    /// How many attached writers are in this channel.
+    /// This is used to determine if we can freeze I/Os or not.
+    pub(super) fn num_writers(&self) -> usize {
+        self.writers.len()
     }
 
     /// Prints elaborate debug info to the logs.

--- a/io-engine/src/bdev/nexus/nexus_io.rs
+++ b/io-engine/src/bdev/nexus/nexus_io.rs
@@ -570,7 +570,6 @@ impl<'n> NexusBio<'n> {
                     core = Cores::current(),
                     thread = Mthread::current().unwrap().name()
                 );
-
                 // Record the name of the device for immediate retire.
                 failed_device = Some(h.get_device().device_name());
                 err
@@ -593,14 +592,51 @@ impl<'n> NexusBio<'n> {
             // set the IO as failed in the submission stage.
             self.ctx_mut().failed += 1;
 
-            self.channel_mut().detach_device(&device);
-            self.channel_mut().disconnect_detached_devices(|_| true);
+            // There's a chance that the device becomes broken and start rejecting submissions before
+            // we've had a chance to retire it.
+            // In this case we can't simply detach the device from the channel, because we may then succeed host
+            // IOs to other children and end up with inconsistent data before we've had a chance to properly
+            // retire the device marking it as not healthy in the pstor/etcd.
+
+            // So instead of removing the device from the channel, we set the write head to this device so that
+            // all subsequent writes will be rejected and the device will be retired properly.
+            self.channel_mut().set_dev_wr_head(&device);
 
             if let Some(log) = self.fault_device(
                 &device,
                 IoCompletionStatus::IoSubmissionError(IoSubmissionFailure::Write),
             ) {
                 self.log_io(&log);
+            }
+
+            // We then place the IOs in the frozen list for a short period of time to allow the
+            // retire to complete and the device to be removed from the channel.
+            // Though if there are inflight IOs then we don't need to do that, since the completion
+            // handler will be called and the IO will be resubmitted to the next available child.
+            if inflight == 0 && self.ctx().resubmits < 3 && self.channel().num_writers() > 1 {
+                // we spoof the resubmits counter to avoid infinite resubmissions, but we don't
+                // want to fail the IO yet, so we will freeze it for a short period of time
+                // and then defrost it.
+                self.ctx_mut().resubmits += 1;
+
+                let s = self.clone();
+                self.channel_mut().freeze_io_submission(s);
+
+                // we schedule a task to defrost the IO after a short period of time, so that
+                // it can be resubmitted to the next available child.
+                // todo: we could also rely on the existing freeze mechanism to do this, but
+                // I wanted to avoid adding more complexity to the freeze mechanism, so I
+                // opted for a simple sleep instead.
+                let nx = self.channel().nexus().nexus_name().to_string();
+                crate::core::Reactors::master().send_future(async move {
+                    _ = crate::sleep::mayastor_sleep(std::time::Duration::from_millis(50)).await;
+                    if let Some(nx) = crate::bdev::nexus::nexus_lookup_mut(&nx) {
+                        nx.defrost_normal().await;
+                    }
+                });
+
+                self.channel().for_each_io_log(|log| self.log_io(log));
+                return result;
             }
         }
 

--- a/io-engine/tests/nexus_crd.rs
+++ b/io-engine/tests/nexus_crd.rs
@@ -14,7 +14,7 @@ use common::{
             nexus::{NexusNvmePreemption, NvmeReservation},
             GrpcConnect, SharedRpcHandle,
         },
-        Binary, Builder,
+        Binary, Builder, ComposeTest,
     },
     file_io::DataSize,
     fio::{spawn_fio_task, FioBuilder, FioJobBuilder, FioJobResult},
@@ -52,7 +52,7 @@ async fn nexus_fail_crd() {
         .expect("I/O expected to succeed");
 }
 
-async fn test_nexus_fail(crdt: &str) -> std::io::Result<()> {
+async fn test_nexus_fail(crdt: &str) -> std::io::Result<Arc<ComposeTest>> {
     common::composer_init();
 
     let test = Builder::new()
@@ -147,7 +147,7 @@ async fn test_nexus_fail(crdt: &str) -> std::io::Result<()> {
     tokio::pin!(j1);
 
     let (io_res, _) = tokio::join!(j0, j1);
-    io_res.unwrap()
+    io_res.unwrap().map(|_| test)
 }
 
 #[derive(Clone)]
@@ -179,7 +179,11 @@ async fn run_io_task(s: Sender<()>, nvmf: &NvmfLocation, cnt: u32, rt: u32) -> s
             .build()
     });
 
-    let fio = FioBuilder::new().with_jobs(jobs).build();
+    let fio = FioBuilder::new()
+        .with_verbose(true)
+        .with_verbose_err(true)
+        .with_jobs(jobs)
+        .build();
 
     // Notify the nexus management task that connection is complete and I/O
     // starts.

--- a/scripts/pytest-tests.sh
+++ b/scripts/pytest-tests.sh
@@ -63,7 +63,7 @@ function run_tests()
       report=${name#$ROOTDIR/test/python}
       report="$REPORTDIR/${report#/}/xunit-report.xml"
       set -x
-      python -m pytest --tc-file='test_config.ini' --docker-compose="$name" "$name" --junit-xml="$report" $TEST_ARGS
+      python -m pytest --tc-file='test_config.ini' --docker-compose="$name" "$name" --junit-xml="$report" --durations=0 $TEST_ARGS
       set +x
     )
     elif [ -f "$name" ] || [ -f "${name%::*}" ]
@@ -75,7 +75,7 @@ function run_tests()
       base_name=$(basename "$name")
       report="$REPORTDIR/${report#/}/${base_name%.py}-xunit-report.xml"
       set -x
-      python -m pytest --tc-file='test_config.ini' --docker-compose="$base" "$name" --junit-xml="$report" $TEST_ARGS
+      python -m pytest --tc-file='test_config.ini' --docker-compose="$base" "$name" --junit-xml="$report" --durations=0 $TEST_ARGS
       set +x
     )
     fi


### PR DESCRIPTION
The control-plane test republished_nexus_io_engine_txn_fail revealed a
race in the nexus.
The test pauses the io-engine container, and then thaws the container.
Upon thaw the container resumes BUT the io channel for nvmf children
is in a broken state and starts failing the submission of IO itself.

The code was currently handling this scenario but detaching the handle
and disconnecting it altogether.
I think this is actually wrong becauses subsequent IOs on the channel
would skip this handle and complete back to the host!

I'm not entirely sure why it was done this way, but I suspect we wanted
to avoid resubmission loops?

A potentially good fix for this would be to freeze the channel, which
is what the retire already does anyway, but it runs some-time after
only.
We could freeze the channel ahead of time, though we have to take care
and ensure we don't leave it frozen.

So for this patch the safer way of at least fixing the issue for now
is to freeze these IOs without changing the state of the channel and
then defrostign them sometime later.

Since we don't want to keep doing this forever, we resubmit only for
a certain number of times and then we let them fail.
To avoid writing to healthy children continuously we change the order
so that this handle is first in the list.

Also, I don't know why we stop at first failure, this should be
investigated further :/