### PR TITLE
build: upgrade to rust 1.97.1 and drop ring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,34 +203,33 @@ dependencies = [
 
 [[package]]
 name = "async-nats"
-version = "0.37.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd3bdd6ea595b2ea504500a3566071beb81125fc15d40a6f6bffa43575f64152"
+checksum = "07d6f157065c3461096d51aacde0c326fa49f3f6e0199e204c566842cdaa5299"
 dependencies = [
  "aws-lc-rs",
  "base64 0.22.1",
  "bytes",
- "futures",
+ "futures-util",
  "memchr",
- "nkeys",
- "nuid",
- "once_cell",
+ "pin-project",
  "portable-atomic",
  "rand",
  "regex",
- "ring",
- "rustls-native-certs 0.7.3",
- "rustls-pemfile",
- "rustls-webpki 0.102.8",
+ "rustls-native-certs 0.8.3",
+ "rustls-pki-types",
+ "rustls-webpki",
  "serde",
  "serde_json",
  "serde_nanos",
  "serde_repr",
- "thiserror",
+ "thiserror 1.0.65",
  "time",
  "tokio",
  "tokio-rustls",
+ "tokio-stream",
  "tokio-util",
+ "tokio-websockets",
  "tracing",
  "tryhard",
  "url",
@@ -395,14 +394,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "backoff"
-version = "0.4.0"
+name = "backon"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
+checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
 dependencies = [
- "getrandom 0.2.15",
- "instant",
- "rand",
+ "fastrand",
+ "gloo-timers",
+ "tokio",
 ]
 
 [[package]]
@@ -431,12 +430,6 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
-
-[[package]]
-name = "base64ct"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bincode"
@@ -544,7 +537,7 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "serde_urlencoded",
- "thiserror",
+ "thiserror 1.0.65",
  "tokio",
  "tokio-util",
  "tower-service",
@@ -829,12 +822,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "const-oid"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
-
-[[package]]
 name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1004,32 +991,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "curve25519-dalek"
-version = "4.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "curve25519-dalek-derive",
- "digest",
- "fiat-crypto",
- "rustc_version",
- "subtle",
-]
-
-[[package]]
-name = "curve25519-dalek-derive"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.89",
-]
-
-[[package]]
 name = "darling"
 version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1065,23 +1026,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "data-encoding"
-version = "2.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
-
-[[package]]
-name = "der"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
-dependencies = [
- "const-oid",
- "pem-rfc7468",
- "zeroize",
-]
-
-[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1089,17 +1033,6 @@ checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
  "serde_core",
-]
-
-[[package]]
-name = "derivative"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -1201,25 +1134,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
 
 [[package]]
-name = "ed25519"
-version = "2.2.3"
+name = "educe"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+checksum = "1d7bc049e1bd8cdeb31b68bbd586a9464ecf9f3944af3958a7a9d0f8b9799417"
 dependencies = [
- "signature",
-]
-
-[[package]]
-name = "ed25519-dalek"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
-dependencies = [
- "curve25519-dalek",
- "ed25519",
- "sha2",
- "signature",
- "subtle",
+ "enum-ordinalize",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -1233,6 +1156,26 @@ name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
+name = "enum-ordinalize"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89dd01549b09589510cf0647475075d12071456586d70f5c75c98ae2a5537677"
+dependencies = [
+ "enum-ordinalize-derive",
+]
+
+[[package]]
+name = "enum-ordinalize-derive"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a65863d15a4ce2888bd2f0f543cc963d3879c3a022c8ee43f6141d479a3ac815"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
+]
 
 [[package]]
 name = "enum-primitive-derive"
@@ -1364,12 +1307,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 
 [[package]]
