### PR TITLE
feat(ublk): add draft ublk experiment

### DIFF
--- a/io-engine/src/bdev/nexus/nexus_bdev.rs
+++ b/io-engine/src/bdev/nexus/nexus_bdev.rs
@@ -66,6 +66,7 @@ pub(crate) static NEXUS_PRODUCT_ID: &str = "Nexus CAS Driver v0.0.1";
 pub enum NexusTarget {
     NbdDisk(NbdDisk),
     NexusNvmfTarget,
+    Ublk,
 }
 
 /// Sensitive nexus operations that might require extra checks against

--- a/io-engine/src/bdev/nexus/nexus_share.rs
+++ b/io-engine/src/bdev/nexus/nexus_share.rs
@@ -50,9 +50,16 @@ impl Share for Nexus<'_> {
                     .await?;
 
                 let name = self.name.clone();
+
+                // self.as_mut()
+                //     .pin_bdev_mut()
+                //     .share_nvmf(props)
+                //     .await
+                //     .context(nexus_err::ShareNvmfNexus { name })?;
+                let _props = props;
                 self.as_mut()
                     .pin_bdev_mut()
-                    .share_nvmf(props)
+                    .share_ublk()
                     .await
                     .context(nexus_err::ShareNvmfNexus { name })?;
 
@@ -60,7 +67,7 @@ impl Share for Nexus<'_> {
                 info!("{:?}: shared NVMF target as '{}'", self, uri);
                 uri
             }
-            Some(Protocol::Nvmf) => {
+            Some(Protocol::Ublk) | Some(Protocol::Nvmf) => {
                 let uri = self.share_uri().unwrap();
                 info!("{:?}: already shared as '{}'", self, uri);
                 uri
@@ -220,6 +227,9 @@ impl<'n> Nexus<'n> {
                 }
                 Ok(uri)
             }
+            Protocol::Ublk => {
+                todo!("add ublk to the protobuf api");
+            }
         }
     }
 
@@ -243,6 +253,9 @@ impl<'n> Nexus<'n> {
             }
             Some(NexusTarget::NexusNvmfTarget) => {
                 info!("{:?}: unsharing NVMF target...", self);
+            }
+            Some(NexusTarget::Ublk) => {
+                info!("{:?}: unsharing UBLK target...", self);
             }
             None => {
                 // Try unshare nexus bdev anyway, just in case it was shared
@@ -285,6 +298,7 @@ impl<'n> Nexus<'n> {
         match self.nexus_target {
             Some(NexusTarget::NbdDisk(ref disk)) => Some(disk.as_uri()),
             Some(NexusTarget::NexusNvmfTarget) => self.share_uri(),
+            Some(NexusTarget::Ublk) => self.share_uri(),
             None => None,
         }
     }

--- a/io-engine/src/bin/io-engine.rs
+++ b/io-engine/src/bin/io-engine.rs
@@ -115,6 +115,11 @@ fn start_tokio_runtime(args: &MayastorCliArgs) {
         debug!("Blob store cluster release on UNMAP is disabled");
     }
 
+    if args.ublk.enabled {
+        env::set_var("ENABLE_UBLK", "true");
+        warn!("ublk support is enabled");
+    }
+
     print_feature!("Async QPair connection", "spdk-async-qpair-connect");
     print_feature!("Fault injection", "fault-injection");
 

--- a/io-engine/src/core/bdev.rs
+++ b/io-engine/src/core/bdev.rs
@@ -19,7 +19,7 @@ use crate::{
         BlockDeviceIoStats, CoreError, DescriptorGuard, PtplProps, ShareNvmf, UnshareNvmf,
         UnshareProps,
     },
-    subsys::NvmfSubsystem,
+    subsys::{NvmfSubsystem, UblkSubsystem},
     target::nvmf,
 };
 
@@ -192,6 +192,7 @@ pub fn is_shared<T: spdk_rs::BdevOps>(bdev: &Bdev<T>) -> Option<Protocol> {
     // TODO: we could do better here
     match bdev.shared() {
         Some(Protocol::Nvmf) => Some(Protocol::Nvmf),
+        Some(Protocol::Ublk) => Some(Protocol::Ublk),
         _else if NvmfSubsystem::nqn_lookup(bdev.name()).is_some() => Some(Protocol::Nvmf),
         _else => _else,
     }
@@ -236,6 +237,10 @@ where
         subsystem.start(is_nexus_bdev).await.context(ShareNvmf {})
     }
 
