### PR TITLE
feat(io-engine): derive core list from kubelet-assigned cgroup cpuset

### DIFF
--- a/io-engine/src/core/cgroup_cpuset.rs
+++ b/io-engine/src/core/cgroup_cpuset.rs
@@ -1,0 +1,105 @@
+//! Reads the CPU set assigned to this process' cgroup by the container
+
+use std::{fs, path::PathBuf};
+
+/// Returns the effective cgroup CPU set as a DPDK `-l`-compatible core-list
+/// string (e.g. `"0-2,7"`), or `None` if it can't be determined.
+pub fn cpuset_from_cgroup() -> Option<String> {
+    let cgroups = read_self_cgroup(&fs::read_to_string("/proc/self/cgroup").ok()?);
+
+    candidate_cpuset_files(&cgroups).into_iter().find_map(|path| {
+        let cpus = fs::read_to_string(&path).ok()?;
+        let cpus = cpus.trim();
+        if cpus.is_empty() {
+            return None;
+        }
+        debug!("Read cgroup cpuset '{cpus}' from {}", path.display());
+        Some(cpus.to_string())
+    })
+}
+
+/// Parses `/proc/self/cgroup` into `(controllers, path)` pairs.
+fn read_self_cgroup(contents: &str) -> Vec<(String, String)> {
+    contents
+        .lines()
+        .filter_map(|line| {
+            let mut parts = line.splitn(3, ':');
+            let _hierarchy_id = parts.next()?;
+            let controllers = parts.next()?.to_string();
+            let path = parts.next()?.to_string();
+            Some((controllers, path))
+        })
+        .collect()
+}
+
+/// Candidate paths to the cpuset "effective" CPUs file, v2 then v1.
+fn candidate_cpuset_files(cgroups: &[(String, String)]) -> Vec<PathBuf> {
+    let mut candidates = Vec::new();
+
+    if let Some((_, path)) = cgroups.iter().find(|(controllers, _)| controllers.is_empty()) {
+        candidates.push(PathBuf::from(format!(
+            "/sys/fs/cgroup{path}/cpuset.cpus.effective"
+        )));
+    }
+
+    if let Some((_, path)) = cgroups
+        .iter()
+        .find(|(controllers, _)| controllers.split(',').any(|c| c == "cpuset"))
+    {
+        candidates.push(PathBuf::from(format!(
+            "/sys/fs/cgroup/cpuset{path}/cpuset.effective_cpus"
+        )));
+    }
+
+    candidates
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_cgroup_v2_unified_line() {
+        let cgroups = read_self_cgroup("0::/kubepods.slice/kubepod-pod123.slice\n");
+        assert_eq!(
+            cgroups,
+            vec![("".to_string(), "/kubepods.slice/kubepod-pod123.slice".to_string())]
+        );
+    }
+
+    #[test]
+    fn parses_cgroup_v1_multi_line() {
+        let cgroups = read_self_cgroup(
+            "12:cpuset:/kubepods/podabc/container\n11:memory:/kubepods/podabc/container\n",
+        );
+        assert_eq!(
+            cgroups,
+            vec![
+                ("cpuset".to_string(), "/kubepods/podabc/container".to_string()),
+                ("memory".to_string(), "/kubepods/podabc/container".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn candidate_files_prefer_v2_then_v1() {
+        let cgroups = vec![
+            ("".to_string(), "/v2path".to_string()),
+            ("cpuset,cpu".to_string(), "/v1path".to_string()),
+        ];
+        let candidates = candidate_cpuset_files(&cgroups);
+        assert_eq!(
+            candidates,
+            vec![
+                PathBuf::from("/sys/fs/cgroup/v2path/cpuset.cpus.effective"),
+                PathBuf::from("/sys/fs/cgroup/cpuset/v1path/cpuset.effective_cpus"),
+            ]
+        );
+    }
+
+    #[test]
+    fn no_cpuset_controller_found() {
+        let cgroups = vec![("memory".to_string(), "/path".to_string())];
+        assert!(candidate_cpuset_files(&cgroups).is_empty());
+    }
+}

--- a/io-engine/src/core/env.rs
+++ b/io-engine/src/core/env.rs
@@ -37,7 +37,7 @@ use crate::{
     bdev::{bdev_io_ctx_pool_init, nexus, nvme_io_ctx_pool_init},
     constants::NVME_NQN_PREFIX,
     core::{
-        nic,
+        cgroup_cpuset, nic,
         nic::SIpAddr,
         reactor::{Reactor, ReactorState, Reactors},
         Cores, MayastorFeatures, Mthread,
@@ -192,6 +192,14 @@ pub struct MayastorCliArgs {
     /// List of cores to run on instead of using the core mask. {n}
     /// When specified it supersedes the core mask (-m) argument.
     pub core_list: Option<String>,
+    /// Derive the core list from the cgroup cpuset assigned by the
+    /// container runtime/kubelet, superseding -l and -m.
+    #[clap(
+        long = "cores-from-cgroup",
+        env = "CORES_FROM_CGROUP",
+        value_parser = delay_compat
+    )]
+    pub cores_from_cgroup: bool,
     #[clap(short = 'p')]
     /// Endpoint of the persistent store.
     pub ps_endpoint: Option<String>,
@@ -712,7 +720,14 @@ impl MayastorEnvironment {
             rpc_addr: args.rpc_address,
             hugedir: args.hugedir,
             env_context: args.env_context,
-            core_list: args.core_list,
+            core_list: if args.cores_from_cgroup {
+                cgroup_cpuset::cpuset_from_cgroup().or_else(|| {
+                    warn!("--cores-from-cgroup was set but the cgroup cpuset could not be determined; falling back to -l/-m");
+                    args.core_list
+                })
+            } else {
+                args.core_list
+            },
             bdev_io_ctx_pool_size: args.bdev_io_ctx_pool_size,
             nvme_ctl_io_ctx_pool_size: args.nvme_ctl_io_ctx_pool_size,
             nvmf_tgt_interface: args.nvmf_tgt_interface,

--- a/io-engine/src/core/mod.rs
+++ b/io-engine/src/core/mod.rs
@@ -53,6 +53,7 @@ use spdk_rs::libspdk::SPDK_NVME_SC_CAPACITY_EXCEEDED;
 
 mod bdev;
 mod block_device;
+mod cgroup_cpuset;
 mod descriptor;
 mod device_events;
 mod device_monitor;


### PR DESCRIPTION
## Summary
- Adds a `--cores-from-cgroup` CLI flag (env `CORES_FROM_CGROUP`) to io-engine that derives the reactor core list from the CPU set actually assigned to the pod's cgroup (`cpuset.cpus.effective` on cgroup v2, `cpuset.effective_cpus` on v1), instead of a statically configured `-l`/`-m`.
- Falls back to `-l`/`-m` if the cgroup cpuset can't be determined.
- Addresses #1458: with the Kubernetes CPU Manager static policy, the exact cores assigned to a pod aren't known ahead of time, so a statically configured core list/mask can mismatch the cores actually granted.

## Test plan
- [x] Unit tests for cgroup parsing and candidate-path resolution (`io-engine/src/core/cgroup_cpuset.rs`)
- [x] Manual test on a kubelet node with CPU Manager static policy enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)