### PR TITLE
Lvol race: listing pools when destroying replicas

### DIFF
--- a/io-engine/src/lvs/lvs_lvol.rs
+++ b/io-engine/src/lvs/lvs_lvol.rs
@@ -303,7 +303,11 @@ impl Lvol {
         if lvol.is_null() {
             return None;
         }
-        Some(Self::from_inner_ptr(lvol))
+        let lvol = Self::from_inner_ptr(lvol);
+        if lvol.is_deleting() {
+            return None;
+        }
+        Some(lvol)
     }
 
     /// Wipe the first 8MB if unmap is not supported on failure the operation
@@ -534,6 +538,25 @@ impl Lvol {
         };
         count
     }
+
+    /// Check if the lvol is deleting.
+    /// This is true if the blob is null, which happens when the lvol is being destroyed but yet
+    /// to be unlinked from the lvstore's list.
+    pub(crate) fn is_deleting(&self) -> bool {
+        self.blob_safe().is_err()
+    }
+    /// Inner variant of [`Self::blob`] that returns an error if the blob is null.
+    /// This one doesn't debug assert, so use it when you want to handle the error in debug mode.
+    fn blob_safe(&self) -> Result<*mut spdk_blob, LvsError> {
+        let blob = self.as_inner_ref().blob;
+        if blob.is_null() {
+            return Err(LvsError::Invalid {
+                source: BsError::LvolNotFound {},
+                msg: "lvol blob is null (lvol is being destroyed)".to_string(),
+            });
+        }
+        Ok(blob)
+    }
 }
 
 pub struct LvolPtpl {
@@ -654,6 +677,9 @@ pub trait LvsLvol: LogicalVolume + Share {
 
     /// Get BlobPtr from spdk_lvol.
     fn blob_checked(&self) -> *mut spdk_blob;
+
+    /// Get the BlobPtr from the spdk_lvol, returning an error if it is null.
+    fn blob(&self) -> Result<*mut spdk_blob, LvsError>;
 
     /// Wrapper function to destroy replica and its associated snapshot if
     /// replica is identified as last clone.
@@ -1053,6 +1079,20 @@ impl LvsLvol for Lvol {
     fn blob_checked(&self) -> *mut spdk_blob {
         let blob = self.as_inner_ref().blob;
         assert!(!blob.is_null());
+        blob
+    }
+
+    /// Get the BlobPtr from the spdk_lvol, returning an error if it is null.
+    ///
+    /// The blob can be null when the lvol is being destroyed:
+    /// it is closed and set to null (`lvol_close_blob_cb`) before
+    /// the lvol is unlinked from the lvstore's list (`lvol_delete_blob_cb`).
+    ///
+    /// Callers on the enumeration/stats path must use this variant and handle
+    /// the error gracefully.
+    fn blob(&self) -> Result<*mut spdk_blob, LvsError> {
+        let blob = self.blob_safe();
+        debug_assert!(blob.is_ok());
         blob
     }
 

--- a/io-engine/src/lvs/lvs_store.rs
+++ b/io-engine/src/lvs/lvs_store.rs
@@ -1162,7 +1162,11 @@ impl Lvs {
     /// return an iterator that filters out all bdevs that patch the pool
     /// signature
     pub fn lvols(&self) -> impl Iterator<Item = Lvol> {
-        super::lvol_iter::LvsLvolIter::new(self)
+        // Skip lvols which are being destroyed: their blob is closed and
+        // nulled before they are unlinked from the lvstore's list, so
+        // inspecting them (e.g. computing committed size) would dereference
+        // a null blob.
+        super::lvol_iter::LvsLvolIter::new(self).filter(|lvol| !lvol.is_deleting())
     }
 
     /// create a new lvol on this pool

--- a/io-engine/tests/lvs_replica_destroy_race.rs
+++ b/io-engine/tests/lvs_replica_destroy_race.rs
@@ -1,0 +1,133 @@
+pub mod common;
+
+use common::compose::{
+    rpc::v1::{
+        pool::{CreatePoolRequest, ListPoolOptions},
+        replica::{destroy_replica_request, CreateReplicaRequest, DestroyReplicaRequest},
+        GrpcConnect,
+    },
+    Binary, Builder,
+};
+
+/// Reproducer for concurrency issues between stats and replica destroy
+/// as seen in openebs/mayastor#2055.
+///
+/// Root cause of the race (all on the single-threaded reactor, inside SPDK):
+///  1. `DestroyReplica` calls `vbdev_lvol_destroy`, which first
+///     `spdk_bdev_unregister`s the lvol bdev. The bdev destruct closes the
+///     lvol and `lvol_close_blob_cb` sets `lvol->blob = NULL`.
+///  2. The lvol is NOT unlinked from the `lvs->lvols` list until later, in
+///     `lvol_delete_blob_cb`, after `spdk_bs_delete_blob` completes.
+///  3. Between those two SPDK callbacks the lvol is still enumerable via
+///     `Lvs::lvols()` but its blob is already null.
+///
+/// A concurrent `ListPools` gRPC (as issued by `metrics-exporter-io-engine`)
+/// builds the `Pool` message, which computes `Lvs::committed()` ->
+/// `Lvol::committed()` -> `blob_checked()`, dereferencing the null blob during
+/// that window and aborting the whole data-plane process.
+#[tokio::test]
+async fn lvs_replica_destroy_committed_race() {
+    // Number of create/destroy iterations. The null-blob window is only a few
+    // reactor iterations wide, so we churn enough times to overlap with the
+    // concurrent `ListPools` stream.
+    const ITERATIONS: usize = 500;
+    const POOL_NAME: &str = "pool-2055";
+    const POOL_UUID: &str = "40baf8b5-6256-4f29-b073-61ebf67d20a0";
+
+    common::composer_init();
+    let test = Builder::new()
+        .name("lvs_replica_destroy_race")
+        .network("10.1.0.0/16")
+        .unwrap()
+        .add_container_bin(
+            "ms",
+            Binary::from_dbg("io-engine").with_args(vec!["-l", "1"]),
+        )
+        .with_clean(true)
+        .build()
+        .await
+        .unwrap();
+
+    let conn = GrpcConnect::new(&test);
+
+    // Two independent gRPC handles to the *same* io-engine, so that the
+    // `DestroyReplica` and `ListPools` calls are processed concurrently by the
+    // engine (mirroring the control-plane and the metrics-exporter).
+    let mut churn_hdl = conn.grpc_handle("ms").await.unwrap();
+    let mut stats_hdl = conn.grpc_handle("ms").await.unwrap();
+
+    // Create the pool used for the churn.
+    churn_hdl
+        .pool
+        .create_pool(CreatePoolRequest {
+            name: POOL_NAME.into(),
+            uuid: Some(POOL_UUID.into()),
+            pooltype: 0,
+            disks: vec!["malloc:///disk0?size_mb=128".into()],
+            cluster_size: None,
+            md_args: None,
+            encryption: None,
+        })
+        .await
+        .unwrap();
+
+    // Task #1: the metrics-exporter path. Repeatedly list pools, which builds
+    // the `Pool` message and computes `committed()` over every lvol. Runs until
+    // the churn signals completion on the channel.
+    let (stop_tx, mut stop_rx) = tokio::sync::oneshot::channel::<()>();
+    let stats_task = async move {
+        loop {
+            if stop_rx.try_recv().is_ok() {
+                break;
+            }
+            // On unfixed code this returns a transport error once the engine
+            // aborts with `assertion failed: !blob.is_null()`.
+            stats_hdl
+                .pool
+                .list_pools(ListPoolOptions {
+                    name: None,
+                    pooltype: None,
+                    uuid: None,
+                })
+                .await
+                .expect("list_pools failed - the io-engine likely panicked (see #2055)");
+        }
+    };
+
+    // Task #2: the control-plane path. Create and destroy thin replicas so that
+    // each destruction overlaps with the concurrent `ListPools` enumeration.
+    let churn_task = async move {
+        for i in 0..ITERATIONS {
+            let uuid = format!("00000000-0000-0000-0000-{i:012x}");
+            let name = format!("replica-{i}");
+
+            churn_hdl
+                .replica
+                .create_replica(CreateReplicaRequest {
+                    name: name.clone(),
+                    uuid: uuid.clone(),
+                    pooluuid: POOL_UUID.into(),
+                    size: 16 * 1024 * 1024,
+                    thin: true,
+                    share: 0,
+                    ..Default::default()
+                })
+                .await
+                .expect("create_replica failed - the io-engine likely panicked (see #2055)");
+
+            churn_hdl
+                .replica
+                .destroy_replica(DestroyReplicaRequest {
+                    uuid: uuid.clone(),
+                    pool: Some(destroy_replica_request::Pool::PoolUuid(POOL_UUID.into())),
+                })
+                .await
+                .expect("destroy_replica failed - the io-engine likely panicked (see #2055)");
+        }
+        let _ = stop_tx.send(());
+    };
+
+    // Drive both concurrently. If the race triggers, the engine aborts and one
+    // of the `.expect(..)`s above fails the test.
+    tokio::join!(stats_task, churn_task);
+}


### PR DESCRIPTION
    fix: don't list lvs lvols which are deleting
    
    Root cause of the race (all on the single-threaded reactor, inside SPDK):
    1. `DestroyReplica` calls `vbdev_lvol_destroy`, which first
        `spdk_bdev_unregister`s the lvol bdev. The bdev destruct closes the
        lvol and `lvol_close_blob_cb` sets `lvol->blob = NULL`.
    2. The lvol is NOT unlinked from the `lvs->lvols` list until later, in
        `lvol_delete_blob_cb`, after `spdk_bs_delete_blob` completes.
    3. Between those two SPDK callbacks the lvol is still enumerable via
        `Lvs::lvols()` but its blob is already null.
    
    When listing lvols from an lvolstore, we now skip the ones which are deleting.
    This means a pool list call will not compute the committed or any other
    information from these deleting lvols.
    
---

    test: concurrent pool list and replica destroy
    
    Adds a test to reproduce the reported issue with the metrics export doing list
    call whilst a replica is being destroyed.
