### PR TITLE
ci(image): build and attest the image SBOMs

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -39,3 +39,11 @@ pull_request_rules:
         type: APPROVE
         message: "Automatically approved backport PR"
         bot_account: openebs-ci
+  - name: auto-approve dependabot PRs
+    conditions:
+      - author=dependabot[bot]
+    actions:
+      review:
+        type: APPROVE
+        message: "Automatically approved dependabot PR"
+        bot_account: openebs-ci

--- a/.github/workflows/image-pr.yml
+++ b/.github/workflows/image-pr.yml
@@ -22,4 +22,7 @@ jobs:
           submodules: 'recursive'
       - uses: cachix/install-nix-action@v31.11.1
       - name: Test building the release images
-        run: ./scripts/release.sh --skip-publish --build-bins
+        # SBOMs are generated here too so a break in the SBOM path is caught
+        # pre-merge rather than on the develop push. Nothing is signed, since
+        # nothing is published.
+        run: ./scripts/release.sh --skip-publish --build-bins --sbom

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -82,10 +82,16 @@ jobs:
         with:
           tag: ${{ env.TAG }}
           registry: ${{ needs.vars.outputs.registry }}
+          sbom: 'true'
 
   manifest-push:
     needs: [vars, image-build]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      # Required for cosign to get an OIDC token for keyless signing.
+      id-token: write
     steps:
       - uses: actions/checkout@v7
         with:
@@ -99,3 +105,4 @@ jobs:
           dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
           dockerhub-password: ${{ secrets.DOCKERHUB_TOKEN }}
           ghcr-token: ${{ secrets.GITHUB_TOKEN }}
+          attest: 'true'

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ ansible-hosts
 /ci-report/
 /local-fio-0-verify.state
 /test/python/local-job-fs-0-verify.state
+/cosign.key
+/cosign.pub
+/sbom/


### PR DESCRIPTION
Bumps the dependencies submodule for its SBOM and attestation support,
and turns it on for the image workflows, so that every published image
carries a CycloneDX SBOM as a signed in-toto attestation.

The SBOM is produced by scanning the built image with syft, rather than
its nix closure: cargo vendors the crates into a single derivation, so a
closure scan lists glibc and openssl but not one of our own rust
dependencies, which is where the advisories are. For io-engine that is
the difference between 8 components and around 830.

Both phases of the multi-arch build are involved:

- the per-arch build jobs each scan the image they built, natively, so
  the SBOM describes that architecture and travels with the archive.

- the manifest push signs the manifest list, and each architecture's
  manifest within it, then attaches each architecture's SBOM to its own
  manifest. A single SBOM describes only the architecture it was scanned
  on, so attesting the list with one of them would claim contents that
  were never scanned.

Nothing is added to the images themselves: the signature and the SBOM
are attached in the registry, as OCI 1.1 referrers of the manifest they
describe. They are addressed by digest rather than by tag, so verifying
a floating tag such as :develop always returns the SBOM of whatever that
tag currently points at, and a previous build's SBOM cannot be returned
for it.

Signing is keyless, against the workflow's own OIDC identity, hence the
"id-token: write" permission on the manifest-push job. The signature
therefore attests which workflow, repository and ref built the image,
and not merely that somebody signed it.

image-pr.yml builds an SBOM as well, so that a break in that path is
caught pre-merge; nothing is signed there, as nothing is published. The
SBOMs are uploaded as workflow artifacts either way, per architecture.

Verify a published image with:

  ISS=https://token.actions.githubusercontent.com
  ID='^https://github\.com/openebs/mayastor/\.github/workflows/image\.yml@'

  cosign verify --experimental-oci11 \
    --certificate-oidc-issuer $ISS --certificate-identity-regexp "$ID" $REF

The SBOMs are attached to the per-architecture manifests rather than to
the list, so they are verified an architecture at a time:

  for D in $(crane manifest $REF | jq -r '.manifests[].digest'); do
    cosign verify-attestation --new-bundle-format --type cyclonedx \
      --certificate-oidc-issuer $ISS --certificate-identity-regexp "$ID" \
      "${REF%:*}@$D"
  done

The identity flags are the point of a keyless signature; without them the
check only proves that the image was signed by someone, which is no check
at all. That identity is the workflow which built the image, so it
differs from one repository to the next. To accept any of ours:

  '^https://github\.com/openebs/[^/]+/\.github/workflows/image\.yml@'

or leave the identity loose and pin the repository itself, with
--certificate-github-workflow-repository, which also has --ref and --sha
counterparts.

The remaining flags depend on the cosign version. --experimental-oci11 is
what makes it look for the signature as a referrer rather than under the
older tag, and without it an image reads as unsigned rather than as an
error; it is deprecated, as referrers are becoming the default. That has
already happened for attestations, which need --new-bundle-format on
cosign 2 and no flag at all on cosign 3.
