### PR TITLE
ci: enable mergeq and mergify

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,0 +1,41 @@
+queue_rules:
+  - name: default
+    update_method: rebase
+    branch_protection_injection_mode: merge
+    update_bot_account: openebs-ci
+    commit_message_format:
+      title: inherit
+      body: pr-body
+      trailers:
+        - co-authored-by
+    batch_size: 3
+    merge_conditions:
+      - check-success = bors-ci
+      - check-success = commitlint
+      - check-success = submodule-branch
+      - -label ~= do-not-merge
+    queue_conditions:
+      - check-success = commitlint
+      - check-success = submodule-branch
+      - -label ~= do-not-merge
+      - -draft
+      - check-success = DCO
+    batch_max_wait_time: 15s
+merge_queue:
+  max_parallel_checks: 2
+  status_comments: outcomes
+merge_protections_settings:
+  reporting_method: check-runs
+pull_request_rules:
+  - name: auto-label and approve backport PRs
+    conditions:
+      - author=mergify[bot]
+      - title~=\(backport \#[0-9]+\)$
+    actions:
+      label:
+        add:
+          - kind/backport
+      review:
+        type: APPROVE
+        message: "Automatically approved backport PR"
+        bot_account: openebs-ci

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -1,22 +1,34 @@
 name: Bors CI
 on:
   workflow_call:
+    inputs:
+      trigger:
+        required: false
+        type: string
+        default: "merge_group"
   push:
     branches:
       - staging
       - trying
+  merge_group:
+  pull_request:
+    types: ['opened', 'reopened', 'synchronize']
 
 jobs:
   lint-ci:
+    if: github.event_name != 'pull_request' || inputs.trigger == 'try' || startsWith(github.head_ref, 'mergify/merge-queue/')
     uses: ./.github/workflows/lint.yml
   int-ci:
+    if: github.event_name != 'pull_request' || inputs.trigger == 'try' || startsWith(github.head_ref, 'mergify/merge-queue/')
     uses: ./.github/workflows/unit-int.yml
   bdd-ci:
+    if: github.event_name != 'pull_request' || inputs.trigger == 'try' || startsWith(github.head_ref, 'mergify/merge-queue/')
     uses: ./.github/workflows/bdd.yml
   image-ci:
+    if: github.event_name != 'pull_request' || inputs.trigger == 'try' || startsWith(github.head_ref, 'mergify/merge-queue/')
     uses: ./.github/workflows/image-pr.yml
   bors-ci:
-    if: ${{ success() }}
+    if: ${{ !cancelled() && (github.event_name != 'pull_request' || inputs.trigger == 'try' || startsWith(github.head_ref, 'mergify/merge-queue/')) }}
     needs:
       - lint-ci
       - int-ci
@@ -25,4 +37,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: CI succeeded
-        run: exit 0
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            exit 1
+          fi
+          exit 0

--- a/.github/workflows/pr-commitlint.yml
+++ b/.github/workflows/pr-commitlint.yml
@@ -1,21 +1,25 @@
 name: Lint Commit Messages
 on:
   pull_request:
-    types: ['opened', 'edited', 'reopened', 'synchronize']
+    types: ['opened', 'reopened', 'synchronize']
   push:
     branches:
       - staging
+  merge_group:
 
 jobs:
   commitlint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        if: ${{ github.event_name != 'merge_group' && !startsWith(github.head_ref, 'mergify/merge-queue/') }}
         with:
           fetch-depth: 0
       - name: Install CommitLint and Dependencies
+        if: ${{ github.event_name != 'merge_group' && !startsWith(github.head_ref, 'mergify/merge-queue/') }}
         run: npm install @commitlint/config-conventional @commitlint/cli
       - name: Lint Commits
+        if: ${{ github.event_name != 'merge_group' && !startsWith(github.head_ref, 'mergify/merge-queue/') }}
         run: |
           # Only run for PR's and simply succeed the bors staging branch
           if [ ! ${{ github.ref }} = "refs/heads/staging" ]; then

--- a/.github/workflows/pr-submodule-branch.yml
+++ b/.github/workflows/pr-submodule-branch.yml
@@ -1,12 +1,14 @@
 name: Submodule Branch Check
 on:
   pull_request:
-    types: ['opened', 'edited', 'reopened', 'synchronize']
+    types: ['opened', 'reopened', 'synchronize']
   push:
     branches:
       - develop
       - 'release/**'
       - staging
+  merge_group:
+
 jobs:
   submodule-branch:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-try-ci.yml
+++ b/.github/workflows/pr-try-ci.yml
@@ -1,0 +1,40 @@
+name: CI Try
+on:
+  pull_request:
+    types: ['labeled']
+
+jobs:
+  ci-try:
+    if: contains(github.event.pull_request.labels.*.name, 'ci/test')
+    uses: ./.github/workflows/pr-ci.yml
+    with:
+      trigger: "try"
+
+  remove-label:
+    if: ${{ always() && contains(github.event.pull_request.labels.*.name, 'ci/test') }}
+    needs:
+      - ci-try
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Remove ci/test label
+        uses: actions/github-script@v9
+        with:
+          script: |
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                name: 'ci/test',
+              });
+            } catch (error) {
+              const status = error.status || error.response?.status;
+              if (status === 403 || status === 404) {
+                const reason = status === 403 ? 'insufficient permissions' : 'label not found';
+                console.log(`Skipping ci/test label removal due to ${reason}: ${error.message}`);
+                return;
+              }
+              throw error;
+            }

--- a/.github/workflows/staging-dco.yml
+++ b/.github/workflows/staging-dco.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - staging
+  merge_group:
 
 jobs:
   DCO:


### PR DESCRIPTION
Support GitHub MergeQ and mergify for merging.
We've seen a few issues on bors, so we've switched to mergeq/mergify on the extensions repo.

So we carry on that initiative and now do the same on this repo.

The native mergeq will be preferred on the develop branch, where it'll be enabled.
On the release branches it has to be manually enabled, so we keep mergify as the alternative that will work on any newer branches in addition to the develop branch.