### PR TITLE
Bugs found in lvs_pool test cases

### DIFF
--- a/io-engine/src/bdev/nexus/mod.rs
+++ b/io-engine/src/bdev/nexus/mod.rs
@@ -152,10 +152,11 @@ pub async fn shutdown_nexuses() {
     let nexuses: Vec<<NexusIterMut<'_> as Iterator>::Item> = nexus_iter_mut().collect();
 
     for mut nexus in nexuses.into_iter() {
+        let nx = Event::event(&(*nexus), EventAction::Shutdown);
         // Destroy nexus and persist its state in the ETCd.
         match nexus.as_mut().destroy_ext(true).await {
             Ok(_) => {
-                Event::event(&(*nexus), EventAction::Shutdown).generate();
+                nx.generate();
             }
             Err(error) => {
                 error!(

--- a/io-engine/tests/lvs_pool.rs
+++ b/io-engine/tests/lvs_pool.rs
@@ -1032,13 +1032,17 @@ async fn lvs_hot_remove() {
 
         lvs_pool.destroy().await.ok();
 
-        assert_eq!(Lvs::iter_all().count(), 1);
+        // this is racy, could be removed already
+        assert!(matches!(Lvs::iter_all().count(), 0 | 1));
         assert_eq!(Lvs::iter().count(), 0);
 
         let error = Lvs::create_or_import(pool_args.clone())
             .await
-            .expect_err("removing");
-        assert_eq!(error.to_errno(), nix::Error::EINPROGRESS);
+            .expect_err("removing or removed");
+        assert!(matches!(
+            error.to_errno(),
+            nix::Error::EINPROGRESS | nix::Error::ENXIO
+        ));
 
         for _ in 0..10 {
             if Lvs::iter_all().count() == 0 {

--- a/io-engine/tests/lvs_pool.rs
+++ b/io-engine/tests/lvs_pool.rs
@@ -576,6 +576,7 @@ async fn lvs_errors() {
                 let args = vec![DISKNAME1.into(), VG_NAME.into(), loop_dev.clone()];
                 run_script::run_script!(script, args, run_script::ScriptOptions::new()).ok();
                 common::detach_loopdev(&loop_dev);
+                common::delete_file(&[DISKNAME1.into()]);
             }
         }
     }
@@ -736,16 +737,19 @@ async fn lvs_stall() {
             if let Some(loop_dev) = self.loop_dev.take() {
                 let script = r#"
                     export LVM_SUPPRESS_FD_WARNINGS=1
-                    dmsetup resume $2/lvol1
-                    dmsetup resume $2/lvol2
-                    lvremove -f vg-1/lvol1
-                    lvremove -f vg-1/lvol2
-                    vgremove -f -y $2
-                    pvremove -f $3
+                    dmsetup resume $1/lvm-lv-aio
+                    dmsetup resume $1/lvm-lv-uring
+                    lvremove -f vg-1/lvm-lv-aio
+                    lvremove -f vg-1/lvm-lv-uring
+                    vgremove -f -y $1
+                    pvremove -f $2
                 "#;
-                let args = vec![DISKNAME2.into(), VG_NAME.into(), loop_dev.clone()];
-                run_script::run_script!(script, args, run_script::ScriptOptions::new()).ok();
+                let args = vec![VG_NAME.into(), loop_dev.clone()];
+                let x =
+                    run_script::run_script!(script, args, run_script::ScriptOptions::new()).ok();
+                tracing::info!("script result: {x:?}");
                 common::detach_loopdev(&loop_dev);
+                common::delete_file(&[DISKNAME1.into()]);
             }
         }
     }
@@ -765,10 +769,13 @@ async fn lvs_stall() {
     .unwrap();
 
     let vg_cln = vg_pool.clone();
+    let (s, r) = oneshot::channel();
     ms().spawn_detached(async move {
         stall_test(vg_cln, StallBdev::Aio).await;
+        _ = s.send(());
     });
     stall_test(vg_pool, StallBdev::Uring).await;
+    r.await.unwrap();
 }
 
 enum StallBdev {


### PR DESCRIPTION
    fix: don't reuse nexus object after destroy
    
    Generate the shutdown event before attempting nexus destruction.
    Is shutdown the right name here?
    
    Also this seems racy still, what if the nexus was already being destroyed?
    
---

    test: lvs_hot_remove race
    
    On this test the hot-removal may race and may be already remove when we
    were expecting it to be removing.
    To handle this we now have to support both removing and removed state.
    
---

    test: ensure lvs_stall awaits all work
    
    We scheduled the aio and ran the uring test directly.
    Before tear-down we have to await for the aio test otherwise the tear-down
    may fail because the aio is still open!