+    async fn share_ublk(self: Pin<&mut Self>) -> Result<Self::Output, Self::Error> {
+        UblkSubsystem::start_disk(&self).await.map_err(Into::into)
+    }
+
     fn create_ptpl(&self) -> Result<Option<PtplProps>, Self::Error> {
         Ok(None)
     }
@@ -255,6 +260,7 @@ where
                         .context(ShareNvmf {})?;
                 }
             }
+            Some(Protocol::Ublk) => {}
             Some(Protocol::Off) | None => {}
         }
 
@@ -269,6 +275,9 @@ where
                     ss.stop_for_destroy().await.context(UnshareNvmf {})?;
                 }
             }
+            Some(Protocol::Ublk) => {
+                UblkSubsystem::stop_disk(&self).await?;
+            }
             Some(Protocol::Off) | None => {}
         }
 
@@ -280,6 +289,8 @@ where
         // TODO: we could do better here
         if self.is_claimed_by("NVMe-oF Target") {
             Some(Protocol::Nvmf)
+        } else if self.is_claimed_by(crate::subsys::UblkModule::name()) {
+            Some(Protocol::Ublk)
         } else {
             Some(Protocol::Off)
         }
@@ -289,6 +300,7 @@ where
     fn share_uri(&self) -> Option<String> {
         match self.shared() {
             Some(Protocol::Nvmf) => nvmf::get_uri(self.name()),
+            Some(Protocol::Ublk) => crate::subsys::UblkSubsystem::uri(self.name()),
             _ => Some(format!("bdev:///{}", self.name())),
         }
     }

--- a/io-engine/src/core/descriptor.rs
+++ b/io-engine/src/core/descriptor.rs
@@ -50,6 +50,20 @@ impl<T: BdevOps> DescriptorGuard<T> {
         }
     }
 
+    /// claim the bdev for exclusive access, when the descriptor is in read-only
+    /// the descriptor will implicitly be upgraded to read/write.
+    ///
+    /// Conversely, Preexisting writers will not be downgraded.
+    pub fn claim_v2(&self, name: &str) -> bool {
+        match BdevModule::find_by_name(name) {
+            Ok(m) => m.claim_bdev(&self.0.bdev(), &self.0).is_ok(),
+            Err(error) => {
+                error!("{error}");
+                false
+            }
+        }
+    }
+
     /// unclaim a bdev previously claimed by NEXUS_MODULE
     pub fn unclaim(&self) {
         match BdevModule::find_by_name(NEXUS_MODULE_NAME) {
@@ -60,6 +74,20 @@ impl<T: BdevOps> DescriptorGuard<T> {
             }
             Err(err) => {
                 error!("{}", err);
+            }
+        }
+    }
+
+    /// unclaim a bdev previously claimed by the given module name.
+    pub fn unclaim_v2(&self, name: &str) {
+        match BdevModule::find_by_name(name) {
+            Ok(m) => {
+                if let Err(err) = m.release_bdev(&self.0.bdev()) {
+                    error!("{}", err)
+                }
+            }
+            Err(error) => {
+                error!("{error}");
             }
         }
     }

--- a/io-engine/src/core/env.rs
+++ b/io-engine/src/core/env.rs
@@ -306,6 +306,10 @@ pub struct MayastorCliArgs {
     /// [`NvmeCliArgs`].
     #[clap(flatten)]
     pub nvme: NvmeCliArgs,
+
+    /// [`UblkCliArgs`].
+    #[clap(flatten)]
+    pub ublk: UblkCliArgs,
 }
 
 /// SPDK tracing related arguments.
@@ -399,6 +403,43 @@ impl Default for NvmeCliArgs {
     }
 }
 
