### PR TITLE
feat(bdev): adopt asynchronous bdev destruction

### DIFF
--- a/io-engine/src/bdev/aio.rs
+++ b/io-engine/src/bdev/aio.rs
@@ -176,7 +176,9 @@ impl CreateDestroy for Aio {
                     })?
                     .context(bdev_api::DestroyBdevFailed {
                         name: self.get_name(),
-                    })
+                    })?;
+                tracing::info!("{:?}: deleted", self);
+                Ok(())
             }
             None => Err(BdevError::BdevNotFound {
                 name: self.get_name(),

--- a/io-engine/src/bdev/nexus/nexus_bdev.rs
+++ b/io-engine/src/bdev/nexus/nexus_bdev.rs
@@ -52,8 +52,8 @@ use crate::{
 use crate::core::{BdevStater, BdevStats, CoreError, IoCompletionStatus};
 use events_api::event::EventAction;
 use spdk_rs::{
-    libspdk::spdk_bdev_notify_blockcnt_change, BdevIo, BdevOps, ChannelTraverseStatus, IoChannel,
-    IoDevice, IoDeviceChannelTraverse, JsonWriteContext,
+    libspdk::spdk_bdev_notify_blockcnt_change, BdevDestruct, BdevDestructCompletion, BdevIo,
+    BdevOps, ChannelTraverseStatus, IoChannel, IoDevice, IoDeviceChannelTraverse, JsonWriteContext,
 };
 
 pub static NVME_MIN_CNTLID: u16 = 1;
@@ -1337,6 +1337,10 @@ impl Drop for Nexus<'_> {
 impl<'n> IoDevice for Nexus<'n> {
     type ChannelData = NexusChannel<'n>;
 
+    fn unregister_callback(self: Pin<&mut Self>) -> Option<BdevDestructCompletion> {
+        Some(unsafe { self.bdev().async_destruct_completion() })
+    }
+
     fn io_channel_create(self: Pin<&mut Self>) -> NexusChannel<'n> {
         NexusChannel::new(self)
     }
@@ -1359,14 +1363,15 @@ impl<'n> BdevOps for Nexus<'n> {
     type IoDev = Nexus<'n>;
 
     /// TODO
-    fn destruct(mut self: Pin<&mut Self>) {
+    fn destruct(mut self: Pin<&mut Self>) -> BdevDestruct {
         info!("{:?}: unregistering nexus bdev...", self);
 
-        // A closed operation might already be in progress calling unregister
-        // will trip an assertion within the external libraries
+        // Actually this should never happen because we shouldn't get 2 destruct calls
+        // for the same nexus, but just in case, we check the state here and if it's already closed.
         if *self.state.lock() == NexusState::Closed {
-            info!("{:?}: nexus already closed", self);
-            return;
+            tracing::error!("{:?}: nexus already closed", self);
+            debug_assert!(false, "BUG: nexus already closed");
+            return BdevDestruct::Async;
         }
 
         let open_children = self.children.iter().filter(|c| c.is_opened()).count();
@@ -1408,6 +1413,7 @@ impl<'n> BdevOps for Nexus<'n> {
         self.as_mut().set_state(NexusState::Closed);
 
         info!("{:?}: nexus bdev unregistered", self);
+        BdevDestruct::Async
     }
 
     /// Main entry point to submit IO to the underlying children this uses

--- a/io-engine/src/bdev/nexus/nexus_bdev_children.rs
+++ b/io-engine/src/bdev/nexus/nexus_bdev_children.rs
@@ -436,17 +436,23 @@ impl<'n> Nexus<'n> {
     pub(crate) async fn close_children(&self) {
         info!("{self:?}: closing {n} children...", n = self.children.len());
 
-        let mut failed = 0;
+        let mut errors = Vec::new();
         for child in self.children_iter() {
-            if child.close().await.is_err() {
-                failed += 1;
+            if let Err(error) = child.close().await {
+                errors.push(error);
             }
         }
 
-        if failed == 0 {
+        if errors.is_empty() {
             info!("{self:?}: all children closed");
         } else {
-            error!("{self:?}: failed to close some of the children");
+            let count = errors.len();
+            let errors = errors
+                .into_iter()
+                .map(|e| e.to_string())
+                .collect::<Vec<_>>()
+                .join(", ");
+            error!(?errors, "{self:?}: failed to close {count} children");
         }
     }
 

--- a/io-engine/src/bdev/null_ng.rs
+++ b/io-engine/src/bdev/null_ng.rs
@@ -2,8 +2,8 @@ use parking_lot::Mutex;
 use std::{cell::RefCell, marker::PhantomData, pin::Pin, time::Duration};
 
 use spdk_rs::{
-    BdevIo, BdevModule, BdevModuleBuild, BdevOps, IoChannel, IoDevice, IoType, Poller,
-    PollerBuilder, WithModuleInit,
+    Bdev, BdevDestruct, BdevDestructCompletion, BdevIo, BdevModule, BdevModuleBuild, BdevOps,
+    IoChannel, IoDevice, IoType, Poller, PollerBuilder, WithModuleInit,
 };
 
 const NULL_MODULE_NAME: &str = "NullNg";
@@ -54,12 +54,26 @@ struct NullIoDevice<'a> {
     _my_name: String,
     _smth: u64,
     next_chan_id: RefCell<i64>,
+    /// Handle to our own bdev, used to complete asynchronous destruction once
+    /// all I/O channels have been torn down.
+    bdev: RefCell<Option<Bdev<NullIoDevice<'a>>>>,
     _a: PhantomData<&'a ()>,
 }
 
 /// TODO
 impl<'a> IoDevice for NullIoDevice<'a> {
     type ChannelData = NullIoChannelData<'a>;
+
+    /// Completes the asynchronous bdev destruction. SPDK only invokes this
+    /// after every I/O channel has been destroyed, so deferring completion
+    /// here (instead of dropping synchronously in `destruct()`) prevents the
+    /// bdev / I/O-device memory from being freed ahead of this callback.
+    fn unregister_callback(self: Pin<&mut Self>) -> Option<BdevDestructCompletion> {
+        self.bdev
+            .borrow()
+            .as_ref()
+            .map(|bdev| unsafe { bdev.async_destruct_completion() })
+    }
 
     /// TODO
     fn io_channel_create(self: Pin<&mut Self>) -> Self::ChannelData {
@@ -81,8 +95,11 @@ impl<'a> BdevOps for NullIoDevice<'a> {
     type IoDev = Self;
 
     /// TODO
-    fn destruct(self: Pin<&mut Self>) {
+    fn destruct(self: Pin<&mut Self>) -> BdevDestruct {
         self.unregister_io_device();
+        // Completion is deferred to `IoDevice::unregister_callback`, which runs
+        // only once every I/O channel has been destroyed.
+        BdevDestruct::Async
     }
 
     /// TODO
@@ -117,6 +134,7 @@ impl NullIoDevice<'_> {
             _my_name: String::from(name),
             _smth: 789,
             next_chan_id: RefCell::new(10),
+            bdev: RefCell::new(None),
             _a: Default::default(),
         };
 
@@ -131,6 +149,9 @@ impl NullIoDevice<'_> {
             .build();
 
         bdev.data().register_io_device(Some(name));
+        // Store a handle to our own bdev so async destruction can be completed
+        // from the I/O device unregister callback.
+        *bdev.data().bdev.borrow_mut() = Some(bdev.clone());
 
         match bdev.register_bdev() {
             Ok(_) => info!("NullNg Bdev regustered"),

--- a/io-engine/src/bdev/uring.rs
+++ b/io-engine/src/bdev/uring.rs
@@ -139,7 +139,9 @@ impl CreateDestroy for Uring {
                     })?
                     .context(bdev_api::DestroyBdevFailed {
                         name: self.get_name(),
-                    })
+                    })?;
+                tracing::info!("{:?}: deleted", self);
+                Ok(())
             }
             None => Err(BdevError::BdevNotFound {
                 name: self.get_name(),


### PR DESCRIPTION
Update io-engine to the spdk-rs API where `BdevOps::destruct()` returns `BdevDestruct` and container teardown can be deferred to the I/O device unregister callback. This avoids freeing a bdev's container (which co-allocates the `spdk_bdev` and its io_device) before SPDK's deferred `spdk_io_device_unregister` callback has run.

- nexus: `destruct()` now unregisters the I/O device and returns `BdevDestruct::Async`, completing teardown via `unregister_callback` using `Bdev::async_destruct_completion()`. The already-`Closed` fast-path also returns `Async` (not `Sync`) so it does not free the container while the pending unregister completion is still in flight, which would be a double-free/use-after-free.
- null_ng: implement the same async-destruction pattern (hold a handle to the bdev, defer completion from the io_device unregister callback) and fix the corresponding latent teardown bug.
- Bump the spdk-rs submodule to the async-destruction commit.

Also includes minor unrelated logging/diagnostics improvements:
- close_children collects and logs the actual child close errors and the count instead of a bare failure message.
- aio/uring: log a confirmation line on successful bdev deletion.