### PR TITLE
fix: abort frozen ios from shutdown nexus on unshare

### DIFF
--- a/io-engine/src/bdev/nexus/nexus_bdev.rs
+++ b/io-engine/src/bdev/nexus/nexus_bdev.rs
@@ -1075,6 +1075,34 @@ impl<'n> Nexus<'n> {
         Ok(())
     }
 
+    /// Aborts all frozen IOs of a shutdown Nexus.
+    /// # Warning
+    /// These aborts may translate into I/O errors for the initiator.
+    pub async fn abort_shutdown_frozen_ios(&self) {
+        if matches!(
+            self.status(),
+            NexusStatus::Shutdown | NexusStatus::ShuttingDown
+        ) {
+            tracing::info!("{self:?}: aborting/rejecting all frozen I/Os");
+
+            // between abort and unshare new IOs may come along so we ensure we reject them
+            self.set_nexus_io_mode(super::IoMode::Reject).await;
+            self.abort_frozen_ios().await;
+        }
+    }
+
+    /// Aborts all frozen IOs.
+    /// # Warning
+    /// These aborts may translate into I/O errors for the initiator.
+    pub async fn abort_frozen_ios(&self) {
+        tracing::info!("{self:?}: aborting all frozen I/Os");
+
+        self.traverse_io_channels_async((), |channel, _| {
+            channel.abort_frozen();
+        })
+        .await;
+    }
+
     /// Suspend any incoming IO to the bdev pausing the controller allows us to
     /// handle internal events and which is a protocol feature.
     /// In case concurrent pause requests take place, the other callers

--- a/io-engine/src/bdev/nexus/nexus_bdev_children.rs
+++ b/io-engine/src/bdev/nexus/nexus_bdev_children.rs
@@ -1157,12 +1157,7 @@ impl<'n> Nexus<'n> {
                 }
 
                 // Step 2: abort all frozen I/Os.
-                debug!("{nexus:?}: aborting all frozen I/Os");
-                nexus
-                    .traverse_io_channels_async((), |channel, _| {
-                        channel.abort_frozen();
-                    })
-                    .await;
+                nexus.abort_frozen_ios().await;
 
                 // Step 3: cancel all active rebuild jobs.
                 let child_uris = nexus.child_uris();

--- a/io-engine/src/bdev/nexus/nexus_channel.rs
+++ b/io-engine/src/bdev/nexus/nexus_channel.rs
@@ -53,6 +53,8 @@ pub enum IoMode {
     Normal,
     /// I/O submissions are frozen.
     Freeze,
+    /// Reject all I/O submissions by failing them.
+    Reject,
 }
 
 #[derive(Debug)]
@@ -400,9 +402,16 @@ impl<'n> NexusChannel<'n> {
         }
     }
 