+/// Ublk related arguments.
+#[derive(Debug, clap::Parser, Clone)]
+pub struct UblkCliArgs {
+    /// Enables ublk support.
+    #[clap(long = "enable-ublk", env = "ENABLE_UBLK", value_parser = delay_compat)]
+    pub enabled: bool,
+
+    /// ublk queue depth.
+    #[clap(
+        long = "ublk-queue-depth",
+        env = "UBLK_QUEUE_DEPTH",
+        default_value_t = 64
+    )]
+    pub q_depth: u32,
+
+    /// Number of ublk hardware queues. {n}
+    /// Defaults to the number of reactors.
+    #[clap(long = "ublk-queue-count", env = "UBLK_QUEUE_COUNT")]
+    pub q_count: Option<u32>,
+}
+impl Default for UblkCliArgs {
+    fn default() -> Self {
+        Self::parse_from(Vec::<String>::new())
+    }
+}
+impl UblkCliArgs {
+    /// Get the number of ublk hardware queues.
+    pub fn q_count(&self) -> u32 {
+        self.q_count
+            .unwrap_or_else(|| Reactors::iter().count() as u32)
+    }
+    /// Get the ublk queue depth.
+    pub fn q_depth(&self) -> u32 {
+        self.q_depth
+    }
+}
+
 fn delay_compat(s: &str) -> Result<bool, String> {
     match s {
         "1" | "true" => Ok(true),
@@ -422,6 +463,7 @@ impl MayastorFeatures {
             rdma_capable_io_engine,
             diskpool_encryption,
             nexus_label_version: io_engine_api::v1::nexus::NexusLabelVersion::LabelV2 as u32,
+            ublk: env::var("ENABLE_UBLK").as_deref() == Ok("true"),
         }
     }
     /// Get all the supported and enabled features.
@@ -526,6 +568,7 @@ pub struct MayastorEnvironment {
     bs_cluster_unmap: bool,
     pub pool_args: PoolCliArgs,
     pub nvme: NvmeCliArgs,
+    pub ublk: UblkCliArgs,
 }
 
 impl Default for MayastorEnvironment {
@@ -579,6 +622,7 @@ impl Default for MayastorEnvironment {
             pool_args: PoolCliArgs::default(),
             traces: SpdkTracingArgs::default(),
             nvme: NvmeCliArgs::default(),
+            ublk: UblkCliArgs::default(),
         }
     }
 }
@@ -727,6 +771,7 @@ impl MayastorEnvironment {
             pool_args: args.pool,
             traces: args.traces,
             nvme: args.nvme,
+            ublk: args.ublk,
             ..Default::default()
         }
         .setup_static()

--- a/io-engine/src/core/mod.rs
+++ b/io-engine/src/core/mod.rs
@@ -43,7 +43,7 @@ pub use share::{
 pub use spdk_rs::{cpu_cores, IoStatus, IoType, NvmeStatus};
 pub use thread::Mthread;
 
-use crate::subsys::NvmfError;
+use crate::subsys::{NvmfError, UblkError};
 pub use snapshot::{
     CloneParams, CloneXattrs, ISnapshotDescriptor, LvolSnapshotOps, PropXattrs, SnapshotDescriptor,
     SnapshotParams, SnapshotXattrs,
@@ -203,6 +203,8 @@ pub enum CoreError {
     WipeFailed { source: wiper::Error },
     #[snafu(display("failed to init crypto module: {reason}"))]
     InitCryptoModule { reason: String },
+    #[snafu(display("{source}"))]
+    Ublk { source: UblkError },
 }
 
 /// Represent error as Errno value.
@@ -249,6 +251,7 @@ impl ToErrno for CoreError {
             Self::SnapshotCreate { source, .. } => *source,
             Self::WipeFailed { .. } => Errno::EIO,
             Self::InitCryptoModule { .. } => Errno::EINVAL,
+            Self::Ublk { source } => source.to_errno(),
         }
     }
 }