-name = "fiat-crypto"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
-
-[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1382,19 +1319,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
-name = "fluent-uri"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17c704e9dbe1ddd863da1e6ff3567795087b1eb201ce80d8fa81162e1516500d"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foreign-types"
@@ -1636,6 +1570,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1671,19 +1617,14 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash 0.8.11",
- "allocator-api2",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "headers"
@@ -1740,6 +1681,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
 dependencies = [
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "hostname"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-link",
 ]
 
 [[package]]
@@ -2105,15 +2057,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "io-engine"
 version = "1.0.0"
 dependencies = [
@@ -2358,38 +2301,35 @@ dependencies = [
 
 [[package]]
 name = "json-patch"
-version = "2.0.0"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b1fb8864823fad91877e6caea0baca82e49e8db50f8e5c9f9a453e27d3330fc"
+checksum = "7421438de105a0827e44fadd05377727847d717c80ce29a229f85fd04c427b72"
 dependencies = [
  "jsonptr",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "jsonpath-rust"
-version = "0.5.1"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19d8fe85bd70ff715f31ce8c739194b423d79811a19602115d611a3ec85d6200"
+checksum = "0c00ae348f9f8fd2d09f82a98ca381c60df9e0820d8d79fce43e649b4dc3128b"
 dependencies = [
- "lazy_static",
- "once_cell",
  "pest",
  "pest_derive",
  "regex",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "jsonptr"
-version = "0.4.7"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c6e529149475ca0b2820835d3dce8fcc41c6b943ca608d32f35b449255e4627"
+checksum = "a5a3cc660ba5d72bce0b3bb295bf20847ccbb40fd423f3f05b61273672e561fe"
 dependencies = [
- "fluent-uri",
  "serde",
  "serde_json",
 ]
@@ -2408,12 +2348,13 @@ dependencies = [
 
 [[package]]
 name = "k8s-openapi"
-version = "0.22.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19501afb943ae5806548bc3ebd7f3374153ca057a38f480ef30adfde5ef09755"
+checksum = "2c75b990324f09bef15e791606b7b7a296d02fc88a344f6eba9390970a870ad5"
 dependencies = [
  "base64 0.22.1",
  "chrono",
+ "schemars",
  "serde",
  "serde-value",
  "serde_json",
@@ -2421,9 +2362,9 @@ dependencies = [
 
 [[package]]
 name = "kube"
-version = "0.94.2"
+version = "0.99.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ace78a62b361077505f2950bd48aa3e46596fb15350c9c993de15ddfa3cac5"
+checksum = "9a4eb20010536b48abe97fec37d23d43069bcbe9686adcf9932202327bc5ca6e"
 dependencies = [
  "k8s-openapi",
  "kube-client",
@@ -2434,9 +2375,9 @@ dependencies = [
 
 [[package]]
 name = "kube-client"
-version = "0.94.2"
+version = "0.99.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18ec0fcafd3add30b413b096a61d69b0a37f94d3f95b6f505a57ea3d27cec2a7"
+checksum = "7fc2ed952042df20d15ac2fe9614d0ec14b6118eab89633985d4b36e688dccf1"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -2457,24 +2398,23 @@ dependencies = [
  "kube-core",
  "pem",
  "rustls",
- "rustls-pemfile",
  "secrecy",
  "serde",
  "serde_json",
  "serde_yaml",
- "thiserror",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-util",
- "tower 0.4.13",
+ "tower 0.5.1",
  "tower-http",
  "tracing",
 ]
 
 [[package]]
 name = "kube-core"
-version = "0.94.2"
+version = "0.99.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a50c095f051dada37740d883b6d47ad0430e95082140718073b773c8a70f231c"
+checksum = "ff0d0793db58e70ca6d689489183816cb3aa481673e7433dc618cf7e8007c675"
 dependencies = [
  "chrono",
  "form_urlencoded",
@@ -2485,45 +2425,46 @@ dependencies = [
  "serde",
  "serde-value",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "kube-derive"
-version = "0.94.2"
+version = "0.99.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7871f02c3c848b63fee3d2f2645bb4a3c0b68ee147badcddf1b0cf8fb5db87ad"
+checksum = "c562f58dc9f7ca5feac8a6ee5850ca221edd6f04ce0dd2ee873202a88cd494c9"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
+ "serde",
  "serde_json",
  "syn 2.0.89",
 ]
 
 [[package]]
 name = "kube-runtime"
-version = "0.94.2"
+version = "0.99.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12d844a274127dfe8fad766db5bc53aa783fb3f9dd48b20f955ec65d454ec9b1"
+checksum = "88f34cfab9b4bd8633062e0e85edb81df23cb09f159f2e31c60b069ae826ffdc"
 dependencies = [
  "ahash 0.8.11",
  "async-broadcast",
  "async-stream",
  "async-trait",
- "backoff",
- "derivative",
+ "backon",
+ "educe",
  "futures",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.2",
+ "hostname",
  "json-patch",
- "jsonptr",
  "k8s-openapi",
  "kube-client",
  "parking_lot",
  "pin-project",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-util",
  "tracing",
@@ -2726,21 +2667,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nkeys"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879011babc47a1c7fdf5a935ae3cfe94f34645ca0cac1c7f6424b36fc743d1bf"
-dependencies = [
- "data-encoding",
- "ed25519",
- "ed25519-dalek",
- "getrandom 0.2.15",
- "log",
- "rand",
- "signatory",
-]
-
-[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2757,15 +2683,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "nuid"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc895af95856f929163a0aa20c26a78d26bfdc839f51b9d5aa7a5b79e52b7e83"
-dependencies = [
- "rand",
 ]
 
 [[package]]
@@ -2914,15 +2831,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pem-rfc7468"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
-dependencies = [
- "base64ct",
-]
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3023,16 +2931,6 @@ dependencies = [
  "atomic-waker",
  "fastrand",
  "futures-io",
-]
-
-[[package]]
-name = "pkcs8"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
-dependencies = [
- "der",
- "spki",
 ]
 
 [[package]]
@@ -3354,7 +3252,7 @@ checksum = "bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891"
 dependencies = [
  "getrandom 0.2.15",
  "libredox",
- "thiserror",
+ "thiserror 1.0.65",
 ]
 
 [[package]]
@@ -3488,15 +3386,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
-name = "rustc_version"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
-dependencies = [
- "semver",
-]
-
-[[package]]
 name = "rustix"
 version = "0.38.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3518,9 +3407,8 @@ dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
- "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.13",
+ "rustls-webpki",
  "subtle",
  "zeroize",
 ]
@@ -3566,17 +3454,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "zeroize",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.102.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
-dependencies = [
- "ring",
- "rustls-pki-types",
- "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -3659,11 +3536,10 @@ checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "secrecy"
-version = "0.8.0"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
 dependencies = [
- "serde",
  "zeroize",
 ]
 
@@ -3905,28 +3781,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "signatory"
-version = "0.27.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e303f8205714074f6068773f0e29527e0453937fe837c9717d066635b65f31"
-dependencies = [
- "pkcs8",
- "rand_core",
- "signature",
- "zeroize",
-]
-
-[[package]]
-name = "signature"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
-dependencies = [
- "digest",
- "rand_core",
-]
-
-[[package]]
 name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3997,16 +3851,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "spki"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
-dependencies = [
- "base64ct",
- "der",
-]
-
-[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4059,6 +3903,17 @@ name = "syn"
 version = "2.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44d46482f1c1c87acd84dea20c1bf5ebff4c757009ed6bf19cfd36fb10e92c4e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4140,7 +3995,16 @@ version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d11abd9594d9b38965ef50805c5e469ca9cc6f197f883f717e0269a3057b3d5"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.65",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
+dependencies = [
+ "thiserror-impl 2.0.20",
 ]
 
 [[package]]
@@ -4152,6 +4016,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.89",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -4296,6 +4171,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-websockets"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f591660438b3038dd04d16c938271c79e7e06260ad2ea2885a4861bfb238605d"
+dependencies = [
+ "aws-lc-rs",
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "httparse",
+ "rand",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4386,22 +4282,24 @@ dependencies = [
  "futures-util",
  "pin-project-lite",
  "sync_wrapper 0.1.2",
+ "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
 name = "tower-http"
-version = "0.5.2"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "base64 0.21.5",
+ "base64 0.22.1",
  "bitflags 2.6.0",
  "bytes",
  "http",
  "http-body",
- "http-body-util",
  "mime",
  "pin-project-lite",
  "tower-layer",
@@ -4746,6 +4644,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.9",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4784,6 +4700,12 @@ checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
  "windows-targets 0.52.6",
 ]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,8 +76,7 @@ run_script = "0.11.0"
 derive_builder = "0.20.2"
 regex = "1.11.1"
 
-async-nats = { version = "0.37.0", default-features = false }
+async-nats = { version = "0.47.0", default-features = false, features = ["aws-lc-rs", "jetstream"] }
 
-k8s-openapi = { version = "0.22.0", features = ["v1_24"] }
-kube = { version = "0.94.2", features = ["derive", "runtime"] }
-
+k8s-openapi = { version = "0.24.0", default-features = false, features = ["v1_28", "schemars"] }
+kube = { version = "0.99.0", default-features = false, features = ["runtime", "derive", "client", "rustls-tls", "aws-lc-rs"] }

--- a/io-engine-tests/src/compose/rpc/v1.rs
+++ b/io-engine-tests/src/compose/rpc/v1.rs
@@ -24,7 +24,7 @@ pub struct SharedRpcHandle {
 }
 
 impl SharedRpcHandle {
-    pub async fn lock(&self) -> HandleLockGuard<RpcHandle> {
+    pub async fn lock(&self) -> HandleLockGuard<'_, RpcHandle> {
         self.handle.lock().await
     }
 

--- a/io-engine-tests/src/file_io.rs
+++ b/io-engine-tests/src/file_io.rs
@@ -210,7 +210,7 @@ pub async fn compare_files(
         for i in 0..na {
             if buf_a[i] != buf_b[i] {
                 return Err(Error::other(format!(
-                    "Miscompare at {pos}: {na:?} {va:#02x} != {nb:?} {vb:#02x}",
+                    "Miscompare at {pos}: {na:?} {va:#0x} != {nb:?} {vb:#0x}",
                     na = name_a,
                     va = buf_a[i],
                     nb = name_b,

--- a/io-engine-tests/src/pool.rs
+++ b/io-engine-tests/src/pool.rs
@@ -222,7 +222,7 @@ impl PoolBuilderRpc {
                 uuid: Some(self.uuid()),
             })
             .await
-            .map(|r| (r.into_inner()))
+            .map(|r| r.into_inner())
     }
 
     pub async fn get_pool(&self) -> Result<Pool, Status> {

--- a/io-engine/src/bdev/nexus/nexus_bdev.rs
+++ b/io-engine/src/bdev/nexus/nexus_bdev.rs
@@ -616,14 +616,14 @@ impl<'n> Nexus<'n> {
     }
 
     /// TODO
-    pub fn children_iter(&self) -> std::slice::Iter<NexusChild<'n>> {
+    pub fn children_iter(&self) -> std::slice::Iter<'_, NexusChild<'n>> {
         self.children.iter()
     }
 
     /// TODO
     pub(super) unsafe fn children_iter_mut(
         self: Pin<&mut Self>,
-    ) -> std::slice::IterMut<NexusChild<'n>> {
+    ) -> std::slice::IterMut<'_, NexusChild<'n>> {
         self.unpin_mut().children.iter_mut()
     }
 

--- a/io-engine/src/bdev/nexus/nexus_bdev_rebuild.rs
+++ b/io-engine/src/bdev/nexus/nexus_bdev_rebuild.rs
@@ -297,7 +297,7 @@ impl<'n> Nexus<'n> {
     }
 
     /// Return a mutex guard of the replica rebuild history.
-    pub fn rebuild_history_guard(&self) -> parking_lot::MutexGuard<Vec<HistoryRecord>> {
+    pub fn rebuild_history_guard(&self) -> parking_lot::MutexGuard<'_, Vec<HistoryRecord>> {
         self.rebuild_history.lock()
     }
 

--- a/io-engine/src/bdev/nexus/nexus_bdev_snapshot.rs
+++ b/io-engine/src/bdev/nexus/nexus_bdev_snapshot.rs
@@ -83,16 +83,17 @@ impl ReplicaSnapshotExecutor {
         let mut skipped_replicas = Vec::new();
 
         for r in &replicas {
-            let replica = match nexus_replicas.get(&r.replica_uuid) {
+            let r_uuid: &String = &r.replica_uuid;
+            let replica = match nexus_replicas.get(r_uuid) {
                 Some(c) => {
                     // Make sure target replica appers only once.
-                    if seen_replicas.contains(&r.replica_uuid) {
+                    if seen_replicas.contains(r_uuid) {
                         return Err(Error::FailedCreateSnapshot {
                             name: nexus.bdev_name(),
-                            reason: format!("Duplicated replica {}", &r.replica_uuid,),
+                            reason: format!("Duplicated replica {r_uuid}"),
                         });
                     }
-                    seen_replicas.insert(r.replica_uuid.to_string());
+                    seen_replicas.insert(r_uuid.to_string());
 
                     *c
                 }
@@ -100,9 +101,8 @@ impl ReplicaSnapshotExecutor {
                     return Err(Error::FailedCreateSnapshot {
                         name: nexus.bdev_name(),
                         reason: format!(
-                            "Nexus {}, does not contain replica with UUID {}",
+                            "Nexus {}, does not contain replica with UUID {r_uuid}",
                             nexus.bdev_name(),
-                            &r.replica_uuid,
                         ),
                     })
                 }
@@ -113,7 +113,7 @@ impl ReplicaSnapshotExecutor {
                 if !replica.is_healthy() {
                     return Err(Error::FailedCreateSnapshot {
                         name: nexus.bdev_name(),
-                        reason: format!("Replica {} is not healthy", &r.replica_uuid,),
+                        reason: format!("Replica {r_uuid} is not healthy"),
                     });
                 }
 
@@ -124,10 +124,7 @@ impl ReplicaSnapshotExecutor {
                     None => {
                         return Err(Error::FailedCreateSnapshot {
                             name: nexus.bdev_name(),
-                            reason: format!(
-                                "Snapshot UUID is missing for replica {}",
-                                &r.replica_uuid,
-                            ),
+                            reason: format!("Snapshot UUID is missing for replica {r_uuid}"),
                         })
                     }
                 };

--- a/io-engine/src/bdev/nexus/nexus_child.rs
+++ b/io-engine/src/bdev/nexus/nexus_child.rs
@@ -1037,8 +1037,8 @@ impl<'c> NexusChild<'c> {
         }
 
         // TODO: Check device claiming scheme.
-        if self.device_descriptor.is_some() {
-            self.device_descriptor.as_ref().unwrap().unclaim();
+        if let Some(descriptor) = &self.device_descriptor {
+            descriptor.unclaim();
         }
 
         // Destruction raises a device removal event.

--- a/io-engine/src/bdev/nvmf.rs
+++ b/io-engine/src/bdev/nvmf.rs
@@ -26,6 +26,7 @@ use crate::{
     ffihelper::{cb_arg, errno_result_from_i32, ErrnoResult},
 };
 
+#[allow(dead_code)]
 const DEFAULT_NVMF_PORT: u16 = 4420;
 
 #[derive(Debug)]
@@ -273,6 +274,7 @@ struct NvmeCreateContext {
 unsafe impl Send for NvmeCreateContext {}
 
 impl NvmeCreateContext {
+    #[allow(dead_code)]
     pub fn new(nvmf: &Nvmf) -> NvmeCreateContext {
         let port = format!("{}", nvmf.port);
         let protocol = "TCP";

--- a/io-engine/src/bdev/nvmx/controller.rs
+++ b/io-engine/src/bdev/nvmx/controller.rs
@@ -1168,16 +1168,11 @@ pub(crate) mod transport {
         }
     }
 
-    #[derive(Debug)]
+    #[derive(Debug, Default)]
     #[allow(clippy::upper_case_acronyms)]
     enum TransportId {
+        #[default]
         TCP = 0x3,
-    }
-
-    impl Default for TransportId {
-        fn default() -> Self {
-            Self::TCP
-        }
     }
 
     impl From<TransportId> for String {
@@ -1188,20 +1183,15 @@ pub(crate) mod transport {
         }
     }
 
-    #[derive(Debug)]
+    #[derive(Debug, Default)]
     #[allow(dead_code)]
     pub(crate) enum AdressFamily {
+        #[default]
         NvmfAdrfamIpv4 = 0x1,
         NvmfAdrfamIpv6 = 0x2,
         NvmfAdrfamIb = 0x3,
         NvmfAdrfamFc = 0x4,
         NvmfAdrfamLoop = 0xfe,
-    }
-
-    impl Default for AdressFamily {
-        fn default() -> Self {
-            Self::NvmfAdrfamIpv4
-        }
     }
 
     #[derive(Default, Debug)]

--- a/io-engine/src/bdev/nvmx/mod.rs
+++ b/io-engine/src/bdev/nvmx/mod.rs
@@ -40,11 +40,11 @@ pub struct NVMeCtlrList<'a> {
 }
 
 impl<'a> NVMeCtlrList<'a> {
-    fn write_lock(&self) -> RwLockWriteGuard<HashMap<String, Arc<Mutex<NvmeController<'a>>>>> {
+    fn write_lock(&self) -> RwLockWriteGuard<'_, HashMap<String, Arc<Mutex<NvmeController<'a>>>>> {
         self.entries.write()
     }
 
-    fn read_lock(&self) -> RwLockReadGuard<HashMap<String, Arc<Mutex<NvmeController<'a>>>>> {
+    fn read_lock(&self) -> RwLockReadGuard<'_, HashMap<String, Arc<Mutex<NvmeController<'a>>>>> {
         self.entries.read()
     }
 

--- a/io-engine/src/bdev/nvmx/uri.rs
+++ b/io-engine/src/bdev/nvmx/uri.rs
@@ -203,7 +203,7 @@ pub(crate) struct NvmeControllerContext<'probe> {
 }
 
 impl NvmeControllerContext<'_> {
-    pub fn new(template: &NvmfDeviceTemplate) -> NvmeControllerContext {
+    pub fn new(template: &NvmfDeviceTemplate) -> NvmeControllerContext<'_> {
         let trid = controller::transport::Builder::new()
             .with_subnqn(&template.subnqn)
             .with_svcid(template.port.to_string())

--- a/io-engine/src/bin/io-engine-client/v1/nexus_cli.rs
+++ b/io-engine/src/bin/io-engine-client/v1/nexus_cli.rs
@@ -664,7 +664,7 @@ async fn nexus_remove(mut ctx: Context, args: RemoveArgs) -> crate::Result<()> {
             println!("{json}");
         }
         OutputFormat::Default => {
-            println!("Removed {} from specified nexus", &args.uri);
+            println!("Removed {} from specified nexus", args.uri);
         }
     };
 

--- a/io-engine/src/bin/io-engine-client/v1/pool_cli.rs
+++ b/io-engine/src/bin/io-engine-client/v1/pool_cli.rs
@@ -369,7 +369,7 @@ async fn destroy(mut ctx: Context, args: DestroyArgs) -> crate::Result<()> {
     match ctx.output {
         OutputFormat::Json => {}
         OutputFormat::Default => {
-            println!("pool: {} is deleted", &name);
+            println!("pool: {name} is deleted");
         }
     };
 
@@ -393,7 +393,7 @@ async fn export(mut ctx: Context, args: ExportArgs) -> crate::Result<()> {
     match ctx.output {
         OutputFormat::Json => {}
         OutputFormat::Default => {
-            println!("pool: {} is exported", &name);
+            println!("pool: {name} is exported");
         }
     };
 

--- a/io-engine/src/core/env.rs
+++ b/io-engine/src/core/env.rs
@@ -824,14 +824,8 @@ impl MayastorEnvironment {
             args.push(CString::new("--single-file-segments").unwrap());
         }
 
-        if self.hugedir.is_some() {
-            args.push(
-                CString::new(format!(
-                    "--huge-dir={}",
-                    &self.hugedir.as_ref().unwrap().clone()
-                ))
-                .unwrap(),
-            )
+        if let Some(hugedir) = &self.hugedir {
+            args.push(CString::new(format!("--huge-dir={hugedir}")).unwrap())
         }
 
         if cfg!(target_os = "linux") {
@@ -864,11 +858,9 @@ impl MayastorEnvironment {
 
         // any additional parameters we want to pass down to the eal. These
         // arguments are not checked or validated.
-        if self.env_context.is_some() {
+        if let Some(env_contex) = &self.env_context {
             args.extend(
-                self.env_context
-                    .as_ref()
-                    .unwrap()
+                env_contex
                     .split_ascii_whitespace()
                     .map(|s| CString::new(s.to_string()).unwrap())
                     .collect::<Vec<_>>(),

--- a/io-engine/src/core/fault_injection/inject_io_ctx.rs
+++ b/io-engine/src/core/fault_injection/inject_io_ctx.rs
@@ -16,7 +16,12 @@ pub enum InjectIoDevice {
 
 impl From<&dyn BlockDevice> for InjectIoDevice {
     fn from(dev: &dyn BlockDevice) -> Self {
-        Self::BlockDevice(dev as *const _ as *mut dyn BlockDevice)
+        // Raw pointer casts of trait objects can no longer extend lifetimes,
+        // so transmute to erase the reference lifetime (this stores an
+        // unmanaged raw pointer that is used unsafely later).
+        Self::BlockDevice(unsafe {
+            std::mem::transmute::<*const dyn BlockDevice, *mut dyn BlockDevice>(dev)
+        })
     }
 }
 

--- a/io-engine/src/core/gpt/label.rs
+++ b/io-engine/src/core/gpt/label.rs
@@ -32,7 +32,7 @@ impl DataExtent {
 
     /// Check if this partition size is multiple of the given number of blocks.
     pub fn is_multiple_of(&self, blocks: u64) -> bool {
-        self.size() % blocks == 0
+        self.size().is_multiple_of(blocks)
     }
 }
 

--- a/io-engine/src/core/gpt/maya.rs
+++ b/io-engine/src/core/gpt/maya.rs
@@ -515,11 +515,11 @@ pub mod v2 {
             let size_bytes = (extent.end - extent.start + 1) * block_size;
             assert_eq!(size_bytes, 5 * 1024 * 1024);
             assert!(
-                size_bytes % (1024 * 1024) == 0,
+                size_bytes.is_multiple_of(1024 * 1024),
                 "size must be 1 MiB aligned"
             );
             assert!(
-                size_bytes % (4 * 1024 * 1024) != 0,
+                !size_bytes.is_multiple_of(4 * 1024 * 1024),
                 "size must not be a multiple of 4 MiB for a 13 MiB device"
             );
             assert_eq!(num_blocks - 1 - extent.end, void);

--- a/io-engine/src/core/gpt/primitives.rs
+++ b/io-engine/src/core/gpt/primitives.rs
@@ -498,7 +498,7 @@ impl GptEntry {
 
     /// Check if this partition size is multiple of the given number of blocks.
     pub fn is_multiple_of(&self, blocks: u64) -> bool {
-        self.size() % blocks == 0
+        self.size().is_multiple_of(blocks)
     }
 }
 

--- a/io-engine/src/core/io_driver.rs
+++ b/io-engine/src/core/io_driver.rs
@@ -15,18 +15,13 @@ use crate::{
 
 use spdk_rs::{DmaBuf, IoChannelGuard, Thread};
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Default, Copy, Clone)]
 pub enum IoType {
     /// perform random read operations
+    #[default]
     Read,
     /// perform random write operations
     Write,
-}
-
-impl Default for IoType {
-    fn default() -> Self {
-        Self::Read
-    }
 }
 
 #[derive(Debug)]

--- a/io-engine/src/core/wiper.rs
+++ b/io-engine/src/core/wiper.rs
@@ -385,7 +385,10 @@ impl WipeIterator {
         let mut chunks = total_bytes / chunk_size_bytes;
         let remainder = total_bytes % chunk_size_bytes;
         // must be aligned to block device
-        snafu::ensure!(remainder % block_len == 0, ChunkBlockSizeInvalid {});
+        snafu::ensure!(
+            remainder.is_multiple_of(block_len),
+            ChunkBlockSizeInvalid {}
+        );
         let extra_chunk_size_bytes = if remainder == 0 {
             None
         } else {

--- a/io-engine/tests/memory_pool.rs
+++ b/io-engine/tests/memory_pool.rs
@@ -116,7 +116,7 @@ async fn test_get() {
         // Free all elements before dropping the pool.
         // Memory pools panic if being dropped whilst having any live
         // allocations - should not happen now.
-        for (_, v) in used_addrs.iter() {
+        for v in used_addrs.values() {
             pool.put(*v);
         }
 

--- a/io-engine/tests/nexus_io.rs
+++ b/io-engine/tests/nexus_io.rs
@@ -240,10 +240,10 @@ async fn nexus_io_multipath() {
     );
     let s = String::from_utf8(output_dis.stdout).unwrap();
     let v: Vec<&str> = s.split(' ').collect();
-    tracing::info!("nvme disconnected: {:?}", v);
+    tracing::info!("nvme disconnected: {v:?}");
     assert_eq!(v.len(), 4);
     assert_eq!(v[1], "disconnected");
-    assert_eq!(v[0], format!("NQN:{}", &nqn), "mismatched NQN disconnected");
+    assert_eq!(v[0], format!("NQN:{nqn}"), "mismatched NQN disconnected");
     assert_eq!(v[2], "2", "mismatched number of controllers disconnected");
 
     // Connect to remote replica to check key registered
@@ -962,10 +962,8 @@ async fn nexus_io_resv_preempt_tabled() {
         test_fn(&mut hdls, test_resv, resv_key, true).await;
     }
 
-    let mut resv_key = 0x1;
-    for test_resv in test_matrix {
-        test_fn(&mut hdls, test_resv, resv_key, true).await;
-        resv_key += 1;
+    for (resv_key, test_resv) in test_matrix.iter().enumerate() {
+        test_fn(&mut hdls, *test_resv, resv_key as u64 + 1, true).await;
     }
 
     let resv_key = 0x1;
@@ -973,10 +971,9 @@ async fn nexus_io_resv_preempt_tabled() {
         test_fn(&mut hdls, test_resv, resv_key, (resv_key % 2) == 1).await;
     }
 
-    let mut resv_key = 0x1;
-    for test_resv in test_matrix {
-        test_fn(&mut hdls, test_resv, resv_key, (resv_key % 2) == 1).await;
-        resv_key += 1;
+    for (resv_key, test_resv) in test_matrix.iter().enumerate() {
+        let resv_key: u64 = resv_key as u64 + 1;
+        test_fn(&mut hdls, *test_resv, resv_key, (resv_key % 2) == 1).await;
     }
 }
 
@@ -1310,7 +1307,7 @@ async fn nexus_io_freeze() {
                 &name,
                 32 * 1024 * 1024,
                 Some(NEXUS_UUID),
-                &[children.to_string()],
+                std::slice::from_ref(&children),
             )
             .await
             .unwrap();

--- a/io-engine/tests/nexus_rebuild.rs
+++ b/io-engine/tests/nexus_rebuild.rs
@@ -227,15 +227,15 @@ async fn rebuild_replica() {
         for child in 0..NUM_CHILDREN {
             NexusRebuildJob::lookup(&get_dev(child)).expect_err("Should not exist");
 
-            NexusRebuildJob::lookup_src(&get_dev(child))
+            let jobs = NexusRebuildJob::lookup_src(&get_dev(child))
                 .iter()
                 .inspect(|&job| {
-                    error!(
-                        "Job {:?} should be associated with src child {}",
-                        job, child
-                    );
+                    error!("Job {job:?} should be associated with src child {child}");
                 })
-                .any(|_| panic!("Should not have found any jobs!"));
+                .count();
+            if jobs > 0 {
+                panic!("Should not have found any jobs!");
+            }
         }
 
         let _ = nexus.start_rebuild(&get_dev(NUM_CHILDREN)).await;
@@ -250,16 +250,16 @@ async fn rebuild_replica() {
 
         for child in 0..NUM_CHILDREN {
             if get_dev(child) != src {
-                NexusRebuildJob::lookup_src(&get_dev(child))
+                let jobs = NexusRebuildJob::lookup_src(&get_dev(child))
                     .iter()
                     .filter(|s| s.dst_uri() != get_dev(child))
                     .inspect(|&job| {
-                        error!(
-                            "Job {:?} should be associated with src child {}",
-                            job, child
-                        );
+                        error!("Job {job:?} should be associated with src child {child}");
                     })
-                    .any(|_| panic!("Should not have found any jobs!"));
+                    .count();
+                if jobs > 0 {
+                    panic!("Should not have found any jobs!");
+                }
             }
         }
 

--- a/io-engine/tests/nexus_rebuild_parallel.rs
+++ b/io-engine/tests/nexus_rebuild_parallel.rs
@@ -34,7 +34,7 @@ async fn nexus_rebuild_parallel() {
     // Create pool data file.
     for r in 0..R {
         let name = format!("/tmp/{DISK_NAME}_{r}");
-        common::delete_file(&[name.clone()]);
+        common::delete_file(std::slice::from_ref(&name));
         common::truncate_file_bytes(&name, DISK_SIZE);
     }
 
@@ -130,7 +130,7 @@ async fn nexus_rebuild_parallel() {
     // Delete test files.
     for r in 0..R {
         let name = format!("/tmp/{DISK_NAME}_{r}");
-        common::delete_file(&[name.clone()]);
+        common::delete_file(std::slice::from_ref(&name));
     }
 }
 

--- a/io-engine/tests/nexus_rebuild_partial.rs
+++ b/io-engine/tests/nexus_rebuild_partial.rs
@@ -269,7 +269,7 @@ async fn nexus_partial_rebuild_io_fault() {
         .unwrap();
 
     // Check the replicas are identical now.
-    validate_replicas(&vec![repl_0.clone(), repl_1.clone()]).await;
+    validate_replicas(&[repl_0.clone(), repl_1.clone()]).await;
 
     // Validate that the rebuild did occur, and it was a partial one.
     let hist = nex_0.get_rebuild_history().await.unwrap();
@@ -319,7 +319,7 @@ async fn nexus_partial_rebuild_offline_online() {
     assert_eq!(children[0].state(), ChildState::Degraded);
     assert_eq!(children[0].state_reason(), ChildStateReason::ByClient);
 
-    validate_replicas(&vec![repl_0.clone(), repl_1.clone()]).await;
+    validate_replicas(&[repl_0.clone(), repl_1.clone()]).await;
 
     // We write 9 x 16-KiB buffers = 147456 bytes = 288 blocks = 2.25 rebuild
     // segments after previously written 10 x 16 KiB buffers.
@@ -340,7 +340,7 @@ async fn nexus_partial_rebuild_offline_online() {
         .await
         .unwrap();
 
-    validate_replicas(&vec![repl_0.clone(), repl_1.clone()]).await;
+    validate_replicas(&[repl_0.clone(), repl_1.clone()]).await;
 
     let hist = nex_0.get_rebuild_history().await.unwrap();
     assert_eq!(hist.len(), 1);
@@ -361,7 +361,7 @@ async fn nexus_partial_rebuild_offline_online() {
     assert_eq!(children[0].state(), ChildState::Degraded);
     assert_eq!(children[0].state_reason(), ChildStateReason::ByClient);
 
-    validate_replicas(&vec![repl_0.clone(), repl_1.clone()]).await;
+    validate_replicas(&[repl_0.clone(), repl_1.clone()]).await;
 
     test_write_to_nexus(
         &nex_0,
@@ -379,7 +379,7 @@ async fn nexus_partial_rebuild_offline_online() {
         .await
         .unwrap();
 
-    validate_replicas(&vec![repl_0.clone(), repl_1.clone()]).await;
+    validate_replicas(&[repl_0.clone(), repl_1.clone()]).await;
 
     let hist = nex_0.get_rebuild_history().await.unwrap();
     assert_eq!(hist.len(), 2);
@@ -644,5 +644,5 @@ async fn nexus_partial_rebuild_double_fault() {
     assert!(hist[0].blocks_transferred < hist[2].blocks_transferred);
 
     // Verify replicas.
-    validate_replicas(&vec![repl_0.clone(), repl_1.clone()]).await;
+    validate_replicas(&[repl_0.clone(), repl_1.clone()]).await;
 }

--- a/io-engine/tests/replica_timeout.rs
+++ b/io-engine/tests/replica_timeout.rs
@@ -83,7 +83,7 @@ async fn replica_stop_cont() {
     let c = child_uri.clone();
     mayastor
         .spawn(async move {
-            nexus_create(NXNAME, 1024 * 1024 * 50, None, &[c.clone()])
+            nexus_create(NXNAME, 1024 * 1024 * 50, None, std::slice::from_ref(&c))
                 .await
                 .unwrap();
             nexus_lookup_mut(NXNAME)

--- a/io-engine/tests/snapshot_lvol.rs
+++ b/io-engine/tests/snapshot_lvol.rs
@@ -1552,7 +1552,7 @@ async fn test_snapshot_verify_restore_data() {
     restore_1.share().await.unwrap();
 
     // Check the original replica and restore clone is identical.
-    validate_replicas(&vec![repl_1.clone(), restore_1.clone()]).await;
+    validate_replicas(&[repl_1.clone(), restore_1.clone()]).await;
 }
 
 #[tokio::test]


### PR DESCRIPTION
Updates spdk-rs and dependencies to match the rust changes. 
This also drops ring as a dependency in favour of aws-lc-rs.