### PR TITLE
fix(ci): trigger release workflow on published instead of created

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release Tagging Workflow
 
 on:
   release:
-    types: [ created ]
+    types: [ published ]
 
 jobs:
   preflight-checks:


### PR DESCRIPTION
The `created` release event also fires when a draft release is saved — before the tag even exists — which would prematurely mirror images from staging to Docker Hub.

`published` is the definitive signal, and this keeps the workflow in step with the mayastor-extensions release pipeline (which uploads the kubectl release assets to this repo's release on publish).

Companion to the mayastor-extensions PR fixing the release/krew artifact race.