@@ -324,6 +327,8 @@ pub struct MayastorFeatures {
     pub diskpool_encryption: bool,
     /// Nexus label versioning capability.
     pub nexus_label_version: u32,
+    /// Expose ublk as a nexus share target.
+    pub ublk: bool,
 }
 impl MayastorFeatures {
     /// Check if LVM feature is enabled.

--- a/io-engine/src/core/share.rs
+++ b/io-engine/src/core/share.rs
@@ -12,6 +12,7 @@ pub enum Protocol {
     Off,
     /// shared as NVMe-oF TCP
     Nvmf,
+    Ublk,
 }
 
 impl TryFrom<i32> for Protocol {
@@ -24,6 +25,7 @@ impl TryFrom<i32> for Protocol {
             // 2 was for iSCSI
             // the gRPC code does not validate enums so we have
             // to do it here
+            3 => Ok(Self::Nvmf),
             _ => Err(LvsError::ReplicaShareProtocol { value }),
         }
     }
@@ -34,6 +36,7 @@ impl Display for Protocol {
         let p = match self {
             Self::Off => "Not shared",
             Self::Nvmf => "NVMe-oF TCP",
+            Self::Ublk => "UBLK",
         };
         write!(f, "{p}")
     }
@@ -227,6 +230,10 @@ pub trait Share: std::fmt::Debug {
         props: Option<NvmfShareProps>,
     ) -> Result<Self::Output, Self::Error>;
     fn create_ptpl(&self) -> Result<Option<PtplProps>, Self::Error>;
+
+    async fn share_ublk(self: Pin<&mut Self>) -> Result<Self::Output, Self::Error> {
+        todo!()
+    }
 
     async fn update_properties<P: Into<Option<UpdateProps>>>(
         self: Pin<&mut Self>,

--- a/io-engine/src/grpc/v0/mayastor_grpc.rs
+++ b/io-engine/src/grpc/v0/mayastor_grpc.rs
@@ -302,6 +302,7 @@ impl From<Protocol> for i32 {
         match p {
             Protocol::Off => 0,
             Protocol::Nvmf => 1,
+            Protocol::Ublk => 3,
         }
     }
 }
@@ -936,6 +937,9 @@ impl mayastor_server::Mayastor for MayastorSvc {
                                             }
                                         })?);
                                     lvol.as_mut().share_nvmf(Some(props)).await?;
+                                }
+                                Protocol::Ublk => {
+                                    //
                                 }
                             }
 

--- a/io-engine/src/lvm/lv_replica.rs
+++ b/io-engine/src/lvm/lv_replica.rs
@@ -559,6 +559,7 @@ impl LogicalVolume {
             Protocol::Off => {
                 Self::bdev_unshare(bdev).await?;
             }
+            Protocol::Ublk => {}
         }
 
         Ok(())
@@ -725,6 +726,9 @@ impl LogicalVolume {
                     .map_err(|source| Error::BdevShare { source })?;
                 bdev.share_uri().ok_or(Error::BdevShareUri {})
             }
+            Some(Protocol::Ublk) => {
+                todo!("this api needs to be refactored to support ublk sharing");
+            }
             Some(Protocol::Off) | None => bdev
                 .share_nvmf(props)
                 .await
