### PR TITLE
Pool hot remove

### DIFF
--- a/io-engine/src/bin/io-engine.rs
+++ b/io-engine/src/bin/io-engine.rs
@@ -21,6 +21,7 @@ use io_engine::{
     eventing::Event,
     grpc, logger,
     persistent_store::PersistentStoreBuilder,
+    pool_backend,
     prctl::Prctl,
     subsys::Registration,
 };
@@ -58,6 +59,7 @@ fn start_tokio_runtime(args: &MayastorCliArgs) {
 
     let reactor_freeze_detection = args.reactor_freeze_detection;
     let reactor_freeze_timeout = args.reactor_freeze_timeout;
+    let handle_rescan_period = args.pool.handle_rescan_period;
 
     // Enable partial rebuild.
     if let Ok(v) = std::env::var("NEXUS_PARTIAL_REBUILD") {
@@ -143,6 +145,11 @@ fn start_tokio_runtime(args: &MayastorCliArgs) {
             // Launch reactor health monitor if diagnostics is enabled.
             if reactor_freeze_detection {
                 runtime::spawn(reactor_monitor_loop(reactor_freeze_timeout));
+            }
+
+            match handle_rescan_period {
+                Some(period) => runtime::spawn(pool_backend::pool_rescanner(period)),
+                None => tracing::warn!("Pool handle rescanner is disabled"),
             }
 
             futures.push(

--- a/io-engine/src/core/env.rs
+++ b/io-engine/src/core/env.rs
@@ -374,6 +374,19 @@ pub struct PoolCliArgs {
         default_value = "3h"
     )]
     pub io_stall_transition_window: humantime::Duration,
+
+    /// Rescan period for detecting removed devices.
+    ///
+    /// # Note
+    ///
+    /// This is only applicable to AIO/URING devices as PCIe devices handle hot-removal automatically.
+    ///
+    /// AIO/URING devices need IO to be submitted to detect hot-removal, so if the device is not being
+    /// used, it will not be detected as removed.
+    /// In this case we can scan the file handles and trigger a hot-removal event if the file handle
+    /// is no longer valid.
+    #[clap(long = "pool-handle-rescan-period", env = "POOL_HANDLE_RESCAN_PERIOD")]
+    pub handle_rescan_period: Option<humantime::Duration>,
 }
 impl Default for PoolCliArgs {
     fn default() -> Self {

--- a/io-engine/src/core/runtime.rs
+++ b/io-engine/src/core/runtime.rs
@@ -53,7 +53,7 @@ pub struct Runtime {
 static RUNTIME: Lazy<Runtime> = Lazy::new(|| {
     let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
-        .worker_threads(4)
+        .worker_threads(5)
         .max_blocking_threads(6)
         .on_thread_start(Mthread::unaffinitize)
         .build()

--- a/io-engine/src/lvm/error.rs
+++ b/io-engine/src/lvm/error.rs
@@ -60,6 +60,8 @@ pub enum Error {
     SnapshotNotSup {},
     #[snafu(display("Pool expansion is not currently supported for LVM volumes"))]
     GrowNotSup {},
+    #[snafu(display("Rescan is not currently supported for LVM"))]
+    RescanNotSup {},
     #[snafu(display("Reset error is not currently supported for LVM volumes"))]
     ResetErrNotSup {},
     #[snafu(display("Reset stall transition is not currently supported for LVM volumes"))]
@@ -103,6 +105,7 @@ impl ToErrno for Error {
             Error::SnapshotNotSup { .. } => Errno::ENOTSUP,
             Error::GrowNotSup { .. } => Errno::ENOTSUP,
             Error::ResetErrNotSup { .. } => Errno::ENOTSUP,
+            Error::RescanNotSup { .. } => Errno::ENOTSUP,
             Error::ResetStallTransitionNotSup { .. } => Errno::ENOTSUP,
             Error::Internal { .. } => Errno::EPIPE,
         }

--- a/io-engine/src/lvm/mod.rs
+++ b/io-engine/src/lvm/mod.rs
@@ -136,6 +136,10 @@ impl PoolOps for VolumeGroup {
         Err(Error::GrowNotSup {}.into())
     }
 
+    fn rescan(&self) -> Result<(), crate::pool_backend::Error> {
+        Err(Error::RescanNotSup {}.into())
+    }
+
     async fn reset_errors(&self) -> Result<(), crate::pool_backend::Error> {
         Err(Error::ResetErrNotSup {}.into())
     }

--- a/io-engine/src/lvs/lvs_store.rs
+++ b/io-engine/src/lvs/lvs_store.rs
@@ -990,6 +990,47 @@ impl Lvs {
         Ok(())
     }
 
+    /// Rescans the bdev.
+    #[tracing::instrument(level = "debug", err)]
+    pub fn rescan(&self) -> Result<(), LvsError> {
+        tracing::debug!("Rescanning lvs...");
+        let lvs_name = self.name();
+
+        let base_bdev = self.base_bdev()?;
+        let disk_bdev = base_bdev
+            .crypto_base_bdev()
+            .map(Bdev::new)
+            .unwrap_or_else(|| base_bdev);
+
+        let uri_str = disk_bdev.bdev_uri_str().unwrap_or_default();
+        let url = Url::parse(&uri_str).map_err(|source| LvsError::InvalidBdev {
+            source: BdevError::UriParseFailed {
+                source,
+                uri: uri_str.to_string(),
+            },
+            name: lvs_name.to_string(),
+        })?;
+
+        let bdev = disk_bdev.name().into_cstring();
+        tracing::debug!("Rescanning bdev: {uri_str}");
+
+        // Performs a rescan only for uring or aio devices, this is a no-op for other device types.
+        let errno = match url.scheme() {
+            "uring" => unsafe { bdev_uring_rescan(bdev.as_ptr().cast()) },
+            "aio" => unsafe { bdev_aio_rescan(bdev.as_ptr().cast()) },
+            _ => 0,
+        };
+
+        if errno != 0 {
+            return Err(LvsError::BdevRescanFailed {
+                source: BsError::from_i32(errno),
+                name: self.base_bdev_name(),
+            });
+        }
+
+        Ok(())
+    }
+
     /// Rescans the bdev and triggers live LVS grow i.e. without closing the blobs and unloading the blobstore.
     #[tracing::instrument(level = "debug", err)]
     pub async fn grow(&self) -> Result<(), LvsError> {

--- a/io-engine/src/lvs/mod.rs
+++ b/io-engine/src/lvs/mod.rs
@@ -166,6 +166,11 @@ impl PoolOps for Lvs {
         Ok(())
     }
 
+    fn rescan(&self) -> Result<(), crate::pool_backend::Error> {
+        (*self).rescan()?;
+        Ok(())
+    }
+
     async fn reset_errors(&self) -> Result<(), crate::pool_backend::Error> {
         self.base_bdev()?
             .reset_stats_ext(spdk_rs::BdevStatsResetMode::Errors)

--- a/io-engine/src/pool_backend.rs
+++ b/io-engine/src/pool_backend.rs
@@ -1,8 +1,9 @@
 use crate::{
     bdev::crypto::EncryptionKey,
-    core::{BdevStater, BdevStats, ToErrno},
+    core::{BdevStater, BdevStats, Reactors, ToErrno},
     replica_backend::ReplicaOps,
 };
+use futures::channel::oneshot;
 use nix::errno::Errno;
 use std::ops::Deref;
 
@@ -169,6 +170,12 @@ pub trait PoolOps: IPoolProps + BdevStater<Stats = BdevStats> + std::fmt::Debug 
     /// The pool will no longer be listable until it is imported again.
     async fn export(self: Box<Self>) -> Result<(), Error>;
 
+    /// Rescan the pool, refreshing the file handles (if any).
+    /// This can be used for 2 purposes:
+    /// 1. to detect any hot-removals without ongoing I/O
+    /// 2. to detect disk resize (we can then grow the pool)
+    fn rescan(&self) -> Result<(), Error>;
+
     /// Grows the given pool by filling the entire underlying device(s).
     async fn grow(&self) -> Result<(), Error>;
 
@@ -320,5 +327,70 @@ impl PoolFactory {
     /// Get the inner factory interface.
     pub fn as_factory(&self) -> &dyn IPoolFactory {
         self.0.deref()
+    }
+}
+
+async fn pool_rescanner_() {
+    // We typically would have to wait for the rescan to complete, or at least delay the next
+    // rescan until the previous one is done, but the rescan itself is a blocking operation and so
+    // We're sure it won't be executed concurrently.
+    //
+    // So we can just spawn it and mostly forget about it (we'll await the reactor down below).
+    Reactors::master().send_future(async move {
+        for factory in PoolFactory::factories() {
+            let pools = match factory.0.list(&ListPoolArgs::default()).await {
+                Ok(pools) => pools,
+                Err(e) => {
+                    tracing::error!("Failed to rescan pools: {e}");
+                    continue;
+                }
+            };
+
+            for pool in pools {
+                if let Err(e) = pool.rescan() {
+                    tracing::error!("Failed to rescan pool {}: {e}", pool.name());
+                }
+            }
+        }
+    });
+
+    // Wait for the reactor to process all the rescan requests before returning.
+    wait_reactor().await;
+}
+
+async fn wait_reactor() {
+    let (s, r) = oneshot::channel::<()>();
+    Reactors::master().send_future(async move {
+        s.send(()).ok();
+    });
+    r.await.ok();
+}
+
+/// Rescan all pools from all backends.
+///
+/// This is used to detect any changes in the underlying devices, such as size changes or
+/// devices being hot-removed.
+///
+/// Device removal is not always handled automatically by the pool device layer:
+///
+/// 1. PCIe processes hot-removal events and will trigger hot-removal of the underlying device and the pool
+///
+/// 2. AIO/URING devices need IO to be submitted to detect hot-removal, so if the device is not being used, it will not be detected as removed.
+///    Rescan on these devices inspects the file handles and will trigger a hot-removal event if the file handle is no longer valid.
+///
+/// # Note
+///
+/// Pools are not currently grown automatically, but this would expose a new size of the underlying device to the pool, if it's extended.
+///
+pub async fn pool_rescanner(period: humantime::Duration) {
+    tracing::info!(?period, "Pool handle rescanner is enabled");
+
+    let interval = period.into();
+    loop {
+        // we could use interval to ensure precise timing, but there's not much point in doing that
+        // also if the reactor is busy we don't want to keep pushing rescans...
+        tokio::time::sleep(interval).await;
+
+        pool_rescanner_().await;
     }
 }

--- a/io-engine/tests/lvs_pool.rs
+++ b/io-engine/tests/lvs_pool.rs
@@ -1202,8 +1202,7 @@ async fn hot_detach_retach_(guard: TestHotRmGuard, share: bool, io: bool) {
     // We bork the device, leading to hot-removal
     drop(guard);
 
-    let error = lvs_pool.grow().await.expect_err("msg");
-    assert_eq!(error.to_errno(), nix::Error::EIO);
+    lvs_pool.rescan().expect("should rescan");
 
     assert_eq!(Lvs::iter_all().count(), 1);
 

--- a/io-engine/tests/lvs_pool.rs
+++ b/io-engine/tests/lvs_pool.rs
@@ -47,6 +47,7 @@ fn ms() -> &'static MayastorTest<'static> {
                 io_stall_transition_threshold: IO_STALL_TRANSITION_THRESHOLD,
                 io_stall_transition_window: IO_STALL_TRANSITION_WINDOW.into(),
                 io_stall_deadline: IO_STALL_DEADLINE.into(),
+                handle_rescan_period: None,
             },
             // log_components: vec!["all".into()],
             ..Default::default()


### PR DESCRIPTION
    test: use new rescan to trigger hot-remove
    
    Changes the hot-remove tests to use rescan instead of grow.

---

    feat: add pool hot-remove rescanner
    
    Device removal is not always handled automatically by the pool device layer
    
    PCIe processes hot-removal events and will trigger hot-removal of the
    underlying device and the pool.
    
    AIO/URING devices need IO to be submitted to detect hot-removal, so if the
     device is not being used, it will not be detected as removed.
    Rescan on these devices inspects the file handles and will trigger a
     hot-removal event if the file handle is no longer valid.
    
    A cli argument is added to enable the rescan and also configure how often
    it should run (rescan period).