-    /// Determines if I/Os are frozen.
-    pub(super) fn is_frozen(&self) -> bool {
-        matches!(self.io_mode, IoMode::Freeze)
+    /// Determines if I/Os should be rejected.
+    #[inline(always)]
+    pub(super) fn io_reject(&self) -> bool {
+        matches!(self.io_mode, IoMode::Reject)
+    }
+
+    /// Determines if I/Os should not be submitted.
+    #[inline(always)]
+    pub(super) fn io_mode(&self) -> &IoMode {
+        &self.io_mode
     }
 
     /// Resubmits all frozen I/Os.
@@ -451,6 +460,12 @@ impl<'n> NexusChannel<'n> {
     pub(super) fn freeze_io_submission(&mut self, io: NexusBio<'n>) {
         trace!("{io:?}: freezing I/O");
         self.frozen_ios.push(io);
+    }
+
+    /// Reject submission of the given Nexus I/O.
+    pub(super) fn reject_io_submission(&mut self, io: NexusBio<'n>) {
+        trace!("{io:?}: rejecting I/O");
+        io.fail();
     }
 
     /// How many attached writers are in this channel.

--- a/io-engine/src/bdev/nexus/nexus_io.rs
+++ b/io-engine/src/bdev/nexus/nexus_io.rs
@@ -16,7 +16,7 @@ use spdk_rs::{
     BdevIo,
 };
 
-use super::{FaultReason, IOLogChannel, Nexus, NexusChannel, NEXUS_PRODUCT_ID};
+use super::{FaultReason, IOLogChannel, IoMode, Nexus, NexusChannel, NEXUS_PRODUCT_ID};
 
 use crate::core::{
     BlockDevice, BlockDeviceHandle, CoreError, Cores, IoCompletionStatus, IoStatus,
@@ -164,9 +164,7 @@ impl<'n> NexusBio<'n> {
 
     /// TODO
     pub(super) fn submit_request(mut self) {
-        if self.channel().is_frozen() {
-            let s = self.clone();
-            self.channel_mut().freeze_io_submission(s);
+        if !self.accept_request() {
             return;
         }
 
@@ -192,6 +190,22 @@ impl<'n> NexusBio<'n> {
         } {
             trace_nexus_io!("Submission error: {self:?}: {_e}");
         }
+    }
+
+    #[inline(always)]
+    fn accept_request(&mut self) -> bool {
+        match self.channel().io_mode() {
+            IoMode::Normal => return true,
+            IoMode::Freeze => {
+                let s = self.clone();
+                self.channel_mut().freeze_io_submission(s);
+            }
+            IoMode::Reject => {
+                let s = self.clone();
+                self.channel_mut().reject_io_submission(s);
+            }
+        }
+        false
     }
 
     /// Obtains a reference to the Nexus struct embedded within the bdev.
@@ -268,7 +282,7 @@ impl<'n> NexusBio<'n> {
 
     /// Fails the current I/O with a generic internal error. If the nexus
     /// already had a last child error, it fails with it.
-    fn fail(&self) {
+    pub fn fail(&self) {
         match self.nexus().last_error {
             IoCompletionStatus::NvmeError(s) => self.fail_nvme_status(s),
             IoCompletionStatus::LvolError(LvolFailure::NoSpace) => {
@@ -613,7 +627,7 @@ impl<'n> NexusBio<'n> {
             // retire to complete and the device to be removed from the channel.
             // Though if there are inflight IOs then we don't need to do that, since the completion
             // handler will be called and the IO will be resubmitted to the next available child.
-            if inflight == 0 && self.ctx().resubmits < 3 && self.channel().num_writers() > 1 {
+            if self.delay_io_resubmit(inflight) {
                 // we spoof the resubmits counter to avoid infinite resubmissions, but we don't
                 // want to fail the IO yet, so we will freeze it for a short period of time
                 // and then defrost it.
@@ -656,6 +670,13 @@ impl<'n> NexusBio<'n> {
         }
 
         result
+    }
+
+    fn delay_io_resubmit(&self, inflight: u8) -> bool {
+        inflight == 0
+            && self.ctx().resubmits < 3
+            && self.channel().num_writers() > 1
+            && !self.channel().io_reject()
     }
 
     /// Logs all write-like operation in the rebuild logs, if any exist.

--- a/io-engine/src/bdev/nexus/nexus_share.rs
+++ b/io-engine/src/bdev/nexus/nexus_share.rs
@@ -88,6 +88,14 @@ impl Share for Nexus<'_> {
     ) -> Result<(), Self::Error> {
         info!("{:?}: unsharing nexus bdev...", self);
 
+        // Aborts frozen I/Os a priori
+        // Note that this is not a foolproof solution, ie what if the nexus is still online
+        // and then IOs become frozen after we start trying to unshare?
+        // In practice this may not be the case since we only unshare when nothing else is
+        // using the nexus, though what if there's a long IO getting stuck, and leading to
+        // retire AND shutdown?
+        self.abort_shutdown_frozen_ios().await;
+
         let name = self.name.clone();
         self.as_mut()
             .pin_bdev_mut()


### PR DESCRIPTION
When a nexus goes into shutdown its frozen IOs remain, and must be
eventually failed otherwise unshare will get stuck..

For now we tackle this by failing them on unshare itself, though
there may be some cases where we may want to handle this a bit
differently.

I'll tackle a solution for shutdown-after-unshare starts on a follow up.

Another interesting topic here is that after shutdown newer IOs may
be received and will again be frozen!
This IIRC is to ensure IOs don't fail back to initiator, and give some
time for a new nexus to be setup.

We should look into this, perhaps kicking initiators out of the nexus
and ensuring no new connection may be established would be sufficient?
This would require some research and testing so not tacking this here.

However, during unshare when nexus is shutdown we can already handle this
by at least ensuring new IOs are rejected.