@@ -734,7 +738,7 @@ impl LogicalVolume {
     async fn bdev_unshare(bdev: &mut UntypedBdev) -> Result<Option<String>, Error> {
         let mut bdev = Pin::new(bdev);
         match bdev.shared() {
-            Some(Protocol::Nvmf) => {
+            Some(Protocol::Ublk) | Some(Protocol::Nvmf) => {
                 bdev.as_mut()
                     .unshare(None)
                     .await

--- a/io-engine/src/lvm/property.rs
+++ b/io-engine/src/lvm/property.rs
@@ -170,6 +170,7 @@ impl Protocol {
         match self {
             Protocol::Off => "off",
             Protocol::Nvmf => "nvmf",
+            Protocol::Ublk => "ublk",
         }
     }
     fn from_value(value: &str) -> Self {

--- a/io-engine/src/subsys/mod.rs
+++ b/io-engine/src/subsys/mod.rs
@@ -15,6 +15,8 @@ use std::mem::zeroed;
 
 pub use registration::{registration_grpc::Registration, RegistrationSubsystem};
 
+pub use ublk::{Error as UblkError, UblkModule, UblkSubsystem};
+
 use crate::subsys::nvmf::Nvmf;
 
 pub(super) mod config;
@@ -23,6 +25,7 @@ mod nvmf;
 pub mod nvmx;
 /// Module for registration of the data-plane with control-plane
 pub mod registration;
+mod ublk;
 
 /// Register initial subsystems
 pub(crate) fn register_subsystem() {
@@ -38,6 +41,7 @@ pub(crate) fn register_subsystem() {
     }
     RegistrationSubsystem::register();
     nvmx::NvmxSubsystem::register();
+    ublk::UblkSubsystem::register();
 }
 
 /// Makes a subsystem serial number from a subsystem UUID or name.

--- a/io-engine/src/subsys/ublk.rs
+++ b/io-engine/src/subsys/ublk.rs
@@ -1,0 +1,348 @@
+use crate::core::{MayastorEnvironment, ToErrno};
+use futures::channel::oneshot;
+use snafu::Snafu;
+use spdk_rs::{
+    ffihelper::{cb_arg, done_errno_cb, drop_cb_arg, ErrnoResult, FfiResult},
+    libspdk::{
+        spdk_add_subsystem, spdk_add_subsystem_depend, spdk_json_val, spdk_subsystem,
+        spdk_subsystem_depend, spdk_subsystem_fini_next, spdk_subsystem_init_next,
+        SPDK_JSON_VAL_NAME, SPDK_JSON_VAL_OBJECT_BEGIN, SPDK_JSON_VAL_OBJECT_END,
+        SPDK_JSON_VAL_TRUE,
+    },
+    BdevModule, BdevModuleBuild, WithModuleInit,
+};
+use std::{ffi::CStr, os::raw::c_void, ptr};
+
+const DISABLE_USER_COPY_KEY: &[u8] = b"disable_user_copy";
+const TRUE_VALUE: &[u8] = b"true";
+const UBLK_MODULE_NAME: &str = "ublk-module";
+
+/// Ublk module for managing ublk devices.
+pub struct UblkModule;
+
+impl WithModuleInit for UblkModule {
+    fn module_init() -> i32 {
+        0
+    }
+}
+
+impl BdevModuleBuild for UblkModule {}
+
+impl UblkModule {
+    fn register() {
+        UblkModule::builder(UBLK_MODULE_NAME)
+            .with_module_init()
+            .register();
+    }
+
+    fn current() -> Result<BdevModule, Error> {
+        BdevModule::find_by_name(UBLK_MODULE_NAME).map_err(|_| Error::ModuleNotFound {})
+    }
+
+    /// Get the name of the ublk module.
+    pub fn name() -> &'static str {
+        UBLK_MODULE_NAME
+    }
+}
+
+fn ublk_create_target_params() -> [spdk_json_val; 4] {
+    [
+        spdk_json_val {
+            start: ptr::null_mut(),
+            len: 2,
+            type_: SPDK_JSON_VAL_OBJECT_BEGIN,
+        },
+        spdk_json_val {
+            start: DISABLE_USER_COPY_KEY.as_ptr() as *mut c_void,
+            len: DISABLE_USER_COPY_KEY.len() as u32,
+            type_: SPDK_JSON_VAL_NAME,
+        },
+        spdk_json_val {
+            start: TRUE_VALUE.as_ptr() as *mut c_void,
+            len: TRUE_VALUE.len() as u32,
+            type_: SPDK_JSON_VAL_TRUE,
+        },
+        spdk_json_val {
+            start: ptr::null_mut(),
+            len: 0,
+            type_: SPDK_JSON_VAL_OBJECT_END,
+        },
+    ]
+}
+
+pub struct UblkSubsystem(pub(crate) *mut spdk_subsystem);
+
+impl Default for UblkSubsystem {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl UblkSubsystem {
+    extern "C" fn init() {
+        tracing::info!("mayastor ublk subsystem ini");
+        let args = MayastorEnvironment::global_or_default();
+        match args.ublk.enabled.then(|| unsafe {
+            let params = ublk_create_target_params();
+            spdk_rs::libspdk::ublk_create_target(ptr::null(), params.as_ptr())
+        }) {
+            None => unsafe { spdk_subsystem_init_next(0) },
+            // any situations where we may want to bail out here?
+            Some(_) => unsafe { spdk_subsystem_init_next(0) },
+        }
+    }
+
+    extern "C" fn done_cb(_arg: *mut std::os::raw::c_void) {
+        tracing::info!("mayastor ublk subsystem fini done");
+        unsafe { spdk_subsystem_fini_next() }
+    }
+
+    extern "C" fn fini() {
+        tracing::info!("mayastor ublk subsystem fini");
+        let args = MayastorEnvironment::global_or_default();
+        let next = args.ublk.enabled.then(|| unsafe {
+            let result =
+                spdk_rs::libspdk::ublk_destroy_target(Some(Self::done_cb), std::ptr::null_mut());
+            if result != 0 {
+                tracing::error!("Failed to destroy ublk target: {result}");
+            }
+            result != 0
+        });
+        if next.unwrap_or(true) {
+            unsafe { spdk_subsystem_fini_next() }
+        }
+    }
+
+    fn new() -> Self {
+        info!("creating Mayastor ublk subsystem...");
+        let mut ss = Box::<spdk_subsystem>::default();
+        ss.name = b"mayastor_grpc_ublk\x00" as *const u8 as *const libc::c_char;
+        ss.init = Some(Self::init);
+        ss.fini = Some(Self::fini);
+        ss.write_config_json = None;
+        Self(Box::into_raw(ss))
+    }
+
+    /// Register the subsystem with spdk.
+    pub(super) fn register() {
+        UblkModule::register();
+        unsafe {
+            let mut depend = Box::<spdk_subsystem_depend>::default();
+            depend.name = b"mayastor_grpc_ublk\0" as *const u8 as *mut _;
+            depend.depends_on = b"ublk\0" as *const u8 as *mut _;
+            spdk_add_subsystem(Self::new().0);
+            spdk_add_subsystem_depend(Box::into_raw(depend));
+        }
+    }
+
+    /// Start the ublk disk with the given name.
+    pub async fn start_disk<T: spdk_rs::BdevOps>(
+        bdev: &crate::core::Bdev<T>,
+    ) -> Result<String, Error> {
+        let ublk = MayastorEnvironment::global().ublk.clone();
+        if !ublk.enabled {
+            return Err(Error::NotEnabled {});
+        }
+
+        if bdev.is_claimed() {
+            // or just return errors?
+            if bdev.is_claimed_by(UBLK_MODULE_NAME) {
+                if let Some(id) = Self::ublk_id(bdev.name())? {
+                    return Ok(Self::uri_(bdev.name(), id));
+                }
+            }
+            return Err(Error::BdevClaim {
+                name: bdev.name().to_string(),
+            });
+        }
+
+        // how to choose the right ublk device id?
+        // Should this be driven by control-plane or solely from the io-engine?
+        // Device recovery may have some implications on this?
+        let ublk_id = 0;
+
+        let cstring = std::ffi::CString::new(bdev.name()).expect("no-mem");
+        let (sender, receiver) = oneshot::channel::<ErrnoResult<()>>();
+        let sender_arg = cb_arg(sender);
+        let rc = unsafe {
+            spdk_rs::libspdk::ublk_start_disk(
+                cstring.as_ptr(),
+                ublk_id,
+                ublk.q_count(),
+                ublk.q_depth(),
+                Some(done_errno_cb),
+                sender_arg,
+            )
+        };
+
+        rc.to_result(|error| {
+            drop_cb_arg::<ErrnoResult<()>>(sender_arg);
+            Error::Start {
+                source: nix::Error::from_raw(error),
+                phase: ErrorPhase::Call,
+            }
+        })?;
+
+        receiver
+            .await
+            .map_err(|_| Error::Start {
+                source: nix::Error::ECANCELED,
+                phase: ErrorPhase::Wait,
+            })?
+            .map_err(|source| Error::Start {
+                source,
+                phase: ErrorPhase::Callback,
+            })?;
+
+        let desc = bdev.open(true).map_err(|source| Error::BdevOpen {
+            source: Box::new(source),
+        })?;
+        if UblkModule::current()?
+            .claim_bdev(&desc.bdev(), &desc)
+            .is_err()
+        {
+            let _ = Self::stop_disk_by_id(ublk_id).await;
+            return Err(Error::BdevClaim {
+                name: bdev.name().to_string(),
+            });
+        }
+
+        Ok(Self::uri_(bdev.name(), ublk_id))
+    }
+
+    async fn stop_disk_by_id(ublk_id: u32) -> Result<(), Error> {
+        let (sender, receiver) = oneshot::channel::<ErrnoResult<()>>();
+        let sender_arg = cb_arg(sender);
+        let rc =
+            unsafe { spdk_rs::libspdk::ublk_stop_disk(ublk_id, Some(done_errno_cb), sender_arg) };
+
+        if rc != 0 {
+            drop_cb_arg::<ErrnoResult<()>>(sender_arg);
+        }
+
+        rc.to_result(|error| Error::Stop {
+            source: nix::Error::from_raw(error),
+            phase: ErrorPhase::Call,
+        })?;
+
+        receiver
+            .await
+            .map_err(|_| Error::Stop {
+                source: nix::Error::ECANCELED,
+                phase: ErrorPhase::Wait,
+            })?
+            .map_err(|source| Error::Stop {
+                source,
+                phase: ErrorPhase::Callback,
+            })
+    }
+
+    /// Stop the ublk disk with the given name.
+    pub async fn stop_disk<T: spdk_rs::BdevOps>(bdev: &spdk_rs::Bdev<T>) -> Result<(), Error> {
+        let Some(ublk_id) = Self::ublk_id(bdev.name())? else {
+            return Ok(());
+        };
+
+        Self::stop_disk_by_id(ublk_id).await?;
+
+        UblkModule::current()?
+            .release_bdev(bdev)
+            .map_err(|_| Error::BdevUnclaim {
+                name: bdev.name().to_string(),
+            })
+    }
+
+    /// Get the ublk device id for the given name.
+    /// ## Output
+    /// Ok(None): ublk device with the given name does not exist.
+    /// Ok(Some(id)): ublk device with the given name exists and has the given id.
+    /// Err(Error): ublk subsystem is not enabled or any error.
+    pub fn ublk_id(name: &str) -> Result<Option<u32>, Error> {
+        let env = MayastorEnvironment::global();
+        if !env.ublk.enabled {
+            return Err(Error::NotEnabled {});
+        }
+
+        let mut ublk = unsafe { spdk_rs::libspdk::ublk_dev_first() };
+        while !ublk.is_null() {
+            let bdev_name = unsafe { spdk_rs::libspdk::ublk_dev_get_bdev_name(ublk) };
+            if !bdev_name.is_null() {
+                if let Ok(bdev_name) = unsafe { CStr::from_ptr(bdev_name) }.to_str() {
+                    if bdev_name == name {
+                        return Ok(Some(unsafe { spdk_rs::libspdk::ublk_dev_get_id(ublk) }));
+                    }
+                }
+            }
+
+            ublk = unsafe { spdk_rs::libspdk::ublk_dev_next(ublk) };
+        }
+
+        Ok(None)
+    }
+
+    fn uri_(name: &str, ublk_id: u32) -> String {
+        format!("ublk:///{name}?id={ublk_id}")
+    }
+
+    pub fn uri(name: &str) -> Option<String> {
+        let ublk_id = Self::ublk_id(name).ok()??;
+        Some(Self::uri_(name, ublk_id))
+    }
+}
+
+/// Ublk subsystem error type.
+#[derive(Debug, Clone, Snafu)]
+#[snafu(visibility(pub(crate)), context(suffix(false)))]
+pub enum Error {
+    #[snafu(display("ublk subsystem is not enabled"))]
+    NotEnabled {},
+    #[snafu(display("ublk bdev module is not registered"))]
+    ModuleNotFound {},
+    #[snafu(display("failed to claim bdev '{name}' for ublk"))]
+    BdevClaim {
+        name: String,
+    },
+    #[snafu(display("failed to release ublk claim for bdev '{name}'"))]
+    BdevUnclaim {
+        name: String,
+    },
+    #[snafu(display("failed to start ublk disk {phase}: {source}"))]
+    Start {
+        source: nix::Error,
+        phase: ErrorPhase,
+    },
+    #[snafu(display("failed to stop ublk disk {phase}: {source}"))]
+    Stop {
+        source: nix::Error,
+        phase: ErrorPhase,
+    },
+    BdevOpen {
+        source: Box<crate::core::CoreError>,
+    },
+}
+
+#[derive(strum_macros::Display, Debug, Clone)]
+pub enum ErrorPhase {
+    Call,
+    Wait,
+    Callback,
+}
+
+impl ToErrno for Error {
+    fn to_errno(&self) -> nix::Error {
+        match self {
+            Self::NotEnabled {} => nix::Error::ENOTSUP,
+            Self::ModuleNotFound {} => nix::Error::ENODEV,
+            Self::BdevClaim { .. } => nix::Error::EBUSY,
+            Self::BdevUnclaim { .. } => nix::Error::EINVAL,
+            Self::Start { source, .. } => *source,
+            Self::Stop { source, .. } => *source,
+            Self::BdevOpen { source } => source.to_errno(),
+        }
+    }
+}
+impl From<Error> for crate::core::CoreError {
+    fn from(source: Error) -> Self {
+        Self::Ublk { source }
+    }
+}


### PR DESCRIPTION
For a single-local-replica volume I'm able to get almost entire performance of the local nvme drive

native:
512B up to 1.5 MIOPS
ublk:
512B up to 1.4 MIOPS

A lot more benches are required as well as figuring out how to pick the device id's, including how to recover them after io-engine restart. We may need the linux device mapper here :/
